### PR TITLE
Make nested makes easier to manage

### DIFF
--- a/ACE/include/makeinclude/macros.GNU
+++ b/ACE/include/makeinclude/macros.GNU
@@ -22,7 +22,8 @@ TARGETS_LOCAL  = \
 	depend.local \
 	rcs_info.local \
 	idl_stubs.local \
-	svnignore.local
+	svnignore.local \
+	$(PRIVATE_TARGETS_LOCAL)
 
 TARGETS_NESTED   = \
 	$(TARGETS_LOCAL:.local=.nested)

--- a/ACE/include/makeinclude/macros.GNU
+++ b/ACE/include/makeinclude/macros.GNU
@@ -22,8 +22,7 @@ TARGETS_LOCAL  = \
 	depend.local \
 	rcs_info.local \
 	idl_stubs.local \
-	svnignore.local \
-	$(PRIVATE_TARGETS_LOCAL)
+	svnignore.local
 
 TARGETS_NESTED   = \
 	$(TARGETS_LOCAL:.local=.nested)

--- a/ACE/include/makeinclude/rules.local.GNU
+++ b/ACE/include/makeinclude/rules.local.GNU
@@ -426,7 +426,8 @@ endif # DO_CLEANUP
 #       Dependency generation target
 #----------------------------------------------------------------------------
 
-MAKEFILE ?= GNUmakefile
+TOP_MAKEFILE := $(word 1,$(MAKEFILE_LIST))
+MAKEFILE ?= $(TOP_MAKEFILE)
 DEPENDENCY_FILE ?= $(MAKEFILE)
 IDL_DEPENDENCY_FILES ?= $(MAKEFILE)
 

--- a/ACE/include/makeinclude/rules.local.GNU
+++ b/ACE/include/makeinclude/rules.local.GNU
@@ -426,8 +426,7 @@ endif # DO_CLEANUP
 #       Dependency generation target
 #----------------------------------------------------------------------------
 
-TOP_MAKEFILE := $(word 1,$(MAKEFILE_LIST))
-MAKEFILE ?= $(TOP_MAKEFILE)
+MAKEFILE ?= GNUmakefile
 DEPENDENCY_FILE ?= $(MAKEFILE)
 IDL_DEPENDENCY_FILES ?= $(MAKEFILE)
 

--- a/ACE/include/makeinclude/rules.nested.GNU
+++ b/ACE/include/makeinclude/rules.nested.GNU
@@ -10,7 +10,8 @@
 # variable must be set to its actual name before including this
 # file to allow the recursive MAKE to work properly.
 
-MAKEFILE ?= GNUmakefile
+TOP_MAKEFILE := $(word 1,$(MAKEFILE_LIST))
+MAKEFILE ?= $(TOP_MAKEFILE)
 SUBDIR_MAKEFILE ?= $(MAKEFILE)
 
 # Make sure that we build directories with DIRS= in sequence instead of in

--- a/ACE/include/makeinclude/rules.nested.GNU
+++ b/ACE/include/makeinclude/rules.nested.GNU
@@ -10,8 +10,7 @@
 # variable must be set to its actual name before including this
 # file to allow the recursive MAKE to work properly.
 
-TOP_MAKEFILE := $(word 1,$(MAKEFILE_LIST))
-MAKEFILE ?= $(TOP_MAKEFILE)
+MAKEFILE ?= GNUmakefile
 SUBDIR_MAKEFILE ?= $(MAKEFILE)
 
 # Make sure that we build directories with DIRS= in sequence instead of in


### PR DESCRIPTION
2 items motivating these changes:

1. The desire to add more targets to the nested make structure; now defining a make variable PRIVATE_TARGETS_LOCAL will cause those targets to be appended to the current set of nested targets.

2. Change the default MAKEFILE variable name from GNUmakefile to the name of the makefile referenced first in the make invocation. Makes it easier to manage nested makes without always remembering to set the MAKEFILE variable. If the MAKEFILE variable is set, it is not changed.