### PR TITLE
Fix compiler issues on macOS with ACE_FACE_SAFETY* defined

### DIFF
--- a/ACE/ace/Pipe.cpp
+++ b/ACE/ace/Pipe.cpp
@@ -55,7 +55,7 @@ ACE_Pipe::open (int buffer_size)
     }
 
   sockaddr_un addr = {
-#ifdef ACE_VXWORKS
+#if defined(ACE_VXWORKS) || defined(__APPLE__)
     sizeof (sockaddr_un),
 #endif
     AF_LOCAL, {}};

--- a/ACE/ace/Shared_Memory_Pool.cpp
+++ b/ACE/ace/Shared_Memory_Pool.cpp
@@ -123,7 +123,7 @@ ACE_Shared_Memory_Pool::commit_backing_store_name (size_t rounded_bytes,
                       "exceeded max number of segments = %d, base = %u, offset = %u\n",
                        counter,
                        this->base_addr_,
-                       offset),
+                       static_cast<unsigned int>(offset)),
                       -1);
   else
     {


### PR DESCRIPTION
The fix allows ACE to compile on macOS when ACE_FACE_SAFETY_BASE or ACE_FACE_SAFETY_EXTENDED is defined.