### PR TITLE
When using Visual Studio 2017 we can enable C++14 and C++17 complianc…

### DIFF
--- a/ACE/ace/Auto_Ptr.cpp
+++ b/ACE/ace/Auto_Ptr.cpp
@@ -11,8 +11,6 @@
 #include "ace/Auto_Ptr.inl"
 #endif /* __ACE_INLINE__ */
 
-
-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_ALLOC_HOOK_DEFINE_Tt(ACE_Auto_Basic_Ptr)

--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -76,7 +76,9 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 #include <memory>
 #if defined (ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB) && \
             (ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB != 0)
+#if !defined (ACE_HAS_CPP17)
 using std::auto_ptr;
+#endif /* !ACE_HAS_CPP17 */
 #endif /* ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB */
 #else /* ACE_HAS_STANDARD_CPP_LIBRARY */
 

--- a/ACE/ace/WFMO_Reactor.cpp
+++ b/ACE/ace/WFMO_Reactor.cpp
@@ -1384,7 +1384,11 @@ ACE_WFMO_Reactor::register_handler_i (ACE_HANDLE event_handle,
 
   long new_network_events = 0;
   bool delete_event = false;
+#if defined (ACE_HAS_CPP11)
+  std::unique_ptr <ACE_Auto_Event> event;
+#else
   auto_ptr <ACE_Auto_Event> event;
+#endif /* ACE_HAS_CPP11 */
 
   // Look up the repository to see if the <event_handler> is already
   // there.
@@ -1401,10 +1405,15 @@ ACE_WFMO_Reactor::register_handler_i (ACE_HANDLE event_handle,
   // need to create one
   if (event_handle == ACE_INVALID_HANDLE)
     {
+#if defined (ACE_HAS_CPP11)
+      std::unique_ptr<ACE_Auto_Event> tmp (new ACE_Auto_Event);
+      event = std::move(tmp);
+#else
       // Note: don't change this since some C++ compilers have
       // <auto_ptr>s that don't work properly...
       auto_ptr<ACE_Auto_Event> tmp (new ACE_Auto_Event);
       event = tmp;
+#endif /* ACE_HAS_CPP11 */
       event_handle = event->handle ();
       delete_event = true;
     }

--- a/ACE/ace/config-win32-msvc-141.h
+++ b/ACE/ace/config-win32-msvc-141.h
@@ -25,5 +25,13 @@
 
 #include "ace/config-win32-msvc-14.h"
 
+#if _MSVC_LANG >= 201402L
+# define ACE_HAS_CPP14
+#endif /* _MSVC_LANG >= 201402L */
+
+#if _MSVC_LANG >= 201703L
+# define ACE_HAS_CPP17
+#endif /* _MSVC_LANG >= 201703L */
+
 #include /**/ "ace/post.h"
 #endif /* ACE_CONFIG_WIN32_MSVC_141_H */


### PR DESCRIPTION
…e, with C++17 we don't have auto_ptr so shouldn't do a using

    * ACE/ace/Auto_Ptr.h:
    * ACE/ace/config-win32-msvc-141.h: