### PR TITLE
When ACE_HAS_FD_MASK has not been defined we set ACE_LACKS_FD_MASK

### DIFF
--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -338,10 +338,8 @@
 # define ACE_HAS_UCONTEXT_T
 #endif
 
-#if __ANDROID_API__ < 24
+#if !defined ACE_HAS_FD_MASK
 # define ACE_LACKS_FD_MASK
-#else
-# define ACE_HAS_FD_MASK
 #endif
 
 #if __ANDROID_API__ >= 9


### PR DESCRIPTION
    * ACE/ace/config-android.h: