### PR TITLE
Disable intel assembly when using the Embarcadero clang compilers

### DIFF
--- a/ACE/ace/CDR_Base.cpp
+++ b/ACE/ace/CDR_Base.cpp
@@ -52,7 +52,7 @@ ACE_CDR::swap_2_array (char const * orig, char* target, size_t n)
     }
 #else
   char const * const o4 = ACE_ptr_align_binary (orig, 4);
-  // this is an _if_, not a _while_. The mistmatch can only be by 2.
+  // this is an _if_, not a _while_. The mismatch can only be by 2.
   if (orig != o4)
     {
       ACE_CDR::swap_2 (orig, target);
@@ -74,7 +74,7 @@ ACE_CDR::swap_2_array (char const * orig, char* target, size_t n)
   // end marks our barrier for not falling outside.
   char const * const end = orig + 2 * (n & (~3));
 
-  // See if we're aligned for writting in 64 or 32 bit chunks...
+  // See if we're aligned for writing in 64 or 32 bit chunks...
 #if ACE_SIZEOF_LONG == 8 && \
     !((defined(__amd64__) || defined (__x86_64__)) && defined(__GNUG__))
   if (target == ACE_ptr_align_binary (target, 8))

--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -189,6 +189,9 @@
 # define ACE_HAS_BUILTIN_BSWAP16
 # define ACE_HAS_BUILTIN_BSWAP32
 # define ACE_HAS_BUILTIN_BSWAP64
+# if (defined (ACE_HAS_PENTIUM) || defined (__amd64__) || defined (__x86_64__))
+#  define ACE_HAS_INTEL_ASSEMBLY
+# endif
 #endif /* __clang__ */
 
 

--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -189,9 +189,7 @@
 # define ACE_HAS_BUILTIN_BSWAP16
 # define ACE_HAS_BUILTIN_BSWAP32
 # define ACE_HAS_BUILTIN_BSWAP64
-# if (defined (ACE_HAS_PENTIUM) || defined (__amd64__) || defined (__x86_64__))
-#  define ACE_HAS_INTEL_ASSEMBLY
-# endif
+# define ACE_LACKS_INLINE_ASSEMBLY
 #endif /* __clang__ */
 
 


### PR DESCRIPTION
    * ACE/ace/CDR_Base.cpp:
    * ACE/ace/config-win32-borland.h: