### PR TITLE
Make use of std::unique_ptr when C++11 is used

### DIFF
--- a/ACE/ace/XML_Utils/XML_Helper.h
+++ b/ACE/ace/XML_Utils/XML_Helper.h
@@ -83,7 +83,11 @@ namespace XML
   private:
     bool initialized_;
     XERCES_CPP_NAMESPACE::DOMImplementation *impl_;
+#if defined (ACE_HAS_CPP11)
+    mutable std::unique_ptr<XERCES_CPP_NAMESPACE::XercesDOMParser> parser_;
+#else
     mutable std::auto_ptr<XERCES_CPP_NAMESPACE::XercesDOMParser> parser_;
+#endif /* ACE_HAS_CPP11 */
 
     Resolver *resolver_;
     bool release_resolver_;

--- a/ACE/ace/XML_Utils/XSCRT/Elements.hpp
+++ b/ACE/ace/XML_Utils/XSCRT/Elements.hpp
@@ -148,7 +148,11 @@ namespace XSCRT
     {
       if (map_.get () == 0)
       {
+#if defined (ACE_HAS_CPP11)
+        map_ = std::unique_ptr<Map_> (new Map_);
+#else
         map_ = std::auto_ptr<Map_> (new Map_);
+#endif /* ACE_HAS_CPP11 */
       }
 
       if (!map_->insert (std::pair<IdentityProvider const*, Type*> (&id, t)).second)
@@ -262,7 +266,11 @@ namespace XSCRT
     std::map<IdentityProvider const*, Type*, IdentityComparator>
     Map_;
 
+#if defined (ACE_HAS_CPP11)
+    std::unique_ptr<Map_> map_;
+#else
     std::auto_ptr<Map_> map_;
+#endif /* ACE_HAS_CPP11 */
   };
 
   // Fundamental types template.


### PR DESCRIPTION
    * ACE/ace/XML_Utils/XML_Helper.h:
    * ACE/ace/XML_Utils/XSCRT/Elements.hpp: