### PR TITLE
Make use of std::atomic for the refcount when we have C++11 enabled

### DIFF
--- a/TAO/tao/PortableServer/Servant_Base.cpp
+++ b/TAO/tao/PortableServer/Servant_Base.cpp
@@ -672,7 +672,11 @@ TAO_ServantBase::_remove_ref (void)
 CORBA::ULong
 TAO_ServantBase::_refcount_value (void) const
 {
+#if defined (ACE_HAS_CPP11)
+  return this->ref_count_;
+#else
   return this->ref_count_.value ();
+#endif /* ACE_HAS_CPP11 */
 }
 
 void

--- a/TAO/tao/PortableServer/Servant_Base.h
+++ b/TAO/tao/PortableServer/Servant_Base.h
@@ -22,7 +22,11 @@
 #include "tao/PortableServer/PS_ForwardC.h"
 #include "tao/PortableServer/Servant_var.h"
 #include "tao/Abstract_Servant_Base.h"
+#if defined (ACE_HAS_CPP11)
+#include <atomic>
+#else
 #include "ace/Atomic_Op.h"
+#endif /* ACE_HAS_CPP11 */
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -205,7 +209,11 @@ protected:
 
 protected:
   /// Reference counter.
+#if defined (ACE_HAS_CPP11)
+  std::atomic_uint32_t ref_count_;
+#else
   ACE_Atomic_Op<TAO_SYNCH_MUTEX, unsigned long> ref_count_;
+#endif /* ACE_HAS_CPP11 */
 
   /// The operation table for this servant.  It is initialized by the
   /// most derived class.


### PR DESCRIPTION
    * TAO/tao/PortableServer/Servant_Base.cpp:
    * TAO/tao/PortableServer/Servant_Base.h: