### PR TITLE
Test on successful startup of the 3rd server did not fail while it should

### DIFF
--- a/TAO/tests/ORB_init/Portspan/run_test.pl
+++ b/TAO/tests/ORB_init/Portspan/run_test.pl
@@ -32,11 +32,12 @@ if ($server_status != 0) {
     exit 1;
 }
 
-$server_status = $SV3->SpawnWaitKill ($server->ProcessStartWaitInterval());
+$server_status = $SV3->Spawn ();
 if ($server_status == 0) {
     print STDERR "ERROR: Last server didn't fail! Err:$server_status\n";
     $SV1->Kill ();
     $SV2->Kill ();
+    $SV3->Kill ();
     exit 1;
 }
 


### PR DESCRIPTION
The test didn't fail when the startup of server3 was successful, because SpawnWaitKill not only returns -1 when the server couldn't start, but also when the server's still running after the wait.