### PR TITLE
Fixing build for Oracle DeveloperStudio12.5 (C++ 5.14)

### DIFF
--- a/ACE/ace/config-lite.h
+++ b/ACE/ace/config-lite.h
@@ -114,7 +114,7 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 // Once all C++ compilers support the standard reverse_iterator
 // adapters, we can drop this generator macro or at least drop the
 // MSVC++ or Sun Studio preprocessor conditional blocks.
-#if defined (__SUNPRO_CC) && __SUNPRO_CC <= 0x5130 \
+#if defined (__SUNPRO_CC) && __SUNPRO_CC <= 0x5140 \
       && !defined (_STLPORT_VERSION)
   // If we're not using the stlport4 C++ library (which has standard
   // iterators), we need to ensure this is included in order to test
@@ -129,7 +129,7 @@ ACE_END_VERSIONED_NAMESPACE_DECL
   typedef std::reverse_iterator<iterator, value_type> reverse_iterator; \
   typedef std::reverse_iterator<const_iterator, \
                                 value_type const> const_reverse_iterator;
-#elif defined (__SUNPRO_CC) && __SUNPRO_CC <= 0x5130 \
+#elif defined (__SUNPRO_CC) && __SUNPRO_CC <= 0x5140 \
       && defined (_RWSTD_NO_CLASS_PARTIAL_SPEC)
 # define ACE_DECLARE_STL_REVERSE_ITERATORS \
   typedef std::reverse_iterator<iterator, \

--- a/ACE/ace/config-sunos5.10.h
+++ b/ACE/ace/config-sunos5.10.h
@@ -59,4 +59,9 @@
 
 #define ACE_HAS_SOLARIS_ATOMIC_LIB
 
+// Solaris Studio 12.4 implements symbol lookup correctly.
+#if defined (__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
+#define ACE_ANY_OPS_USE_NAMESPACE
+#endif
+
 #endif /* ACE_CONFIG_H */

--- a/TAO/orbsvcs/tests/CosEvent/Basic/Random.cpp
+++ b/TAO/orbsvcs/tests/CosEvent/Basic/Random.cpp
@@ -344,12 +344,6 @@ RND_Consumer::push (const CORBA::Any &event)
 }
 
 void
-RND_Timer::push (const CORBA::Any &event)
-{
-   RND_Consumer::push(event);
-}
-
-void
 RND_Consumer::disconnect_push_consumer (void)
 {
 }

--- a/TAO/orbsvcs/tests/CosEvent/Basic/Random.cpp
+++ b/TAO/orbsvcs/tests/CosEvent/Basic/Random.cpp
@@ -344,6 +344,12 @@ RND_Consumer::push (const CORBA::Any &event)
 }
 
 void
+RND_Timer::push (const CORBA::Any &event)
+{
+   RND_Consumer::push(event);
+}
+
+void
 RND_Consumer::disconnect_push_consumer (void)
 {
 }

--- a/TAO/orbsvcs/tests/CosEvent/Basic/Random.h
+++ b/TAO/orbsvcs/tests/CosEvent/Basic/Random.h
@@ -67,8 +67,6 @@ class RND_Timer : public RND_Consumer
 {
 public:
   RND_Timer (RND_Driver *driver);
-
-  void push (const CORBA::Any &event);
 };
 
 inline

--- a/TAO/tests/IDL_Test/union.idl
+++ b/TAO/tests/IDL_Test/union.idl
@@ -56,7 +56,7 @@ module Necessary
 // At the moment, the SunCC preprocessor separates the negative
 // sign from the number.  This causes problems for the scanner/lexer
 // used by tao_idl.
-#if !defined (__SUNPRO_CC) || (__SUNPRO_CC > 0x5120)
+#if !defined (__SUNPRO_CC) || (__SUNPRO_CC > 0x5140)
 union foo switch (short)
 {
   case -3:


### PR DESCRIPTION
These changes were necessary to get a complete successful build with the Oracle's developerstudio12.5 on Solaris 11.3 including examples and tests. 

I'm not sure whether the tests are also run, or merely compiled with a plain "make" within each of ACE_ROOT and TAO_ROOT.

I can't test it on any other platform, but I am positive that these changes would fix more than break.

Having someone test it e.g. with DeveloperStudio12.5 on Linux (just to be safe) wouldn't hurt, though.
