### PR TITLE
Added ACE_DES_FREE_THIS which doesn't check the pointer for nil becau…

### DIFF
--- a/ACE/ace/Global_Macros.h
+++ b/ACE/ace/Global_Macros.h
@@ -254,6 +254,13 @@ ACE_END_VERSIONED_NAMESPACE_DECL
       } \
    while (0)
 
+# define ACE_DES_FREE_THIS(POINTER,DEALLOCATOR,CLASS) \
+   do { \
+        (POINTER)->~CLASS (); \
+        DEALLOCATOR (POINTER); \
+      } \
+   while (0)
+
 # define ACE_DES_ARRAY_FREE(POINTER,SIZE,DEALLOCATOR,CLASS) \
    do { \
         if (POINTER) \

--- a/ACE/ace/Message_Block.cpp
+++ b/ACE/ace/Message_Block.cpp
@@ -845,9 +845,9 @@ ACE_Data_Block::release (ACE_Lock *lock)
   // since otherwise we'd be trying to "release" through a deleted
   // pointer!
   if (result == 0)
-    ACE_DES_FREE (this,
-                  allocator->free,
-                  ACE_Data_Block);
+    ACE_DES_FREE_THIS (this,
+                       allocator->free,
+                       ACE_Data_Block);
   return result;
 }
 
@@ -950,9 +950,9 @@ ACE_Message_Block::release_i (ACE_Lock *lock)
   else
     {
       ACE_Allocator *allocator = this->message_block_allocator_;
-      ACE_DES_FREE (this,
-                    allocator->free,
-                    ACE_Message_Block);
+      ACE_DES_FREE_THIS (this,
+                         allocator->free,
+                         ACE_Message_Block);
     }
 
   return result;

--- a/TAO/tao/Asynch_Queued_Message.cpp
+++ b/TAO/tao/Asynch_Queued_Message.cpp
@@ -177,9 +177,9 @@ TAO_Asynch_Queued_Message::destroy (void)
       // pool.
       if (this->allocator_)
         {
-          ACE_DES_FREE (this,
-                        this->allocator_->free,
-                        TAO_Asynch_Queued_Message);
+          ACE_DES_FREE_THIS (this,
+                             this->allocator_->free,
+                             TAO_Asynch_Queued_Message);
 
         }
       else // global release..

--- a/TAO/tao/Synch_Queued_Message.cpp
+++ b/TAO/tao/Synch_Queued_Message.cpp
@@ -158,9 +158,9 @@ TAO_Synch_Queued_Message::destroy (void)
       // pool.
       if (this->allocator_)
         {
-          ACE_DES_FREE (this,
-                        this->allocator_->free,
-                        TAO_Synch_Queued_Message);
+          ACE_DES_FREE_THIS (this,
+                             this->allocator_->free,
+                             TAO_Synch_Queued_Message);
 
         }
       else // global release..


### PR DESCRIPTION
…se this can't be nil, fixes compiler warnings with newer GCC versions

    * ACE/ace/Global_Macros.h:
    * ACE/ace/Message_Block.cpp:
    * TAO/tao/Asynch_Queued_Message.cpp:
    * TAO/tao/Synch_Queued_Message.cpp: