### PR TITLE
Correctly determine the location of tao_idl, fixes the failure of IDL…

### DIFF
--- a/TAO/orbsvcs/tests/Bug_1393_Regression/run_test.pl
+++ b/TAO/orbsvcs/tests/Bug_1393_Regression/run_test.pl
@@ -18,7 +18,10 @@ my $ifr_service_bin = "../../IFR_Service";
 my $tao_ifr_bin = "$ENV{ACE_ROOT}/bin";
 
 # The location of the tao_idl utility binary
-my $tao_idl_bin = "$ENV{ACE_ROOT}/bin";
+my $tao_idl = "$ENV{ACE_ROOT}/bin/tao_idl";
+if (exists $ENV{HOST_ROOT}) {
+    $tao_idl = "$ENV{HOST_ROOT}/bin/tao_idl";
+}
 
 my $service = PerlACE::TestTarget::create_target (1) || die "Create target 1 failed\n";
 my $client  = PerlACE::TestTarget::create_target (2) || die "Create target 2 failed\n";
@@ -36,7 +39,7 @@ $service->DeleteFile ($ifr_ior);
 $client->DeleteFile ($ifr_ior);
 $taoifr->DeleteFile ($ifr_ior);
 
-$TAO_IDL     = $service->CreateProcess("$tao_idl_bin/tao_idl", "$service_test_idl");
+$TAO_IDL     = $service->CreateProcess("$tao_idl", "$service_test_idl");
 $IFR_SERVICE = $service->CreateProcess("$ifr_service_bin/tao_ifr_service", "-o $service_ifr_ior");
 $TAO_IFR     = $service->CreateProcess("$tao_ifr_bin/tao_ifr",
                                        "-ORBInitRef InterfaceRepository=file://$taoifr_ifr_ior ".

--- a/TAO/tests/Bug_1628_Regression/run_test.pl
+++ b/TAO/tests/Bug_1628_Regression/run_test.pl
@@ -9,14 +9,10 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 use lib "$ENV{ACE_ROOT}/bin";
 use PerlACE::TestTarget;
 
-$status =0;
-
-# The location of the tao_idl utility - depends on O/S
-if ($^O eq "MSWin32"){
-   $tao_idl = "../../../bin/tao_idl";
-}
-else{
-   $tao_idl = "../../../TAO/TAO_IDL/tao_idl";
+$status = 0;
+my $tao_idl = "$ENV{ACE_ROOT}/bin/tao_idl";
+if (exists $ENV{HOST_ROOT}) {
+    $tao_idl = "$ENV{HOST_ROOT}/bin/tao_idl";
 }
 
 my $server = PerlACE::TestTarget::create_target (1) || die "Create target 1 failed\n";

--- a/TAO/tests/Bug_3154_Regression/run_test.pl
+++ b/TAO/tests/Bug_3154_Regression/run_test.pl
@@ -7,7 +7,7 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 use lib "$ENV{ACE_ROOT}/bin";
 use PerlACE::TestTarget;
 
-$tao_idl = "$PerlACE::ACE_ROOT/bin/tao_idl";
+my $tao_idl = "$ENV{ACE_ROOT}/bin/tao_idl";
 if (exists $ENV{HOST_ROOT}) {
     $tao_idl = "$ENV{HOST_ROOT}/bin/tao_idl";
 }

--- a/TAO/tests/Bug_3743_Regression/run_test.pl
+++ b/TAO/tests/Bug_3743_Regression/run_test.pl
@@ -11,7 +11,7 @@ $status = 0;
 
 my $test = PerlACE::TestTarget::create_target (1) || die "Create target 1 failed\n";
 
-my $tao_idl = "$PerlACE::ACE_ROOT/bin/tao_idl";
+my $tao_idl = "$ENV{ACE_ROOT}/bin/tao_idl";
 if (exists $ENV{HOST_ROOT}) {
     $tao_idl = "$ENV{HOST_ROOT}/bin/tao_idl";
 }

--- a/TAO/tests/Bug_3845_Regression/run_test.pl
+++ b/TAO/tests/Bug_3845_Regression/run_test.pl
@@ -17,12 +17,9 @@ open (STDOUT, ">" . File::Spec->devnull());
 open (OLDERR, ">&STDERR");
 open (STDERR, ">&STDOUT");
 
-# The location of the tao_idl utility - depends on O/S
-if ($^O eq "MSWin32"){
-   $tao_idl = "$ENV{ACE_ROOT}/bin/tao_idl";
-}
-else{
-   $tao_idl = "$ENV{TAO_ROOT}/TAO_IDL/tao_idl";
+my $tao_idl = "$ENV{ACE_ROOT}/bin/tao_idl";
+if (exists $ENV{HOST_ROOT}) {
+    $tao_idl = "$ENV{HOST_ROOT}/bin/tao_idl";
 }
 
 my $server = PerlACE::TestTarget::create_target (1) || die "Create target 1 failed\n";

--- a/TAO/tests/IDL_Test/run_test.pl
+++ b/TAO/tests/IDL_Test/run_test.pl
@@ -23,12 +23,9 @@ open (STDOUT, ">" . File::Spec->devnull());
 open (OLDERR, ">&STDERR");
 open (STDERR, ">&STDOUT");
 
-# The location of the tao_idl utility - depends on O/S
-if ($^O eq "MSWin32"){
-   $tao_idl = "../../../bin/tao_idl";
-}
-else{
-   $tao_idl = "../../TAO_IDL/tao_idl";
+my $tao_idl = "$ENV{ACE_ROOT}/bin/tao_idl";
+if (exists $ENV{HOST_ROOT}) {
+    $tao_idl = "$ENV{HOST_ROOT}/bin/tao_idl";
 }
 
 my $server2 = PerlACE::TestTarget::create_target (2) || die "Create target 2 failed\n";


### PR DESCRIPTION
…_Test on windows, other tests probably failed silently on Windows because the test couldn't spawn tao_idl

    * TAO/orbsvcs/tests/Bug_1393_Regression/run_test.pl:
    * TAO/tests/Bug_1628_Regression/run_test.pl:
    * TAO/tests/Bug_3154_Regression/run_test.pl:
    * TAO/tests/Bug_3743_Regression/run_test.pl:
    * TAO/tests/Bug_3845_Regression/run_test.pl:
    * TAO/tests/IDL_Test/run_test.pl: