### PR TITLE
Fix compile for Solaris Studio 12.4

### DIFF
--- a/ACE/ace/config-suncc-common.h
+++ b/ACE/ace/config-suncc-common.h
@@ -48,5 +48,10 @@
 
 #define ACE_TEMPLATES_REQUIRE_SOURCE
 
+// Solaris Studio 12.4 implements symbol lookup correctly.
+#if defined (__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
+#define ACE_ANY_OPS_USE_NAMESPACE
+#endif
+
 #include /**/ "ace/post.h"
 #endif /* ACE_SUNCC_COMMON_H */

--- a/ACE/ace/config-sunos5.10.h
+++ b/ACE/ace/config-sunos5.10.h
@@ -59,4 +59,9 @@
 
 #define ACE_HAS_SOLARIS_ATOMIC_LIB
 
+// Solaris Studio 12.4 implements symbol lookup correctly.
+#if defined (__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
+#define ACE_ANY_OPS_USE_NAMESPACE
+#endif
+
 #endif /* ACE_CONFIG_H */

--- a/ACE/ace/config-sunos5.10.h
+++ b/ACE/ace/config-sunos5.10.h
@@ -59,9 +59,4 @@
 
 #define ACE_HAS_SOLARIS_ATOMIC_LIB
 
-// Solaris Studio 12.4 implements symbol lookup correctly.
-#if defined (__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
-#define ACE_ANY_OPS_USE_NAMESPACE
-#endif
-
 #endif /* ACE_CONFIG_H */


### PR DESCRIPTION
Solaris Studio 12.4 now implements symbol lookup correctly.
Added #define ACE_ANY_OPS_USE_NAMESPACE to
config-sunos5.10.h when 12.4 or later compiler is detected.