### PR TITLE
Make ACE 6.4.6 and TAO 2.4.6 public

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN ACE-6.4.6 and ACE-6.4.7
+====================================================
+
 USER VISIBLE CHANGES BETWEEN ACE-6.4.5 and ACE-6.4.6
 ====================================================
 
@@ -5,7 +8,7 @@ USER VISIBLE CHANGES BETWEEN ACE-6.4.5 and ACE-6.4.6
 
 . VxWorks 7 (SR0510) support
 
-. Support make install on newer Apple macOS versions
+. Support make install on newer Apple MacOS versions
 
 USER VISIBLE CHANGES BETWEEN ACE-6.4.4 and ACE-6.4.5
 ====================================================

--- a/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
+++ b/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
@@ -2,7 +2,7 @@
 
 if test -z $1; then newdate=`date -u +%Y_%m_%d`; else newdate=$1; fi
 if test -z $2; then prefix=`date -u +%Y%m%d%a`; else prefix=$2; fi
-if test -z $3; then olddate=2017_09_07; else olddate=$3; fi
+if test -z $3; then olddate=2017_12_08; else olddate=$3; fi
 if test -z $ACE_ROOT; then ACE_ROOT=..; fi
 if test -z $TAO_ROOT; then TAO_ROOT=${ACE_ROOT}/TAO; fi
 if test -z $CIAO_ROOT; then CIAO_ROOT=${TAO_ROOT}/CIAO; fi

--- a/ACE/debian/debian.control
+++ b/ACE/debian/debian.control
@@ -154,7 +154,7 @@ Description: ACE Inet protocol library - development files
 Package: libace-inet-ssl-6.4.6
 Architecture: any
 Section: libs
-Depends: libace-inet-6.4.5, libace-ssl-6.4.6, ${shlibs:Depends}, ${misc:Depends}
+Depends: libace-inet-6.4.6, libace-ssl-6.4.6, ${shlibs:Depends}, ${misc:Depends}
 Description: ACE SSL-enabled Inet protocol library
  This package provides an ACE addon library for clients (and possibly
  servers at some point) using Inet protocols which support SSL, such as
@@ -257,7 +257,7 @@ Description: ACE-GUI reactor integration for Xt
 Package: libace-xtreactor-dev
 Architecture: any
 Section: libdevel
-Depends: libace-xtreactor-6.4.5 (= ${binary:Version}), libace-dev (= ${binary:Version}), libxt-dev (>= 6.4.6), ${misc:Depends}
+Depends: libace-xtreactor-6.4.6 (= ${binary:Version}), libace-dev (= ${binary:Version}), libxt-dev (>= 6.4.6), ${misc:Depends}
 Description: ACE-GUI reactor integration for Xt - development files
  This package contains header files and static library for the ACE-Xt
  reactor integration.
@@ -304,7 +304,7 @@ Description: ACE-GUI reactor integration for FLTK
 Package: libace-flreactor-dev
 Architecture: any
 Section: libdevel
-Depends: libace-flreactor-6.4.5 (= ${binary:Version}), libace-dev (= ${binary:Version}), libfltk1.1-dev (>= 6.4.6), ${misc:Depends}
+Depends: libace-flreactor-6.4.6 (= ${binary:Version}), libace-dev (= ${binary:Version}), libfltk1.1-dev (>= 6.4.6), ${misc:Depends}
 Description: ACE-GUI reactor integration for FLTK - development files
  This package contains header files and static library for the ACE-FLTK
  reactor integration.

--- a/ACE/docs/Download.html
+++ b/ACE/docs/Download.html
@@ -92,81 +92,81 @@ Windows line feeds. For all other platforms download a .gz/.bz2 package.
 </P>
 
 <UL>
-<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 6.4.5 and TAO 2.4.5
+<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 6.4.6 and TAO 2.4.6
 (ACE+TAO x.4.5), please use the links below to download it.<P>
 
 <TABLE BORDER="4">
   <TR><TH>Filename</TH><TH>Description</TH><TH>Full</TH><TH>Sources only</TH></TR>
   <TR><TD>ACE+TAO.tar.gz</TD>
       <TD>ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.5.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.5.tar.gz">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.6.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.6.tar.gz">FTP</A>]
       </TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.5.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.5.tar.gz">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.6.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.6.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE+TAO.tar.bz2</TD>
       <TD>ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.5.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.5.tar.bz2">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.6.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.6.tar.bz2">FTP</A>]
       </TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.5.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.5.tar.bz2">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.6.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.6.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE+TAO.zip</TD>
       <TD>ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.5.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.5.zip">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.6.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-6.4.6.zip">FTP</A>]
       </TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.5.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.5.zip">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.6.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-6.4.6.zip">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.tar.gz</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.5.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.5.tar.gz">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.6.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.6.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.tar.bz2</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.5.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.5.tar.bz2">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.6.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.6.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.zip</TD>
       <TD>Doxygen documentation for ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.5.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.5.zip">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.6.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-6.4.6.zip">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.tar.gz</TD>
       <TD>ACE only (tar+gzip format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.5.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.5.tar.gz">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.6.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.6.tar.gz">FTP</A>]
       </TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.5.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.5.tar.gz">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.6.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.6.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.tar.bz2</TD>
       <TD>ACE only (tar+bzip2 format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.5.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.5.tar.bz2">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.6.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.6.tar.bz2">FTP</A>]
       </TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.5.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.5.tar.bz2">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.6.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.6.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.zip</TD>
       <TD>ACE only (zip format)</TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.5.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.5.zip">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.6.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.6.zip">FTP</A>]
       </TD>
-      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.5.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.5.zip">FTP</A>]
+      <TD>[<A HREF="http://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.6.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-6.4.6.zip">FTP</A>]
       </TD>
   </TR>
 </TABLE>

--- a/ACE/docs/bczar/bczar.html
+++ b/ACE/docs/bczar/bczar.html
@@ -102,17 +102,17 @@
           Make sure your release system has all the needed tools. This can be achieved on Fedora
           using:
           <ul>
-            <li><code>yum install perl svn screen pysvn automake doxygen bzip2 tar gzip openssh graphviz zip libtool GitPython</code></li>
+            <li><code>yum install perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool GitPython</code></li>
             <li><code>yum update</code></li>
           </ul>
           or on OpenSuSE
           <ul>
-            <li><code>zypper install perl screen python-pysvn automake doxygen bzip2 tar gzip openssh graphviz zip libtool python-gitpython</code></li>
+            <li><code>zypper install perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool python-gitpython</code></li>
             <li><code>zypper update</code></li>
           </ul>
           If you want to perform a full build with qt support, than run:
           <ul>
-            <li><code>yum install deltarpm ntp rubygem-rmagick bison xerces-c-devel psmisc yum-utils gdb unzip glibc-devel libasan bison redhat-lsb perl-Pod-Usage rubygems clang make patch libcgroup-devel ant setuptool system-config-network-tui system-config-firewall-tui lcov gnuplot java-1.8.0-openjdk git-svn perl svn screen pysvn automake doxygen bzip2 tar gzip openssh graphviz zip libtool gcc-c++ boost-devel valgrind openssl-devel gcc qt4 fltk-devel bzip2-devel rsync openssl lzo-devel zziplib-devel acpid acpi nfs-utils java xerces-c xerces-c-devel mc qt qt-devel icecream ruby ruby-devel lksctp-tools-devel git telnet GitPython NetworkManager wget mailx</code></li>
+            <li><code>yum install deltarpm ntp rubygem-rmagick bison xerces-c-devel psmisc yum-utils gdb unzip glibc-devel libasan bison redhat-lsb perl-Pod-Usage rubygems clang make patch libcgroup-devel ant setuptool system-config-network-tui system-config-firewall-tui lcov gnuplot java-1.8.0-openjdk perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool gcc-c++ boost-devel valgrind openssl-devel gcc qt4 fltk-devel bzip2-devel rsync openssl lzo-devel zziplib-devel acpid acpi nfs-utils java xerces-c xerces-c-devel mc qt qt-devel icecream ruby ruby-devel lksctp-tools-devel git telnet GitPython NetworkManager wget mailx</code></li>
           </ul>
           For some optional i686 packages run
           <ul>
@@ -185,9 +185,6 @@
               TAO/tao/Version.h</li>
             ace/Version.h</li> </code>
         </ul>
-        In most cases, a<br>
-        <code>svn revert -R *</code><br>
-        from DOC_ROOT will suffice.<br />
     The tag will also need to be removed (both in Middleware and MPC):
     ACE+TAO-X_Y_Z (where X is the ACE Major version number, and Y & Z are the
     Minor and Micro release numbers of the release that is to be restarted).<p>
@@ -298,7 +295,7 @@
         rm -rf doxygen<br>
         mkdir doxygen<br>
         cd doxygen<br>
-        git clone https://github.com/DOCGroup/ACE_TAO.git --depth 1 --branch ACE+TAO-6_4_5 ACE_TAO<br>
+        git clone https://github.com/DOCGroup/ACE_TAO.git --depth 1 --branch ACE+TAO-6_4_6 ACE_TAO<br>
         cd ACE_TAO<br>
         export ACE_ROOT=$PWD/ACE<br>
         export TAO_ROOT=$PWD/TAO<br>
@@ -456,8 +453,8 @@
       Tips to being a Build Czar</h2>
     <p><ol>
       <li>Trust no one.</li>
-      <li>Be careful with <a href="http://www.cs.wustl.edu/~schmidt">this guy</a>, he
-      is notorious in breaking builds (and fixing them as well...Rumour has it that
+      <li>Be careful with <a href="http://www.dre.vanderbilt.edu/~schmidt/">this guy</a>, he
+      is notorious in breaking builds (and fixing them as well...rumour has it that
       it's actually a super-scalar, super-pipelined processor capable of out-of-order
       execution, in human incarnation).</li>
       <li>Don't forgive people who break ACE :-)</li>
@@ -467,20 +464,12 @@
       <li>Think of the group who wrote the scoreboard update script, every time you
       catch an otherwise not so obvious error with the help of the scoreboard. Tell <a href="mailto:devo-group@list.isis.vanderbilt.edu">
         DEVO group</a> about it.</li>
-      <li>Send a note to  <a href="mailto:sysadmin@isis.vanderbilt.edu">sysadmin@isis.vanderbilt.edu</a> asking for the repo to be frozen. Provide them a list of names, including yourself and bczar to be granted write permission.
-      </li>
-      <li>Compile once on Win32, Linux and Solaris before cutting a micro.</li>
+      <li>Compile once on Win32 and Linux before cutting a micro.</li>
       <li>Trust the release script when making a release. Don't make tar balls by
       hand.</li>
       <li>When all hell breaks loose, don't wait for the nightly builds to monitor
       improvement. Instead manually start the builds.</li>
-      <li>Maintain private up-to-date workspaces for problem platforms (read as
-      Solaris).</li>
       <li>Don't hesitate to ask for help.</li>
-      <li>When you get an account to access the svn repo, make sure you are added to
-      the correct groups, for example,
-      gid=100(users),5000(doc),5002(acetaodev),5003(cvs). Otherwise you will have
-      problem to checkout various modules.</li>
       <li>Install your public key to the different machines you have frequent access
       to avoid typing password.</li>
       <li>Update this page if you have any more tips for future build czars :-). This

--- a/ACE/etc/index.html
+++ b/ACE/etc/index.html
@@ -30,6 +30,7 @@
     <hr>
     We do have the documentation for previous releases
     <ul>
+      <LI><P><A HREF="6.4.6/html">6.4.6</A></P></LI>
       <LI><P><A HREF="6.4.5/html">6.4.5</A></P></LI>
       <LI><P><A HREF="6.4.4/html">6.4.4</A></P></LI>
       <LI><P><A HREF="6.4.3/html">6.4.3</A></P></LI>

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN TAO-2.4.6 and TAO-2.4.7
+====================================================
+
 USER VISIBLE CHANGES BETWEEN TAO-2.4.5 and TAO-2.4.6
 ====================================================
 


### PR DESCRIPTION
    * ACE/NEWS:
    * ACE/bin/diff-builds-and-group-fixed-tests-only.sh:
    * ACE/debian/debian.control:
    * ACE/docs/Download.html:
    * ACE/docs/bczar/bczar.html:
    * ACE/etc/index.html:
    * TAO/NEWS: