### PR TITLE
Catch exceptions by reference, not by value

### DIFF
--- a/TAO/orbsvcs/tests/Bug_3215_Regression/client.cpp
+++ b/TAO/orbsvcs/tests/Bug_3215_Regression/client.cpp
@@ -75,7 +75,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           ACE_DEBUG ((LM_ERROR, "REGRESSION - Test has failed !!!\n"));
           result = 1;
         }
-      catch (const CORBA::TRANSIENT my_ex)
+      catch (const CORBA::TRANSIENT& my_ex)
         {
           ACE_UNUSED_ARG (my_ex);
           ACE_DEBUG ((LM_DEBUG, "Client catches a TRANSIENT, as expected. No problem !\n"));

--- a/TAO/orbsvcs/tests/FT_Naming/stress_storable/client.cpp
+++ b/TAO/orbsvcs/tests/FT_Naming/stress_storable/client.cpp
@@ -38,7 +38,7 @@ public:
         try {
           group_svc.member_list (group_names[g]);
         }
-        catch (PortableGroup::ObjectGroupNotFound) {
+        catch (PortableGroup::ObjectGroupNotFound&) {
           }
         catch (CORBA::Exception &ex) {
           ACE_DEBUG ((LM_DEBUG,

--- a/TAO/orbsvcs/tests/Notify/Bug_1884_Regression/consumer.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_1884_Regression/consumer.cpp
@@ -115,7 +115,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       proxySupplier_obj = ca->obtain_notification_push_supplier(ctype, proxy_id);
     }
-    catch(CosNotifyChannelAdmin::AdminLimitExceeded err)
+    catch(CosNotifyChannelAdmin::AdminLimitExceeded& err)
     {
       std::cerr << "CosNotifyChannelAdmin::AdminLimitExceeded Exception!" << std::endl;
       throw;
@@ -164,7 +164,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       pps->connect_structured_push_consumer(spc.in());
     }
-    catch (CosEventChannelAdmin::AlreadyConnected ac)
+    catch (CosEventChannelAdmin::AlreadyConnected& ac)
     {
       std::cerr << "CosEventChannelAdmin::AlreadyConnected" << std::endl;
       throw;

--- a/TAO/orbsvcs/tests/Notify/Bug_1884_Regression/filter.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_1884_Regression/filter.cpp
@@ -96,7 +96,7 @@ void match_structure_test (const CosNotifyFilter::Filter_var& filter,
   try{
     bResult = filter->match_structured(event);
   }
-  catch(CosNotifyFilter::UnsupportedFilterableData)
+  catch(CosNotifyFilter::UnsupportedFilterableData&)
   {
     std::cerr << "UnsupportedFilterableData!" << std::endl;
   }

--- a/TAO/orbsvcs/tests/Notify/Bug_1884_Regression/supplier.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_1884_Regression/supplier.cpp
@@ -57,7 +57,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       proxyCon_obj = sa->obtain_notification_push_consumer(ctype, proxy_id);
     }
-    catch(CosNotifyChannelAdmin::AdminLimitExceeded err)
+    catch(CosNotifyChannelAdmin::AdminLimitExceeded& err)
     {
       std::cerr << "CosNotifyChannelAdmin::AdminLimitExceeded Exception!" << std::endl;
       throw;
@@ -71,7 +71,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       ppc->connect_structured_push_supplier(sps.in());
     }
-    catch (CosEventChannelAdmin::AlreadyConnected ac)
+    catch (CosEventChannelAdmin::AlreadyConnected& ac)
     {
       std::cerr << "CosEventChannelAdmin::AlreadyConnected" << std::endl;
       throw;

--- a/TAO/orbsvcs/tests/Notify/Bug_3688_Regression/consumer.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_3688_Regression/consumer.cpp
@@ -114,7 +114,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       proxySupplier_obj = ca->obtain_notification_push_supplier(ctype, proxy_id);
     }
-    catch(CosNotifyChannelAdmin::AdminLimitExceeded err)
+    catch(CosNotifyChannelAdmin::AdminLimitExceeded& err)
     {
       std::cerr << "CosNotifyChannelAdmin::AdminLimitExceeded Exception!" << std::endl;
       throw;
@@ -163,7 +163,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       pps->connect_structured_push_consumer(spc.in());
     }
-    catch (CosEventChannelAdmin::AlreadyConnected ac)
+    catch (CosEventChannelAdmin::AlreadyConnected& ac)
     {
       std::cerr << "CosEventChannelAdmin::AlreadyConnected" << std::endl;
       throw;

--- a/TAO/orbsvcs/tests/Notify/Bug_3688_Regression/supplier.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_3688_Regression/supplier.cpp
@@ -59,7 +59,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       proxyCon_obj = sa->obtain_notification_push_consumer(ctype, proxy_id);
     }
-    catch(CosNotifyChannelAdmin::AdminLimitExceeded err)
+    catch(CosNotifyChannelAdmin::AdminLimitExceeded& err)
     {
       std::cerr << "CosNotifyChannelAdmin::AdminLimitExceeded Exception!" << std::endl;
       throw;
@@ -73,7 +73,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       ppc->connect_structured_push_supplier(sps.in());
     }
-    catch (CosEventChannelAdmin::AlreadyConnected ac)
+    catch (CosEventChannelAdmin::AlreadyConnected& ac)
     {
       std::cerr << "CosEventChannelAdmin::AlreadyConnected" << std::endl;
       throw;

--- a/TAO/tests/Bug_2241_Regression/Client_Task.cpp
+++ b/TAO/tests/Bug_2241_Regression/Client_Task.cpp
@@ -39,7 +39,7 @@ Client_Task::svc (void)
 
            hello->shutdown ();
         }
-      catch (const CORBA::INTERNAL)
+      catch (const CORBA::INTERNAL&)
         {
           exception = true;
           ACE_DEBUG ((LM_DEBUG, "OK: Client_Task Expected exception received\n"));

--- a/TAO/tests/Collocated_ThruP_Sp/Client_Task.cpp
+++ b/TAO/tests/Collocated_ThruP_Sp/Client_Task.cpp
@@ -41,7 +41,7 @@ Client_Task::svc (void)
 
           hello->shutdown ();
         }
-      catch (const CORBA::INTERNAL)
+      catch (const CORBA::INTERNAL&)
         {
           exception = true;
           ACE_DEBUG ((LM_DEBUG, "OK: Client_Task Expected exception received\n"));

--- a/TAO/tests/Collocated_ThruP_Sp_Gd/Client_Task.cpp
+++ b/TAO/tests/Collocated_ThruP_Sp_Gd/Client_Task.cpp
@@ -41,7 +41,7 @@ Client_Task::svc (void)
 
           hello->shutdown ();
         }
-      catch (const CORBA::INTERNAL)
+      catch (const CORBA::INTERNAL&)
         {
           exception = true;
           ACE_DEBUG ((LM_DEBUG, "OK: Client_Task Expected exception received\n"));

--- a/TAO/tests/UNKNOWN_Exception/client.cpp
+++ b/TAO/tests/UNKNOWN_Exception/client.cpp
@@ -67,7 +67,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         {
           test->unknown_exception_in_method ();
         }
-      catch (const CORBA::UNKNOWN)
+      catch (const CORBA::UNKNOWN&)
         {
           unknown_exception_raised = 1;
 


### PR DESCRIPTION
    * TAO/orbsvcs/tests/Bug_3215_Regression/client.cpp:
    * TAO/orbsvcs/tests/FT_Naming/stress_storable/client.cpp:
    * TAO/orbsvcs/tests/Notify/Bug_1884_Regression/consumer.cpp:
    * TAO/orbsvcs/tests/Notify/Bug_1884_Regression/filter.cpp:
    * TAO/orbsvcs/tests/Notify/Bug_1884_Regression/supplier.cpp:
    * TAO/orbsvcs/tests/Notify/Bug_3688_Regression/consumer.cpp:
    * TAO/orbsvcs/tests/Notify/Bug_3688_Regression/supplier.cpp:
    * TAO/tests/Bug_2241_Regression/Client_Task.cpp:
    * TAO/tests/Collocated_ThruP_Sp/Client_Task.cpp:
    * TAO/tests/Collocated_ThruP_Sp_Gd/Client_Task.cpp:
    * TAO/tests/UNKNOWN_Exception/client.cpp: