### PR TITLE
Fixed typo

### DIFF
--- a/ACE/ACEXML/common/DTD_Manager.h
+++ b/ACE/ACEXML/common/DTD_Manager.h
@@ -37,7 +37,7 @@ public:
    * definition builder and use the builder to create
    * the DTD element definition.  The resulting builder
    * is then registered with the DTD Manager or destroyed
-   * if error occured when the builder encountered errors.
+   * if error occurred when the builder encountered errors.
    *
    * @retval 0 if error occurs creating the builder.
    */

--- a/ACE/ACEXML/common/NamespaceSupport.h
+++ b/ACE/ACEXML/common/NamespaceSupport.h
@@ -146,7 +146,7 @@ public:
 
   /**
    * Declare a Namespace prefix.  Return -1 if the prefix was illegal
-   * or an internal error occured.  Return 0 if the prefix gets declared
+   * or an internal error occurred.  Return 0 if the prefix gets declared
    * successfully, 1 if the prefix replaces an existing prefix definition.
    */
   int declarePrefix (const ACEXML_Char *prefix,

--- a/ACE/ACEXML/parser/debug_validator/Debug_DTD_Manager.h
+++ b/ACE/ACEXML/parser/debug_validator/Debug_DTD_Manager.h
@@ -30,7 +30,7 @@ public:
    * Acquire a pointer to an element definition builder. The XML parser use
    * this interface to acquire the definition builder and use the builder
    * to create the DTD element definition. The resulting builder is then
-   * registered with the DTD Manager or destroyed if error occured when the
+   * registered with the DTD Manager or destroyed if error occurred when the
    * builder encountered errors.
    *
    * @retval 0 if error occurs creating the builder.

--- a/ACE/ace/Containers_T.h
+++ b/ACE/ace/Containers_T.h
@@ -963,7 +963,7 @@ protected:
   /**
    * Insert a @a new_item into the list.  It will be added before
    * or after @a old_item.  Default is to insert the new item *after*
-   * {head_}.  Return 0 if succeed, -1 if error occured.
+   * {head_}.  Return 0 if succeed, -1 if error occurred.
    */
   int insert_element (T *new_item,
                       int before = 0,

--- a/ACE/ace/DLL.h
+++ b/ACE/ace/DLL.h
@@ -154,7 +154,7 @@ public:
    */
   void *symbol (const ACE_TCHAR *symbol_name, int ignore_errors = 0);
 
-  /// Returns a pointer to a string explaining that an error occured.  You
+  /// Returns a pointer to a string explaining that an error occurred.  You
   /// will need to consult the error log for the actual error string
   /// returned by the OS.
   ACE_TCHAR *error (void) const;

--- a/ACE/ace/QoS/QoS_Session.h
+++ b/ACE/ace/QoS/QoS_Session.h
@@ -115,10 +115,10 @@ public:
   virtual ACE_HANDLE rsvp_events_handle (void) = 0;
 
   virtual void  rsvp_event_type (RSVP_Event_Type event_type) = 0;
-  ///Set the RAPI event that last occured
+  ///Set the RAPI event that last occurred
 
   virtual RSVP_Event_Type rsvp_event_type (void) = 0;
-  ///Get the RAPI event that last occured
+  ///Get the RAPI event that last occurred
 
 
   /// Get the destination address for this session.
@@ -171,7 +171,7 @@ protected:
   ACE_End_Point_Type flags_;
 
   RSVP_Event_Type rsvp_event_type_;
-  //Has the last rsvp event that occured
+  //Has the last rsvp event that occurred
 
 };
 

--- a/ACE/ace/QoS/QoS_Session_Impl.cpp
+++ b/ACE/ace/QoS/QoS_Session_Impl.cpp
@@ -286,14 +286,14 @@ ACE_RAPI_Session::close (void)
   return 0;
 }
 
-//Get the most recent RSVP event that occured
+//Get the most recent RSVP event that occurred
 ACE_QoS_Session::RSVP_Event_Type
 ACE_RAPI_Session::rsvp_event_type (void)
 {
   return this->rsvp_event_type_;
 }
 
-//Set the most recent RSVP event that occured
+//Set the most recent RSVP event that occurred
 void
 ACE_RAPI_Session::rsvp_event_type (ACE_QoS_Session::RSVP_Event_Type event_type)
 {
@@ -697,14 +697,14 @@ ACE_GQoS_Session::update_qos (void)
   return 0;
 }
 
-//Get the most recent RSVP event that occured
+//Get the most recent RSVP event that occurred
 ACE_QoS_Session::RSVP_Event_Type
 ACE_GQoS_Session::rsvp_event_type (void)
 {
   return this->rsvp_event_type_;
 }
 
-//Set the most recent RSVP event that occured
+//Set the most recent RSVP event that occurred
 void
 ACE_GQoS_Session::rsvp_event_type (ACE_QoS_Session::RSVP_Event_Type event_type)
 {

--- a/ACE/ace/QoS/QoS_Session_Impl.h
+++ b/ACE/ace/QoS/QoS_Session_Impl.h
@@ -93,10 +93,10 @@ public:
   /// Get the RAPI file descriptor for RSVP events.
   virtual ACE_HANDLE rsvp_events_handle (void);
 
-  ///Set the RAPI event that last occured
+  ///Set the RAPI event that last occurred
   virtual void  rsvp_event_type (RSVP_Event_Type event_type);
 
-  ///Get the RAPI event that last occured
+  ///Get the RAPI event that last occurred
   virtual RSVP_Event_Type rsvp_event_type (void);
 
   /// Get the destination address for this RAPI session.
@@ -233,10 +233,10 @@ public:
   virtual ACE_HANDLE rsvp_events_handle (void);
 
   virtual void  rsvp_event_type (RSVP_Event_Type event_type);
-  ///Set the RAPI event that last occured
+  ///Set the RAPI event that last occurred
 
   virtual RSVP_Event_Type rsvp_event_type (void);
-  ///Get the RAPI event that last occured
+  ///Get the RAPI event that last occurred
 
   /// GQoS version.
   virtual int version ();

--- a/ACE/ace/RB_Tree.h
+++ b/ACE/ace/RB_Tree.h
@@ -124,7 +124,7 @@ public:
    *       inlining is disabled and on platforms where
    *       @c ACE_TEMPLATES_REQUIRE_SOURCE is defined.  In those
    *       platform/configuration combinations, multiple definitions
-   *       of this method occured.  Placing the definition inline in
+   *       of this method occurred.  Placing the definition inline in
    *       the header avoids such errors.
    */
   ACE_Allocator * allocator (void) const { return this->allocator_; }

--- a/ACE/ace/SSL/SSL_SOCK_Stream.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Stream.cpp
@@ -102,7 +102,7 @@ ACE_SSL_SOCK_Stream::sendv (const iovec iov[],
           // amount of data sent was less than the amount data given.
           // This avoids a subtle problem where "holes" in the data
           // stream would occur if partial sends of a given buffer in
-          // the iovec array occured.
+          // the iovec array occurred.
           if (static_cast<size_t> (result) < static_cast<size_t> (iov[i].iov_len))
             break;
         }
@@ -254,7 +254,7 @@ ACE_SSL_SOCK_Stream::send (size_t n, ...) const
           // amount of data sent was less than the amount of data
           // given.  This avoids a subtle problem where "holes" in the
           // data stream would occur if partial sends of a given
-          // buffer in the varargs occured.
+          // buffer in the varargs occurred.
           if (result < data_len)
             break;
 
@@ -308,7 +308,7 @@ ACE_SSL_SOCK_Stream::recv (size_t n, ...) const
           // amount of data received was less than the amount of data
           // desired.  This avoids a subtle problem where "holes" in
           // the data stream would occur if partial receives of a
-          // given buffer in the varargs occured.
+          // given buffer in the varargs occurred.
           if (result < data_len)
             {
               break;

--- a/ACE/ace/SSL/SSL_SOCK_Stream.inl
+++ b/ACE/ace/SSL/SSL_SOCK_Stream.inl
@@ -59,7 +59,7 @@ ACE_SSL_SOCK_Stream::send_i (const void *buf,
 
     case SSL_ERROR_SYSCALL:
       if (bytes_sent == 0)
-        // An EOF occured but the SSL "close_notify" message was not
+        // An EOF occurred but the SSL "close_notify" message was not
         // sent.  This is a protocol error, but we ignore it.
         return 0;
 
@@ -187,7 +187,7 @@ ACE_SSL_SOCK_Stream::recv_i (void *buf,
 
         case SSL_ERROR_SYSCALL:
           if (bytes_read == 0)
-            // An EOF occured but the SSL "close_notify" message was not
+            // An EOF occurred but the SSL "close_notify" message was not
             // sent.  This is a protocol error, but we ignore it.
             break;
 

--- a/ACE/ace/Select_Reactor_T.cpp
+++ b/ACE/ace/Select_Reactor_T.cpp
@@ -1364,7 +1364,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::dispatch
                (dispatch_set,
                 active_handle_count,
                 other_handlers_dispatched) == -1)
-        // State has changed or a serious failure has occured, so exit
+        // State has changed or a serious failure has occurred, so exit
         // loop.
         break;
 

--- a/ACE/ace/TP_Reactor.cpp
+++ b/ACE/ace/TP_Reactor.cpp
@@ -315,7 +315,7 @@ int
 ACE_TP_Reactor::handle_notify_events (int & /*event_count*/,
                                       ACE_TP_Token_Guard &guard)
 {
-  // Get the handle on which notify calls could have occured
+  // Get the handle on which notify calls could have occurred
   ACE_HANDLE notify_handle = this->get_notify_handle ();
 
   int result = 0;

--- a/ACE/ace/Token.cpp
+++ b/ACE/ace/Token.cpp
@@ -294,7 +294,7 @@ ACE_Token::shared_acquire (void (*sleep_hook_func)(void *),
   ACELIB_DEBUG ((LM_DEBUG, "(%t) ACE_Token::shared_acquire (UNBLOCKED)\n"));
 #endif /* ACE_TOKEN_DEBUGGING */
 
-  // If timeout occured
+  // If timeout occurred
   if (timed_out)
     {
       // This thread was still selected to own the token.
@@ -440,7 +440,7 @@ ACE_Token::renew (int requeue_position,
   ACELIB_DEBUG ((LM_DEBUG, "(%t) ACE_Token::renew (UNBLOCKED)\n"));
 #endif /* ACE_TOKEN_DEBUGGING */
 
-  // If timeout occured
+  // If timeout occurred
   if (timed_out)
     {
       // This thread was still selected to own the token.

--- a/ACE/apps/JAWS/clients/WebSTONE/src/nsapi-includes/base/file.h
+++ b/ACE/apps/JAWS/clients/WebSTONE/src/nsapi-includes/base/file.h
@@ -158,7 +158,7 @@ int system_fwrite(SYS_FILE fd,char *buf,int sz);
 int system_fwrite_atomic(SYS_FILE fd, char *buf, int sz);
 
 /*
- * system_errmsg returns the last error that occured while processing file
+ * system_errmsg returns the last error that occurred while processing file
  * descriptor fd. fd does not have to be specified (if the error is a global
  * such as in UNIX systems). PPS: Rob is a halfwit. This parameter is useless.
  */

--- a/ACE/examples/APG/Signals/SigHandler.cpp
+++ b/ACE/examples/APG/Signals/SigHandler.cpp
@@ -22,7 +22,7 @@ public:
     // Make sure the right handler was called back.
     ACE_ASSERT (signum == this->signum_);
 
-    ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("%S occured\n"), signum));
+    ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("%S occurred\n"), signum));
     return 0;
   }
 

--- a/ACE/examples/APG/Signals/SigHandlers.cpp
+++ b/ACE/examples/APG/Signals/SigHandlers.cpp
@@ -19,7 +19,7 @@ public:
     // Make sure the right handler was called back..
     ACE_ASSERT(signum == this->signum_);
 
-    ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("%d occured\n"), signum));
+    ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("%d occurred\n"), signum));
 
     return 0;
   }

--- a/ACE/examples/Reactor/Proactor/test_aiosig.cpp
+++ b/ACE/examples/Reactor/Proactor/test_aiosig.cpp
@@ -197,7 +197,7 @@ query_aio_completions (void)
           return -1;
         }
 
-      // No error occured in the AIO operation.
+      // No error occurred in the AIO operation.
       int nbytes = aio_return (aiocb_ptr);
       if (nbytes == -1)
         {

--- a/ACE/examples/Reactor/Proactor/test_aiosig_ace.cpp
+++ b/ACE/examples/Reactor/Proactor/test_aiosig_ace.cpp
@@ -262,7 +262,7 @@ query_aio_completions (void)
                                "An AIO call has failed"),
                               error_code);
 
-          // No error occured in the AIO operation.
+          // No error occurred in the AIO operation.
           int nbytes = aio_return (aiocb_ptr);
           if (nbytes == -1)
             ACE_ERROR_RETURN ((LM_ERROR, "%p\n",

--- a/ACE/examples/Reactor/WFMO_Reactor/APC.cpp
+++ b/ACE/examples/Reactor/WFMO_Reactor/APC.cpp
@@ -41,7 +41,7 @@ static void WINAPI
 apc_callback (DWORD)
 {
   ACE_DEBUG ((LM_DEBUG,
-              "(%t) apc occured @ %T\n"));
+              "(%t) apc occurred @ %T\n"));
 
   global_event_handler->handle_.signal ();
 }
@@ -79,7 +79,7 @@ Event_Handler::handle_timeout (const ACE_Time_Value &,
                                const void *)
 {
   ACE_DEBUG ((LM_DEBUG,
-              "(%t) timeout occured @ %T\n"));
+              "(%t) timeout occurred @ %T\n"));
   queue_apc ();
   return 0;
 }

--- a/ACE/examples/Reactor/WFMO_Reactor/Abandoned.cpp
+++ b/ACE/examples/Reactor/WFMO_Reactor/Abandoned.cpp
@@ -77,7 +77,7 @@ Event_Handler::handle_timeout (const ACE_Time_Value &,
 {
   --this->iterations_;
   ACE_DEBUG ((LM_DEBUG,
-              "(%t) timeout occured @ %T, iterations left %d\n",
+              "(%t) timeout occurred @ %T, iterations left %d\n",
               this->iterations_));
 
   if (this->iterations_ == 0)

--- a/ACE/examples/Reactor/WFMO_Reactor/Window_Messages.cpp
+++ b/ACE/examples/Reactor/WFMO_Reactor/Window_Messages.cpp
@@ -50,7 +50,7 @@ timer_callback (HWND,
                 UINT,
                 DWORD dwTime)
 {
-  ACE_DEBUG ((LM_DEBUG, "(%t) timeout occured @ %u\n", dwTime));
+  ACE_DEBUG ((LM_DEBUG, "(%t) timeout occurred @ %u\n", dwTime));
 
   global_event_handler->handle_.signal ();
 }

--- a/ACE/tests/Cached_Accept_Conn_Test.cpp
+++ b/ACE/tests/Cached_Accept_Conn_Test.cpp
@@ -59,7 +59,7 @@ Accept_Strategy<SVC_HANDLER, ACE_PEER_ACCEPTOR_2>::open (const ACE_PEER_ACCEPTOR
   if (result == 0)
     return result;
 
-  // If the error occured due to the fact that the file descriptor
+  // If the error occurred due to the fact that the file descriptor
   // limit was exhausted, then purge the connection cache of some
   // entries.
   result = this->out_of_sockets_handler ();
@@ -98,7 +98,7 @@ Accept_Strategy<SVC_HANDLER, ACE_PEER_ACCEPTOR_2>::accept_svc_handler (SVC_HANDL
       return result;
     }
 
-  // If the error occured due to the fact that the file descriptor
+  // If the error occurred due to the fact that the file descriptor
   // limit was exhausted, then purge the connection cache of some
   // entries.
   if (0 != this->out_of_sockets_handler ())

--- a/ACE/tests/Dev_Poll_Reactor_Echo_Test.cpp
+++ b/ACE/tests/Dev_Poll_Reactor_Echo_Test.cpp
@@ -189,7 +189,7 @@ int
 Client::handle_timeout (const ACE_Time_Value &, const void *)
 {
   ACE_DEBUG ((LM_INFO,
-              ACE_TEXT ("(%t) Expected client timeout occured at: %T\n")));
+              ACE_TEXT ("(%t) Expected client timeout occurred at: %T\n")));
 
   if (this->call_count_ != 10)
     {

--- a/ACE/tests/Dev_Poll_Reactor_Test.cpp
+++ b/ACE/tests/Dev_Poll_Reactor_Test.cpp
@@ -152,7 +152,7 @@ int
 Client::handle_timeout (const ACE_Time_Value &, const void *)
 {
   ACE_DEBUG ((LM_INFO,
-              ACE_TEXT ("(%t) Expected client timeout occured at: %T\n")));
+              ACE_TEXT ("(%t) Expected client timeout occurred at: %T\n")));
 
   this->call_count_++;
 
@@ -260,7 +260,7 @@ Server::handle_timeout (const ACE_Time_Value &,
                         const void *)
 {
   ACE_DEBUG ((LM_INFO,
-              ACE_TEXT ("(%t) Expected server timeout occured at: %T\n")));
+              ACE_TEXT ("(%t) Expected server timeout occurred at: %T\n")));
 
 //   if (this->call_count_ == 0
 //       && this->handle_input (this->get_handle ()) != 0

--- a/TAO/DevGuideExamples/PortableInterceptors/Auth/ServerInitializer.cpp
+++ b/TAO/DevGuideExamples/PortableInterceptors/Auth/ServerInitializer.cpp
@@ -32,7 +32,7 @@ ServerInitializer::post_init (
     }
   catch(...)
     {
-      std::cerr << "Exception occured trying to create ServerInterceptor." << std::endl;
+      std::cerr << "Exception occurred trying to create ServerInterceptor." << std::endl;
     }
 
   PortableInterceptor::ServerRequestInterceptor_var si_interceptor =

--- a/TAO/examples/Content_Server/AMI_Observer/Callback_Handler.cpp
+++ b/TAO/examples/Content_Server/AMI_Observer/Callback_Handler.cpp
@@ -91,7 +91,7 @@ Callback_Handler::next_chunk_excep
   catch (const CORBA::Exception& ex)
     {
       ex._tao_print_exception (
-        ACE_TEXT ("Exception occured during ")
+        ACE_TEXT ("Exception occurred during ")
         ACE_TEXT ("sendc_next_chunk() call:"));
     }
 }

--- a/TAO/orbsvcs/examples/Notify/Subscribe/Subscribe.h
+++ b/TAO/orbsvcs/examples/Notify/Subscribe/Subscribe.h
@@ -41,7 +41,7 @@ class Subscribe
   /// Run the demo.
   void run (void);
 
-  /// Called when all events we are waiting for have occured.
+  /// Called when all events we are waiting for have occurred.
   void done (void);
 
  protected:

--- a/TAO/orbsvcs/examples/RtEC/Kokyu/Supplier.cpp
+++ b/TAO/orbsvcs/examples/RtEC/Kokyu/Supplier.cpp
@@ -13,7 +13,7 @@ Supplier::Supplier (RtecEventComm::EventSourceID id,
 }
 
 void
-Supplier::timeout_occured (void)
+Supplier::timeout_occurred (void)
 {
   RtecEventComm::EventSet event (1);
   if (id_ == 1)
@@ -55,7 +55,7 @@ Timeout_Consumer::push (const RtecEventComm::EventSet& events)
     }
 
   ACE_DEBUG ((LM_DEBUG, "(%t) Timeout Event received\n"));
-  supplier_impl_->timeout_occured ();
+  supplier_impl_->timeout_occurred ();
 }
 
 void

--- a/TAO/orbsvcs/examples/RtEC/Kokyu/Supplier.h
+++ b/TAO/orbsvcs/examples/RtEC/Kokyu/Supplier.h
@@ -43,7 +43,7 @@ public:
   /// The skeleton methods.
   virtual void disconnect_push_supplier (void);
 
-  void timeout_occured (void);
+  void timeout_occurred (void);
 
 private:
   RtecEventComm::EventSourceID id_;

--- a/TAO/orbsvcs/orbsvcs/Event/EC_ObserverStrategy.cpp
+++ b/TAO/orbsvcs/orbsvcs/Event/EC_ObserverStrategy.cpp
@@ -291,13 +291,13 @@ TAO_EC_Reactive_ObserverStrategy::supplier_qos_update (
         }
       catch (const CORBA::OBJECT_NOT_EXIST&)
         {
-          // Exception occured while updating observer, so remove it from the
+          // Exception occurred while updating observer, so remove it from the
           // observer list
           this->observer_not_exists (entry);
         }
       catch (const CORBA::TRANSIENT&)
         {
-          // Exception occured while updating observer, so remove it from the
+          // Exception occurred while updating observer, so remove it from the
           // observer list
           this->observer_not_exists (entry);
         }
@@ -333,13 +333,13 @@ TAO_EC_Reactive_ObserverStrategy::consumer_qos_update (
         }
       catch (const CORBA::OBJECT_NOT_EXIST&)
         {
-          // Exception occured while updating observer, so remove it from the
+          // Exception occurred while updating observer, so remove it from the
           // observer list
           this->observer_not_exists (entry);
         }
       catch (const CORBA::TRANSIENT&)
         {
-          // Exception occured while updating observer, so remove it from the
+          // Exception occurred while updating observer, so remove it from the
           // observer list
           this->observer_not_exists (entry);
         }

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.cpp
@@ -64,7 +64,7 @@ TAO_FT_Round_Robin::next_location (
   CORBA::ULong start = 0;
   location = locations[start++];
   if (this->location_index_map_.bind (id, start) != 0)
-  { // The location was already bound or some failure occured. Should not happen.
+  { // The location was already bound or some failure occurred. Should not happen.
     throw CORBA::INTERNAL ();
   }
   return true;

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Connection_Handler.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Connection_Handler.cpp
@@ -155,7 +155,7 @@ TAO::SSLIOP::Connection_Handler::open (void *)
       // occur.  For most protocol implementations this is fine.
       // OpenSSL, on the other hand, requires that the same arguments
       // be passed to SSL_write() if an SSL_ERROR_WANT_WRITE error
-      // occured on a previous SSL_write() attempt, which cannot be
+      // occurred on a previous SSL_write() attempt, which cannot be
       // guaranteed by TAO's current message queuing/construction
       // code, often resulting in a "bad write retry" OpenSSL error.
       // To work around this issue, we enable partial SSL_write()s in

--- a/TAO/orbsvcs/tests/Bug_1630_Regression/testclient.cpp
+++ b/TAO/orbsvcs/tests/Bug_1630_Regression/testclient.cpp
@@ -218,7 +218,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
    }
    catch (...)
    {
-     ACE_DEBUG((LM_DEBUG, "An unknown exception occured - test failed\n"));
+     ACE_DEBUG((LM_DEBUG, "An unknown exception occurred - test failed\n"));
      return 1;
    }
 

--- a/TAO/orbsvcs/tests/Concurrency/CC_command.cpp
+++ b/TAO/orbsvcs/tests/Concurrency/CC_command.cpp
@@ -448,7 +448,7 @@ int
 CC_Excep_Cmd::execute(void)
 {
   ACE_OS::printf ("Executing excep command (expected: %s)\n", ex_);
-  // First we check to see if an exception has occured. If not we fail
+  // First we check to see if an exception has occurred. If not we fail
   // because we expected to see one
   if(excep_==0)
     return 0; // CC_FAIL

--- a/TAO/orbsvcs/tests/Event/Mcast/Two_Way/application.cpp
+++ b/TAO/orbsvcs/tests/Event/Mcast/Two_Way/application.cpp
@@ -520,7 +520,7 @@ Heartbeat_Application::shutdown (void)
   catch (const CORBA::Exception& ex)
     {
       ex._tao_print_exception (
-        "The following exception occured in ""Heartbeat_Application::shutdown:\n");
+        "The following exception occurred in ""Heartbeat_Application::shutdown:\n");
     }
 }
 

--- a/TAO/orbsvcs/tests/Notify/performance-tests/RedGreen/RedGreen_Test.h
+++ b/TAO/orbsvcs/tests/Notify/performance-tests/RedGreen/RedGreen_Test.h
@@ -83,7 +83,7 @@ class RedGreen_Test
   /// Run the demo.
   void run (void);
 
-  /// Called when all events we are waiting for have occured.
+  /// Called when all events we are waiting for have occurred.
   void done (void);
 
   /// Destroy from the EC

--- a/TAO/tao/Connection_Handler.cpp
+++ b/TAO/tao/Connection_Handler.cpp
@@ -131,7 +131,7 @@ TAO_Connection_Handler::svc_i (void)
   // We exit of the loop if
   // - If the ORB core is shutdown by another thread
   // - Or if the transport is null. This could happen if an error
-  // occured.
+  // occurred.
   // - Or if during processing a return value of -1 is received.
   while (!this->orb_core_->has_shutdown () && result >= 0)
     {

--- a/TAO/tao/IIOP_Connector.cpp
+++ b/TAO/tao/IIOP_Connector.cpp
@@ -529,7 +529,7 @@ TAO_IIOP_Connector::complete_connection (int result,
   // closing the connection.  However the remainder of this method
   // only checked to see if the keep_waiting status was true, and bump
   // the refcount then. However if the status was really
-  // error_detected, then no bump in refcount occured allowing the
+  // error_detected, then no bump in refcount occurred allowing the
   // connection_handler's close_handler method to effectively steal
   // the reference to be handed back to the caller. That would then
   // trigger an abort as the profile_transport_resolver (our caller)

--- a/TAO/tao/Invocation_Utils.h
+++ b/TAO/tao/Invocation_Utils.h
@@ -29,7 +29,7 @@ namespace TAO
       /// Initial state of the FSM in the invocation class.
       TAO_INVOKE_START = 0,
       /// The request must be restarted, a temporary failure has
-      /// occured.
+      /// occurred.
       TAO_INVOKE_RESTART,
       /// invoke() call successful. Final state of the FSM.
       TAO_INVOKE_SUCCESS,

--- a/TAO/tao/LF_CH_Event.h
+++ b/TAO/tao/LF_CH_Event.h
@@ -89,7 +89,7 @@ private:
    * LFS_TIMEOUT               - The event has timed out.
    *
    * LFS_CONNECTION_CLOSED     - The connection was closed since
-   *                             an error occured while trying to
+   *                             an error occurred while trying to
    *                             establish connection
    *
    *  Event State Diagram

--- a/TAO/tao/ORB_Core.cpp
+++ b/TAO/tao/ORB_Core.cpp
@@ -3258,7 +3258,7 @@ TAO_ORB_Core::connection_timeout_hook (Timeout_Hook hook)
   // calls this function as part of pre_init processing, and this call
   // happes for every ORB instance. This was the case before these The
   // latter call occurs when the messaging library is loaded. The
-  // redundant calls occured then as well. Second, it isn't clear how
+  // redundant calls occurred then as well. Second, it isn't clear how
   // a lock in this static method would react in the face of windows
   // dlls, shared memory segments, etc. Therefore we are continuing to
   // keep this code lockless as it always was, assuming no

--- a/TAO/tao/Stub.h
+++ b/TAO/tao/Stub.h
@@ -145,7 +145,7 @@ public:
   /// Obtain a pointer to the forwarded profile set
   TAO_MProfile *forward_profiles (void);
 
-  /// True if permanent location forward occured, in this case the lock must be set and the
+  /// True if permanent location forward occurred, in this case the lock must be set and the
 
   // Manage forward and base profiles.
   /**

--- a/TAO/tao/Stub.inl
+++ b/TAO/tao/Stub.inl
@@ -103,7 +103,7 @@ TAO_Stub::next_profile_i (void)
 {
   TAO_Profile *pfile_next = 0;
 
-  // First handle the case that a permanent forward occured
+  // First handle the case that a permanent forward occurred
   if (this->forward_profiles_perm_) // the permanent forward defined
                                     // at bottom of stack
                                     // forward_profiles_

--- a/TAO/tao/Transport.h
+++ b/TAO/tao/Transport.h
@@ -1211,7 +1211,7 @@ private:
   TAO_Codeset_Translator_Base *char_translator_;
   TAO_Codeset_Translator_Base *wchar_translator_;
 
-  /// The tcs_set_ flag indicates that negotiation has occured and so the
+  /// The tcs_set_ flag indicates that negotiation has occurred and so the
   /// translators are correct, since a null translator is valid if both ends
   /// are using the same codeset, whatever that codeset might be.
   CORBA::Boolean tcs_set_;

--- a/TAO/tests/Bug_1495_Regression/Threaded_Server.cpp
+++ b/TAO/tests/Bug_1495_Regression/Threaded_Server.cpp
@@ -143,7 +143,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
       if (server_interceptor->forward_location_done() == false)
         {
-          ACE_ERROR ((LM_ERROR, "ERROR: Forward location has not occured!\n"));
+          ACE_ERROR ((LM_ERROR, "ERROR: Forward location has not occurred!\n"));
         }
 
       ACE_DEBUG ((LM_DEBUG, "Threaded Server event loop finished\n"));

--- a/TAO/tests/Bug_1495_Regression/server_interceptor.cpp
+++ b/TAO/tests/Bug_1495_Regression/server_interceptor.cpp
@@ -102,7 +102,7 @@ Echo_Server_Request_Interceptor::send_other (
 {
 
   // This will throw an exception if a location forward has not
-  // occured.  If an exception is thrown then something is wrong with
+  // occurred.  If an exception is thrown then something is wrong with
   // the PortableInterceptor::ForwardRequest support.
   CORBA::Object_var forward = ri->forward_reference ();
 

--- a/TAO/tests/Bug_3748_Regression/client.cpp
+++ b/TAO/tests/Bug_3748_Regression/client.cpp
@@ -73,7 +73,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
       if (encountered_failures == 0)
         ACE_ERROR ((LM_ERROR,
-                    "ERROR: No expected exceptions occured.\n"));
+                    "ERROR: No expected exceptions occurred.\n"));
 
       // By this time the server should accept the connection and
       // must handle shutdown gracefully.

--- a/TAO/tests/DII_AMI_Forward/server_interceptor.cpp
+++ b/TAO/tests/DII_AMI_Forward/server_interceptor.cpp
@@ -105,7 +105,7 @@ ForwardTest_Request_Interceptor::send_other (
 {
 
   // This will throw an exception if a location forward has not
-  // occured.  If an exception is thrown then something is wrong with
+  // occurred.  If an exception is thrown then something is wrong with
   // the PortableInterceptor::ForwardRequest support.
   CORBA::Object_var forward = ri->forward_reference ();
 

--- a/TAO/tests/DynValue_Test/main.cpp
+++ b/TAO/tests/DynValue_Test/main.cpp
@@ -474,7 +474,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       if (myAny_var.in () >>= myNestedValueExtracted)
         {
           ACE_DEBUG ((LM_DEBUG,
-            "..%N:%l FAILED the extraction occured without factory\n"));
+            "..%N:%l FAILED the extraction occurred without factory\n"));
           return 1;
         }
 
@@ -708,7 +708,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       myNullValueExtracted= reinterpret_cast<DynValue_Test::NullValue::_ptr_type> (9);
       if (myAny_var.in () >>= myNullValueExtracted)
         {
-          ACE_DEBUG ((LM_DEBUG, "..%N:%l FAILED the extraction occured without factory\n"));
+          ACE_DEBUG ((LM_DEBUG, "..%N:%l FAILED the extraction occurred without factory\n"));
           return 1;
         }
 
@@ -1020,7 +1020,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       myTruncExtracted= reinterpret_cast<DynValue_Test::Trunc::_ptr_type> (9);
       if (myAny_var.in () >>= myTruncExtracted)
         {
-          ACE_DEBUG ((LM_DEBUG, "..%N:%l FAILED the extraction occured without factory\n"));
+          ACE_DEBUG ((LM_DEBUG, "..%N:%l FAILED the extraction occurred without factory\n"));
           return 1;
         }
 
@@ -1160,7 +1160,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       myBaseExtracted= reinterpret_cast<DynValue_Test::BaseValue::_ptr_type> (9);
       if (myAny_var.in () >>= myBaseExtracted)
         {
-          ACE_DEBUG ((LM_DEBUG, "..%N:%l FAILED the extraction occured without factory\n"));
+          ACE_DEBUG ((LM_DEBUG, "..%N:%l FAILED the extraction occurred without factory\n"));
           return 1;
         }
 

--- a/TAO/tests/Explicit_Event_Loop/client.cpp
+++ b/TAO/tests/Explicit_Event_Loop/client.cpp
@@ -72,7 +72,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   catch (const CORBA::Exception& ex)
     {
-      ex._tao_print_exception ("client: a CORBA exception occured");
+      ex._tao_print_exception ("client: a CORBA exception occurred");
       return 1;
     }
   catch (...)

--- a/TAO/tests/Explicit_Event_Loop/server.cpp
+++ b/TAO/tests/Explicit_Event_Loop/server.cpp
@@ -157,7 +157,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   catch (const CORBA::Exception& ex)
     {
-      ex._tao_print_exception ("server: a CORBA exception occured");
+      ex._tao_print_exception ("server: a CORBA exception occurred");
       return 1;
     }
   catch (...)

--- a/TAO/tests/IORManipulation/IORTest.cpp
+++ b/TAO/tests/IORManipulation/IORTest.cpp
@@ -260,7 +260,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     }
   if (Status == 0)
     {
-      ACE_DEBUG ((LM_DEBUG, "An ERROR occured during the tests!\n"));
+      ACE_DEBUG ((LM_DEBUG, "An ERROR occurred during the tests!\n"));
       return -1;
     }
   else

--- a/TAO/tests/POA/On_Demand_Act_Direct_Coll/Collocated_Test.cpp
+++ b/TAO/tests/POA/On_Demand_Act_Direct_Coll/Collocated_Test.cpp
@@ -7,7 +7,7 @@
 
 const ACE_TCHAR *output = ACE_TEXT("test.ior");
 const ACE_TCHAR *input = ACE_TEXT("file://test.ior");
-CORBA::Boolean exception_occured = false;
+CORBA::Boolean exception_occurred = false;
 ACE_CString server_orb;
 ACE_CString client_orb;
 
@@ -28,11 +28,11 @@ parse_args (int argc, ACE_TCHAR *argv[])
         break;
       case 't':
         // no exception expected
-        exception_occured = false;
+        exception_occurred = false;
         break;
       case 'd':
         // exception expected
-        exception_occured = true;
+        exception_occurred = true;
         break;
       case '?':
       default:
@@ -83,7 +83,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       Client_Task client_task (input,
                                corb.in (),
                                ACE_Thread_Manager::instance (),
-                               exception_occured);
+                               exception_occurred);
 
       if (client_task.activate (THR_NEW_LWP | THR_JOINABLE,
                                 1,

--- a/TAO/tests/Portable_Interceptors/Bug_1559/server_interceptor.cpp
+++ b/TAO/tests/Portable_Interceptors/Bug_1559/server_interceptor.cpp
@@ -241,7 +241,7 @@ Echo_Server_Request_Interceptor::send_other (
   // LOCATION_FORWARD reply.
 
   // This will throw an exception if a location forward has not
-  // occured.  If an exception is thrown then something is wrong with
+  // occurred.  If an exception is thrown then something is wrong with
   // the PortableInterceptor::ForwardRequest support.
   CORBA::Object_var forward = ri->forward_reference ();
 

--- a/TAO/tests/Portable_Interceptors/ForwardRequest/Client_Request_Interceptor.cpp
+++ b/TAO/tests/Portable_Interceptors/ForwardRequest/Client_Request_Interceptor.cpp
@@ -109,7 +109,7 @@ Client_Request_Interceptor::receive_other (
   // interceptor (not this one) or from the server.
 
   // This will throw an exception if a location forward has not
-  // occured.  If an exception is thrown then something is wrong with
+  // occurred.  If an exception is thrown then something is wrong with
   // the PortableInterceptor::ForwardRequest support.
   CORBA::Object_var forward = ri->forward_reference ();
 

--- a/TAO/tests/Portable_Interceptors/ForwardRequest/Server_Request_Interceptor.cpp
+++ b/TAO/tests/Portable_Interceptors/ForwardRequest/Server_Request_Interceptor.cpp
@@ -173,7 +173,7 @@ Server_Request_Interceptor::send_other (
   // LOCATION_FORWARD reply.
 
   // This will throw an exception if a location forward has not
-  // occured.  If an exception is thrown then something is wrong with
+  // occurred.  If an exception is thrown then something is wrong with
   // the PortableInterceptor::ForwardRequest support.
   CORBA::Object_var forward = ri->forward_reference ();
 

--- a/TAO/tests/TransportCurrent/Framework/client.cpp
+++ b/TAO/tests/TransportCurrent/Framework/client.cpp
@@ -193,7 +193,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       catch (const Transport::NoContext& )
         {
           ACE_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("Client (%P|%t) Expected exception occured when trying ")
+                      ACE_TEXT ("Client (%P|%t) Expected exception occurred when trying ")
                       ACE_TEXT ("to access traits outside the ")
                       ACE_TEXT ("interceptor or upcall context.\n")));
         }

--- a/TAO/tests/TransportCurrent/IIOP/client.cpp
+++ b/TAO/tests/TransportCurrent/IIOP/client.cpp
@@ -193,7 +193,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       catch (const Transport::NoContext& )
         {
           ACE_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("Client (%P|%t) Expected exception occured when trying ")
+                      ACE_TEXT ("Client (%P|%t) Expected exception occurred when trying ")
                       ACE_TEXT ("to access traits outside the ")
                       ACE_TEXT ("interceptor or upcall context.\n")));
         }


### PR DESCRIPTION
    * ACE/ACEXML/common/DTD_Manager.h:
    * ACE/ACEXML/common/NamespaceSupport.h:
    * ACE/ACEXML/parser/debug_validator/Debug_DTD_Manager.h:
    * ACE/ace/Containers_T.h:
    * ACE/ace/DLL.h:
    * ACE/ace/QoS/QoS_Session.h:
    * ACE/ace/QoS/QoS_Session_Impl.cpp:
    * ACE/ace/QoS/QoS_Session_Impl.h:
    * ACE/ace/RB_Tree.h:
    * ACE/ace/SSL/SSL_SOCK_Stream.cpp:
    * ACE/ace/SSL/SSL_SOCK_Stream.inl:
    * ACE/ace/Select_Reactor_T.cpp:
    * ACE/ace/TP_Reactor.cpp:
    * ACE/ace/Token.cpp:
    * ACE/apps/JAWS/clients/WebSTONE/src/nsapi-includes/base/file.h:
    * ACE/examples/APG/Signals/SigHandler.cpp:
    * ACE/examples/APG/Signals/SigHandlers.cpp:
    * ACE/examples/Reactor/Proactor/test_aiosig.cpp:
    * ACE/examples/Reactor/Proactor/test_aiosig_ace.cpp:
    * ACE/examples/Reactor/WFMO_Reactor/APC.cpp:
    * ACE/examples/Reactor/WFMO_Reactor/Abandoned.cpp:
    * ACE/examples/Reactor/WFMO_Reactor/Window_Messages.cpp:
    * ACE/tests/Cached_Accept_Conn_Test.cpp:
    * ACE/tests/Dev_Poll_Reactor_Echo_Test.cpp:
    * ACE/tests/Dev_Poll_Reactor_Test.cpp:
    * TAO/DevGuideExamples/PortableInterceptors/Auth/ServerInitializer.cpp:
    * TAO/examples/Content_Server/AMI_Observer/Callback_Handler.cpp:
    * TAO/orbsvcs/examples/Notify/Subscribe/Subscribe.h:
    * TAO/orbsvcs/examples/RtEC/Kokyu/Supplier.cpp:
    * TAO/orbsvcs/examples/RtEC/Kokyu/Supplier.h:
    * TAO/orbsvcs/orbsvcs/Event/EC_ObserverStrategy.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.cpp:
    * TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Connection_Handler.cpp:
    * TAO/orbsvcs/tests/Bug_1630_Regression/testclient.cpp:
    * TAO/orbsvcs/tests/Concurrency/CC_command.cpp:
    * TAO/orbsvcs/tests/Event/Mcast/Two_Way/application.cpp:
    * TAO/orbsvcs/tests/Notify/performance-tests/RedGreen/RedGreen_Test.h:
    * TAO/tao/Connection_Handler.cpp:
    * TAO/tao/IIOP_Connector.cpp:
    * TAO/tao/Invocation_Utils.h:
    * TAO/tao/LF_CH_Event.h:
    * TAO/tao/ORB_Core.cpp:
    * TAO/tao/Stub.h:
    * TAO/tao/Stub.inl:
    * TAO/tao/Transport.h:
    * TAO/tests/Bug_1495_Regression/Threaded_Server.cpp:
    * TAO/tests/Bug_1495_Regression/server_interceptor.cpp:
    * TAO/tests/Bug_3748_Regression/client.cpp:
    * TAO/tests/DII_AMI_Forward/server_interceptor.cpp:
    * TAO/tests/DynValue_Test/main.cpp:
    * TAO/tests/Explicit_Event_Loop/client.cpp:
    * TAO/tests/Explicit_Event_Loop/server.cpp:
    * TAO/tests/IORManipulation/IORTest.cpp:
    * TAO/tests/POA/On_Demand_Act_Direct_Coll/Collocated_Test.cpp:
    * TAO/tests/Portable_Interceptors/Bug_1559/server_interceptor.cpp:
    * TAO/tests/Portable_Interceptors/ForwardRequest/Client_Request_Interceptor.cpp:
    * TAO/tests/Portable_Interceptors/ForwardRequest/Server_Request_Interceptor.cpp:
    * TAO/tests/TransportCurrent/Framework/client.cpp:
    * TAO/tests/TransportCurrent/IIOP/client.cpp: