### PR TITLE
Don't use auto_ptr for the fragmentation strategy, that was the only …

### DIFF
--- a/TAO/tao/AnyTypeCode/Any_Array_Impl_T.cpp
+++ b/TAO/tao/AnyTypeCode/Any_Array_Impl_T.cpp
@@ -22,8 +22,7 @@ template<typename T_slice, typename T_forany>
 TAO::Any_Array_Impl_T<T_slice, T_forany>::Any_Array_Impl_T (
     _tao_destructor destructor,
     CORBA::TypeCode_ptr tc,
-    T_slice * const val
-  )
+    T_slice * const val)
   : Any_Impl (destructor,
               tc),
     value_ (val)

--- a/TAO/tao/CodecFactory/CDR_Encaps_Codec.cpp
+++ b/TAO/tao/CodecFactory/CDR_Encaps_Codec.cpp
@@ -13,7 +13,6 @@
 #include "tao/ORB_Constants.h"
 #include "tao/Codeset_Translator_Base.h"
 
-#include "ace/Auto_Ptr.h"
 #include "ace/OS_NS_string.h"
 #include "ace/CORBA_macros.h"
 

--- a/TAO/tao/GIOP_Fragmentation_Strategy.cpp
+++ b/TAO/tao/GIOP_Fragmentation_Strategy.cpp
@@ -1,7 +1,6 @@
 
 #include "tao/GIOP_Fragmentation_Strategy.h"
 
-
 TAO_GIOP_Fragmentation_Strategy::~TAO_GIOP_Fragmentation_Strategy (void)
 {
 }

--- a/TAO/tao/GIOP_Message_Base.h
+++ b/TAO/tao/GIOP_Message_Base.h
@@ -29,8 +29,6 @@
 #include "tao/CDR.h"
 #include "tao/Incoming_Message_Stack.h"
 
-#include "ace/Auto_Ptr.h"
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 class TAO_Pluggable_Reply_Params;
@@ -267,7 +265,7 @@ protected:
   //@{
   /// Strategy that sends data currently marshaled into this
   /// TAO_OutputCDR stream if necessary.
-  auto_ptr<TAO_GIOP_Fragmentation_Strategy> fragmentation_strategy_;
+  TAO_GIOP_Fragmentation_Strategy* fragmentation_strategy_;
 
   /// Buffer where the request is placed.
   TAO_OutputCDR out_stream_;

--- a/TAO/tao/IIOP_Acceptor.cpp
+++ b/TAO/tao/IIOP_Acceptor.cpp
@@ -19,7 +19,6 @@
 #include "tao/IIOP_Acceptor.inl"
 #endif /* __ACE_INLINE__ */
 
-#include "ace/Auto_Ptr.h"
 #include "ace/OS_NS_string.h"
 #include "ace/os_include/os_netdb.h"
 

--- a/TAO/tao/ORB_Core.cpp
+++ b/TAO/tao/ORB_Core.cpp
@@ -3075,7 +3075,7 @@ TAO_ORB_Core::connector_registry (void)
   return conn;
 }
 
-auto_ptr<TAO_GIOP_Fragmentation_Strategy>
+TAO_GIOP_Fragmentation_Strategy*
 TAO_ORB_Core::fragmentation_strategy (TAO_Transport * transport)
 {
   return

--- a/TAO/tao/ORB_Core.h
+++ b/TAO/tao/ORB_Core.h
@@ -37,7 +37,6 @@
 #include "tao/Service_Context_Handler_Registry.h"
 
 #include "ace/Array_Map.h"
-#include "ace/Auto_Ptr.h"
 #include "ace/Thread_Manager.h"
 #include "ace/Lock_Adapter_T.h"
 #include "ace/TSS_T.h"
@@ -900,7 +899,7 @@ public:
   ACE_Service_Gestalt* configuration () const;
 
   /// Get outgoing fragmentation strategy.
-  auto_ptr<TAO_GIOP_Fragmentation_Strategy>
+  TAO_GIOP_Fragmentation_Strategy*
   fragmentation_strategy (TAO_Transport * transport);
 
 #if (TAO_HAS_BUFFERING_CONSTRAINT_POLICY == 1)

--- a/TAO/tao/Resource_Factory.h
+++ b/TAO/tao/Resource_Factory.h
@@ -236,7 +236,7 @@ public:
   virtual TAO_LF_Strategy *create_lf_strategy (void) = 0;
 
   /// Outgoing fragment creation strategy.
-  virtual auto_ptr<TAO_GIOP_Fragmentation_Strategy>
+  virtual TAO_GIOP_Fragmentation_Strategy*
     create_fragmentation_strategy (TAO_Transport * transport,
                                    CORBA::ULong max_message_size) const = 0;
 

--- a/TAO/tao/default_resource.cpp
+++ b/TAO/tao/default_resource.cpp
@@ -1110,14 +1110,12 @@ TAO_Default_Resource_Factory::create_lf_strategy (void)
   return strategy;
 }
 
-auto_ptr<TAO_GIOP_Fragmentation_Strategy>
+TAO_GIOP_Fragmentation_Strategy*
 TAO_Default_Resource_Factory::create_fragmentation_strategy (
   TAO_Transport * transport,
   CORBA::ULong max_message_size) const
 {
-  auto_ptr<TAO_GIOP_Fragmentation_Strategy> strategy (0);
-
-  TAO_GIOP_Fragmentation_Strategy * tmp = 0;
+  TAO_GIOP_Fragmentation_Strategy* strategy = 0;
 
   // Minimum GIOP message size is 24 (a multiple of 8):
   //   12   GIOP Message Header
@@ -1136,22 +1134,20 @@ TAO_Default_Resource_Factory::create_fragmentation_strategy (
           || (TAO_DEF_GIOP_MAJOR == 1 && TAO_DEF_GIOP_MINOR < 2))
         {
           // No maximum was set by the user.
-          ACE_NEW_RETURN (tmp,
+          ACE_NEW_RETURN (strategy,
                           TAO_Null_Fragmentation_Strategy,
                           strategy);
 
         }
       else
         {
-          ACE_NEW_RETURN (tmp,
+          ACE_NEW_RETURN (strategy,
                           TAO_On_Demand_Fragmentation_Strategy (
                             transport,
                             max_message_size),
                           strategy);
         }
     }
-
-  ACE_auto_ptr_reset (strategy, tmp);
 
   return strategy;
 }

--- a/TAO/tao/default_resource.h
+++ b/TAO/tao/default_resource.h
@@ -181,7 +181,7 @@ public:
   virtual TAO_Connection_Purging_Strategy *create_purging_strategy (void);
   TAO_Resource_Factory::Resource_Usage resource_usage_strategy (void) const;
   virtual TAO_LF_Strategy *create_lf_strategy (void);
-  virtual auto_ptr<TAO_GIOP_Fragmentation_Strategy>
+  virtual TAO_GIOP_Fragmentation_Strategy*
     create_fragmentation_strategy (TAO_Transport * transport,
                                    CORBA::ULong max_message_size) const;
   virtual void disable_factory (void);


### PR DESCRIPTION
…one that used this in the ORB interface. With C++17 auto_ptr has been removed completely

    * TAO/tao/AnyTypeCode/Any_Array_Impl_T.cpp:
    * TAO/tao/CodecFactory/CDR_Encaps_Codec.cpp:
    * TAO/tao/GIOP_Fragmentation_Strategy.cpp:
    * TAO/tao/GIOP_Message_Base.cpp:
    * TAO/tao/GIOP_Message_Base.h:
    * TAO/tao/IIOP_Acceptor.cpp:
    * TAO/tao/ORB_Core.cpp:
    * TAO/tao/ORB_Core.h:
    * TAO/tao/Resource_Factory.h:
    * TAO/tao/default_resource.cpp:
    * TAO/tao/default_resource.h: