### PR TITLE
Replace some prints of exceptions with an ACE_DEBUG, this are really …

### DIFF
--- a/TAO/orbsvcs/tests/FT_Naming/FaultTolerant/client.cpp
+++ b/TAO/orbsvcs/tests/FT_Naming/FaultTolerant/client.cpp
@@ -658,7 +658,7 @@ do_failover_name_test (
       }
       catch (const CosNaming::NamingContext::NotFound& ex)
         {
-          ex._tao_print_exception (
+          ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT ("INFO: Unable to resolve wide context object from ")
               ACE_TEXT ("replica. Sleeping for a second.\n"));
 
@@ -1293,7 +1293,7 @@ do_persistence_name_test (
       }
       catch (const CosNaming::NamingContext::NotFound& ex)
         {
-          ex._tao_print_exception (
+          ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT ("INFO: Unable to resolve wide context object from ")
               ACE_TEXT ("repository. Sleeping for a second.\n"));
 
@@ -1878,7 +1878,7 @@ do_equivalence_name_test (
       }
       catch (const CosNaming::NamingContext::NotFound& ex)
         {
-          ex._tao_print_exception (
+          ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT ("INFO: Unable to resolve wide context object from ")
               ACE_TEXT ("replica. Sleeping for a second.\n"));
 


### PR DESCRIPTION
…informational messages which shouldn't pollute the scoreboard

    * TAO/orbsvcs/tests/FT_Naming/FaultTolerant/client.cpp: