### PR TITLE
Disable deprecated warnings when using clang

### DIFF
--- a/ACE/ace/OS_NS_sys_utsname.cpp
+++ b/ACE/ace/OS_NS_sys_utsname.cpp
@@ -27,9 +27,16 @@ ACE_OS::uname (ACE_utsname *name)
   /* Since MS found it necessary to deprecate these. */
 #   pragma warning(push)
 #   pragma warning(disable:4996)
+#   if defined(__clang__)
+#     pragma clang diagnostic push
+#     pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#   endif /* __clang__ */
   ACE_TEXT_OSVERSIONINFO vinfo;
   vinfo.dwOSVersionInfoSize = sizeof(ACE_TEXT_OSVERSIONINFO);
   ACE_TEXT_GetVersionEx (&vinfo);
+#   if defined(__clang__)
+#     pragma clang diagnostic pop
+#   endif /* __clang__ */
 #   pragma warning(pop)
 # endif
 

--- a/ACE/ace/Object_Manager_Base.cpp
+++ b/ACE/ace/Object_Manager_Base.cpp
@@ -282,9 +282,16 @@ ACE_OS_Object_Manager::init (void)
 /* Since MS found it necessary to deprecate these. */
 #   pragma warning(push)
 #   pragma warning(disable:4996)
+#   if defined(__clang__)
+#     pragma clang diagnostic push
+#     pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#   endif /* __clang__ */
       ACE_OS::win32_versioninfo_.dwOSVersionInfoSize =
         sizeof (ACE_TEXT_OSVERSIONINFO);
       ACE_TEXT_GetVersionEx (&ACE_OS::win32_versioninfo_);
+#   if defined(__clang__)
+#     pragma clang diagnostic pop
+#   endif /* __clang__ */
 #   pragma warning(pop)
 # endif /* ACE_WIN32 */
       return 0;

--- a/ACE/tests/tests.mpc
+++ b/ACE/tests/tests.mpc
@@ -678,7 +678,9 @@ project(Compiler_Features_16_Test) : acetest {
   Source_Files {
     Compiler_Features_16_Test.cpp
   }
-  macros      += NOMINMAX // Don't #define min and max in Win32 headers
+  specific(prop:microsoft) {
+    macros      += NOMINMAX // Don't #define min and max in Win32 headers
+  }
 }
 
 project(Compiler_Features_17_Test) : acetest {
@@ -686,7 +688,9 @@ project(Compiler_Features_17_Test) : acetest {
   Source_Files {
     Compiler_Features_17_Test.cpp
   }
-  macros      += NOMINMAX // Don't #define min and max in Win32 headers
+  specific(prop:microsoft) {
+    macros      += NOMINMAX // Don't #define min and max in Win32 headers
+  }
 }
 
 project(Compiler_Features_18_Test) : acetest {


### PR DESCRIPTION
    * ACE/ace/OS_NS_sys_utsname.cpp:
    * ACE/ace/Object_Manager_Base.cpp: