### PR TITLE
Any bcc32 version doesn't support inlined assembly

### DIFF
--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -174,6 +174,12 @@
 #endif
 
 #if defined (ACE_HAS_BCC32)
+// The bcc32 compiler can't handle assembly in inline methods or
+// templates (E2211). When we build for pentium optimized and we are inlining
+// then we disable inline assembly
+# if defined (ACE_HAS_PENTIUM) && defined(__ACE_INLINE__) && !defined(__clang__)
+#  define ACE_LACKS_INLINE_ASSEMBLY
+# endif
 # define ACE_SIZEOF_LONG_DOUBLE 10
 # define ACE_NEEDS_DL_UNDERSCORE
 #endif


### PR DESCRIPTION
    * ACE/ace/config-win32-borland.h: