### PR TITLE
BZ-4216 Android build fails when not cross-compiled on Linux

### DIFF
--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -9,11 +9,6 @@ no_hidden_visibility ?= 1
 # as of NDK r6 inlining is required
 inline ?= 1
 
-# start of: include most of platform_linux_common.GNU
-
-# We always include config-linux.h on Linux platforms.
-ACE_PLATFORM_CONFIG ?= config-linux.h
-
 debug ?= 1
 optimize ?= 1
 threads ?= 1
@@ -119,6 +114,11 @@ ifeq ($(ssl),1)
 endif # ssl
 
 SYSARCH := $(shell uname -m)
+
+PIC      = -fPIC
+AR      ?= ar
+ARFLAGS ?= rsuv
+RANLIB   = @true
 
 PIC      = -fPIC
 AR      ?= ar

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -9,7 +9,123 @@ no_hidden_visibility ?= 1
 # as of NDK r6 inlining is required
 inline ?= 1
 
-include $(ACE_ROOT)/include/makeinclude/platform_linux_common.GNU
+# start of: include most of platform_linux_common.GNU
+
+# We always include config-linux.h on Linux platforms.
+ACE_PLATFORM_CONFIG ?= config-linux.h
+
+debug ?= 1
+optimize ?= 1
+threads ?= 1
+insure ?= 0
+
+LSB_RELEASE_ID := $(shell lsb_release -i 2> /dev/null || echo Distributor ID: Unknown)
+LSB_RELEASE_RELEASE := $(shell lsb_release -r 2> /dev/null || echo Release: Unknown)
+
+PLATFORM_XT_CPPFLAGS=
+PLATFORM_XT_LIBS=-lXt
+PLATFORM_XT_LDFLAGS=
+
+PLATFORM_FL_CPPFLAGS=
+PLATFORM_FL_LIBS=-lfltk -lfltk_forms -lfltk_gl
+PLATFORM_FL_LDFLAGS=
+
+PLATFORM_X11_CPPFLAGS=-I/usr/X11R6/include
+PLATFORM_X11_LIBS=-lX11
+PLATFORM_X11_LDFLAGS=-L/usr/X11R6/lib
+
+PLATFORM_GL_CPPFLAGS=-I/usr/X11R6/include
+PLATFORM_GL_LIBS    =-lGL
+PLATFORM_GL_LDFLAGS =-L/usr/X11R6/lib
+
+PLATFORM_GTK_CPPFLAGS=$(shell gtk-config --cflags)
+PLATFORM_GTK_LIBS    =$(shell gtk-config --libs)
+PLATFORM_GTK_LDFLAGS =
+
+PLATFORM_FOX_CPPFLAGS ?= -I/usr/include/fox
+PLATFORM_FOX_LIBS     ?= -lFOX
+PLATFORM_FOX_LDFLAGS  ?=
+
+# NOTE: we only support wxWindows over GTK
+PLATFORM_WX_CPPFLAGS= $(shell wx-config --cxxflags) $(PLATFORM_GTK_CPPFLAGS)
+PLATFORM_WX_LIBS    = $(shell wx-config --libs)     $(PLATFORM_GTK_LIBS)
+PLATFORM_WX_LDFLAGS = $(shell wx-config --ldflags)  $(PLATFORM_GTK_LDFLAGS)
+
+PLATFORM_BOOST_CPPFLAGS ?=
+PLATFORM_BOOST_LDLAGS ?=
+PLATFORM_BOOST_UTF_LIBS ?= -lboost_unit_test_framework
+
+ifeq ($(buildbits),64)
+PLATFORM_TK_CPPFLAGS=$(shell . /usr/lib64/tkConfig.sh && echo -n $$TK_INCLUDE_SPEC $$TK_DEFS)
+PLATFORM_TK_LIBS=$(shell . /usr/lib64/tkConfig.sh && echo -n $$TK_LIB_FLAG)
+else
+PLATFORM_TK_CPPFLAGS=$(shell . /usr/lib/tkConfig.sh && echo -n $$TK_INCLUDE_SPEC $$TK_DEFS)
+PLATFORM_TK_LIBS=$(shell . /usr/lib/tkConfig.sh && echo -n $$TK_LIB_FLAG)
+endif
+PLATFORM_TK_LDFLAGS=
+
+ifeq ($(buildbits),64)
+PLATFORM_TCL_CPPFLAGS=$(shell . /usr/lib64/tclConfig.sh && echo -n $$TCL_INCLUDE_SPEC $$TCL_DEFS)
+PLATFORM_TCL_LIBS=$(shell . /usr/lib64/tclConfig.sh && echo -n $$(eval echo $$TCL_LIB_FLAG))
+else
+PLATFORM_TCL_CPPFLAGS=$(shell . /usr/lib/tclConfig.sh && echo -n $$TCL_INCLUDE_SPEC $$TCL_DEFS)
+PLATFORM_TCL_LIBS=$(shell . /usr/lib/tclConfig.sh && echo -n $$(eval echo $$TCL_LIB_FLAG))
+endif
+PLATFORM_TCL_LDFLAGS=
+
+PLATFORM_QT_CPPFLAGS ?= -I$(QTDIR)/include
+PLATFORM_QT_LIBS ?= -lqt-mt
+PLATFORM_QT_LDFLAGS ?= -L$(QTDIR)/lib
+
+sctp ?=
+# support for OpenSS7 SCTP
+ifeq ($(sctp),openss7)
+  PLATFORM_SCTP_CPPFLAGS+= -DACE_HAS_OPENSS7_SCTP
+  PLATFORM_SCTP_LDFLAGS?=
+  PLATFORM_SCTP_LIBS?=
+endif
+
+# support for LKSCTP (Linux Kernel 2.5)
+ifeq ($(sctp),lksctp)
+  PLATFORM_SCTP_CPPFLAGS+= -DACE_HAS_LKSCTP
+  PLATFORM_SCTP_LDFLAGS?= -L/usr/local/lib
+  PLATFORM_SCTP_LIBS?= -lsctp
+endif
+
+GNU_LIBPTHREAD_VERSION := $(shell getconf GNU_LIBPTHREAD_VERSION 2> /dev/null || echo Unknown)
+ifeq (NPTL, $(word 1,$(GNU_LIBPTHREAD_VERSION)))
+  NPTL_VERS := $(subst ., ,$(word 2,$(GNU_LIBPTHREAD_VERSION)))
+  ifneq (0, $(word 1,$(NPTL_VERS)))
+    nptl ?= 1
+  endif
+endif
+nptl ?= 0
+ifeq ($(nptl),0)
+  CPPFLAGS += -DACE_LACKS_LINUX_NPTL
+endif
+
+ssl ?= 0
+ifeq ($(ssl),1)
+  # Some Linux OpenSSL installations compile in Kerberos support.  Add
+  # the Kerberos include path to preprocessor include path.
+  #
+  # We should probably also add the Kerberos libraries to
+  # PLATFORM_SSL_LIBS but we can't be sure if they are needed without
+  # a more sophisticated check.  This will only be a problem when
+  # statically linking the OpenSSL library.  The majority of
+  # installations use shared OpenSSL libraries so we should be okay,
+  # at least until we migrate to Autoconf.
+  PLATFORM_SSL_CPPFLAGS += -I/usr/kerberos/include
+endif # ssl
+
+SYSARCH := $(shell uname -m)
+
+PIC      = -fPIC
+AR      ?= ar
+ARFLAGS ?= rsuv
+RANLIB   = @true
+
+# end of: include most of platform_linux_common.GNU
 
 #No rwho on Android
 rwho = 0


### PR DESCRIPTION
[Changed]
platform_android.GNU
- replace the platform_linux_common.GNU include with its contents
  except the erroneous call to getconf

[Tests]
Test 1:
1) Compile ACE for Android using OSX or Windows
2) Verify build is successful