### PR TITLE
Removed ACE_IS_SPLITTING, simplifies our code

### DIFF
--- a/ACE/ace/Capabilities.cpp
+++ b/ACE/ace/Capabilities.cpp
@@ -283,7 +283,6 @@ ACE_Capabilities::getval (const ACE_TCHAR *keyname, int &val)
   return 0;
 }
 
-#if !defined (ACE_IS_SPLITTING)
 static int
 is_empty (const ACE_TCHAR *line)
 {
@@ -301,7 +300,6 @@ is_line (const ACE_TCHAR *line)
 
   return *line != ACE_TEXT ('\0');
 }
-#endif /* !ACE_IS_SPLITTING */
 
 int
 ACE_Capabilities::getent (const ACE_TCHAR *fname, const ACE_TCHAR *name)

--- a/ACE/ace/Capabilities.h
+++ b/ACE/ace/Capabilities.h
@@ -25,11 +25,6 @@
 #include "ace/SString.h"
 #include "ace/Functor_String.h"
 
-#if defined (ACE_IS_SPLITTING)
-# include "ace/OS_NS_ctype.h"
-#endif  /* ACE_IS_SPLITTING */
-
-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /**
@@ -191,26 +186,6 @@ private:
   /// This is the set of ACE_CapEntry.
   CAPABILITIES_MAP caps_;
 };
-
-#if defined (ACE_IS_SPLITTING)
-int
-is_empty (const ACE_TCHAR *line)
-{
-  while (*line && ACE_OS::ace_isspace (*line))
-    ++line;
-
-  return *line == ACE_TEXT ('\0') || *line == ACE_TEXT ('#');
-}
-
-int
-is_line (const ACE_TCHAR *line)
-{
-  while (*line && ACE_OS::ace_isspace (*line))
-    ++line;
-
-  return *line != ACE_TEXT ('\0');
-}
-#endif /* ACE_IS_SPLITTING */
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -367,7 +367,7 @@ ACE_TSS_Ref::operator== (const ACE_TSS_Ref &info) const
 }
 
 // Check for inequality.
-ACE_SPECIAL_INLINE
+ACE_INLINE
 bool
 ACE_TSS_Ref::operator != (const ACE_TSS_Ref &tss_ref) const
 {
@@ -441,7 +441,7 @@ ACE_TSS_Keys::ACE_TSS_Keys (void)
     }
 }
 
-ACE_SPECIAL_INLINE
+ACE_INLINE
 void
 ACE_TSS_Keys::find (const u_int key, u_int &word, u_int &bit)
 {

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -367,7 +367,6 @@ ACE_TSS_Ref::operator== (const ACE_TSS_Ref &info) const
 }
 
 // Check for inequality.
-ACE_INLINE
 bool
 ACE_TSS_Ref::operator != (const ACE_TSS_Ref &tss_ref) const
 {
@@ -441,7 +440,7 @@ ACE_TSS_Keys::ACE_TSS_Keys (void)
     }
 }
 
-ACE_INLINE
+
 void
 ACE_TSS_Keys::find (const u_int key, u_int &word, u_int &bit)
 {

--- a/ACE/ace/OS_NS_Thread.inl
+++ b/ACE/ace/OS_NS_Thread.inl
@@ -3801,13 +3801,6 @@ ACE_OS::thread_mutex_unlock (ACE_thread_mutex_t *m)
 
 /*****************************************************************************/
 
-# if defined (ACE_IS_SPLITTING)
-#   define ACE_SPECIAL_INLINE
-# else
-#   define ACE_SPECIAL_INLINE ACE_INLINE
-//#   define ACE_SPECIAL_INLINE inline
-# endif
-
 #if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
 
 ACE_INLINE

--- a/ACE/ace/Object_Manager.cpp
+++ b/ACE/ace/Object_Manager.cpp
@@ -893,13 +893,10 @@ static ACE_Object_Manager_Manager ACE_Object_Manager_Manager_instance;
 
 #if defined (ACE_HAS_THREADS)
 
-// hack to get around errors while compiling using split-cpp
-#if !defined (ACE_IS_SPLITTING)
 // This is global so that it doesn't have to be declared in the header
 // file.  That would cause nasty circular include problems.
 typedef ACE_Cleanup_Adapter<ACE_Recursive_Thread_Mutex> ACE_Static_Object_Lock_Type;
 static ACE_Static_Object_Lock_Type *ACE_Static_Object_Lock_lock = 0;
-#endif /* ! ACE_IS_SPLITTING */
 
 // ACE_SHOULD_MALLOC_STATIC_OBJECT_LOCK isn't (currently) used by ACE.
 // But, applications may find it useful for avoiding recursive calls

--- a/ACE/ace/Static_Object_Lock.h
+++ b/ACE/ace/Static_Object_Lock.h
@@ -51,26 +51,5 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 
 #endif /* ACE_HAS_THREADS */
 
-// hack to get around errors while compiling using split-cpp
-#if defined (ACE_HAS_THREADS)
-
-ACE_BEGIN_VERSIONED_NAMESPACE_DECL
-
-# if defined (ACE_IS_SPLITTING)
-typedef ACE_Cleanup_Adapter<ACE_Recursive_Thread_Mutex> ACE_Static_Object_Lock_Type;
-
-#  if defined (__GNUC__)
-// With g++, suppress the warning that this is unused.
-static ACE_Static_Object_Lock_Type *ACE_Static_Object_Lock_lock __attribute__ ((unused)) = 0;
-#  else
-static ACE_Static_Object_Lock_Type *ACE_Static_Object_Lock_lock = 0;
-#  endif /* __GNUC__ */
-
-# endif /* ACE_IS_SPLITTING */
-
-ACE_END_VERSIONED_NAMESPACE_DECL
-
-#endif /* ACE_HAS_THREADS */
-
 #include /**/ "ace/post.h"
 #endif /* ACE_STATIC_OBJECT_LOCK_H */


### PR DESCRIPTION
    * ACE/ace/Capabilities.cpp:
    * ACE/ace/Capabilities.h:
    * ACE/ace/OS_NS_Thread.cpp:
    * ACE/ace/OS_NS_Thread.inl:
    * ACE/ace/Object_Manager.cpp:
    * ACE/ace/Static_Object_Lock.h: