### PR TITLE
Test and Potential Fix for Issue #363 Native Windows Condition Variables do not set errno to ETIME

### DIFF
--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -1623,7 +1623,15 @@ ACE_OS::cond_timedwait (ACE_cond_t *cv,
   ACE_OSCALL (ACE_ADAPT_RETVAL (::SleepConditionVariableCS (cv, external_mutex, msec_timeout),
                                 result),
               int, -1, result);
+
+  // Make sure we mutate errno if required
+  if (result == -1)
+  {
+      ACE_FAIL_RETURN(result);
+  }
+
   return result;
+
 #else
   // Prevent race conditions on the <waiters_> count.
   if (ACE_OS::thread_mutex_lock (&cv->waiters_lock_) != 0)

--- a/ACE/ace/OS_NS_macros.h
+++ b/ACE/ace/OS_NS_macros.h
@@ -62,6 +62,7 @@
   case ERROR_FILE_EXISTS:       errno = EEXIST; break; \
   case ERROR_SHARING_VIOLATION: errno = EACCES; break; \
   case ERROR_PATH_NOT_FOUND:    errno = ENOENT; break; \
+  case ERROR_TIMEOUT:           errno = ETIME;  break; \
   } \
   return RESULT; } while (0)
 

--- a/ACE/tests/Native_Condition_Variable_Test.cpp
+++ b/ACE/tests/Native_Condition_Variable_Test.cpp
@@ -1,0 +1,47 @@
+
+//=============================================================================
+/**
+ *  @file    Native_Condition_Variable_Test.cpp
+ *
+ *    This program tests the support of Native Condition Variables on
+ *    Microsoft Windows. It checks that errno is correctly mutated to
+ *    ensure return and errno values are consistent across implementations
+ *    using ACE_Condition.
+ *
+ *  @author Michael Mathers <michael.p.mathers@live.com>
+ */
+//=============================================================================
+
+
+#include "test_config.h"
+#include "ace/Condition_T.h"
+#include "ace/Guard_T.h"
+
+
+int
+run_main(int, ACE_TCHAR *[])
+{
+    ACE_START_TEST(ACE_TEXT("Native_Condition_Variable_Test"));
+
+    ACE_SYNCH_MUTEX mutex;
+    ACE_Condition<ACE_SYNCH_MUTEX> cond(mutex);
+    ACE_Time_Value timeout(1, 0);
+    bool condition = false; // Condition we are waiting on - will never changed (never intentionally signalled)
+    int result = 0;
+
+    // Place the wait within a loop such that we don't just pass on account of a spurious wakeup
+    while (!condition && !(result == -1))
+    {
+        ACE_Guard<ACE_SYNCH_MUTEX> guard(mutex);
+        result = cond.wait(&timeout);
+    }
+
+    // We should've timed out waiting for the condition variable to be signalled
+    // Expected behavior is to return -1 and have errno set to ETIME
+    // Note that native Windows condition variable will set errno to ERROR_TIMEOUT instead (mutation required)
+    ACE_TEST_ASSERT(result == -1);
+    ACE_TEST_ASSERT(ACE_OS::last_error() == ETIME);
+
+    ACE_END_TEST;
+    return 0;
+}

--- a/ACE/tests/run_test.lst
+++ b/ACE/tests/run_test.lst
@@ -170,6 +170,7 @@ Monotonic_Task_Test: !ACE_FOR_TAO
 Multicast_Test: !ST !NO_MCAST !nsk !LynxOS !LabVIEW_RT
 Multihomed_INET_Addr_Test: !ACE_FOR_TAO
 Naming_Test: !NO_OTHER !LynxOS !VxWorks !nsk !ACE_FOR_TAO !PHARLAP
+Native_Condition_Variable_Test
 Network_Adapters_Test: !ACE_FOR_TAO
 New_Fail_Test: ALL !DISABLED
 NonBlocking_Conn_Test

--- a/ACE/tests/tests.mpc
+++ b/ACE/tests/tests.mpc
@@ -2236,3 +2236,12 @@ project(Missing_Svc_Conf_Test) : acetest {
     Missing_Svc_Conf_Test.cpp
   }
 }
+
+
+project(Native_Condition_Variable_Test) : acetest {
+  exename = *
+  Source_Files {
+    Native_Condition_Variable_Test.cpp
+  }
+}
+


### PR DESCRIPTION
- Added a really simple test for the return value and errno combination expected when a wait on a condition variable times out. Project name is Native_Condition_Variable_Test.
- Added new test onto the list for automatic testing via run_test.lst
- Added an additional case to the ACE_FAIL_RETURN macro to mutate ERROR_TIMEOUT into ETIME.
- Added an additional check at the end of the implementation of ACE_Condition<T>::wait(const ACE_Time_Value*) to mutate WIN32 errors into errno (as expected).

It might be worth considering revisiting the MSVC configuration files to enable ACE_HAS_WTHREADS_CONDITION_VARIABLE (with appropriate include statements) for Windows Vista/Server2008 and beyond.