### PR TITLE
When we have C++11 ACE_Strong_Bound_Ptr doesn't provide std::auto_ptr…

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,10 @@
 USER VISIBLE CHANGES BETWEEN ACE-6.5.0 and ACE-6.5.1
 ====================================================
 
+. At the moment C++11 or newer is enabled ACE_Strong_Bound_Ptr
+  doesn't provide the convenience functions to use a
+  std::auto_ptr anymore
+
 USER VISIBLE CHANGES BETWEEN ACE-6.4.8 and ACE-6.5.0
 ====================================================
 

--- a/ACE/ace/Bound_Ptr.h
+++ b/ACE/ace/Bound_Ptr.h
@@ -20,7 +20,9 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Auto_Ptr.h"
+#if !defined (ACE_HAS_CPP11)
+# include "ace/Auto_Ptr.h"
+#endif /* !ACE_HAS_CPP11 */
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -114,9 +116,11 @@ public:
   /// object \<p\> immediately.
   explicit ACE_Strong_Bound_Ptr (X *p = 0);
 
+#if !defined (ACE_HAS_CPP11)
   /// Constructor that initializes an ACE_Strong_Bound_Ptr by stealing
   /// ownership of an object from an auto_ptr.
   explicit ACE_Strong_Bound_Ptr (auto_ptr<X> p);
+#endif /* !ACE_HAS_CPP11 */
 
   /// Copy constructor binds @c this and @a r to the same object.
   ACE_Strong_Bound_Ptr (const ACE_Strong_Bound_Ptr<X, ACE_LOCK> &r);
@@ -214,10 +218,12 @@ public:
   /// underlying object.
   void reset (X *p = 0);
 
+#if !defined (ACE_HAS_CPP11)
   /// Resets the ACE_Strong_Bound_Ptr to refer to a different
   /// underlying object, ownership of which is stolen from the
   /// auto_ptr.
   void reset (auto_ptr<X> p);
+#endif /* !ACE_HAS_CPP11 */
 
   /// Allows us to check for NULL on all ACE_Strong_Bound_Ptr
   /// objects.

--- a/ACE/ace/Bound_Ptr.inl
+++ b/ACE/ace/Bound_Ptr.inl
@@ -146,12 +146,14 @@ ACE_Strong_Bound_Ptr<X, ACE_LOCK>::ACE_Strong_Bound_Ptr (X *p)
 {
 }
 
+#if !defined (ACE_HAS_CPP11)
 template <class X, class ACE_LOCK> inline
 ACE_Strong_Bound_Ptr<X, ACE_LOCK>::ACE_Strong_Bound_Ptr (auto_ptr<X> p)
   : counter_ (COUNTER::create_strong ()),
     ptr_ (p.release())
 {
 }
+#endif /* !ACE_HAS_CPP11 */
 
 template <class X, class ACE_LOCK> inline
 ACE_Strong_Bound_Ptr<X, ACE_LOCK>::ACE_Strong_Bound_Ptr (const ACE_Strong_Bound_Ptr<X, ACE_LOCK> &r)
@@ -301,6 +303,7 @@ ACE_Strong_Bound_Ptr<X, ACE_LOCK>::reset (X *p)
     delete old_ptr;
 }
 
+#if !defined (ACE_HAS_CPP11)
 template<class X, class ACE_LOCK> inline void
 ACE_Strong_Bound_Ptr<X, ACE_LOCK>::reset (auto_ptr<X> p)
 {
@@ -311,6 +314,7 @@ ACE_Strong_Bound_Ptr<X, ACE_LOCK>::reset (auto_ptr<X> p)
   if (COUNTER::detach_strong (old_counter) == 0)
     delete old_ptr;
 }
+#endif /* !ACE_HAS_CPP11 */
 
 template <class X, class ACE_LOCK> inline
 ACE_Weak_Bound_Ptr<X, ACE_LOCK>::ACE_Weak_Bound_Ptr (X *p)

--- a/ACE/tests/Bound_Ptr_Test.cpp
+++ b/ACE/tests/Bound_Ptr_Test.cpp
@@ -464,9 +464,13 @@ run_main (int, ACE_TCHAR *[])
                     Printer ("I am printer 2"),
                     -1);
 
+#if !defined (ACE_HAS_CPP11)
     // Ownership is transferred from the auto_ptr to the strong pointer.
     auto_ptr<Printer> a (printer2);
     Printer_var r (a);
+#else
+    Printer_var r (printer2);
+#endif /* !ACE_HAS_CPP11 */
 
     for (int i = 0; i < n_loops; i++)
       // Spawn off the methods, which run in a separate thread as

--- a/TAO/orbsvcs/orbsvcs/Notify/ThreadPool_Task.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/ThreadPool_Task.h
@@ -21,6 +21,7 @@
 #include "ace/Message_Queue.h"
 #include "ace/Reactor.h"
 #include "ace/Null_Condition.h"
+#include "ace/Auto_Ptr.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once


### PR DESCRIPTION
… support, that is deprecated

    * ACE/ace/Bound_Ptr.h:
    * ACE/ace/Bound_Ptr.inl:
    * ACE/tests/Bound_Ptr_Test.cpp: