### PR TITLE
Doxygen fixes and fixed some typos

### DIFF
--- a/TAO/orbsvcs/orbsvcs/CosEvent/CEC_TypedEventChannel.h
+++ b/TAO/orbsvcs/orbsvcs/CosEvent/CEC_TypedEventChannel.h
@@ -86,7 +86,7 @@ public:
 
   /**
    * If not zero the event channel will deactive its Impl and call
-   * orb->shutdown(0), when destoy is invoked.
+   * orb->shutdown(0), when destroy is invoked.
    */
   int destroy_on_shutdown;
 

--- a/TAO/orbsvcs/orbsvcs/Naming/Hash_Naming_Context.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/Hash_Naming_Context.h
@@ -61,7 +61,7 @@ public:
   /**
    * Add a binding with the specified parameters to the table.
    * Return 0 on success and -1 on failure, 1 if there already is a
-   * binding with <id> and <kind>.
+   * binding with @a id and @a kind.
    */
   virtual int bind (const char *id,
                     const char *kind,
@@ -69,7 +69,7 @@ public:
                     CosNaming::BindingType type) = 0;
 
   /**
-   * Overwrite a binding containing <id> and <kind> (or create a new
+   * Overwrite a binding containing @a id and @a kind (or create a new
    * one if one doesn't exist) with the specified parameters.  Returns
    * -1 on failure.
    */
@@ -78,16 +78,16 @@ public:
                       CORBA::Object_ptr obj,
                       CosNaming::BindingType type) = 0;
 
-  /// Remove a binding containing <id> and <kind> from the table.
+  /// Remove a binding containing @a id and @a kind from the table.
   /// Return 0 on success and -1 on failure.
   virtual int unbind (const char * id,
                       const char * kind) = 0;
 
   /**
-   * Find the binding containing <id> and <kind> in the table, and
+   * Find the binding containing @a id and @a kind in the table, and
    * pass binding's type and object back to the caller by reference.
    * Return 0 on success and -1 on failure.   Note: a 'duplicated' object
-   * reference is assigned to <obj>, so the caller is responsible for
+   * reference is assigned to @a obj, so the caller is responsible for
    * its deallocation.
    */
   virtual int find (const char * id,
@@ -141,7 +141,7 @@ public:
   // = CosNaming::NamingContext idl interface methods.
 
   /**
-   * Create a binding for name <n> and object <obj> in the naming
+   * Create a binding for name @a n and object @a obj in the naming
    * context.  Compound names are treated as follows: ctx->bind (<c1;
    * c2; c3; cn>, obj) = (ctx->resolve (<c1; c2; cn-1>))->bind (<cn>,
    * obj) if the there already exists a binding for the specified
@@ -153,7 +153,7 @@ public:
                      CORBA::Object_ptr obj);
 
   /**
-   * This is similar to <bind> operation above, except for when the
+   * This is similar to bind() operation above, except for when the
    * binding for the specified name already exists in the specified
    * context.  In that case, the existing binding is replaced with the
    * new one.
@@ -205,7 +205,7 @@ public:
    * Delete the naming context.  The user should take care to <unbind> any
    * bindings in which the given context is bound to some names, to
    * avoid dangling references when invoking <destroy> operation.
-   * NOTE: <destory> is a no-op on the root context.
+   * NOTE: <destroy> is a no-op on the root context.
    * NOTE: after <destroy> is invoked on a Naming Context, all
    * BindingIterators associated with that Naming Context are also destroyed.
    */

--- a/TAO/orbsvcs/orbsvcs/Naming/Naming_Context_Interface.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/Naming_Context_Interface.h
@@ -129,7 +129,7 @@ public:
    * Delete the naming context.  The user should take care to <unbind> any
    * bindings in which the given context is bound to some names, to
    * avoid dangling references when invoking <destroy> operation.
-   * NOTE: <destory> is a no-op on the root context.
+   * NOTE: <destroy> is a no-op on the root context.
    * NOTE: after <destroy> is invoked on a Naming Context, all
    * BindingIterators associated with that Naming Context are also destroyed.
    */
@@ -325,7 +325,7 @@ public:
    * Delete the naming context.  The user should take care to <unbind> any
    * bindings in which the given context is bound to some names, to
    * avoid dangling references when invoking <destroy> operation.
-   * NOTE: <destory> is a no-op on the root context.
+   * NOTE: <destroy> is a no-op on the root context.
    * NOTE: after <destroy> is invoked on a Naming Context, all
    * BindingIterators associated with that Naming Context are also destroyed.
    */

--- a/TAO/orbsvcs/orbsvcs/Naming/Storable_Naming_Context.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/Storable_Naming_Context.h
@@ -351,7 +351,7 @@ public:
    * Delete the naming context.  The user should take care to <unbind> any
    * bindings in which the given context is bound to some names, to
    * avoid dangling references when invoking <destroy> operation.
-   * NOTE: <destory> is a no-op on the root context.
+   * NOTE: <destroy> is a no-op on the root context.
    * NOTE: after <destroy> is invoked on a Naming Context, all
    * BindingIterators associated with that Naming Context are also destroyed.
    */

--- a/TAO/tests/Bug_2953_Regression/client.cpp
+++ b/TAO/tests/Bug_2953_Regression/client.cpp
@@ -18,7 +18,7 @@ void shutdownORB(CORBA::ORB_ptr orb, const char * orbid)
 
   orb->destroy();
   ACE_DEBUG ((LM_DEBUG,
-              "ORB <%C> is destoyed\n",
+              "ORB <%C> is destroyed\n",
               orbid));
 }
 

--- a/TAO/tests/Bug_2953_Regression/server.cpp
+++ b/TAO/tests/Bug_2953_Regression/server.cpp
@@ -209,7 +209,7 @@ void shutdownORB(CORBA::ORB_ptr orb, const char * orbid)
 
   orb->destroy();
   ACE_DEBUG ((LM_DEBUG,
-              "ORB <%C> is destoyed\n",
+              "ORB <%C> is destroyed\n",
               orbid));
 }
 

--- a/TAO/tests/Smart_Proxies/Benchmark/client.cpp
+++ b/TAO/tests/Smart_Proxies/Benchmark/client.cpp
@@ -125,7 +125,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
           // user-defined smart factory on the heap as the smart proxy
           // generated classes take care of destroying the object. This
           // way it a win situation for the application developer who
-          // doesnt have to make sure to destoy it and also for the smart
+          // doesnt have to make sure to destroy it and also for the smart
           // proxy designer who now can manage the lifetime of the object
           // much surely.
 

--- a/TAO/tests/Smart_Proxies/Policy/client.cpp
+++ b/TAO/tests/Smart_Proxies/Policy/client.cpp
@@ -103,7 +103,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       // user-defined smart factory on the heap as the smart proxy
       // generated classes take care of destroying the object. This
       // way it a win situation for the application developer who
-      // doesnt have to make sure to destoy it and also for the smart
+      // doesnt have to make sure to destroy it and also for the smart
       // proxy designer who now can manage the lifetime of the object
       // much surely.
       // By default this factory is permanent (i.e. registered for

--- a/TAO/tests/Smart_Proxies/client.cpp
+++ b/TAO/tests/Smart_Proxies/client.cpp
@@ -60,7 +60,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       // user-defined smart factory on the heap as the smart proxy
       // generated classes take care of destroying the object. This
       // way it a win situation for the application developer who
-      // doesnt have to make sure to destoy it and also for the smart
+      // doesnt have to make sure to destroy it and also for the smart
       // proxy designer who now can manage the lifetime of the object
       // much surely.
       Smart_Test_Factory *test_factory = 0;


### PR DESCRIPTION
    * TAO/orbsvcs/orbsvcs/CosEvent/CEC_TypedEventChannel.h:
    * TAO/orbsvcs/orbsvcs/Naming/Hash_Naming_Context.h:
    * TAO/orbsvcs/orbsvcs/Naming/Naming_Context_Interface.h:
    * TAO/orbsvcs/orbsvcs/Naming/Storable_Naming_Context.h:
    * TAO/tests/Bug_2953_Regression/client.cpp:
    * TAO/tests/Bug_2953_Regression/server.cpp:
    * TAO/tests/Smart_Proxies/Benchmark/client.cpp:
    * TAO/tests/Smart_Proxies/Policy/client.cpp:
    * TAO/tests/Smart_Proxies/client.cpp: