### PR TITLE
Use ACE_WIN32 and bcc32c doesn't set __WIN32__ but uses _WIN32

### DIFF
--- a/ACE/ASNMP/asnmp/octet.cpp
+++ b/ACE/ASNMP/asnmp/octet.cpp
@@ -572,11 +572,11 @@ const char *OctetStr::to_string_hex()
 
 // TODO: verify ACE_OS:: on NT works like this or not
 
-#if defined(_WIN32)
+#if defined(ACE_WIN32)
     const char *fmt = "   %s\r\n";
 #else
     const char *fmt = "   %s\n";
-#endif // _WIN32
+#endif // ACE_WIN32
 
     ACE_OS::sprintf(line_ptr, fmt, char_buf);
     line_ptr += 3 + ACE_OS::strlen(char_buf);

--- a/ACE/ASNMP/tests/Counter64_Test.cpp
+++ b/ACE/ASNMP/tests/Counter64_Test.cpp
@@ -38,7 +38,7 @@ DAMAGES.
 #include "test_config.h"
 
 // TODO: verify this with ACE folks
-#if defined(_WIN32)
+#if defined(ACE_WIN32)
 #define LLONG __int64
 #define ULLONG unsigned __int64
 #else

--- a/ACE/ace/Configuration_Import_Export.cpp
+++ b/ACE/ace/Configuration_Import_Export.cpp
@@ -365,11 +365,9 @@ ACE_Registry_ImpExp::export_section (const ACE_Configuration_Section_Key& sectio
                 line += string_value + ACE_TEXT ("\"");
                 break;
               }
-#ifdef _WIN32
+#ifdef ACE_WIN32
             case ACE_Configuration::INVALID:
-              break;  // JDO added break.  Otherwise INVALID is processed
-              // like BINARY. If that's correct, please remove the
-              // break and these comments
+              break;
 #endif
             case ACE_Configuration::BINARY:
               {

--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -35,11 +35,11 @@
 # define ACE_CC_PREPROCESSOR_ARGS "-q -Sl -o%s"
 #endif
 
-// Automatically define WIN32 macro if the compiler tells us it is our
-// target platform.
-# if defined (__WIN32__) && !defined (WIN32)
+#if !defined (WIN32)
+# if defined (__WIN32__) || defined (_WIN32)
 #  define WIN32 1
 # endif
+#endif
 
 // When building a VCL application, the main VCL header file should be
 // included before anything else. You can define ACE_HAS_VCL=1 in your

--- a/ACE/examples/Mem_Map/IO-tests/IO_Test.cpp
+++ b/ACE/examples/Mem_Map/IO-tests/IO_Test.cpp
@@ -1,5 +1,3 @@
-#if !defined(_WIN32)
-
 #include "ace/OS_NS_string.h"
 #include "ace/OS_NS_unistd.h"
 #include "ace/OS_NS_stdio.h"
@@ -7,8 +5,7 @@
 #include "ace/Log_Msg.h"
 #include "IO_Test.h"
 
-
-
+#if !defined(ACE_WIN32)
 
 
 IO_Test::IO_Test (const char *name,

--- a/ACE/examples/Mem_Map/IO-tests/test_io.cpp
+++ b/ACE/examples/Mem_Map/IO-tests/test_io.cpp
@@ -9,9 +9,7 @@
 #include "ace/Log_Msg.h"
 #include "IO_Test.h"
 
-
-
-#if !defined(_WIN32)
+#if !defined(ACE_WIN32)
 
 // Name of program.
 static const ACE_TCHAR *program_name;

--- a/TAO/tao/orbconf.h
+++ b/TAO/tao/orbconf.h
@@ -202,15 +202,6 @@ const size_t TAO_DEFAULT_VALUE_FACTORY_TABLE_SIZE = 128;
 
 #define TAO_HAS_EXCEPTIONS
 
-// BC++ seems to have a different convention for detecting Win32 than
-// VC++.
-
-#if defined (__WIN32__)
-# if !defined(_WIN32)
-#   define _WIN32
-# endif /* !defined(_WIN32) */
-#endif /* __WIN32__ */
-
 // Define if your processor does not store words with the most significant
 // byte first.
 

--- a/TAO/tao/orbconf.h
+++ b/TAO/tao/orbconf.h
@@ -217,15 +217,6 @@ const size_t TAO_DEFAULT_VALUE_FACTORY_TABLE_SIZE = 128;
                                      the value = 0 */
 #endif /* ! ACE_LITTLE_ENDIAN */
 
-// Define as the return type of signal handlers (int or void).
-#define RETSIGTYPE void
-
-// Define if you don't have vprintf but do have _doprnt.
-/* #undef HAVE_DOPRNT */
-
-// Define if you have the vprintf function.
-#define HAVE_VPRINTF 1
-
 // Comment out to enable only ACE monitors...
 #if defined (ACE_HAS_MONITOR_FRAMEWORK) && (ACE_HAS_MONITOR_FRAMEWORK == 1)
 #  define TAO_HAS_MONITOR_FRAMEWORK 1


### PR DESCRIPTION
    * ACE/ASNMP/asnmp/octet.cpp:
    * ACE/ASNMP/tests/Counter64_Test.cpp:
    * ACE/ace/Configuration_Import_Export.cpp:
    * ACE/ace/config-win32-borland.h:
    * ACE/examples/Mem_Map/IO-tests/IO_Test.cpp:
    * ACE/examples/Mem_Map/IO-tests/test_io.cpp:
    * TAO/tao/orbconf.h: