### PR TITLE
gnuace build improvements

### DIFF
--- a/ACE/ace/config-macros.h
+++ b/ACE/ace/config-macros.h
@@ -114,6 +114,11 @@
 #   endif
 # endif /* ACE_HAS_DYNAMIC_LINKING */
 
+# if defined (ACE_HAS_DYNAMIC_LINKING) && ACE_HAS_DYNAMIC_LINKING == 0 && \
+     defined (ACE_HAS_SVR4_DYNAMIC_LINKING)
+#   undef ACE_HAS_SVR4_DYNAMIC_LINKING
+# endif /* ACE_HAS_DYNAMIC_LINKING == 0 */
+
 # if defined (ACE_USES_FIFO_SEM)
 #   if defined (ACE_HAS_POSIX_SEM) || defined (ACE_LACKS_MKFIFO) || defined (ACE_LACKS_FCNTL)
 #     undef ACE_USES_FIFO_SEM

--- a/ACE/bin/MakeProjectCreator/modules/GNUACEWorkspaceCreator.pm
+++ b/ACE/bin/MakeProjectCreator/modules/GNUACEWorkspaceCreator.pm
@@ -100,7 +100,8 @@ sub write_comps {
     $self->write_named_targets($fh, $crlf, \%targnum, \@list,
                                'REMAINING_TARGETS := ' .
                                '$(filter-out all depend,$(TARGETS_NESTED:.nested=)) $(CUSTOM_TARGETS)' .
-                               "$crlf$crlf\$(REMAINING_TARGETS)", '', '',
+                               "$crlf.PHONY: \$(REMAINING_TARGETS)$crlf$crlf".
+                               "\$(REMAINING_TARGETS)", '', '',
                                $self->project_target_translation(1), 1);
   }
   else {

--- a/ACE/bin/MakeProjectCreator/templates/gnu.mpd
+++ b/ACE/bin/MakeProjectCreator/templates/gnu.mpd
@@ -793,16 +793,8 @@ install: <%if(postbuild)%>__postbuild__<%else%>all<%endif%>
 INSTALL_LIB ?= lib
 ifneq ($(INSTALL_PREFIX),)
 ifneq ($(install_rpath),0)
-UNAME := $(shell uname)
-ifeq ($(UNAME), HP-UX)
-LDFLAGS += -Wl,+s,+b,$(INSTALL_PREFIX)/$(INSTALL_LIB) $(LD_RPATH_FLAGS)
-else
-ifeq ($(UNAME), Darwin)
-LDFLAGS += -Wl,-rpath $(INSTALL_PREFIX)/$(INSTALL_LIB) $(LD_RPATH_FLAGS)
-else
-LDFLAGS += -Wl,-R$(INSTALL_PREFIX)/$(INSTALL_LIB) $(LD_RPATH_FLAGS)
-endif
-endif
+LD_RPATH ?= -Wl,-rpath,
+LDFLAGS += $(LD_RPATH)$(INSTALL_PREFIX)/$(INSTALL_LIB) $(LD_RPATH_FLAGS)
 endif
 endif
 

--- a/ACE/include/makeinclude/platform_hpux_aCC.GNU
+++ b/ACE/include/makeinclude/platform_hpux_aCC.GNU
@@ -209,3 +209,5 @@ endif
 ifeq ($(c++0x),1)
   CCFLAGS += -Ax
 endif
+
+LD_RPATH = -Wl,+s,+b,

--- a/ACE/include/makeinclude/platform_linux.GNU
+++ b/ACE/include/makeinclude/platform_linux.GNU
@@ -57,7 +57,9 @@ DCCFLAGS += -ggdb
 DLD      = $(CXX)
 LD       = $(CXX)
 
-ifneq ($(dynamic_loader),0)
+ifeq ($(dynamic_loader),0)
+  CPPFLAGS += -DACE_HAS_DYNAMIC_LINKING=0
+else
   LIBS     += -ldl
 endif
 


### PR DESCRIPTION
- Set ACE_HAS_DYNAMIC_LINKING=0 when not linking to libdl on linux
- rpath: move HP-UX settings to its own config file; support newer Apple macOS