### PR TITLE
ACE_HAS_GCC_ATOMIC_BUILTINS should be defined for clang

### DIFF
--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -146,9 +146,6 @@
   // this must appear before its #include.
 # define ACE_HAS_STRING_CLASS
 # include "ace/config-g++-common.h"
-# ifdef __clang__
-#  undef ACE_HAS_GCC_ATOMIC_BUILTINS
-# endif
 #elif defined (__SUNCC_PRO) || defined (__SUNPRO_CC)
 # include "ace/config-suncc-common.h"
 #elif defined (__PGI)

--- a/ACE/ace/config-macosx-lion.h
+++ b/ACE/ace/config-macosx-lion.h
@@ -4,10 +4,6 @@
 #include "ace/config-macosx-leopard.h"
 
 #ifdef __clang__
-# ifdef ACE_HAS_GCC_ATOMIC_BUILTINS
-# undef ACE_HAS_GCC_ATOMIC_BUILTINS
-# endif
-
 # define ACE_ANY_OPS_USE_NAMESPACE
 #endif /* __clang__ */
 

--- a/ACE/ace/config-macosx-snowleopard.h
+++ b/ACE/ace/config-macosx-snowleopard.h
@@ -4,12 +4,7 @@
 #include "ace/config-macosx-leopard.h"
 
 #ifdef __clang__
-#ifdef ACE_HAS_GCC_ATOMIC_BUILTINS
-#undef ACE_HAS_GCC_ATOMIC_BUILTINS
-#endif
-
 #define ACE_ANY_OPS_USE_NAMESPACE
-
 #endif
 
 #define ACE_LACKS_UCONTEXT_H


### PR DESCRIPTION
Making pull request upon request.  
More info can be found on [mailing lists](http://list.isis.vanderbilt.edu/pipermail/ace-bugs/2017-January/000032.html).