### PR TITLE
added explicit include of <string> to fix older MSVC compile errors

### DIFF
--- a/ACE/ace/CDR_Stream.h
+++ b/ACE/ace/CDR_Stream.h
@@ -56,6 +56,7 @@
 #include "Monitor_Size.h"
 #endif /* ACE_HAS_MONITOR_POINTS==1 */
 
+#include <string>
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 


### PR DESCRIPTION
    * ACE/ace/CDR_Stream.h: