### PR TITLE
When __cplusplus is larger than 201402L we have C++17 support so set …

### DIFF
--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -38,6 +38,9 @@
 # if __cplusplus > 201103L
 #  define ACE_HAS_CPP14
 # endif
+# if __cplusplus > 201402L
+#  define ACE_HAS_CPP17
+# endif
 #endif
 
 #if (defined (i386) || defined (__i386__)) && !defined (ACE_SIZEOF_LONG_DOUBLE)


### PR DESCRIPTION
…ACE_HAS_CPP17

    * ACE/ace/config-g++-common.h: