### PR TITLE
BZ-4217 Android 6 with 3rd party AIO not working

### DIFF
--- a/ACE/ace/POSIX_Proactor.cpp
+++ b/ACE/ace/POSIX_Proactor.cpp
@@ -920,6 +920,12 @@ int ACE_POSIX_AIOCB_Proactor::delete_result_aiocb_list (void)
 
 void ACE_POSIX_AIOCB_Proactor::check_max_aio_num ()
 {
+#if !defined (ACE_ANDROID)
+  // Android API 23 introduced a define _POSIX_AIO_MAX 1 which gets used by _SC_AIO_MAX.
+  // Previously, without the define, the value returned was -1, which got ignored.
+  // Officially, the Android OS does not support AIO so if ACE_HAS_AIO_CALLS is defined
+  // then a 3rd party library must be in use and this check is invalid.
+
   long max_os_aio_num = ACE_OS::sysconf (_SC_AIO_MAX);
 
   // Define max limit AIO's for concrete OS
@@ -929,6 +935,7 @@ void ACE_POSIX_AIOCB_Proactor::check_max_aio_num ()
   if (max_os_aio_num > 0 &&
       aiocb_list_max_size_ > (unsigned long) max_os_aio_num)
      aiocb_list_max_size_ = max_os_aio_num;
+#endif
 
 #if defined (HPUX) || defined (__FreeBSD__)
   // Although HPUX 11.00 allows to start 2048 AIO's for all process in


### PR DESCRIPTION
[Changed]
POSIX_Proactor.cpp
- disable an OS bounds check for Android since it does not support AIO
  and ACE_HAS_AIO_CALLS will only be defined if a 3rd party lib is used

[Tests]
Test 1:
1) Compile ACE for Android using a 3rd party AIO lib
2) In the implementation of ACE_Service_Handler::open, try to read from
   an ACE_Asynch_Read_Stream
3) Verify it returns >= 0 with no error