### PR TITLE
New ACE test: check if ACE_Singleton works after ACE::fini, ACE::init

### DIFF
--- a/ACE/tests/.gitignore
+++ b/ACE/tests/.gitignore
@@ -217,6 +217,7 @@
 /Sigset_Ops_Test
 /Simple_Message_Block_Test
 /Singleton_Test
+/Singleton_Restart_Test
 /SOCK_Connector_Test
 /SOCK_Dgram_Bcast_Test
 /SOCK_Dgram_Test

--- a/ACE/tests/Singleton_Restart_Test.cpp
+++ b/ACE/tests/Singleton_Restart_Test.cpp
@@ -1,0 +1,54 @@
+#define ACE_DOESNT_DEFINE_MAIN
+
+#include "test_config.h"
+
+#include "ace/Init_ACE.h"
+#include "ace/Singleton.h"
+
+int restart_test_logging (const ACE_TCHAR *program)
+{
+  if (ACE_LOG_MSG->open (program, ACE_Log_Msg::OSTREAM |
+                         ACE_Log_Msg::VERBOSE_LITE) != 0)
+    ACE_ERROR_RETURN ((LM_ERROR, ACE_TEXT ("%p\n"),
+                       ACE_TEXT ("open log_msg failed")), -1);
+  if (ace_file_stream::instance()->set_output (program, 1) != 0)
+    ACE_ERROR_RETURN ((LM_ERROR, ACE_TEXT ("%p\n"),
+                       ACE_TEXT ("set_output failed")), -1);
+  return 0;
+}
+
+void report_error (const ACE_TCHAR *lock)
+{
+  ACE_ERROR ((LM_ERROR, ACE_TEXT ("ACE_Singleton<int, %s> ")
+              ACE_TEXT ("failed to allocate\n"), lock));
+}
+
+typedef ACE_Singleton<int, ACE_SYNCH_MUTEX> Singleton1;
+typedef ACE_Singleton<int, ACE_SYNCH_RECURSIVE_MUTEX> Singleton2;
+
+int main ()
+{
+  ACE::init ();
+  ACE_START_TEST (ACE_TEXT ("Singleton_Restart_Test"));
+
+  *Singleton1::instance () = 1;
+  *Singleton2::instance () = 2;
+
+  ACE::fini ();
+  ACE::init ();
+  if (restart_test_logging (program) != 0) // program defined in ACE_START_TEST
+    return -1;
+
+  int *i1 = Singleton1::instance ();
+  if (!i1)
+    report_error (ACE_TEXT ("ACE_SYNCH_MUTEX"));
+
+  int *i2 = Singleton2::instance ();
+  if (!i2)
+    report_error (ACE_TEXT ("ACE_SYNCH_RECURSIVE_MUTEX"));
+
+  ACE_END_TEST;
+  ACE::fini ();
+
+  return (i1 && i2) ? 0 : 1;
+}

--- a/ACE/tests/run_test.lst
+++ b/ACE/tests/run_test.lst
@@ -232,6 +232,7 @@ Service_Config_Stream_Test: !STATIC !FIXED_BUGS_ONLY
 Sigset_Ops_Test
 Simple_Message_Block_Test
 Singleton_Test
+Singleton_Restart_Test: !ST !FIXED_BUGS_ONLY
 Svc_Handler_Test: !ACE_FOR_TAO
 Task_Wait_Test
 TP_Reactor_Test: !ACE_FOR_TAO

--- a/ACE/tests/tests.mpc
+++ b/ACE/tests/tests.mpc
@@ -1609,6 +1609,15 @@ project(Singleton Test) : acetest {
   }
 }
 
+project(Singleton Restart Test) : aceexe {
+  exename = Singleton_Restart_Test
+  after += Test_Output
+  libs += Test_Output
+  Source_Files {
+    Singleton_Restart_Test.cpp
+  }
+}
+
 project(SOCK Test) : acetest {
   exename = SOCK_Test
   Source_Files {


### PR DESCRIPTION
Some lock types work, others don't, due to different logic per lock type
in ACE_Object_Manager::get_singleton_lock and how ACE_Singleton uses it.