### PR TITLE
feature/cross-aarch64-mips64el

### DIFF
--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -307,7 +307,7 @@
 # define ACE_HAS_STRBUF_T
 #endif
 
-#if defined (__ia64) || defined(__alpha) || defined (__x86_64__) || defined(__powerpc64__)
+#if defined (__ia64) || defined(__alpha) || defined (__x86_64__) || defined(__powerpc64__) || (defined(__mips__) && defined(__LP64__))
 // On 64 bit platforms, the "long" type is 64-bits.  Override the
 // default 32-bit platform-specific format specifiers appropriately.
 # define ACE_UINT64_FORMAT_SPECIFIER_ASCII "%lu"

--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -307,7 +307,7 @@
 # define ACE_HAS_STRBUF_T
 #endif
 
-#if defined (__ia64) || defined(__alpha) || defined (__x86_64__) || defined(__powerpc64__) || (defined(__mips__) && defined(__LP64__))
+#if defined (__ia64) || defined(__alpha) || defined (__x86_64__) || defined(__powerpc64__) || (defined(__mips__) && defined(__LP64__)) || defined (__aarch64__)
 // On 64 bit platforms, the "long" type is 64-bits.  Override the
 // default 32-bit platform-specific format specifiers appropriately.
 # define ACE_UINT64_FORMAT_SPECIFIER_ASCII "%lu"


### PR DESCRIPTION
Fix compilation warning in

* Ubuntu 14.04/14.10 aarch64 cross compilation.
* Native compilation in Linux mips64el 