### PR TITLE
Removed the non-const Any extraction operators

### DIFF
--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -4,6 +4,12 @@ USER VISIBLE CHANGES BETWEEN TAO-2.4.1 and TAO-2.4.2
 . Fixed some problems with versioned namespaces in the
   tao_idl generated code
 
+. Removed the non-const Any extraction operators which
+  are deprecated within the IDL to C++ specification
+  for a long time. Reduces footprint and simplifies the
+  code. Make sure you are using 'const Foo*' as extraction
+  type for Foo instead of 'Foo*'.
+
 USER VISIBLE CHANGES BETWEEN TAO-2.4.0 and TAO-2.4.1
 ====================================================
 

--- a/TAO/README
+++ b/TAO/README
@@ -1,5 +1,3 @@
-
-
 Welcome to the latest release of The ACE ORB (TAO).  TAO is a freely
 available, open-source implementation of a CORBA 3.x-compliant ORB
 that supports real-time extensions.  Please see
@@ -13,8 +11,8 @@ enhancements, etc. and will strive to integrate correct bug fixes
 quickly!  The current release has been tested extensively, but if you
 find any bugs, please report them to the TAO mailing list
 tao-users@list.isis.vanderbilt.edu using the $TAO_ROOT/PROBLEM-REPORT-FORM.
-Please see http://www.cs.wustl.edu/~schmidt/TAO-mail.html for details on how
-to subscribe to the mailing list.
+Please see http://www.dre.vanderbilt.edu/~schmidt/TAO-mail.html for details
+on how to subscribe to the mailing list.
 
 Please use the same form to submit questions, comments, etc.
 To ensure that you see responses, please do one of the following:

--- a/TAO/TAO_IDL/be/be_visitor_any_extracted_type_decl.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_any_extracted_type_decl.cpp
@@ -224,7 +224,7 @@ be_visitor_any_extracted_type_decl::visit_typedef (be_typedef *node)
 int
 be_visitor_any_extracted_type_decl::visit_union (be_union *node)
 {
-  os_ << node->full_name () << " * " << var_name_ << " = 0;";
+  os_ << "const " << node->full_name () << " * " << var_name_ << " = 0;";
   return 0;
 }
 

--- a/TAO/TAO_IDL/be/be_visitor_exception/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_exception/any_op_ch.cpp
@@ -70,8 +70,6 @@ be_visitor_exception_any_op_ch::visit_exception (be_exception *node)
               << " &); // copying version" << be_nl;
           *os << macro << " void operator<<= (::CORBA::Any &, ::" << node->name ()
               << "*); // noncopying version" << be_nl;
-          *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, ::"
-              << node->name () << " *&); // deprecated\n";
           *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const ::"
               << node->name () << " *&);";
 
@@ -90,8 +88,6 @@ be_visitor_exception_any_op_ch::visit_exception (be_exception *node)
       << " &); // copying version" << be_nl;
   *os << macro << " void operator<<= (::CORBA::Any &, " << node->name ()
       << "*); // noncopying version" << be_nl;
-  *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
-      << node->name () << " *&); // deprecated\n";
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const "
       << node->name () << " *&);";
 

--- a/TAO/TAO_IDL/be/be_visitor_exception/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_exception/any_op_cs.cpp
@@ -165,19 +165,6 @@ be_visitor_exception_any_op_cs::visit_exception (be_exception *node)
               << be_uidt << be_uidt_nl
               << "}" << be_nl_2;
 
-          // Extraction to non-const pointer operator.
-          *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-              << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
-              << "const ::CORBA::Any &_tao_any," << be_nl
-              << "::" << node->name () << " *&_tao_elem)" << be_uidt
-              << be_uidt_nl
-              << "{" << be_idt_nl
-              << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-              << "const ::" << node->name () << " *&> (_tao_elem);"
-              << be_uidt
-              << be_uidt << be_uidt_nl
-              << "}" << be_nl_2;
-
           // Extraction to const pointer operator.
           *os << "/// Extraction to const pointer." << be_nl
               << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
@@ -237,19 +224,6 @@ be_visitor_exception_any_op_cs::visit_exception (be_exception *node)
       << node->name () << "::_tao_any_destructor," << be_nl
       << node->tc_name () << "," << be_nl
       << "_tao_elem);" << be_uidt
-      << be_uidt << be_uidt_nl
-      << "}" << be_nl_2;
-
-  // Extraction to non-const pointer operator.
-  *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-      << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
-      << "const ::CORBA::Any &_tao_any," << be_nl
-      << node->name () << " *&_tao_elem)" << be_uidt
-      << be_uidt_nl
-      << "{" << be_idt_nl
-      << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-      << "const " << node->name () << " *&> (_tao_elem);"
-      << be_uidt
       << be_uidt << be_uidt_nl
       << "}" << be_nl_2;
 

--- a/TAO/TAO_IDL/be/be_visitor_sequence/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_sequence/any_op_ch.cpp
@@ -108,12 +108,6 @@ be_visitor_sequence_any_op_ch::visit_sequence (be_sequence *node)
                   << " operator<<= ( ::CORBA::Any &, ::"
                   << name.c_str ()
                   << "*); // noncopying version" << be_nl;
-
-              *os << macro
-                  << " ::CORBA::Boolean"
-                  << " operator>>= (const ::CORBA::Any &, ::"
-                  << name.c_str ()
-                  << " *&); // deprecated" << be_nl;
             }
 
           *os << macro
@@ -146,12 +140,6 @@ be_visitor_sequence_any_op_ch::visit_sequence (be_sequence *node)
           << " operator<<= ( ::CORBA::Any &, "
           << name.c_str ()
           << "*); // noncopying version" << be_nl;
-
-      *os << macro
-          << " ::CORBA::Boolean"
-          << " operator>>= (const ::CORBA::Any &, "
-          << name.c_str ()
-          << " *&); // deprecated" << be_nl;
     }
 
   *os << macro

--- a/TAO/TAO_IDL/be/be_visitor_sequence/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_sequence/any_op_cs.cpp
@@ -246,19 +246,6 @@ be_visitor_sequence_any_op_cs::visit_sequence (be_sequence *node)
               << be_uidt << be_uidt_nl
               << "}" << be_nl_2;
 
-          // Extraction to non-const pointer (deprecated, just calls the other).
-          *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-              << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
-              << "const ::CORBA::Any &_tao_any," << be_nl
-              << "::" << node->name () << " *&_tao_elem)" << be_uidt
-              << be_uidt_nl
-              << "{" << be_idt_nl
-              << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-              << "const ::" << node->name () << " *&> (_tao_elem);"
-              << be_uidt
-              << be_uidt << be_uidt_nl
-              << "}" << be_nl_2;
-
           // Extraction to const pointer.
           *os << "/// Extraction to const pointer." << be_nl
               << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
@@ -317,19 +304,6 @@ be_visitor_sequence_any_op_cs::visit_sequence (be_sequence *node)
       << node->name () << "::_tao_any_destructor," << be_nl
       << (td != 0 ? td->tc_name () : node->tc_name ()) << "," << be_nl
       << "_tao_elem);" << be_uidt
-      << be_uidt << be_uidt_nl
-      << "}" << be_nl_2;
-
-  // Extraction to non-const pointer (deprecated, just calls the other).
-  *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-      << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
-      << "const ::CORBA::Any &_tao_any," << be_nl
-      << node->name () << " *&_tao_elem)" << be_uidt
-      << be_uidt_nl
-      << "{" << be_idt_nl
-      << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-      << "const " << node->name () << " *&> (_tao_elem);"
-      << be_uidt
       << be_uidt << be_uidt_nl
       << "}" << be_nl_2;
 

--- a/TAO/TAO_IDL/be/be_visitor_sequence/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_sequence/any_op_cs.cpp
@@ -217,8 +217,8 @@ be_visitor_sequence_any_op_cs::visit_sequence (be_sequence *node)
               << "/// Copying insertion." << be_nl
               << "void operator<<= (" << be_idt << be_idt_nl
               << "::CORBA::Any &_tao_any," << be_nl
-              << "const ::" << node->name () << " &_tao_elem" << be_uidt_nl
-              << ")" << be_uidt_nl
+              << "const ::" << node->name () << " &_tao_elem)" << be_uidt
+              << be_uidt_nl
               << "{" << be_idt_nl
 
               << "TAO::Any_Dual_Impl_T< ::" << node->name () << ">::insert_copy ("
@@ -227,7 +227,7 @@ be_visitor_sequence_any_op_cs::visit_sequence (be_sequence *node)
               << "::" << node->name () << "::_tao_any_destructor," << be_nl
               << "::" << (td != 0 ? td->tc_name () : node->tc_name ()) << "," << be_nl
               << "_tao_elem);" << be_uidt
-              << be_uidt << be_uidt << be_uidt_nl
+              << be_uidt << be_uidt_nl
               << "}" << be_nl_2;
 
           // Non-copying insertion.

--- a/TAO/TAO_IDL/be/be_visitor_structure/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_structure/any_op_ch.cpp
@@ -73,8 +73,6 @@ be_visitor_structure_any_op_ch::visit_structure (be_structure *node)
               << " &); // copying version" << be_nl;
           *os << macro << " void operator<<= (::CORBA::Any &, ::" << node->name ()
               << "*); // noncopying version" << be_nl;
-          *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, ::"
-              << node->name () << " *&); // deprecated\n";
           *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const ::"
               << node->name () << " *&);";
 
@@ -92,8 +90,6 @@ be_visitor_structure_any_op_ch::visit_structure (be_structure *node)
       << " &); // copying version" << be_nl;
   *os << macro << " void operator<<= (::CORBA::Any &, " << node->name ()
       << "*); // noncopying version" << be_nl;
-  *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
-      << node->name () << " *&); // deprecated\n";
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const "
       << node->name () << " *&);";
 

--- a/TAO/TAO_IDL/be/be_visitor_structure/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_structure/any_op_cs.cpp
@@ -138,19 +138,6 @@ be_visitor_structure_any_op_cs::visit_structure (be_structure *node)
               << be_uidt << be_uidt_nl
               << "}" << be_nl_2;
 
-          // Extraction to non-const pointer (deprecated, just calls the other).
-          *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-              << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
-              << "const ::CORBA::Any &_tao_any," << be_nl
-              << "::" << node->name () << " *&_tao_elem)" << be_uidt
-              << be_uidt_nl
-              << "{" << be_idt_nl
-              << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-              << "const ::" << node->name () << " *&> (_tao_elem);"
-              << be_uidt
-              << be_uidt << be_uidt_nl
-              << "}" << be_nl_2;
-
           // Extraction to const pointer.
           *os << "/// Extraction to const pointer." << be_nl
               << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
@@ -208,19 +195,6 @@ be_visitor_structure_any_op_cs::visit_structure (be_structure *node)
       << node->name () << "::_tao_any_destructor," << be_nl
       << node->tc_name () << "," << be_nl
       << "_tao_elem);"
-      << be_uidt << be_uidt_nl
-      << "}" << be_nl_2;
-
-  // Extraction to non-const pointer (deprecated, just calls the other).
-  *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-      << "::CORBA::Boolean operator>>= (" << be_idt_nl
-      << "const ::CORBA::Any &_tao_any," << be_nl
-      << node->name () << " *&_tao_elem)"
-      << be_uidt_nl
-      << "{" << be_idt_nl
-      << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-      << "const " << node->name () << " *&> (_tao_elem);"
-      << be_uidt
       << be_uidt << be_uidt_nl
       << "}" << be_nl_2;
 

--- a/TAO/TAO_IDL/be/be_visitor_union/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_union/any_op_ch.cpp
@@ -72,8 +72,6 @@ be_visitor_union_any_op_ch::visit_union (be_union *node)
               << " &); // copying version" << be_nl;
           *os << macro << " void operator<<= (::CORBA::Any &, ::" << node->name ()
               << "*); // noncopying version" << be_nl;
-          *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, ::"
-              << node->name () << " *&); // deprecated\n";
           *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const ::"
               << node->name () << " *&);";
 
@@ -91,8 +89,6 @@ be_visitor_union_any_op_ch::visit_union (be_union *node)
       << " &); // copying version" << be_nl;
   *os << macro << " void operator<<= (::CORBA::Any &, " << node->name ()
       << "*); // noncopying version" << be_nl;
-  *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
-      << node->name () << " *&); // deprecated\n";
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const "
       << node->name () << " *&);";
 

--- a/TAO/TAO_IDL/be/be_visitor_union/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_union/any_op_cs.cpp
@@ -134,19 +134,6 @@ be_visitor_union_any_op_cs::visit_union (be_union *node)
               << be_uidt << be_uidt_nl
               << "}" << be_nl_2;
 
-          // Extraction to non-const pointer (deprecated, just calls the other).
-          *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-              << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
-              << "const ::CORBA::Any &_tao_any," << be_nl
-              << "::" << node->name () << " *&_tao_elem" << be_uidt_nl
-              << ")" << be_uidt_nl
-              << "{" << be_idt_nl
-              << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-              << "const ::" << node->name () << " *&> (_tao_elem);"
-              << be_uidt
-              << be_uidt << be_uidt_nl
-              << "}" << be_nl_2;
-
           // Extraction to const pointer.
           *os << "/// Extraction to const pointer." << be_nl
               << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
@@ -204,19 +191,6 @@ be_visitor_union_any_op_cs::visit_union (be_union *node)
       << node->name () << "::_tao_any_destructor," << be_nl
       << node->tc_name () << "," << be_nl
       << "_tao_elem);" << be_uidt
-      << be_uidt << be_uidt_nl
-      << "}" << be_nl_2;
-
-  // Extraction to non-const pointer (deprecated, just calls the other).
-  *os << "/// Extraction to non-const pointer (deprecated)." << be_nl
-      << "::CORBA::Boolean operator>>= (" << be_idt << be_idt_nl
-      << "const ::CORBA::Any &_tao_any," << be_nl
-      << node->name () << " *&_tao_elem" << be_uidt_nl
-      << ")" << be_uidt_nl
-      << "{" << be_idt_nl
-      << "return _tao_any >>= const_cast<" << be_idt << be_idt_nl
-      << "const " << node->name () << " *&> (_tao_elem);"
-      << be_uidt
       << be_uidt << be_uidt_nl
       << "}" << be_nl_2;
 

--- a/TAO/docs/ORBEndpoint.html
+++ b/TAO/docs/ORBEndpoint.html
@@ -84,7 +84,7 @@
       separated by a forward slash '<CODE>/</CODE>' in this case,
       i.e. for IIOP endpoints.  This character may differ for other
       types of pluggable protocol endpoints.  For example, UIOP
-      endpoint-specifc options are separated from the address by a
+      endpoint-specific options are separated from the address by a
       vertical bar '<CODE>|</CODE>'.  Also note that when using more
       than option, quotes should be used to prevent the shell from
       interpreting the ampersand '<CODE>&amp;</CODE>' as a command to
@@ -355,12 +355,12 @@
           <TD>
             Available in IIOP & SSLIOP the <CODE>reuse_addr</CODE> option allows one to
             set the SO_REUSEADDR socket option on an endpoint. Doing so bypasses
-	    the TCP TIME_WAIT and can be used to open an endpoint
-	    on a port still in TIME_WAIT state. Use caution using this option. Its not
-	    recommended for the general use-case. Setting
-	    SO_REUSEADDR has been observed to cause unexpected side-effects on some
-	    platforms (e.g. Solaris 5.7 x86 allows programs run as same or different
-	    users to bind to the same port when SO_REUSEADDR is set by all users).
+      the TCP TIME_WAIT and can be used to open an endpoint
+      on a port still in TIME_WAIT state. Use caution using this option. Its not
+      recommended for the general use-case. Setting
+      SO_REUSEADDR has been observed to cause unexpected side-effects on some
+      platforms (e.g. Solaris 5.7 x86 allows programs run as same or different
+      users to bind to the same port when SO_REUSEADDR is set by all users).
             <P>
             The format for <CODE>ORBListenEndpoints</CODE> with the
             <CODE>reuse_addr</CODE> option is:

--- a/TAO/docs/ORBEndpoint.html
+++ b/TAO/docs/ORBEndpoint.html
@@ -355,12 +355,12 @@
           <TD>
             Available in IIOP & SSLIOP the <CODE>reuse_addr</CODE> option allows one to
             set the SO_REUSEADDR socket option on an endpoint. Doing so bypasses
-      the TCP TIME_WAIT and can be used to open an endpoint
-      on a port still in TIME_WAIT state. Use caution using this option. Its not
-      recommended for the general use-case. Setting
-      SO_REUSEADDR has been observed to cause unexpected side-effects on some
-      platforms (e.g. Solaris 5.7 x86 allows programs run as same or different
-      users to bind to the same port when SO_REUSEADDR is set by all users).
+            the TCP TIME_WAIT and can be used to open an endpoint
+            on a port still in TIME_WAIT state. Use caution using this option. Its not
+            recommended for the general use-case. Setting
+            SO_REUSEADDR has been observed to cause unexpected side-effects on some
+            platforms (e.g. Solaris 5.7 x86 allows programs run as same or different
+            users to bind to the same port when SO_REUSEADDR is set by all users).
             <P>
             The format for <CODE>ORBListenEndpoints</CODE> with the
             <CODE>reuse_addr</CODE> option is:

--- a/TAO/docs/PP_Memory_Management.txt
+++ b/TAO/docs/PP_Memory_Management.txt
@@ -25,7 +25,7 @@
     specializations of the ACE_Svc_Handler class.
     However, the original design considered the possibility of using
     protocols without any ACE abstractions, though in practice this
-    hasn't happenned so far,
+    hasn't happened so far,
     all changes to the framework should keep this possibility open.
 
     This is the main source of memory management problems in the

--- a/TAO/docs/tutorials/Quoter/Event_Service/Stock_Consumer.cpp
+++ b/TAO/docs/tutorials/Quoter/Event_Service/Stock_Consumer.cpp
@@ -30,7 +30,7 @@ Stock_Consumer::disconnect ()
 void
 Stock_Consumer::push (const CORBA::Any& data)
 {
-  Quoter::Event *event;
+  const Quoter::Event *event = 0;
   if ((data >>= event) == 0)
     return; // Invalid event
 

--- a/TAO/docs/tutorials/Quoter/RT_Event_Service/Stock_Consumer.cpp
+++ b/TAO/docs/tutorials/Quoter/RT_Event_Service/Stock_Consumer.cpp
@@ -35,7 +35,7 @@ Stock_Consumer::push (const RtecEventComm::EventSet &data)
   for (CORBA::ULong i = 0; i != data.length (); ++i) {
     const RtecEventComm::Event &e = data[i];
 
-    Quoter::Event *event;
+    const Quoter::Event *event = 0;
     if ((e.data.any_value >>= event) == 0)
       continue; // Invalid event
 

--- a/TAO/examples/Kokyu_dsrt_schedulers/FP_Scheduler.cpp
+++ b/TAO/examples/Kokyu_dsrt_schedulers/FP_Scheduler.cpp
@@ -331,7 +331,7 @@ Fixed_Priority_Scheduler::receive_request (PortableInterceptor::ServerRequestInf
                                 CORBA::Policy_out sched_param_out,
                                 CORBA::Policy_out /*implicit_sched_param_out*/)
 {
-  Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr;
+  const Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr = 0;
 
 #ifdef KOKYU_DSRT_LOGGING
   ACE_DEBUG ((LM_DEBUG, "(%t|%T):entered FP_Scheduler::receive_request\n"));
@@ -531,7 +531,7 @@ Fixed_Priority_Scheduler::receive_reply (PortableInterceptor::ClientRequestInfo_
 
       //Don't store in a _var, since >>= returns a pointer to an internal buffer
       //and we are not supposed to free it.
-      Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr;
+      const Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr = 0;
       CORBA::Any sc_qos_as_any;
       CORBA::Any_var scqostmp = codec_->decode (oc_seq);
       sc_qos_as_any = scqostmp.in ();

--- a/TAO/examples/Kokyu_dsrt_schedulers/MIF_Scheduler.cpp
+++ b/TAO/examples/Kokyu_dsrt_schedulers/MIF_Scheduler.cpp
@@ -326,7 +326,7 @@ MIF_Scheduler::receive_request (PortableInterceptor::ServerRequestInfo_ptr ri,
                                 CORBA::Policy_out sched_param_out,
                                 CORBA::Policy_out /*implicit_sched_param_out*/)
 {
-  Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr;
+  const Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr = 0;
 
 #ifdef KOKYU_DSRT_LOGGING
   ACE_DEBUG ((LM_DEBUG, "(%t|%T):entered MIF_Scheduler::receive_request\n"));
@@ -530,7 +530,7 @@ MIF_Scheduler::receive_reply (PortableInterceptor::ClientRequestInfo_ptr ri)
 
       //Don't store in a _var, since >>= returns a pointer to an internal buffer
       //and we are not supposed to free it.
-      Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr;
+      const Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr = 0;
       CORBA::Any sc_qos_as_any;
       CORBA::Any_var scqostmp = codec_->decode (oc_seq);
       sc_qos_as_any = scqostmp.in ();

--- a/TAO/examples/Kokyu_dsrt_schedulers/MUF_Scheduler.cpp
+++ b/TAO/examples/Kokyu_dsrt_schedulers/MUF_Scheduler.cpp
@@ -340,7 +340,7 @@ MUF_Scheduler::receive_request (PortableInterceptor::ServerRequestInfo_ptr ri,
                                 CORBA::Policy_out sched_param_out,
                                 CORBA::Policy_out /*implicit_sched_param_out*/)
 {
-  Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr;
+  const Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr = 0;
 
 #ifdef KOKYU_DSRT_LOGGING
   ACE_DEBUG ((LM_DEBUG, "(%t|%T):entered MUF_Scheduler::receive_request\n"));
@@ -575,7 +575,7 @@ MUF_Scheduler::receive_reply (PortableInterceptor::ClientRequestInfo_ptr ri)
 
       //Don't store in a _var, since >>= returns a pointer to an internal buffer
       //and we are not supposed to free it.
-      Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr;
+      const Kokyu::Svc_Ctxt_DSRT_QoS* sc_qos_ptr = 0;
       CORBA::Any sc_qos_as_any;
       CORBA::Any_var scqostmp = codec_->decode (oc_seq);
       sc_qos_as_any = scqostmp.in ();

--- a/TAO/interop-tests/AnyTypeCode/tao/Demo_i.cpp
+++ b/TAO/interop-tests/AnyTypeCode/tao/Demo_i.cpp
@@ -44,7 +44,7 @@ ATC_Test_i::~ATC_Test_i (void)
 char *
 ATC_Test_i::do_union (const ::CORBA::Any & a)
 {
-  Demo::NestedUnion *any_union;
+  const Demo::NestedUnion *any_union = 0;
   const char *result = "do_union called";
   if (a >>= any_union)
     {
@@ -104,7 +104,7 @@ ATC_Test_i::do_union (const ::CORBA::Any & a)
 char *
 ATC_Test_i::do_struct (const ::CORBA::Any & a)
 {
-  Demo::NestedStruct *bar;
+  const Demo::NestedStruct *bar = 0;
   const char *result = "do_struct called";
   if (a >>= bar)
     {

--- a/TAO/orbsvcs/FT_ReplicationManager/FT_Property_Validator.cpp
+++ b/TAO/orbsvcs/FT_ReplicationManager/FT_Property_Validator.cpp
@@ -184,7 +184,7 @@ TAO::FT_Property_Validator::validate_criteria (
         }
         else if (property.nam == this->factories_)
         {
-          PortableGroup::FactoriesValue * factories;
+          const PortableGroup::FactoriesValue * factories = 0;
           if (!(property.val >>= factories))
             invalid_criteria[p++] = property;
           else

--- a/TAO/orbsvcs/FT_ReplicationManager/FT_ReplicationManagerFaultAnalyzer.cpp
+++ b/TAO/orbsvcs/FT_ReplicationManager/FT_ReplicationManagerFaultAnalyzer.cpp
@@ -331,7 +331,7 @@ int TAO::FT_ReplicationManagerFaultAnalyzer::get_factories (
   prop_name[0].id = CORBA::string_dup (FT::FT_FACTORIES);
   int result = 0;
 
-  PortableGroup::FactoryInfos_var temp_factories;
+  const PortableGroup::FactoryInfos_var temp_factories;
   PortableGroup::Value value;
   if (TAO_PG::get_property_value (prop_name, properties, value) == 1)
   {

--- a/TAO/orbsvcs/FT_ReplicationManager/FT_ReplicationManagerFaultAnalyzer.cpp
+++ b/TAO/orbsvcs/FT_ReplicationManager/FT_ReplicationManagerFaultAnalyzer.cpp
@@ -331,7 +331,7 @@ int TAO::FT_ReplicationManagerFaultAnalyzer::get_factories (
   prop_name[0].id = CORBA::string_dup (FT::FT_FACTORIES);
   int result = 0;
 
-  const PortableGroup::FactoryInfos_var temp_factories;
+  const PortableGroup::FactoryInfos* temp_factories = 0;
   PortableGroup::Value value;
   if (TAO_PG::get_property_value (prop_name, properties, value) == 1)
   {
@@ -346,7 +346,7 @@ int TAO::FT_ReplicationManagerFaultAnalyzer::get_factories (
     else
     {
       // Make a deep copy of the Factories.
-      ACE_NEW_RETURN (factories, PortableGroup::FactoryInfos (temp_factories.in()), -1);
+      ACE_NEW_RETURN (factories, PortableGroup::FactoryInfos (*temp_factories), -1);
       result = 0;
     }
   }

--- a/TAO/orbsvcs/Fault_Detector/FT_FaultDetectorFactory_i.cpp
+++ b/TAO/orbsvcs/Fault_Detector/FT_FaultDetectorFactory_i.cpp
@@ -538,7 +538,7 @@ CORBA::Object_ptr TAO::FT_FaultDetectorFactory_i::create_object (
 //    missingParameterName = ::FT::FT_DOMAIN_ID;
   }
 
-  PortableGroup::Location * object_location = 0;
+  const PortableGroup::Location * object_location = 0;
   if (! ::TAO::find (decoder, ::FT::FT_LOCATION, object_location) )
   {
       object_location = & this->location_;

--- a/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.cpp
+++ b/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.cpp
@@ -24,12 +24,12 @@ Criteria_Evaluator::~Criteria_Evaluator ()
 {
 }
 
-LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *
+const LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *
 Criteria_Evaluator::getInitialization (void)
 {
   const LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *sequence_ptr = 0;
 
-  CORBA::Any *any_ptr =
+  CORBA::Any_ptr any_ptr =
     this->getCriteriaMember ("initialization");
 
   if (any_ptr == 0)

--- a/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.cpp
+++ b/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.cpp
@@ -27,7 +27,7 @@ Criteria_Evaluator::~Criteria_Evaluator ()
 LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *
 Criteria_Evaluator::getInitialization (void)
 {
-  LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *sequence_ptr = 0;
+  const LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *sequence_ptr = 0;
 
   CORBA::Any *any_ptr =
     this->getCriteriaMember ("initialization");

--- a/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.h
+++ b/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.h
@@ -9,8 +9,6 @@
  */
 //=============================================================================
 
-
-
 #include "orbsvcs/CosLifeCycleC.h"
 #include "orbsvcs/LifeCycleServiceC.h"
 
@@ -18,7 +16,7 @@
 #define CRITERIA_EVALUATOR_H_H
 
 /**
- * @class Criteria_Evaluator//
+ * @class Criteria_Evaluator
  */
 class Criteria_Evaluator// : public LifeCycleService::Criteria_Evaluator
 {

--- a/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.h
+++ b/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.h
@@ -26,7 +26,7 @@ public:
   Criteria_Evaluator (const CosLifeCycle::Criteria &criteria);
   ~Criteria_Evaluator (void);
 
-  LifeCycleService::Criteria_Evaluator::SeqNamedValuePair * getInitialization (void);
+  const LifeCycleService::Criteria_Evaluator::SeqNamedValuePair * getInitialization (void);
 
   char * getFilter (void);
 

--- a/TAO/orbsvcs/orbsvcs/AV/AVStreams_i.cpp
+++ b/TAO/orbsvcs/orbsvcs/AV/AVStreams_i.cpp
@@ -718,9 +718,11 @@ TAO_StreamCtrl::bind_devs (AVStreams::MMDevice_ptr a_party,
           try
             {
               CORBA::Any_ptr flows_any = this->sep_a_->get_property_value ("Flows");
-              AVStreams::flowSpec_var flows;
-              *flows_any >>= flows.out ();
-              for (CORBA::ULong i=0; i< flows->length ();++i)
+              AVStreams::flowSpec flows;
+              const AVStreams::flowSpec *temp_flows = 0;
+              *flows_any >>= temp_flows;
+              flows = *temp_flows;
+              for (CORBA::ULong i=0; i< flows.length ();++i)
                 {
                   CORBA::Object_var fep_obj =
                     this->sep_a_->get_fep (flows [i]);
@@ -911,15 +913,15 @@ TAO_StreamCtrl::bind (AVStreams::StreamEndPoint_A_ptr sep_a,
       AVStreams::flowSpec a_flows, b_flows;
       CORBA::Any_var flows_any;
       flows_any = sep_a_->get_property_value ("Flows");
-      AVStreams::flowSpec *temp_flows = 0;
+      const AVStreams::flowSpec *temp_flows = 0;
       flows_any.in () >>= temp_flows;
       a_flows = *temp_flows;
       flows_any = sep_b_->get_property_value ("Flows");
       flows_any.in () >>= temp_flows;
       b_flows = *temp_flows;
       u_int i;
-      FlowEndPoint_Map *a_fep_map;
-      FlowEndPoint_Map *b_fep_map;
+      FlowEndPoint_Map *a_fep_map = 0;
+      FlowEndPoint_Map *b_fep_map = 0;
       ACE_NEW_RETURN (a_fep_map,
                       FlowEndPoint_Map,
                       0);
@@ -1611,7 +1613,7 @@ TAO_StreamEndPoint::connect (AVStreams::StreamEndPoint_ptr responder,
           CORBA::Any_var protocols_any =
             responder->get_property_value ("AvailableProtocols");
           AVStreams::protocolSpec peer_protocols;
-          AVStreams::protocolSpec *temp_protocols = 0;
+          const AVStreams::protocolSpec *temp_protocols = 0;
           protocols_any.in () >>= temp_protocols;
           peer_protocols = *temp_protocols;
           for (u_int i=0;i<peer_protocols.length ();i++)
@@ -4024,7 +4026,7 @@ TAO_FlowEndPoint::set_protocol_restriction (const AVStreams::protocolSpec & prot
       AvailableProtocols_property <<= protocols;
       this->define_property ("AvailableProtocols",
                              AvailableProtocols_property);
-      AVStreams::protocolSpec *temp_spec = 0;
+      const AVStreams::protocolSpec *temp_spec = 0;
       CORBA::Any_var temp_any = this->get_property_value ("AvailableProtocols");
       temp_any.in () >>= temp_spec;
       if (TAO_debug_level > 0) ORBSVCS_DEBUG ((LM_DEBUG, "%N:%l\n"));
@@ -4072,7 +4074,7 @@ TAO_FlowEndPoint::is_fep_compatible (AVStreams::FlowEndPoint_ptr peer_fep)
       // since formats are same, check for a common protocol
       CORBA::Any_var AvailableProtocols_ptr;
       AVStreams::protocolSpec my_protocol_spec, peer_protocol_spec;
-      AVStreams::protocolSpec *temp_protocols = 0;
+      const AVStreams::protocolSpec *temp_protocols = 0;
 
       exception_message =
         "TAO_FlowEndPoint::is_fep_compatible - AvailableProtocols";
@@ -4158,7 +4160,7 @@ TAO_FlowEndPoint::go_to_listen_i (TAO_FlowSpec_Entry::Role role,
       break;
     }
   AVStreams::protocolSpec my_protocol_spec, peer_protocol_spec;
-  AVStreams::protocolSpec *temp_protocols = 0;
+  const AVStreams::protocolSpec *temp_protocols = 0;
   CORBA::Any_var AvailableProtocols_ptr =
     peer_fep->get_property_value ("AvailableProtocols");
   AvailableProtocols_ptr.in () >>= temp_protocols;

--- a/TAO/orbsvcs/orbsvcs/AV/AVStreams_i.h
+++ b/TAO/orbsvcs/orbsvcs/AV/AVStreams_i.h
@@ -567,7 +567,7 @@ protected:
   TAO_AV_FlowSpecSet forward_flow_spec_set;
   TAO_AV_FlowSpecSet reverse_flow_spec_set;
   AVStreams::StreamEndPoint_var peer_sep_;
-  AVStreams::SFPStatus *sfp_status_;
+  const AVStreams::SFPStatus *sfp_status_;
   AVStreams::StreamCtrl_var streamctrl_;
 };
 

--- a/TAO/orbsvcs/orbsvcs/FaultTolerance/FT_ClientPolicy_i.cpp
+++ b/TAO/orbsvcs/orbsvcs/FaultTolerance/FT_ClientPolicy_i.cpp
@@ -103,7 +103,7 @@ TAO_FT_Heart_Beat_Policy::heartbeat_policy_value (void)
 CORBA::Policy_ptr
 TAO_FT_Heart_Beat_Policy::create (const CORBA::Any& val)
 {
-  FT::HeartbeatPolicyValue *value = 0;
+  const FT::HeartbeatPolicyValue *value = 0;
   if ((val >>= value) == 0)
     throw CORBA::PolicyError (CORBA::BAD_POLICY_VALUE);
 

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/ClientORB/FTRT_ClientORB_Loader.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/ClientORB/FTRT_ClientORB_Loader.cpp
@@ -35,17 +35,18 @@ namespace TAO_FTRT {
 
     // Parse any service configurator parameters.
     for (curarg = 0; curarg < argc; curarg++)
-      if (ACE_OS::strcasecmp (argv[curarg],
-        ACE_TEXT("-ORBTransactionDepth")) == 0)
       {
-        curarg++;
-        if (curarg < argc)
-          transaction_depth = ACE_OS::atoi(argv[curarg]);
+        if (ACE_OS::strcasecmp (argv[curarg],
+          ACE_TEXT("-ORBTransactionDepth")) == 0)
+        {
+          curarg++;
+          if (curarg < argc)
+            transaction_depth = ACE_OS::atoi(argv[curarg]);
+        }
       }
 
-
-      // Register the ORB initializer.
-      try
+    // Register the ORB initializer.
+    try
       {
         PortableInterceptor::ORBInitializer_ptr temp_orb_initializer =
           PortableInterceptor::ORBInitializer::_nil ();
@@ -63,14 +64,14 @@ namespace TAO_FTRT {
 
         PortableInterceptor::register_orb_initializer (orb_initializer.in ());
       }
-      catch (const CORBA::Exception& ex)
+    catch (const CORBA::Exception& ex)
       {
         ex._tao_print_exception (
           "Unexpected exception caught while ""initializing the TransactionDepth");
         return 1;
       }
 
-      return 0;
+    return 0;
   }
 }
 

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/FTEC_Event_Channel_Impl.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/FTEC_Event_Channel_Impl.cpp
@@ -267,9 +267,9 @@ TAO_FTEC_Event_Channel_Impl::connect_push_consumer (
 
   ACE_NEW_THROW_EX(oid, FtRtecEventChannelAdmin::ObjectId, CORBA::NO_MEMORY());
 
-  FtRtecEventChannelAdmin::ObjectId_var  object_id = oid;
+  FtRtecEventChannelAdmin::ObjectId_var object_id = *oid;
 
-  Request_Context_Repository().generate_object_id(*oid);
+  Request_Context_Repository().generate_object_id(object_id.inout ());
 
   obtain_push_supplier_and_connect(this,
                                    object_id.in(),
@@ -302,9 +302,9 @@ TAO_FTEC_Event_Channel_Impl::connect_push_supplier (
 
 
   ACE_NEW_THROW_EX(oid, FtRtecEventChannelAdmin::ObjectId, CORBA::NO_MEMORY());
-  FtRtecEventChannelAdmin::ObjectId_var object_id = oid;
+  FtRtecEventChannelAdmin::ObjectId_var object_id = *oid;
 
-  Request_Context_Repository().generate_object_id(*oid);
+  Request_Context_Repository().generate_object_id(object_id.inout ());
 
   obtain_push_consumer_and_connect(this,
                                    object_id.in(),

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/FTEC_Event_Channel_Impl.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/FTEC_Event_Channel_Impl.cpp
@@ -254,7 +254,7 @@ TAO_FTEC_Event_Channel_Impl::connect_push_consumer (
   CORBA::Any_var any
     = Request_Context_Repository().get_cached_result();
 
-  FtRtecEventChannelAdmin::ObjectId *oid;
+  const FtRtecEventChannelAdmin::ObjectId *oid = 0;
 
   if (any.in() >>= oid) {
     FtRtecEventChannelAdmin::ObjectId* result;
@@ -290,7 +290,7 @@ TAO_FTEC_Event_Channel_Impl::connect_push_supplier (
   CORBA::Any_var any
     = Request_Context_Repository().get_cached_result();
 
-  FtRtecEventChannelAdmin::ObjectId *oid;
+  const FtRtecEventChannelAdmin::ObjectId *oid = 0;
 
   if (any.in() >>= oid) {
     FtRtecEventChannelAdmin::ObjectId* result;

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Request_Context_Repository.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Request_Context_Repository.cpp
@@ -63,7 +63,7 @@ Request_Context_Repository::set_object_id(
 FtRtecEventChannelAdmin::ObjectId_var
 get_object_id(CORBA::Any_var a)
 {
-  FtRtecEventChannelAdmin::ObjectId *object_id, *r;
+  const FtRtecEventChannelAdmin::ObjectId *object_id, *r;
   FtRtecEventChannelAdmin::ObjectId_var result;
 
   if ((a.in() >>= object_id) ==0)

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Request_Context_Repository.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Request_Context_Repository.cpp
@@ -73,7 +73,7 @@ get_object_id(CORBA::Any_var a)
                    FtRtecEventChannelAdmin::ObjectId(*object_id),
                    CORBA::NO_MEMORY());
 
-  result = r;
+  result = *r;
   return result;
 }
 

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Set_Update_Interceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Set_Update_Interceptor.cpp
@@ -45,7 +45,7 @@ TAO_Set_Update_Interceptor::send_request (
     {
       CORBA::Any_var a = Request_Context_Repository().get_ft_request_service_context(ri);
 
-      IOP::ServiceContext* sc;
+      const IOP::ServiceContext* sc = 0;
 
       if ((a.in() >>= sc) ==0)
         return;

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Set_Update_Interceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Set_Update_Interceptor.cpp
@@ -45,12 +45,13 @@ TAO_Set_Update_Interceptor::send_request (
     {
       CORBA::Any_var a = Request_Context_Repository().get_ft_request_service_context(ri);
 
-      const IOP::ServiceContext* sc = 0;
+      const IOP::ServiceContext* scp = 0;
 
-      if ((a.in() >>= sc) ==0)
+      if ((a.in() >>= scp) == 0)
         return;
 
-      ri->add_request_service_context (*sc, 0);
+      IOP::ServiceContext sc = *scp;
+      ri->add_request_service_context (sc, 0);
 
       FTRT::TransactionDepth transaction_depth =
         Request_Context_Repository().get_transaction_depth(ri);
@@ -64,26 +65,26 @@ TAO_Set_Update_Interceptor::send_request (
         // Add Transaction Depth Context
         if ((cdr << transaction_depth) == 0)
           throw CORBA::MARSHAL ();
-        sc->context_id = FTRT::FT_TRANSACTION_DEPTH;
+        sc.context_id = FTRT::FT_TRANSACTION_DEPTH;
 
         ACE_CDR::consolidate(&mb, cdr.begin());
 #if (TAO_NO_COPY_OCTET_SEQUENCES == 1)
-        sc->context_data.replace(mb.length(), &mb);
+        sc.context_data.replace(mb.length(), &mb);
 #else
         // If the replace method is not available, we will need
         // to do the copy manually.  First, set the octet sequence length.
         CORBA::ULong length = mb.length ();
-        sc->context_data.length (length);
+        sc.context_data.length (length);
 
         // Now copy over each byte.
         char* base = mb.data_block ()->base ();
         for(CORBA::ULong i = 0; i < length; i++)
           {
-            sc->context_data[i] = base[i];
+            sc.context_data[i] = base[i];
           }
 #endif /* TAO_NO_COPY_OCTET_SEQUENCES == 1 */
 
-        ri->add_request_service_context (*sc, 0);
+        ri->add_request_service_context (sc, 0);
 
         cdr.reset();
       }
@@ -99,26 +100,26 @@ TAO_Set_Update_Interceptor::send_request (
           throw CORBA::MARSHAL ();
         if ((cdr << sequence_number) == 0)
           throw CORBA::MARSHAL ();
-        sc->context_id = FTRT::FT_SEQUENCE_NUMBER;
+        sc.context_id = FTRT::FT_SEQUENCE_NUMBER;
 
         ACE_CDR::consolidate(&mb, cdr.begin());
 #if (TAO_NO_COPY_OCTET_SEQUENCES == 1)
-        sc->context_data.replace(mb.length(), &mb);
+        sc.context_data.replace(mb.length(), &mb);
 #else
         // If the replace method is not available, we will need
         // to do the copy manually.  First, set the octet sequence length.
         CORBA::ULong length = mb.length ();
-        sc->context_data.length (length);
+        sc.context_data.length (length);
 
         // Now copy over each byte.
         char* base = mb.data_block ()->base ();
         for(CORBA::ULong i = 0; i < length; i++)
           {
-            sc->context_data[i] = base[i];
+            sc.context_data[i] = base[i];
           }
 #endif /* TAO_NO_COPY_OCTET_SEQUENCES == 1 */
 
-        ri->add_request_service_context (*sc, 0);
+        ri->add_request_service_context (sc, 0);
       }
     }
 }

--- a/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_LoadManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_LoadManager.cpp
@@ -958,7 +958,7 @@ TAO_LB_LoadManager::preprocess_properties (PortableGroup::Properties & props)
 }
 
 CosLoadBalancing::Strategy_ptr
-TAO_LB_LoadManager::make_strategy (CosLoadBalancing::StrategyInfo * info)
+TAO_LB_LoadManager::make_strategy (const CosLoadBalancing::StrategyInfo * info)
 {
   /**
    * @todo We need a strategy factory.  This is just too messy.

--- a/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_LoadManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_LoadManager.cpp
@@ -925,7 +925,7 @@ TAO_LB_LoadManager::preprocess_properties (PortableGroup::Properties & props)
 
       else if (property.nam == this->built_in_balancing_strategy_info_name_)
         {
-          CosLoadBalancing::StrategyInfo * info;
+          const CosLoadBalancing::StrategyInfo * info = 0;
 
           if (property.val >>= info)
             {

--- a/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_LoadManager.h
+++ b/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_LoadManager.h
@@ -312,7 +312,7 @@ private:
   /// Create a built-in load balancing strategy and return a reference
   /// to it.
   CosLoadBalancing::Strategy_ptr make_strategy (
-    CosLoadBalancing::StrategyInfo * info);
+    const CosLoadBalancing::StrategyInfo * info);
 
 private:
 

--- a/TAO/orbsvcs/orbsvcs/Notify/Property_T.cpp
+++ b/TAO/orbsvcs/orbsvcs/Notify/Property_T.cpp
@@ -112,7 +112,7 @@ TAO_Notify_StructProperty_T<TYPE>::set (
 
   if (property_seq.find (this->name_, value) == 0)
     {
-      TYPE* extract_type = 0;
+      const TYPE* extract_type = 0;
 
       if ((value >>= extract_type)  && extract_type != 0) // make sure we get something valid.
         {

--- a/TAO/orbsvcs/orbsvcs/Notify/RT_Properties.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/RT_Properties.h
@@ -23,7 +23,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 /**
  * @class TAO_Notify_RT_Properties
  *
- * @brief RT specifc global properties are stored here.
+ * @brief RT specific global properties are stored here.
  */
 class TAO_RT_Notify_Export TAO_Notify_RT_Properties
 {

--- a/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Default_Property_Validator.cpp
+++ b/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Default_Property_Validator.cpp
@@ -94,7 +94,7 @@ TAO_PG_Default_Property_Validator::validate_criteria (
         }
       else if (property.nam == this->factories_)
         {
-          PortableGroup::FactoriesValue * factories;
+          copnst PortableGroup::FactoriesValue * factories = 0;
           if (!(property.val >>= factories))
             invalid_criteria[p++] = property;
           else

--- a/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Default_Property_Validator.cpp
+++ b/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Default_Property_Validator.cpp
@@ -94,7 +94,7 @@ TAO_PG_Default_Property_Validator::validate_criteria (
         }
       else if (property.nam == this->factories_)
         {
-          copnst PortableGroup::FactoriesValue * factories = 0;
+          const PortableGroup::FactoriesValue * factories = 0;
           if (!(property.val >>= factories))
             invalid_criteria[p++] = property;
           else

--- a/TAO/orbsvcs/orbsvcs/PortableGroup/PG_GenericFactory.cpp
+++ b/TAO/orbsvcs/orbsvcs/PortableGroup/PG_GenericFactory.cpp
@@ -405,7 +405,7 @@ TAO_PG_GenericFactory::get_ObjectId (
   // with the LoadManager.  Previously used values will not be reused
   // to ensure that a ServantLocator does not inadvertently return a
   // reference to an object that had a previously used ObjectId.
-  // Specifcally, the numerical value used for the ObjectId increases
+  // Specifically, the numerical value used for the ObjectId increases
   // monotonically.
 
   // 4294967295UL -- Largest 32 bit unsigned integer

--- a/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Property_Set_Find.h
+++ b/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Property_Set_Find.h
@@ -37,7 +37,7 @@ namespace TAO
   int find (const PG_Property_Set & decoder, const ACE_CString & key, TYPE & value)
   {
     int result = 0;
-    PortableGroup::Value const * any;
+    const PortableGroup::Value const * any = 0;
     if ( decoder.find (key, any))
     {
       result = ((*any) >>= value);

--- a/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Property_Set_Find.h
+++ b/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Property_Set_Find.h
@@ -37,7 +37,7 @@ namespace TAO
   int find (const PG_Property_Set & decoder, const ACE_CString & key, TYPE & value)
   {
     int result = 0;
-    const PortableGroup::Value const * any = 0;
+    const PortableGroup::Value * any = 0;
     if ( decoder.find (key, any))
     {
       result = ((*any) >>= value);

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_CredentialsAcquirer.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_CredentialsAcquirer.cpp
@@ -128,7 +128,7 @@ TAO::SSLIOP::CredentialsAcquirer::get_credentials (CORBA::Boolean on_list)
 {
   this->check_validity ();
 
-  ::SSLIOP::AuthData *data = 0;
+  const ::SSLIOP::AuthData *data = 0;
 
   if (!(this->acquisition_arguments_ >>= data))
     throw CORBA::BAD_PARAM ();

--- a/TAO/orbsvcs/orbsvcs/Security/SL3_PolicyFactory.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/SL3_PolicyFactory.cpp
@@ -12,7 +12,7 @@ TAO::SL3::PolicyFactory::create_policy (CORBA::PolicyType type,
 
   if (type == SecurityLevel3::ContextEstablishmentPolicyType)
     {
-      SecurityLevel3::ContextEstablishmentPolicyArgument * arg = 0;
+      const SecurityLevel3::ContextEstablishmentPolicyArgument * arg = 0;
       if (!(value >>= arg))
         throw CORBA::INTERNAL ();
 
@@ -28,7 +28,7 @@ TAO::SL3::PolicyFactory::create_policy (CORBA::PolicyType type,
     }
   else if (type == SecurityLevel3::ObjectCredentialsPolicyType)
     {
-      SecurityLevel3::ObjectCredentialsPolicyArgument * creds = 0;
+      const SecurityLevel3::ObjectCredentialsPolicyArgument * creds = 0;
       if (!(value >>= creds))
         throw CORBA::INTERNAL ();
 

--- a/TAO/orbsvcs/orbsvcs/Security/Security_PolicyFactory.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/Security_PolicyFactory.cpp
@@ -49,7 +49,7 @@ TAO::Security::PolicyFactory::create_policy (
 
   else if (type == ::Security::SecEstablishTrustPolicy)
     {
-      ::Security::EstablishTrust *trust = 0;
+      const ::Security::EstablishTrust *trust = 0;
 
       // Extract the desired establishing of trust value from the
       // given Any.
@@ -74,7 +74,7 @@ TAO::Security::PolicyFactory::create_policy (
 
   else if (type == SecurityLevel3::ContextEstablishmentPolicyType)
     {
-      SecurityLevel3::ContextEstablishmentPolicyArgument * args = 0;
+      const SecurityLevel3::ContextEstablishmentPolicyArgument * args = 0;
 
       // Extract the desired establishing of trust value from the
       // given Any.
@@ -105,7 +105,7 @@ TAO::Security::PolicyFactory::create_policy (
 
   else if (type == SecurityLevel3::ObjectCredentialsPolicyType)
     {
-      SecurityLevel3::OwnCredentialsList * creds = 0;
+      const SecurityLevel3::OwnCredentialsList * creds = 0;
 
       // Extract the desired establishing of trust value from the
       // given Any.

--- a/TAO/orbsvcs/orbsvcs/Trader/Trader_Interfaces.cpp
+++ b/TAO/orbsvcs/orbsvcs/Trader/Trader_Interfaces.cpp
@@ -29,7 +29,7 @@ TAO_Lookup<TRADER_LOCK_TYPE,MAP_LOCK_TYPE>::~TAO_Lookup (void)
        ! riter.done ();
        riter.advance ())
     {
-      CosTrading::Admin::OctetSeq** old_seq = 0;
+      const CosTrading::Admin::OctetSeq** old_seq = 0;
       riter.next (old_seq);
       delete *old_seq;
     }
@@ -52,7 +52,7 @@ query (const char *type,
 
   // If a federated query returns to us, ignore it to prevent
   // redundant results and infinite loops.
-  CosTrading::Admin::OctetSeq* request_id = 0;
+  const CosTrading::Admin::OctetSeq* request_id = 0;
   int check = this->seen_request_id (policies, request_id);
 
   if (check)
@@ -69,7 +69,7 @@ query (const char *type,
 
   // If the importer has specified a starting trader, foward the
   // query.
-  CosTrading::TraderName* trader_name =
+  const CosTrading::TraderName* trader_name =
     policies.starting_trader ();
 
   if (! CORBA::is_nil (link_if) && trader_name != 0)
@@ -729,7 +729,7 @@ template <class TRADER_LOCK_TYPE, class MAP_LOCK_TYPE>
 CORBA::Boolean
 TAO_Lookup<TRADER_LOCK_TYPE,MAP_LOCK_TYPE>::
 seen_request_id (TAO_Policies& policies,
-                 CosTrading::Admin::OctetSeq*& seq)
+                 const CosTrading::Admin::OctetSeq*& seq)
 {
   CORBA::Boolean return_value = 0;
 
@@ -756,7 +756,7 @@ seen_request_id (TAO_Policies& policies,
        ! riter.done ();
        riter.advance ())
     {
-      CosTrading::Admin::OctetSeq** old_seq = 0;
+      const CosTrading::Admin::OctetSeq** old_seq = 0;
       riter.next (old_seq);
 
       if (**old_seq == *seq)
@@ -770,7 +770,7 @@ seen_request_id (TAO_Policies& policies,
     {
       if (this->request_ids_.size () == IDS_SAVED)
         {
-          CosTrading::Admin::OctetSeq* octet_seq = 0;
+          const CosTrading::Admin::OctetSeq* octet_seq = 0;
           this->request_ids_.dequeue_head (octet_seq);
           delete octet_seq;
         }

--- a/TAO/orbsvcs/orbsvcs/Trader/Trader_Interfaces.h
+++ b/TAO/orbsvcs/orbsvcs/Trader/Trader_Interfaces.h
@@ -237,7 +237,7 @@ private:
                               CosTrading::OfferSeq& offers);
 
   CORBA::Boolean seen_request_id (TAO_Policies& policies,
-                                  CosTrading::Admin::OctetSeq*& seq);
+                                  const CosTrading::Admin::OctetSeq*& seq);
 
   // = Disallow these operations.
   ACE_UNIMPLEMENTED_FUNC (void operator= (const TAO_Lookup<TRADER_LOCK_TYPE,MAP_LOCK_TYPE> &))
@@ -248,7 +248,7 @@ private:
   /// A reference to the trader for obtaining offer maps.
   TAO_Trader<TRADER_LOCK_TYPE,MAP_LOCK_TYPE> &trader_;
 
-  typedef ACE_Unbounded_Queue<CosTrading::Admin::OctetSeq*> Request_Ids;
+  typedef ACE_Unbounded_Queue<const CosTrading::Admin::OctetSeq*> Request_Ids;
 
   /// A list of recent request_id_stems
   Request_Ids request_ids_;

--- a/TAO/orbsvcs/orbsvcs/Trader/Trader_Utils.cpp
+++ b/TAO/orbsvcs/orbsvcs/Trader/Trader_Utils.cpp
@@ -263,7 +263,7 @@ TAO_Property_Evaluator::property_value (int index)
   else if (this->supports_dp_)
     {
       // Property is defined at this point.
-      CosTradingDynamic::DynamicProp* dp_struct;
+      const CosTradingDynamic::DynamicProp* dp_struct = 0;
       const CORBA::String_var name = this->props_[index].name.in ();
       const CORBA::Any& value = this->props_[index].value;
 
@@ -314,7 +314,7 @@ TAO_Property_Evaluator::property_type (int index)
     {
       // Extract type information from the DP_Struct.
       const CORBA::Any& value = this->props_[index].value;
-      CosTradingDynamic::DynamicProp* dp_struct = 0;
+      const CosTradingDynamic::DynamicProp* dp_struct = 0;
       value >>= dp_struct;
 
       // Grab a pointer to the returned_type description
@@ -706,7 +706,7 @@ TAO_Policies::exact_type_match (void) const
 CosTrading::TraderName*
 TAO_Policies::starting_trader (void) const
 {
-  CosTrading::TraderName* trader_name = 0;
+  const CosTrading::TraderName* trader_name = 0;
 
   if (this->policies_[STARTING_TRADER] != 0)
     {
@@ -791,7 +791,7 @@ TAO_Policies::hop_count (void) const
 CosTrading::Admin::OctetSeq*
 TAO_Policies::request_id (void) const
 {
-  CosTrading::Admin::OctetSeq* request_id = 0;
+  const CosTrading::Admin::OctetSeq* request_id = 0;
 
   if (this->policies_[REQUEST_ID] != 0)
     {

--- a/TAO/orbsvcs/orbsvcs/Trader/Trader_Utils.cpp
+++ b/TAO/orbsvcs/orbsvcs/Trader/Trader_Utils.cpp
@@ -283,7 +283,7 @@ TAO_Property_Evaluator::property_value (int index)
       else
         {
           CORBA::TypeCode* type = dp_struct->returned_type.in ();
-          CORBA::Any& info = dp_struct->extra_info;
+          const CORBA::Any& info = dp_struct->extra_info;
 
           try
             {
@@ -703,7 +703,7 @@ TAO_Policies::exact_type_match (void) const
 }
 
 
-CosTrading::TraderName*
+const CosTrading::TraderName*
 TAO_Policies::starting_trader (void) const
 {
   const CosTrading::TraderName* trader_name = 0;
@@ -788,7 +788,7 @@ TAO_Policies::hop_count (void) const
   return this->ulong_prop (HOP_COUNT);
 }
 
-CosTrading::Admin::OctetSeq*
+const CosTrading::Admin::OctetSeq*
 TAO_Policies::request_id (void) const
 {
   const CosTrading::Admin::OctetSeq* request_id = 0;

--- a/TAO/orbsvcs/orbsvcs/Trader/Trader_Utils.h
+++ b/TAO/orbsvcs/orbsvcs/Trader/Trader_Utils.h
@@ -371,7 +371,7 @@ public:
    * "starting_trader" policy with the first component removed.
    * END SPEC
    */
-  CosTrading::TraderName* starting_trader (void) const;
+  const CosTrading::TraderName* starting_trader (void) const;
 
   /// Determine the link follow policy for this query overall.
   CosTrading::FollowOption link_follow_rule (void) const;
@@ -411,7 +411,7 @@ public:
 
   /// Return the request_id passed to the query method across a link to
   /// another trader.
-  CosTrading::Admin::OctetSeq* request_id (void) const;
+  const CosTrading::Admin::OctetSeq* request_id (void) const;
 
   /// Policies to forward to the next trader in a federated query.
   void copy_to_pass (CosTrading::PolicySeq& policy_seq,

--- a/TAO/orbsvcs/tests/InterfaceRepo/IDL3_Test/idl3_client.cpp
+++ b/TAO/orbsvcs/tests/InterfaceRepo/IDL3_Test/idl3_client.cpp
@@ -890,7 +890,7 @@ IDL3_Client::component_port_test (
 }
 
 int
-IDL3_Client::provides_test (CORBA::ComponentIR::ProvidesDescriptionSeq &pds)
+IDL3_Client::provides_test (const CORBA::ComponentIR::ProvidesDescriptionSeq &pds)
 {
   if (pds.length () != PROVIDES_LEN)
     {
@@ -943,7 +943,7 @@ IDL3_Client::provides_test (CORBA::ComponentIR::ProvidesDescriptionSeq &pds)
 }
 
 int
-IDL3_Client::uses_test (CORBA::ComponentIR::UsesDescriptionSeq &uds)
+IDL3_Client::uses_test (const CORBA::ComponentIR::UsesDescriptionSeq &uds)
 {
   if (uds.length () != USES_LEN)
     {
@@ -1012,7 +1012,7 @@ IDL3_Client::uses_test (CORBA::ComponentIR::UsesDescriptionSeq &uds)
 }
 
 int
-IDL3_Client::event_port_test (CORBA::ComponentIR::EventPortDescriptionSeq &eds,
+IDL3_Client::event_port_test (const CORBA::ComponentIR::EventPortDescriptionSeq &eds,
                               CORBA::ULong seq_length,
                               const char *port_type,
                               const char **names,
@@ -1585,7 +1585,7 @@ IDL3_Client::home_inheritance_test (CORBA::ComponentIR::HomeDef_var &hd)
 }
 
 int
-IDL3_Client::home_factory_test (CORBA::ComponentIR::HomeDescription *hd)
+IDL3_Client::home_factory_test (const CORBA::ComponentIR::HomeDescription *hd)
 {
   CORBA::ULong length = hd->factories.length ();
 
@@ -1682,7 +1682,7 @@ IDL3_Client::home_factory_test (CORBA::ComponentIR::HomeDescription *hd)
 }
 
 int
-IDL3_Client::home_finder_test (CORBA::ComponentIR::HomeDescription *hd)
+IDL3_Client::home_finder_test (const CORBA::ComponentIR::HomeDescription *hd)
 {
   CORBA::ULong length = hd->finders.length ();
 

--- a/TAO/orbsvcs/tests/InterfaceRepo/IDL3_Test/idl3_client.cpp
+++ b/TAO/orbsvcs/tests/InterfaceRepo/IDL3_Test/idl3_client.cpp
@@ -555,7 +555,7 @@ IDL3_Client::home_test (void)
   CORBA::Contained::Description_var desc =
     home->describe ();
 
-  CORBA::ComponentIR::HomeDescription *home_desc = 0;
+  const CORBA::ComponentIR::HomeDescription *home_desc = 0;
 
   if ((desc->value >>= home_desc) == 0)
     {
@@ -654,8 +654,7 @@ IDL3_Client::valuetype_test (const char *repo_id,
       return -1;
     }
 
-  status = this->valuetype_factory_test (desc,
-                                         prefix);
+  status = this->valuetype_factory_test (desc, prefix);
 
   if (status != 0)
     {
@@ -667,8 +666,7 @@ IDL3_Client::valuetype_test (const char *repo_id,
 
 int
 IDL3_Client::component_attribute_test (
-    CORBA::InterfaceAttrExtension::ExtFullInterfaceDescription_var &desc
-  )
+    CORBA::InterfaceAttrExtension::ExtFullInterfaceDescription_var &desc)
 {
   if (desc->attributes.length () != ATTRS_LEN)
     {
@@ -750,8 +748,7 @@ IDL3_Client::component_attribute_test (
 
 int
 IDL3_Client::component_inheritance_test (
-    CORBA::ComponentIR::ComponentDef_var &comp_def
-  )
+    CORBA::ComponentIR::ComponentDef_var &comp_def)
 {
   CORBA::ComponentIR::ComponentDef_var comp_base =
     comp_def->base_component ();
@@ -823,13 +820,12 @@ IDL3_Client::component_inheritance_test (
 
 int
 IDL3_Client::component_port_test (
-    CORBA::ComponentIR::ComponentDef_var &comp_def
-  )
+    CORBA::ComponentIR::ComponentDef_var &comp_def)
 {
   CORBA::Contained::Description_var desc =
     comp_def->describe ();
 
-  CORBA::ComponentIR::ComponentDescription *cd = 0;
+  const CORBA::ComponentIR::ComponentDescription *cd = 0;
 
   if ((desc->value >>= cd) == 0)
     {
@@ -1153,8 +1149,7 @@ IDL3_Client::valuetype_inheritance_test (CORBA::ExtValueDef_var &vd,
 int
 IDL3_Client::valuetype_attribute_test (
     CORBA::ExtValueDef::ExtFullValueDescription_var &desc,
-    const char *prefix
-  )
+    const char *prefix)
 {
   if (desc->attributes.length () != ATTRS_LEN)
     {
@@ -1358,8 +1353,7 @@ IDL3_Client::valuetype_operation_test (
 int
 IDL3_Client::valuetype_member_test (
     CORBA::ExtValueDef::ExtFullValueDescription_var &desc,
-    const char *prefix
-  )
+    const char *prefix)
 {
   CORBA::ULong length = desc->members.length ();
 
@@ -1417,8 +1411,7 @@ IDL3_Client::valuetype_member_test (
 int
 IDL3_Client::valuetype_factory_test (
     CORBA::ExtValueDef::ExtFullValueDescription_var &desc,
-    const char *prefix
-  )
+    const char *prefix)
 {
   CORBA::ULong length = desc->initializers.length ();
 

--- a/TAO/orbsvcs/tests/InterfaceRepo/IDL3_Test/idl3_client.h
+++ b/TAO/orbsvcs/tests/InterfaceRepo/IDL3_Test/idl3_client.h
@@ -60,11 +60,11 @@ private:
 
   int component_port_test (CORBA::ComponentIR::ComponentDef_var &);
 
-  int provides_test (CORBA::ComponentIR::ProvidesDescriptionSeq &);
+  int provides_test (const CORBA::ComponentIR::ProvidesDescriptionSeq &);
 
-  int uses_test (CORBA::ComponentIR::UsesDescriptionSeq &);
+  int uses_test (const CORBA::ComponentIR::UsesDescriptionSeq &);
 
-  int event_port_test (CORBA::ComponentIR::EventPortDescriptionSeq &,
+  int event_port_test (const CORBA::ComponentIR::EventPortDescriptionSeq &,
                        CORBA::ULong seq_length,
                        const char *port_type,
                        const char **names,
@@ -95,9 +95,9 @@ private:
 
   int home_inheritance_test (CORBA::ComponentIR::HomeDef_var &);
 
-  int home_factory_test (CORBA::ComponentIR::HomeDescription *);
+  int home_factory_test (const CORBA::ComponentIR::HomeDescription *);
 
-  int home_finder_test (CORBA::ComponentIR::HomeDescription *);
+  int home_finder_test (const CORBA::ComponentIR::HomeDescription *);
 
 private:
   /// Flag to output detailed error messages.

--- a/TAO/orbsvcs/tests/InterfaceRepo/IFR_Test/Admin_Client.cpp
+++ b/TAO/orbsvcs/tests/InterfaceRepo/IFR_Test/Admin_Client.cpp
@@ -403,7 +403,7 @@ Admin_Client::enum_test (void)
 
   ACE_TEST_ASSERT (dkind == CORBA::dk_Enum);
 
-  CORBA::TypeDescription *td;
+  const CORBA::TypeDescription *td = 0;
   desc->value >>= td;
 
   if (this->debug_)
@@ -744,7 +744,7 @@ Admin_Client::alias_test (void)
   CORBA::Contained::Description_var desc =
     a_var->describe ();
 
-  CORBA::TypeDescription *td;
+  const CORBA::TypeDescription *td = 0;
   desc->value >>= td;
 
   if (this->debug_)
@@ -972,7 +972,7 @@ Admin_Client::struct_test (void)
   CORBA::Contained::Description_var desc =
     svar->describe ();
 
-  CORBA::TypeDescription *td;
+  const CORBA::TypeDescription *td = 0;
   desc->value >>= td;
 
   if (this->debug_)
@@ -1209,7 +1209,7 @@ Admin_Client::struct_test (void)
 
   for (i = 0; i < length; ++i)
     {
-      CORBA::TypeDescription *td;
+      const CORBA::TypeDescription *td = 0;
       cont_desc[i].value >>= td;
 
       str = td->type->id ();
@@ -1573,7 +1573,7 @@ Admin_Client::exception_test (void)
   CORBA::Contained::Description_var desc =
     exvar->describe ();
 
-  CORBA::ExceptionDescription *ed;
+  const CORBA::ExceptionDescription *ed = 0;
   desc->value >>= ed;
 
   if (this->debug_)
@@ -1830,7 +1830,7 @@ Admin_Client::exception_test (void)
 
   ACE_TEST_ASSERT (length == 2);
 
-  CORBA::TypeDescription *td;
+  const CORBA::TypeDescription *td = 0;
 
   for (i = 0; i < length; ++i)
     {
@@ -2216,7 +2216,7 @@ Admin_Client::interface_test (void)
   CORBA::Contained::Description_var desc =
     p_op->describe ();
 
-  CORBA::OperationDescription *od;
+  const CORBA::OperationDescription *od = 0;
   desc->value >>= od;
 
   if (this->debug_)
@@ -2421,7 +2421,7 @@ Admin_Client::interface_test (void)
 
   desc = ivar->describe ();
 
-  CORBA::InterfaceDescription *ifd;
+  const CORBA::InterfaceDescription *ifd = 0;
   desc->value >>= ifd;
 
   length = ifd->base_interfaces.length ();

--- a/TAO/orbsvcs/tests/Trading/TT_Info.cpp
+++ b/TAO/orbsvcs/tests/Trading/TT_Info.cpp
@@ -178,7 +178,7 @@ TT_Info::dump_properties (const CosTrading::PropertySeq& prop_seq,
 
       if (check)
         {
-          TAO_Trader_Test::StringSeq* str_seq;
+          const TAO_Trader_Test::StringSeq* str_seq = 0;
           (*value) >>= str_seq;
 
           for (seq_length = str_seq->length (), i = 0; i < seq_length; i++)
@@ -192,7 +192,7 @@ TT_Info::dump_properties (const CosTrading::PropertySeq& prop_seq,
 
           if (check)
             {
-              TAO_Trader_Test::ULongSeq* ulong_seq;
+              const TAO_Trader_Test::ULongSeq* ulong_seq = 0;
               (*value) >>= ulong_seq;
 
               for (seq_length = ulong_seq->length (), i = 0; i < seq_length; i++)

--- a/TAO/performance-tests/Anyop/anyop.cpp
+++ b/TAO/performance-tests/Anyop/anyop.cpp
@@ -383,7 +383,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                 ACE_hrtime_t now = ACE_OS::gethrtime ();
                 history.sample (now - start);
 
-                Param_Test::Fixed_Struct *o;
+                const Param_Test::Fixed_Struct *o = 0;
 
                 result = any >>= o;
               }
@@ -391,7 +391,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
               {
                 any <<= i;
 
-                Param_Test::Fixed_Struct *o;
+                const Param_Test::Fixed_Struct *o = 0;
 
                 ACE_hrtime_t start = ACE_OS::gethrtime ();
 
@@ -461,7 +461,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                 ACE_hrtime_t now = ACE_OS::gethrtime ();
                 history.sample (now - start);
 
-                Param_Test::Fixed_Struct *o;
+                const Param_Test::Fixed_Struct *o = 0;
 
                 result = any >>= o;
               }
@@ -469,7 +469,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
               {
                 any <<= i;
 
-                Param_Test::Fixed_Struct *o;
+                const Param_Test::Fixed_Struct *o = 0;
 
                 ACE_hrtime_t start = ACE_OS::gethrtime ();
 
@@ -538,7 +538,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                 ACE_hrtime_t now = ACE_OS::gethrtime ();
                 history.sample (now - start);
 
-                Param_Test::Long_Seq *o;
+                const Param_Test::Long_Seq *o = 0;
 
                 result = any >>= o;
               }
@@ -546,7 +546,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
               {
                 any <<= i;
 
-                Param_Test::Long_Seq *o;
+                const Param_Test::Long_Seq *o = 0;
 
                 ACE_hrtime_t start = ACE_OS::gethrtime ();
 
@@ -616,7 +616,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                 ACE_hrtime_t now = ACE_OS::gethrtime ();
                 history.sample (now - start);
 
-                Param_Test::Long_Seq *o;
+                const Param_Test::Long_Seq *o = 0;
 
                 result = any >>= o;
               }
@@ -624,7 +624,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
               {
                 any <<= i;
 
-                Param_Test::Long_Seq *o;
+                const Param_Test::Long_Seq *o = 0;
 
                 ACE_hrtime_t start = ACE_OS::gethrtime ();
 

--- a/TAO/performance-tests/Cubit/TAO/DII_Cubit/client.cpp
+++ b/TAO/performance-tests/Cubit/TAO/DII_Cubit/client.cpp
@@ -535,7 +535,8 @@ DII_Cubit_Client::cube_struct_dii (void)
       // Create the request ...
       CORBA::Request_var req (this->obj_var_->_request ("cube_struct"));
 
-      const Cubit::Many arg_struct, *ret_struct_ptr;
+      Cubit::Many arg_struct;
+      const Cubit::Many*ret_struct_ptr;
 
       arg_struct.l = 5;
       arg_struct.s = -7;

--- a/TAO/performance-tests/Cubit/TAO/DII_Cubit/client.cpp
+++ b/TAO/performance-tests/Cubit/TAO/DII_Cubit/client.cpp
@@ -506,7 +506,7 @@ DII_Cubit_Client::cube_union_dii (void)
 
 
       // Extract the result and check validity.
-      Cubit::oneof* ret_ptr;
+      const Cubit::oneof* ret_ptr = 0;
       req->return_value () >>= ret_ptr;
 
       if (ret_ptr->cm ().l != arg_union.cm ().l * arg_union.cm ().l * arg_union.cm ().l
@@ -535,8 +535,7 @@ DII_Cubit_Client::cube_struct_dii (void)
       // Create the request ...
       CORBA::Request_var req (this->obj_var_->_request ("cube_struct"));
 
-
-      Cubit::Many arg_struct, *ret_struct_ptr;
+      const Cubit::Many arg_struct, *ret_struct_ptr;
 
       arg_struct.l = 5;
       arg_struct.s = -7;
@@ -552,7 +551,6 @@ DII_Cubit_Client::cube_struct_dii (void)
       this->call_count_++;
 
       req->invoke ();
-
 
       req->return_value () >>= ret_struct_ptr;
 
@@ -585,7 +583,8 @@ DII_Cubit_Client::cube_octet_seq_dii (int length)
 
       // Same length as in IDL_Cubit tests so timings can be compared.
       // Return value holder is set to a different length to test resizing.
-      Cubit::octet_seq arg_octet_seq (length), *ret_octet_seq_ptr;
+      Cubit::octet_seq arg_octet_seq (length);
+      const Cubit::octet_seq *ret_octet_seq_ptr = 0;
       arg_octet_seq.length (length);
       arg_octet_seq[0] = 4;
 
@@ -600,7 +599,6 @@ DII_Cubit_Client::cube_octet_seq_dii (int length)
       this->call_count_++;
 
       req->invoke ();
-
 
       req->return_value () >>= ret_octet_seq_ptr;
 
@@ -642,7 +640,7 @@ DII_Cubit_Client::cube_long_seq_dii (int length)
       // Same length as in IDL_Cubit tests so timings can be compared.
       // Return value holder is set to a different length to test
       // resizing.
-      Cubit::long_seq *ret_long_seq_ptr;
+      const Cubit::long_seq *ret_long_seq_ptr = 0;
       Cubit::long_seq arg_long_seq (length);
       arg_long_seq.length (length);
       arg_long_seq[0] = 4;

--- a/TAO/performance-tests/Cubit/TAO/IDL_Cubit/Cubit_Client.cpp
+++ b/TAO/performance-tests/Cubit/TAO/IDL_Cubit/Cubit_Client.cpp
@@ -1064,7 +1064,7 @@ Cubit_Client::cube_any_struct (int i)
   try
     {
       Cubit::Many arg_struct;
-      Cubit::Many * ret_struct;
+      const Cubit::Many * ret_struct = 0;
 
       this->call_count_++;
 

--- a/TAO/performance-tests/Cubit/TAO/IDL_Cubit/Cubit_i.cpp
+++ b/TAO/performance-tests/Cubit/TAO/IDL_Cubit/Cubit_i.cpp
@@ -393,7 +393,7 @@ CORBA::Any *
 Cubit_i::cube_any_struct (const CORBA::Any & any)
 {
   ACE_FUNCTION_TIMEPROBE (CUBIT_I_CUBE_ANY_STRUCT_START);
-  Cubit::Many * arg_struct;
+  const Cubit::Many * arg_struct = 0;
   Cubit::Many ret_struct;
   any >>= arg_struct;
 

--- a/TAO/tao/AnyTypeCode/BasicTypeTraits.h
+++ b/TAO/tao/AnyTypeCode/BasicTypeTraits.h
@@ -225,8 +225,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::Char * insert_type;
-    typedef CORBA::Char * extract_type;
-    typedef CORBA::Char * return_type;
+    typedef const CORBA::Char * extract_type;
+    typedef const CORBA::Char * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -238,8 +238,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::WChar * insert_type;
-    typedef CORBA::WChar * extract_type;
-    typedef CORBA::WChar * return_type;
+    typedef const CORBA::WChar * extract_type;
+    typedef const CORBA::WChar * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -251,8 +251,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::Any insert_type;
-    typedef CORBA::Any * extract_type;
-    typedef CORBA::Any * return_type;
+    typedef const CORBA::Any * extract_type;
+    typedef const CORBA::Any * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -277,7 +277,7 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::TypeCode_ptr insert_type;
-    typedef CORBA::TypeCode_ptr extract_type;
+    typedef const CORBA::TypeCode_ptr extract_type;
     typedef CORBA::TypeCode_ptr return_type;
 
     static return_type convert (extract_type& et);
@@ -290,8 +290,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::BooleanSeq insert_type;
-    typedef CORBA::BooleanSeq * extract_type;
-    typedef CORBA::BooleanSeq * return_type;
+    typedef const CORBA::BooleanSeq * extract_type;
+    typedef const CORBA::BooleanSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -303,8 +303,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value ;
 
     typedef CORBA::OctetSeq insert_type;
-    typedef CORBA::OctetSeq * extract_type;
-    typedef CORBA::OctetSeq * return_type;
+    typedef const CORBA::OctetSeq * extract_type;
+    typedef const CORBA::OctetSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -316,8 +316,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::CharSeq insert_type;
-    typedef CORBA::CharSeq * extract_type;
-    typedef CORBA::CharSeq * return_type;
+    typedef const CORBA::CharSeq * extract_type;
+    typedef const CORBA::CharSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -329,8 +329,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::WCharSeq insert_type;
-    typedef CORBA::WCharSeq * extract_type;
-    typedef CORBA::WCharSeq * return_type;
+    typedef const CORBA::WCharSeq * extract_type;
+    typedef const CORBA::WCharSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -342,8 +342,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::ShortSeq insert_type;
-    typedef CORBA::ShortSeq * extract_type;
-    typedef CORBA::ShortSeq * return_type;
+    typedef const CORBA::ShortSeq * extract_type;
+    typedef const CORBA::ShortSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -355,8 +355,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::UShortSeq insert_type;
-    typedef CORBA::UShortSeq * extract_type;
-    typedef CORBA::UShortSeq * return_type;
+    typedef const CORBA::UShortSeq * extract_type;
+    typedef const CORBA::UShortSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -368,8 +368,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::LongSeq insert_type;
-    typedef CORBA::LongSeq * extract_type;
-    typedef CORBA::LongSeq * return_type;
+    typedef const CORBA::LongSeq * extract_type;
+    typedef const CORBA::LongSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -381,8 +381,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::ULongSeq insert_type;
-    typedef CORBA::ULongSeq * extract_type;
-    typedef CORBA::ULongSeq * return_type;
+    typedef const CORBA::ULongSeq * extract_type;
+    typedef const CORBA::ULongSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -394,8 +394,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::LongLongSeq insert_type;
-    typedef CORBA::LongLongSeq * extract_type;
-    typedef CORBA::LongLongSeq * return_type;
+    typedef const CORBA::LongLongSeq * extract_type;
+    typedef const CORBA::LongLongSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -407,8 +407,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::ULongLongSeq insert_type;
-    typedef CORBA::ULongLongSeq * extract_type;
-    typedef CORBA::ULongLongSeq * return_type;
+    typedef const CORBA::ULongLongSeq * extract_type;
+    typedef const CORBA::ULongLongSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -420,8 +420,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::FloatSeq insert_type;
-    typedef CORBA::FloatSeq * extract_type;
-    typedef CORBA::FloatSeq * return_type;
+    typedef const CORBA::FloatSeq * extract_type;
+    typedef const CORBA::FloatSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -433,8 +433,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::DoubleSeq insert_type;
-    typedef CORBA::DoubleSeq * extract_type;
-    typedef CORBA::DoubleSeq * return_type;
+    typedef const CORBA::DoubleSeq * extract_type;
+    typedef const CORBA::DoubleSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -446,8 +446,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::LongDoubleSeq insert_type;
-    typedef CORBA::LongDoubleSeq * extract_type;
-    typedef CORBA::LongDoubleSeq * return_type;
+    typedef const CORBA::LongDoubleSeq * extract_type;
+    typedef const CORBA::LongDoubleSeq * return_type;
 
     static return_type convert (extract_type& et);
   };
@@ -459,8 +459,8 @@ namespace TAO
     static CORBA::TCKind const tckind_value;
 
     typedef CORBA::AnySeq insert_type;
-    typedef CORBA::AnySeq * extract_type;
-    typedef CORBA::AnySeq * return_type;
+    typedef const CORBA::AnySeq * extract_type;
+    typedef const CORBA::AnySeq * return_type;
 
     static return_type convert (extract_type& et);
   };

--- a/TAO/tao/Codeset/Codeset_Manager_i.cpp
+++ b/TAO/tao/Codeset/Codeset_Manager_i.cpp
@@ -344,7 +344,7 @@ void
 TAO_Codeset_Manager_i::open(TAO_ORB_Core& core)
 {
 #if 0
-  // These translators help comply with the CORBA 3.0.2 specifcation
+  // These translators help comply with the CORBA 3.0.2 specification
   TAO_Codeset_Translator_Factory *fact =
     ACE_Dynamic_Service<TAO_Codeset_Translator_Factory>::
     instance ("UTF8_Latin1_Factory");

--- a/TAO/tao/DynamicAny/DynCommon.cpp
+++ b/TAO/tao/DynamicAny/DynCommon.cpp
@@ -1034,7 +1034,7 @@ TAO_DynCommon::insert_wchar_seq (const CORBA::WCharSeq &value)
 CORBA::BooleanSeq *
 TAO_DynCommon::get_boolean_seq (void)
 {
-  CORBA::BooleanSeq *owned =
+  const CORBA::BooleanSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::BooleanSeq>::get_value (this);
   return new CORBA::BooleanSeq (*owned);
 }
@@ -1042,7 +1042,7 @@ TAO_DynCommon::get_boolean_seq (void)
 CORBA::OctetSeq *
 TAO_DynCommon::get_octet_seq (void)
 {
-  CORBA::OctetSeq *owned =
+  const CORBA::OctetSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::OctetSeq>::get_value (this);
   return new CORBA::OctetSeq (*owned);
 }
@@ -1050,7 +1050,7 @@ TAO_DynCommon::get_octet_seq (void)
 CORBA::CharSeq *
 TAO_DynCommon::get_char_seq (void)
 {
-  CORBA::CharSeq *owned =
+  const CORBA::CharSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::CharSeq>::get_value (this);
   return new CORBA::CharSeq (*owned);
 }
@@ -1058,7 +1058,7 @@ TAO_DynCommon::get_char_seq (void)
 CORBA::ShortSeq *
 TAO_DynCommon::get_short_seq (void)
 {
-  CORBA::ShortSeq *owned =
+  const CORBA::ShortSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::ShortSeq>::get_value (this);
   return new CORBA::ShortSeq (*owned);
 }
@@ -1066,7 +1066,7 @@ TAO_DynCommon::get_short_seq (void)
 CORBA::UShortSeq *
 TAO_DynCommon::get_ushort_seq (void)
 {
-  CORBA::UShortSeq *owned =
+  const CORBA::UShortSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::UShortSeq>::get_value (this);
   return new CORBA::UShortSeq (*owned);
 }
@@ -1074,7 +1074,7 @@ TAO_DynCommon::get_ushort_seq (void)
 CORBA::LongSeq *
 TAO_DynCommon::get_long_seq (void)
 {
-  CORBA::LongSeq *owned =
+  const CORBA::LongSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::LongSeq>::get_value (this);
   return new CORBA::LongSeq (*owned);
 }
@@ -1082,7 +1082,7 @@ TAO_DynCommon::get_long_seq (void)
 CORBA::ULongSeq *
 TAO_DynCommon::get_ulong_seq (void)
 {
-  CORBA::ULongSeq *owned =
+  const CORBA::ULongSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::ULongSeq>::get_value (this);
   return new CORBA::ULongSeq (*owned);
 }
@@ -1090,7 +1090,7 @@ TAO_DynCommon::get_ulong_seq (void)
 CORBA::FloatSeq *
 TAO_DynCommon::get_float_seq (void)
 {
-  CORBA::FloatSeq *owned =
+  const CORBA::FloatSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::FloatSeq>::get_value (this);
   return new CORBA::FloatSeq (*owned);
 }
@@ -1098,7 +1098,7 @@ TAO_DynCommon::get_float_seq (void)
 CORBA::DoubleSeq *
 TAO_DynCommon::get_double_seq (void)
 {
-  CORBA::DoubleSeq *owned =
+  const CORBA::DoubleSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::DoubleSeq>::get_value (this);
   return new CORBA::DoubleSeq (*owned);
 }
@@ -1106,7 +1106,7 @@ TAO_DynCommon::get_double_seq (void)
 CORBA::LongLongSeq *
 TAO_DynCommon::get_longlong_seq (void)
 {
-  CORBA::LongLongSeq *owned =
+  const CORBA::LongLongSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::LongLongSeq>::get_value (this);
   return new CORBA::LongLongSeq (*owned);
 }
@@ -1114,7 +1114,7 @@ TAO_DynCommon::get_longlong_seq (void)
 CORBA::ULongLongSeq *
 TAO_DynCommon::get_ulonglong_seq (void)
 {
-  CORBA::ULongLongSeq *owned =
+  const CORBA::ULongLongSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::ULongLongSeq>::get_value (this);
   return new CORBA::ULongLongSeq (*owned);
 }
@@ -1122,7 +1122,7 @@ TAO_DynCommon::get_ulonglong_seq (void)
 CORBA::LongDoubleSeq *
 TAO_DynCommon::get_longdouble_seq (void)
 {
-  CORBA::LongDoubleSeq *owned =
+  const CORBA::LongDoubleSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::LongDoubleSeq>::get_value (this);
   return new CORBA::LongDoubleSeq (*owned);
 }
@@ -1130,7 +1130,7 @@ TAO_DynCommon::get_longdouble_seq (void)
 CORBA::WCharSeq *
 TAO_DynCommon::get_wchar_seq (void)
 {
-  CORBA::WCharSeq *owned =
+  const CORBA::WCharSeq *owned =
     TAO::DynAnyBasicTypeUtils<CORBA::WCharSeq>::get_value (this);
   return new CORBA::WCharSeq (*owned);
 }

--- a/TAO/tao/RTCORBA/RT_Policy_i.cpp
+++ b/TAO/tao/RTCORBA/RT_Policy_i.cpp
@@ -315,7 +315,7 @@ TAO_PriorityBandedConnectionPolicy::~TAO_PriorityBandedConnectionPolicy (void)
 CORBA::Policy_ptr
 TAO_PriorityBandedConnectionPolicy::create (const CORBA::Any &val)
 {
-  RTCORBA::PriorityBands *value = 0;
+  const RTCORBA::PriorityBands *value = 0;
   if (!(val >>= value))
     throw ::CORBA::PolicyError (CORBA::BAD_POLICY_VALUE);
 
@@ -421,7 +421,7 @@ TAO_ServerProtocolPolicy::~TAO_ServerProtocolPolicy (void)
 CORBA::Policy_ptr
 TAO_ServerProtocolPolicy::create (const CORBA::Any &val)
 {
-  RTCORBA::ProtocolList *value = 0;
+  const RTCORBA::ProtocolList *value = 0;
   if (!(val >>= value))
     throw ::CORBA::PolicyError (CORBA::BAD_POLICY_VALUE);
 
@@ -520,7 +520,7 @@ TAO_ClientProtocolPolicy::~TAO_ClientProtocolPolicy ()
 CORBA::Policy_ptr
 TAO_ClientProtocolPolicy::create (const CORBA::Any &val)
 {
-  RTCORBA::ProtocolList *value = 0;
+  const RTCORBA::ProtocolList *value = 0;
   if (!(val >>= value))
     throw ::CORBA::PolicyError (CORBA::BAD_POLICY_VALUE);
 

--- a/TAO/tao/Strategies/advanced_resource.h
+++ b/TAO/tao/Strategies/advanced_resource.h
@@ -111,9 +111,6 @@ protected:
   /// List of loaded protocol factories.
   TAO_ProtocolFactorySet protocol_factories_;
 
-  /// The type of reactor registry.
-  int reactor_registry_type_;
-
   /// Flag indicating which kind of reactor we should use.
   int reactor_type_;
 

--- a/TAO/tao/TAO_Server_Request.inl
+++ b/TAO/tao/TAO_Server_Request.inl
@@ -10,6 +10,7 @@ TAO_ServerRequest::TAO_ServerRequest (void)
     operation_ (0),
     operation_len_ (0),
     release_operation_ (false),
+    is_forwarded_ (false),
     incoming_ (0),
     outgoing_ (0),
     response_expected_ (false),

--- a/TAO/tao/ZIOP/ZIOP_PolicyFactory.cpp
+++ b/TAO/tao/ZIOP/ZIOP_PolicyFactory.cpp
@@ -38,7 +38,7 @@ TAO_ZIOP_PolicyFactory::create_policy (
     }
   case ZIOP::COMPRESSOR_ID_LEVEL_LIST_POLICY_ID :
     {
-      ::Compression::CompressorIdLevelList* val = 0;
+      const ::Compression::CompressorIdLevelList* val = 0;
 
       // Extract the value from the any.
       if (!(value >>= val))

--- a/TAO/tests/Any/Recursive/client.cpp
+++ b/TAO/tests/Any/Recursive/client.cpp
@@ -112,7 +112,7 @@ perform_invocation (Test::Hello_ptr hello,
       CORBA::Any_var my_any =
         hello->get_any (the_any);
 
-      T * my_foo = 0;
+      const T * my_foo = 0;
       if (!(my_any.in () >>= my_foo))
         throw Test::Demarshaling_From_Any_Failed ();
 

--- a/TAO/tests/Bug_2678_Regression/client.cpp
+++ b/TAO/tests/Bug_2678_Regression/client.cpp
@@ -67,14 +67,14 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
       for (CORBA::ULong count = 0; count < params->length(); ++count)
       {
-        Container* container = 0;
+        const Container* container = 0;
         if (!(params[count] >>= container))
         {
           ACE_ERROR ((LM_ERROR, "ERROR, failed extract\n"));
         }
         else
         {
-          Inner* inner = 0;
+          const Inner* inner = 0;
           if (!(container->contents >>= inner))
           {
             ACE_ERROR ((LM_ERROR, "ERROR, failed extract\n"));

--- a/TAO/tests/Bug_2678_Regression/server.cpp
+++ b/TAO/tests/Bug_2678_Regression/server.cpp
@@ -30,7 +30,7 @@ AnySeq *Test_impl::RunTest(const AnySeq &params)
   ACE_DEBUG ((LM_DEBUG, "RunTest: params.length == %d\n", params.length()));
   for (CORBA::ULong count = 0; count < params.length(); ++count)
   {
-    Container* container = 0;
+    const Container* container = 0;
     if (!(params[count] >>= container))
     {
       ACE_ERROR ((LM_ERROR, "ERROR, failed extract\n"));

--- a/TAO/tests/Bug_2678_Regression/server.cpp
+++ b/TAO/tests/Bug_2678_Regression/server.cpp
@@ -37,7 +37,7 @@ AnySeq *Test_impl::RunTest(const AnySeq &params)
     }
     else
     {
-      Inner* inner = 0;
+      const Inner* inner = 0;
       if (!(container->contents >>= inner))
       {
         ACE_ERROR ((LM_ERROR, "ERROR, failed extract\n"));

--- a/TAO/tests/Bug_2804_Regression/client.cpp
+++ b/TAO/tests/Bug_2804_Regression/client.cpp
@@ -51,7 +51,7 @@ perform_invocation (Test::Hello_ptr hello,
       CORBA::Any_var my_any =
         hello->get_any (the_any);
 
-      T * my_foo = 0;
+      const T * my_foo = 0;
       if (!(my_any.in () >>= my_foo))
         throw Test::Demarshaling_From_Any_Failed ();
 

--- a/TAO/tests/Bug_2844_Regression/client.cpp
+++ b/TAO/tests/Bug_2844_Regression/client.cpp
@@ -51,7 +51,7 @@ perform_invocation (Test::Hello_ptr hello,
       CORBA::Any_var my_any =
         hello->get_any (the_any);
 
-      T * my_foo = 0;
+      const T * my_foo = 0;
       if (!(my_any.in () >>= my_foo))
         throw Test::Demarshaling_From_Any_Failed ();
 

--- a/TAO/tests/Bug_2918_Regression/client.cpp
+++ b/TAO/tests/Bug_2918_Regression/client.cpp
@@ -50,7 +50,7 @@ perform_invocation (Test::Hello_ptr hello,
       CORBA::Any_var my_any =
         hello->get_any (the_any);
 
-      T * my_foo = 0;
+      const T * my_foo = 0;
       if (!(my_any.in () >>= my_foo))
         throw Test::Demarshaling_From_Any_Failed ();
 

--- a/TAO/tests/Bug_3506_Regression/server.cpp
+++ b/TAO/tests/Bug_3506_Regression/server.cpp
@@ -45,7 +45,7 @@ public:
   virtual void
   foo (const ::IF_EXE_M_R::Test_Struct &ts)
   {
-    IF_EXE_M_R::CORBA_FOOIInPlan *anUnion_p = new IF_EXE_M_R::CORBA_FOOIInPlan;
+    const IF_EXE_M_R::CORBA_FOOIInPlan *anUnion_p = new IF_EXE_M_R::CORBA_FOOIInPlan;
     if (ts.whatEver >>= anUnion_p)
       {
         ACE_DEBUG((LM_DEBUG, "Any successfully marshalled\nAny is %@\nID: %C\nNAME: %C\nKIND: %d\n", &ts.whatEver,

--- a/TAO/tests/Bug_3552_Regression/check.cpp
+++ b/TAO/tests/Bug_3552_Regression/check.cpp
@@ -67,7 +67,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       CORBA::Any_var
         decodedData = codec->decode (OctSeq);
       // And extract the actual struct (still owned by the any)
-      Test::theStruct *myStruct;
+      const Test::theStruct *myStruct = 0;
       if (decodedData.in () >>= myStruct)
         {
           if (!strcmp (myStruct->theString, "Hello"))

--- a/TAO/tests/Bug_3919_Regression/client.cpp
+++ b/TAO/tests/Bug_3919_Regression/client.cpp
@@ -51,7 +51,7 @@ perform_invocation (Test::Hello_ptr hello,
       CORBA::Any_var my_any =
         hello->get_any (the_any);
 
-      T * my_foo = 0;
+      const T * my_foo = 0;
       if (!(my_any.in () >>= my_foo))
         throw Test::Demarshaling_From_Any_Failed ();
 

--- a/TAO/tests/Codec/client.cpp
+++ b/TAO/tests/Codec/client.cpp
@@ -95,7 +95,7 @@ test_codec (IOP::Codec_ptr codec)
 
   CORBA::OctetSeq_var encoded_data;
   CORBA::Any_var decoded_data;
-  Foo::Bar *extracted_value = 0;
+  const Foo::Bar *extracted_value = 0;
 
   // Encode the structure into an octet sequence using the CDR
   // enscapsulation Codec.

--- a/TAO/tests/Codec/client.cpp
+++ b/TAO/tests/Codec/client.cpp
@@ -29,7 +29,7 @@ gen_wstring (CORBA::ULong max_length)
 }
 
 int
-verify_data (Foo::Bar *original, Foo::Bar *extracted)
+verify_data (Foo::Bar *original, const Foo::Bar *extracted)
 {
   if (!original || !extracted)
     return -1;

--- a/TAO/tests/DynAny_Test/test_dynany.cpp
+++ b/TAO/tests/DynAny_Test/test_dynany.cpp
@@ -304,7 +304,7 @@ Test_DynAny::run_test (void)
       analyzer.analyze (ftc3.in ());
       CORBA::Any_var out_any3 = ftc3->to_any ();
 
-      CORBA::ShortSeq *outseq = 0;
+      const CORBA::ShortSeq *outseq = 0;
       out_any3.in () >>= outseq;
 
       good =

--- a/TAO/tests/DynAny_Test/test_dynsequence.cpp
+++ b/TAO/tests/DynAny_Test/test_dynsequence.cpp
@@ -311,7 +311,7 @@ Test_DynSequence::run_test (void)
       CORBA::Any_var out_any1 =
         ftc1->to_any ();
 
-      DynAnyTests::test_seq *ts_out;
+      const DynAnyTests::test_seq *ts_out = 0;
       out_any1.in () >>= ts_out;
 
       if (!ACE_OS::strcmp ((*ts_out)[0U], data.m_string1))

--- a/TAO/tests/DynAny_Test/test_dynstruct.cpp
+++ b/TAO/tests/DynAny_Test/test_dynstruct.cpp
@@ -183,7 +183,7 @@ Test_DynStruct::run_test (void)
       CORBA::Any_var out_any1 =
         ftc1->to_any ();
 
-      DynAnyTests::test_struct* ts_out;
+      const DynAnyTests::test_struct* ts_out = 0;
       out_any1.in () >>= ts_out;
 
       if (ts_out->es.s == data.m_short1)

--- a/TAO/tests/IDL_Test/main.cpp
+++ b/TAO/tests/IDL_Test/main.cpp
@@ -337,7 +337,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       field.value._d (FTYPE_VARCHAR);
       CORBA::Any any1;
       any1 <<= field;
-      Field *outfield;
+      const Field *outfield = 0;
 
       if ((any1 >>= outfield) == 0)
         {

--- a/TAO/tests/Param_Test/any.cpp
+++ b/TAO/tests/Param_Test/any.cpp
@@ -215,7 +215,8 @@ Test_Any::reset_parameters (void)
 
         if (TAO_debug_level > 0)
           {
-            Param_Test::Big_Union *bu_in, *bu_inout;
+            const Param_Test::Big_Union *bu_in = 0;
+            const Param_Test::Big_Union *bu_inout = 0;
             this->in_ >>= bu_in;
             this->inout_ >>= bu_inout;
             ACE_DEBUG ((LM_DEBUG,
@@ -238,7 +239,8 @@ Test_Any::reset_parameters (void)
 
         if (TAO_debug_level > 0)
           {
-            Param_Test::Small_Union *bu_in, *bu_inout;
+            const Param_Test::Small_Union *bu_in = 0;
+            const Param_Test::Small_Union *bu_inout = 0;
             this->in_ >>= bu_in;
             this->inout_ >>= bu_inout;
             ACE_DEBUG ((LM_DEBUG,
@@ -280,11 +282,11 @@ Test_Any::check_validity (void)
   const char *str_ret;
   Coffee_ptr obj_in, obj_inout, obj_out, obj_ret;
   Param_Test::Fixed_Array_forany array_in, array_inout, array_out, array_ret;
-  Param_Test::Bounded_Short_Seq *bdss_in, *bdss_inout, *bdss_out, *bdss_ret;
-  CORBA::ShortSeq *ubss_in, *ubss_inout, *ubss_out, *ubss_ret;
-  Param_Test::Fixed_Struct *fs_in, *fs_inout, *fs_out, *fs_ret;
-  Param_Test::Big_Union *bu_in, *bu_inout, *bu_out, *bu_ret;
-  Param_Test::Small_Union *su_in, *su_inout, *su_out, *su_ret;
+  const Param_Test::Bounded_Short_Seq *bdss_in, *bdss_inout, *bdss_out, *bdss_ret;
+  const CORBA::ShortSeq *ubss_in, *ubss_inout, *ubss_out, *ubss_ret;
+  const Param_Test::Fixed_Struct *fs_in, *fs_inout, *fs_out, *fs_ret;
+  const Param_Test::Big_Union *bu_in, *bu_inout, *bu_out, *bu_ret;
+  const Param_Test::Small_Union *su_in, *su_inout, *su_out, *su_ret;
 
   if ((this->in_ >>= short_in) &&
       (this->inout_ >>= short_inout) &&

--- a/TAO/tests/Param_Test/anyop.cpp
+++ b/TAO/tests/Param_Test/anyop.cpp
@@ -240,7 +240,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             i->d = 3.1416;
 
             any <<= *i;
-            Param_Test::Fixed_Struct *o;
+            const Param_Test::Fixed_Struct *o = 0;
 
             if (!(any >>= o)
                 || o->l != i->l
@@ -288,7 +288,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
               }
 
             any <<= *i;
-            CORBA::LongSeq *o;
+            const CORBA::LongSeq *o = 0;
 
             if (!(any >>= o)
                 || (*i)[0] != (*o)[0]

--- a/TAO/tests/Param_Test/bd_array_seq.cpp
+++ b/TAO/tests/Param_Test/bd_array_seq.cpp
@@ -51,7 +51,7 @@ Test_Bounded_Array_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Bounded_ArraySeq *tmp;
+  const Param_Test::Bounded_ArraySeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Bounded_ArraySeq (*tmp);
 

--- a/TAO/tests/Param_Test/bd_short_seq.cpp
+++ b/TAO/tests/Param_Test/bd_short_seq.cpp
@@ -48,7 +48,7 @@ Test_Bounded_Short_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Bounded_Short_Seq *tmp;
+  const Param_Test::Bounded_Short_Seq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Bounded_Short_Seq (*tmp);
 

--- a/TAO/tests/Param_Test/bd_struct_seq.cpp
+++ b/TAO/tests/Param_Test/bd_struct_seq.cpp
@@ -51,7 +51,7 @@ Test_Bounded_Struct_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Bounded_StructSeq *tmp;
+  const Param_Test::Bounded_StructSeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Bounded_StructSeq (*tmp);
 

--- a/TAO/tests/Param_Test/big_union.cpp
+++ b/TAO/tests/Param_Test/big_union.cpp
@@ -47,7 +47,7 @@ Test_Big_Union::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Big_Union *tmp;
+  const Param_Test::Big_Union *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Big_Union (*tmp);
 

--- a/TAO/tests/Param_Test/complex_any.cpp
+++ b/TAO/tests/Param_Test/complex_any.cpp
@@ -174,8 +174,8 @@ Test_Complex_Any::run_sii_test (Param_Test_ptr objref)
 CORBA::Boolean
 Test_Complex_Any::check_validity (void)
 {
-  CORBA::AnySeq *level2_in_seq;
-  CORBA::AnySeq *level2_test_seq;
+  const CORBA::AnySeq *level2_in_seq = 0;
+  const CORBA::AnySeq *level2_test_seq = 0;
 
   if (!(this->in_ >>= level2_in_seq))
     return 0;

--- a/TAO/tests/Param_Test/complex_any.cpp
+++ b/TAO/tests/Param_Test/complex_any.cpp
@@ -215,8 +215,8 @@ Test_Complex_Any::comp_engine (const CORBA::AnySeq *level2_in_seq,
 
   for (CORBA::ULong i = 0; i < level2_in_seq->length (); i++)
     {
-      CORBA::AnySeq *level3_in_seq;
-      CORBA::AnySeq *level3_test_seq;
+      const CORBA::AnySeq *level3_in_seq = 0;
+      const CORBA::AnySeq *level3_test_seq = 0;
 
       if (!((*level2_in_seq)[i] >>= level3_in_seq))
         return 0;
@@ -232,8 +232,8 @@ Test_Complex_Any::comp_engine (const CORBA::AnySeq *level2_in_seq,
 
       for (CORBA::ULong j = 0; j < level3_in_seq->length (); j ++)
         {
-          Param_Test::level4 *level4_in_struct;
-          Param_Test::level4 *level4_test_struct;
+          const Param_Test::level4 *level4_in_struct = 0;
+          const Param_Test::level4 *level4_test_struct = 0;
 
           if (!((*level3_in_seq)[j] >>= level4_in_struct))
             return 0;
@@ -263,8 +263,8 @@ Test_Complex_Any::comp_engine (const CORBA::AnySeq *level2_in_seq,
           if (!((*level6_test_any) >>= level7_test_any))
             return 0;
 
-          Param_Test::level8 *level8_in_struct;
-          Param_Test::level8 *level8_test_struct;
+          const Param_Test::level8 *level8_in_struct = 0;
+          const Param_Test::level8 *level8_test_struct = 0;
 
           if (!((*level7_in_any) >>= level8_in_struct))
             return 0;

--- a/TAO/tests/Param_Test/except.cpp
+++ b/TAO/tests/Param_Test/except.cpp
@@ -70,8 +70,8 @@ Test_Exception::dii_req_invoke (CORBA::Request_ptr req)
     }
   catch (CORBA::UnknownUserException& user_ex)
     {
-      Param_Test::Ooops* oops;
-      Param_Test::BadBoy* bad_boy;
+      const Param_Test::Ooops* oops = 0;
+      const Param_Test::BadBoy* bad_boy = 0;
 
       if (user_ex.exception () >>= oops)
         {

--- a/TAO/tests/Param_Test/fixed_struct.cpp
+++ b/TAO/tests/Param_Test/fixed_struct.cpp
@@ -44,7 +44,7 @@ Test_Fixed_Struct::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Fixed_Struct *tmp;
+  const Param_Test::Fixed_Struct *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = *tmp;
 

--- a/TAO/tests/Param_Test/nested_struct.cpp
+++ b/TAO/tests/Param_Test/nested_struct.cpp
@@ -49,7 +49,7 @@ Test_Nested_Struct::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Nested_Struct *tmp;
+  const Param_Test::Nested_Struct *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Nested_Struct (*tmp);
 

--- a/TAO/tests/Param_Test/objref_struct.cpp
+++ b/TAO/tests/Param_Test/objref_struct.cpp
@@ -50,7 +50,7 @@ Test_Objref_Struct::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Objref_Struct *tmp;
+  const Param_Test::Objref_Struct *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Objref_Struct (*tmp);
 

--- a/TAO/tests/Param_Test/param_test_i.cpp
+++ b/TAO/tests/Param_Test/param_test_i.cpp
@@ -701,10 +701,10 @@ Param_Test_i::test_any (const CORBA::Any &a1,
   Coffee_ptr coffee;
   Param_Test::Fixed_Array_forany array;
   CORBA::ShortSeq *ub_short_sequence;
-  Param_Test::Bounded_Short_Seq *bd_short_sequence;
-  Param_Test::Fixed_Struct *fixed_structure;
-  Param_Test::Big_Union *big_union;
-  Param_Test::Small_Union *small_union;
+  const Param_Test::Bounded_Short_Seq *bd_short_sequence;
+  const Param_Test::Fixed_Struct *fixed_structure;
+  const Param_Test::Big_Union *big_union;
+  const Param_Test::Small_Union *small_union;
 
   a2 = a1;
   a3 = new CORBA::Any (a1);
@@ -795,7 +795,7 @@ Param_Test_i::test_any (const CORBA::Any &a1,
     }
   else if (a1 >>= big_union)
     {
-      Param_Test::Big_Union *bu_in, *bu_inout, *bu_out, *bu_ret;
+      const Param_Test::Big_Union *bu_in, *bu_inout, *bu_out, *bu_ret;
       a1 >>= bu_in;
 
       // Insert copies....
@@ -821,7 +821,7 @@ Param_Test_i::test_any (const CORBA::Any &a1,
     }
   else if (a1 >>= small_union)
     {
-      Param_Test::Small_Union *bu_in, *bu_inout, *bu_out, *bu_ret;
+      const Param_Test::Small_Union *bu_in, *bu_inout, *bu_out, *bu_ret;
       a1 >>= bu_in;
 
       // Insert copies....

--- a/TAO/tests/Param_Test/param_test_i.cpp
+++ b/TAO/tests/Param_Test/param_test_i.cpp
@@ -700,7 +700,7 @@ Param_Test_i::test_any (const CORBA::Any &a1,
   const char *str_in;
   Coffee_ptr coffee;
   Param_Test::Fixed_Array_forany array;
-  CORBA::ShortSeq *ub_short_sequence;
+  const CORBA::ShortSeq *ub_short_sequence;
   const Param_Test::Bounded_Short_Seq *bd_short_sequence;
   const Param_Test::Fixed_Struct *fixed_structure;
   const Param_Test::Big_Union *big_union;

--- a/TAO/tests/Param_Test/param_test_i.cpp
+++ b/TAO/tests/Param_Test/param_test_i.cpp
@@ -769,10 +769,11 @@ Param_Test_i::test_any (const CORBA::Any &a1,
             ACE_DEBUG ((LM_DEBUG, " %d", (*ub_short_sequence)[i]));
           ACE_DEBUG ((LM_DEBUG, "\n"));
         }
+      CORBA::ShortSeq newseq (*ub_short_sequence);
       for (size_t i = 0; i < ub_short_sequence->length (); i++)
-        (*ub_short_sequence)[i] = (CORBA::Short) (i * i);
-      a2   <<= *ub_short_sequence;
-      *ret <<= *ub_short_sequence;
+        newseq[i] = (CORBA::Short) (i * i);
+      a2   <<= newseq;
+      *ret <<= newseq;
     }
   else if (a1 >>= bd_short_sequence)
     {
@@ -783,10 +784,11 @@ Param_Test_i::test_any (const CORBA::Any &a1,
             ACE_DEBUG ((LM_DEBUG, " %d", (*bd_short_sequence)[i]));
           ACE_DEBUG ((LM_DEBUG, "\n"));
         }
+      Param_Test::Bounded_Short_Seq newseq (*bd_short_sequence);
       for (size_t i = 0; i < bd_short_sequence->length (); i++)
-        (*bd_short_sequence)[i] = (CORBA::Short) (i * i);
-      a2 <<= *bd_short_sequence;
-      *ret <<= *bd_short_sequence;
+        newseq[i] = (CORBA::Short) (i * i);
+      a2 <<= newseq;
+      *ret <<= newseq;
     }
   else if (a1 >>= fixed_structure)
     {

--- a/TAO/tests/Param_Test/recursive_struct.cpp
+++ b/TAO/tests/Param_Test/recursive_struct.cpp
@@ -50,7 +50,7 @@ Test_Recursive_Struct::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Recursive_Struct *tmp;
+  const Param_Test::Recursive_Struct *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Recursive_Struct (*tmp);
 

--- a/TAO/tests/Param_Test/recursive_union.cpp
+++ b/TAO/tests/Param_Test/recursive_union.cpp
@@ -49,7 +49,7 @@ Test_Recursive_Union::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Recursive_Union *tmp;
+  const Param_Test::Recursive_Union *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Recursive_Union (*tmp);
 

--- a/TAO/tests/Param_Test/small_union.cpp
+++ b/TAO/tests/Param_Test/small_union.cpp
@@ -47,7 +47,7 @@ Test_Small_Union::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Small_Union *tmp;
+  const Param_Test::Small_Union *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Small_Union (*tmp);
 

--- a/TAO/tests/Param_Test/ub_any_seq.cpp
+++ b/TAO/tests/Param_Test/ub_any_seq.cpp
@@ -53,7 +53,7 @@ Test_AnySeq::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  CORBA::AnySeq* tmp;
+  const CORBA::AnySeq* tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new CORBA::AnySeq (*tmp);
 

--- a/TAO/tests/Param_Test/ub_array_seq.cpp
+++ b/TAO/tests/Param_Test/ub_array_seq.cpp
@@ -50,7 +50,7 @@ Test_Array_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::ArraySeq *tmp;
+  const Param_Test::ArraySeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::ArraySeq (*tmp);
 

--- a/TAO/tests/Param_Test/ub_long_seq.cpp
+++ b/TAO/tests/Param_Test/ub_long_seq.cpp
@@ -49,7 +49,7 @@ Test_Long_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  CORBA::LongSeq *tmp;
+  const CORBA::LongSeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = CORBA::LongSeq (*tmp);
 

--- a/TAO/tests/Param_Test/ub_objref_seq.cpp
+++ b/TAO/tests/Param_Test/ub_objref_seq.cpp
@@ -59,7 +59,7 @@ Test_ObjRef_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Coffee_Mix *tmp;
+  const Param_Test::Coffee_Mix *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Coffee_Mix (*tmp);
 

--- a/TAO/tests/Param_Test/ub_short_seq.cpp
+++ b/TAO/tests/Param_Test/ub_short_seq.cpp
@@ -49,7 +49,7 @@ Test_Short_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  CORBA::ShortSeq *tmp;
+  const CORBA::ShortSeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new CORBA::ShortSeq (*tmp);
 

--- a/TAO/tests/Param_Test/ub_str_seq.cpp
+++ b/TAO/tests/Param_Test/ub_str_seq.cpp
@@ -49,7 +49,7 @@ Test_String_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  CORBA::StringSeq *tmp;
+  const CORBA::StringSeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new CORBA::StringSeq (*tmp);
 

--- a/TAO/tests/Param_Test/ub_struct_seq.cpp
+++ b/TAO/tests/Param_Test/ub_struct_seq.cpp
@@ -248,7 +248,7 @@ Test_Unbounded_Struct_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::PathSpec *tmp;
+  const Param_Test::PathSpec *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::PathSpec (*tmp);
 

--- a/TAO/tests/Param_Test/ub_struct_seq.cpp
+++ b/TAO/tests/Param_Test/ub_struct_seq.cpp
@@ -51,7 +51,7 @@ Test_Struct_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::StructSeq *tmp;
+  const Param_Test::StructSeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::StructSeq (*tmp);
 

--- a/TAO/tests/Param_Test/ub_wstr_seq.cpp
+++ b/TAO/tests/Param_Test/ub_wstr_seq.cpp
@@ -50,7 +50,7 @@ Test_WString_Sequence::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  CORBA::WStringSeq *tmp;
+  const CORBA::WStringSeq *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new CORBA::WStringSeq (*tmp);
 

--- a/TAO/tests/Param_Test/var_struct.cpp
+++ b/TAO/tests/Param_Test/var_struct.cpp
@@ -50,7 +50,7 @@ Test_Var_Struct::dii_req_invoke (CORBA::Request *req)
 
   req->invoke ();
 
-  Param_Test::Var_Struct *tmp;
+  const Param_Test::Var_Struct *tmp = 0;
   req->return_value () >>= tmp;
   this->ret_ = new Param_Test::Var_Struct (*tmp);
 

--- a/TAO/tests/Portable_Interceptors/Benchmark/client_interceptors.cpp
+++ b/TAO/tests/Portable_Interceptors/Benchmark/client_interceptors.cpp
@@ -66,7 +66,7 @@ Vault_Client_Request_Interceptor::send_request (
       Dynamic::ParameterList_var paramlist =
         ri->arguments ();
 
-      Test_Interceptors::Secure_Vault::Record *record;
+      const Test_Interceptors::Secure_Vault::Record *record = 0;
       CORBA::Long id;
       CORBA::ULong i = 0;  // index -- explicitly used to avoid
                            // overloaded operator ambiguity.
@@ -261,7 +261,7 @@ Vault_Client_Request_Dynamic_Interceptor::send_request (
       Dynamic::ParameterList_var paramlist =
         ri->arguments ();
 
-      Test_Interceptors::Secure_Vault::Record *record;
+      const Test_Interceptors::Secure_Vault::Record *record = 0;
       CORBA::Long id;
       CORBA::ULong i = 0;  // index -- explicitly used to avoid
                            // overloaded operator ambiguity.

--- a/TAO/tests/Portable_Interceptors/Benchmark/server_interceptors.cpp
+++ b/TAO/tests/Portable_Interceptors/Benchmark/server_interceptors.cpp
@@ -60,7 +60,7 @@ Vault_Server_Request_Interceptor::receive_request (
       Dynamic::ParameterList_var paramlist =
         ri->arguments ();
 
-      Test_Interceptors::Secure_Vault::Record *record;
+      const Test_Interceptors::Secure_Vault::Record *record = 0;
       CORBA::Long id;
       CORBA::ULong i = 0;  // index -- explicitly used to avoid
                            // overloaded operator ambiguity.
@@ -209,7 +209,7 @@ Vault_Server_Request_Dynamic_Interceptor::receive_request (
       Dynamic::ParameterList_var paramlist =
         ri->arguments ();
 
-      Test_Interceptors::Secure_Vault::Record *record;
+      const Test_Interceptors::Secure_Vault::Record *record = 0;
       CORBA::Long id;
       CORBA::ULong i = 0;  // index -- explicitly used to avoid
                            // overloaded operator ambiguity.

--- a/TAO/tests/Portable_Interceptors/Dynamic/client_interceptor.cpp
+++ b/TAO/tests/Portable_Interceptors/Dynamic/client_interceptor.cpp
@@ -210,7 +210,7 @@ Echo_Client_Request_Interceptor::receive_reply (
     {
       CORBA::Any_var a = ri->result ();
 
-      Test_Interceptors::Visual::VarLenStruct * v;
+      const Test_Interceptors::Visual::VarLenStruct * v = 0;
 
       (a.in ()) >>= v;
 


### PR DESCRIPTION
These are deprecated within the IDL to C++ specification for a long time. Reduces footprint and simplifies the code. Make sure you are using 'const Foo*' as extraction type for Foo instead of 'Foo*'.