### PR TITLE
Remove ACE_STATIC_CONSTANT because there is no compiler anymore that …

### DIFF
--- a/ACE/ace/Global_Macros.h
+++ b/ACE/ace/Global_Macros.h
@@ -867,7 +867,7 @@ ACE_MAKE_SVC_CONFIG_FACTORY_NAME(ACE_VERSIONED_NAMESPACE_NAME,SERVICE_CLASS) (AC
 #endif /* ACE_WIN32 */
 
 
-// Some useful abstrations for expressions involving
+// Some useful abstractions for expressions involving
 // ACE_Allocator.malloc ().  The difference between ACE_NEW_MALLOC*
 // with ACE_ALLOCATOR* is that they call constructors also.
 
@@ -1033,16 +1033,6 @@ ACE_MAKE_SVC_CONFIG_FACTORY_NAME(ACE_VERSIONED_NAMESPACE_NAME,SERVICE_CLASS) (AC
 #   define ACE_SHARED_MEMORY_POOL ACE_Shared_Memory_Pool
 #   define ACE_LOCAL_MEMORY_POOL ACE_Local_Memory_Pool
 #   define ACE_PAGEFILE_MEMORY_POOL ACE_Pagefile_Memory_Pool
-
-// Work around compilers that don't like in-class static integral
-// constants.  Constants in this case are meant to be compile-time
-// constants so that they may be used as template arguments, for
-// example.  BOOST provides a similar macro.
-#ifndef ACE_LACKS_STATIC_IN_CLASS_CONSTANTS
-# define ACE_STATIC_CONSTANT(TYPE, ASSIGNMENT) static TYPE const ASSIGNMENT
-#else
-# define ACE_STATIC_CONSTANT(TYPE, ASSIGNMENT) enum { ASSIGNMENT }
-#endif  /* !ACE_LACKS_STATIC_IN_CLASS_CONSTANTS */
 
 #include /**/ "ace/post.h"
 

--- a/ACE/ace/Truncate.h
+++ b/ACE/ace/Truncate.h
@@ -32,28 +32,28 @@ namespace ACE_Utils
   template<typename T> struct Sign_Check;
 
   // Specialize the unsigned signed cases.
-  template<> struct Sign_Check<unsigned char>  { ACE_STATIC_CONSTANT (bool, is_signed = 0); };
-  template<> struct Sign_Check<unsigned short> { ACE_STATIC_CONSTANT (bool, is_signed = 0); };
-  template<> struct Sign_Check<unsigned int>   { ACE_STATIC_CONSTANT (bool, is_signed = 0); };
-  template<> struct Sign_Check<unsigned long>  { ACE_STATIC_CONSTANT (bool, is_signed = 0); };
+  template<> struct Sign_Check<unsigned char>  { static bool const is_signed = false; };
+  template<> struct Sign_Check<unsigned short> { static bool const is_signed = false; };
+  template<> struct Sign_Check<unsigned int>   { static bool const is_signed = false; };
+  template<> struct Sign_Check<unsigned long>  { static bool const is_signed = false; };
 # ifdef __GNUC__
   // Silence g++ "-pedantic" warnings regarding use of "long long"
   // type.
   __extension__
 # endif  /* __GNUC__ */
-  template<> struct Sign_Check<unsigned long long> { ACE_STATIC_CONSTANT (bool, is_signed = 0); };
+  template<> struct Sign_Check<unsigned long long> { static bool const is_signed = false; };
 
   // Specialize the signed cases.
-  template<> struct Sign_Check<signed char>  { ACE_STATIC_CONSTANT (bool, is_signed = 1); };
-  template<> struct Sign_Check<signed short> { ACE_STATIC_CONSTANT (bool, is_signed = 1); };
-  template<> struct Sign_Check<signed int>   { ACE_STATIC_CONSTANT (bool, is_signed = 1); };
-  template<> struct Sign_Check<signed long>  { ACE_STATIC_CONSTANT (bool, is_signed = 1); };
+  template<> struct Sign_Check<signed char>  { static bool const is_signed = true; };
+  template<> struct Sign_Check<signed short> { static bool const is_signed = true; };
+  template<> struct Sign_Check<signed int>   { static bool const is_signed = true; };
+  template<> struct Sign_Check<signed long>  { static bool const is_signed = true; };
 # ifdef __GNUC__
   // Silence g++ "-pedantic" warnings regarding use of "long long"
   // type.
   __extension__
 # endif  /* __GNUC__ */
-  template<> struct Sign_Check<signed long long> { ACE_STATIC_CONSTANT (bool, is_signed = 1); };
+  template<> struct Sign_Check<signed long long> { static bool const is_signed = true; };
 
   // -----------------------------------------------------
 
@@ -271,9 +271,8 @@ namespace ACE_Utils
   template<typename LEFT, typename RIGHT>
   struct Fast_Comparator
   {
-    ACE_STATIC_CONSTANT (
-      bool,
-      USE_LEFT  = ((sizeof (LEFT) > sizeof (RIGHT)
+    static bool const USE_LEFT  =
+                 ((sizeof (LEFT) > sizeof (RIGHT)
                     && (Sign_Check<LEFT>::is_signed == 1
                         || Sign_Check<RIGHT>::is_signed == 0))
 
@@ -289,15 +288,14 @@ namespace ACE_Utils
                        && ((Sign_Check<LEFT>::is_signed == 1
                             && Sign_Check<RIGHT>::is_signed == 1)
                            || (Sign_Check<LEFT>::is_signed == 0
-                               && Sign_Check<RIGHT>::is_signed == 0)))));
+                               && Sign_Check<RIGHT>::is_signed == 0))));
 
-    ACE_STATIC_CONSTANT (
-      bool,
-      USE_RIGHT = (sizeof (RIGHT) > sizeof (LEFT)
+    static bool const USE_RIGHT =
+                  (sizeof (RIGHT) > sizeof (LEFT)
                    && (Sign_Check<RIGHT>::is_signed == 1
-                       || Sign_Check<LEFT>::is_signed == 0)));
+                       || Sign_Check<LEFT>::is_signed == 0));
 
-    ACE_STATIC_CONSTANT (bool, USABLE = (USE_LEFT || USE_RIGHT));
+    static bool const USABLE = (USE_LEFT || USE_RIGHT);
 
     typedef typename ACE::If_Then_Else<
       USE_LEFT,
@@ -370,12 +368,11 @@ namespace ACE_Utils
   template<typename FROM, typename TO>
   struct Truncator
   {
-    ACE_STATIC_CONSTANT (
-      bool,
+    static bool const
       // max FROM always greater than max TO
       MAX_FROM_GT_MAX_TO = (sizeof(FROM) > sizeof (TO)
                             || (sizeof(FROM) == sizeof (TO)
-                                && Sign_Check<FROM>::is_signed == 0)));
+                                && Sign_Check<FROM>::is_signed == 0));
 
     typedef typename ACE::If_Then_Else<
       MAX_FROM_GT_MAX_TO,


### PR DESCRIPTION
…lacks the support for static constants

    * ACE/ace/Global_Macros.h:
    * ACE/ace/Truncate.h: