### PR TITLE
Fix gcc7 warnings and remove commented out throws

### DIFF
--- a/ACE/ace/OS_NS_Thread.h
+++ b/ACE/ace/OS_NS_Thread.h
@@ -810,7 +810,7 @@ class ACE_TSS_Keys;
 class ACE_Export ACE_TSS_Emulation
 {
 public:
-  typedef void (*ACE_TSS_DESTRUCTOR)(void *value) /* throw () */;
+  typedef void (*ACE_TSS_DESTRUCTOR)(void *value);
 
   /// Maximum number of TSS keys allowed over the life of the program.
   enum { ACE_TSS_THREAD_KEYS_MAX = ACE_DEFAULT_THREAD_KEYS };

--- a/TAO/examples/Quoter/Factory_Finder.cpp
+++ b/TAO/examples/Quoter/Factory_Finder.cpp
@@ -178,6 +178,7 @@ Quoter_Factory_Finder_Server::parse_args (void)
         ACE_ERROR ((LM_ERROR,
                     "%s: unknown arg, -%c\n",
                     this->argv_[0], char(opt)));
+        // fallthrough
       case '?':
         ACE_DEBUG ((LM_DEBUG,
                     "usage:  %s"

--- a/TAO/examples/Quoter/client.cpp
+++ b/TAO/examples/Quoter/client.cpp
@@ -60,6 +60,7 @@ Quoter_Client::parse_args (void)
         ACE_ERROR ((LM_ERROR,
                     "%s: unknown arg, -%c\n",
                     this->argv_[0], char(opt)));
+        // fallthrough
       case '?':
         ACE_DEBUG ((LM_DEBUG,
                     "usage:  %s"

--- a/TAO/orbsvcs/LifeCycle_Service/LifeCycle_Service.cpp
+++ b/TAO/orbsvcs/LifeCycle_Service/LifeCycle_Service.cpp
@@ -159,6 +159,7 @@ Life_Cycle_Service_Server::parse_args (int argc,
         ORBSVCS_ERROR ((LM_ERROR,
                     "%s: unknown arg, -%c\n",
                     argv[0], char(opt)));
+        // fallthrough
       case '?':
         ORBSVCS_DEBUG ((LM_DEBUG,
                     ACE_TEXT("usage:  %s")

--- a/TAO/tao/PortableServer/Servant_var.h
+++ b/TAO/tao/PortableServer/Servant_var.h
@@ -55,7 +55,7 @@ namespace PortableServer
     /**
      * This destructor doesn't throw exceptions.
      */
-    ~Servant_var (void) /* throw () */;
+    ~Servant_var (void);
 
     /// Assignment operator.  Assumes ownership of @c p.
     Servant_var<T> & operator= (T * p);
@@ -105,7 +105,7 @@ namespace PortableServer
      * Non-throwing swap operation.
      * Often used to implement strong exception safety.
      */
-    void swap (Servant_var<T> & rhs) /* throw () */;
+    void swap (Servant_var<T> & rhs);
 
   private:
     T * ptr_;


### PR DESCRIPTION
    * ACE/ace/OS_NS_Thread.h:
    * TAO/examples/Quoter/Factory_Finder.cpp:
    * TAO/examples/Quoter/client.cpp:
    * TAO/orbsvcs/LifeCycle_Service/LifeCycle_Service.cpp:
    * TAO/tao/PortableServer/Servant_var.h: