### PR TITLE
Riverace-2053: improve start/finish build logging

### DIFF
--- a/ACE/include/makeinclude/rules.nested.GNU
+++ b/ACE/include/makeinclude/rules.nested.GNU
@@ -31,11 +31,11 @@ endif
 
 %.subdir: %
 ifneq ($(timed),)
-	echo -n "START: $< " && date
+	@date=`date`; echo "START: $< $$date"
 endif
 	cd $< && $(MAKE) -f $(SUBDIR_MAKEFILE) $(SUBDIR_TARGET)
 ifneq ($(timed),)
-	echo -n "FINISH: $< " && date
+	@date=`date`;echo "FINISH: $< $$date"
 endif
 
 # Build FOO.nested by calling MAKE again, this time with DIRS (with


### PR DESCRIPTION
Improves start/finish logging for applications using the ACE-supplied GNU build system. This is not for the ACE build itself.