### PR TITLE
For per client activated servers store the server reference within the AAM

### DIFF
--- a/ACE/ace/Connector.h
+++ b/ACE/ace/Connector.h
@@ -70,7 +70,7 @@ public:
 
   /// Close up and return underlying SVC_HANDLER through @c sh.
   /**
-   * If the return value is true the close was performed succesfully,
+   * If the return value is true the close was performed successfully,
    * implying that this object was removed from the reactor and thereby
    * (by means of reference counting decremented to 0) deleted.
    * If the return value is false, the close was not successful.

--- a/TAO/bin/tao_other_tests.lst
+++ b/TAO/bin/tao_other_tests.lst
@@ -145,6 +145,7 @@ TAO/orbsvcs/tests/ImplRepo/locked/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_
 TAO/orbsvcs/tests/ImplRepo/manual_start/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO !OpenVMS
 TAO/orbsvcs/tests/ImplRepo/scale/run_test.pl -servers 5 -objects 5: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !ACE_FOR_TAO !LynxOS
 TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !ACE_FOR_TAO !LynxOS
+TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl -clients 3 -secs_between_clients 0 -activationmode per_client: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !ACE_FOR_TAO !LynxOS
 TAO/orbsvcs/tests/ImplRepo/servers_list/run_test.pl: !ST !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !ACE_FOR_TAO !LynxOS
 TAO/orbsvcs/tests/ImplRepo/servers_list/run_test_ft.pl: !ST !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !ACE_FOR_TAO !LynxOS
 TAO/orbsvcs/tests/ImplRepo/Bug_689_Regression/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !ACE_FOR_TAO

--- a/TAO/docs/pluggable_messaging.html
+++ b/TAO/docs/pluggable_messaging.html
@@ -4,17 +4,17 @@
   <head>
     <title>Pluggable Messaging framework</title>
   </head>
-  
+
   <BODY text = "#000000"
     link="#0000ff"
     vlink="#cc0000"
     bgcolor="#ffffff">
-    
+
     <body>
       <HR>
-          	<h1>Pluggable Messaging Framework</h1>
-	<HR>
-	  <h2>Context</h2>
+            <h1>Pluggable Messaging Framework</h1>
+  <HR>
+    <h2>Context</h2>
           TAO uses GIOP message formats to exchange messages between
           inter-operating ORBs. GIOP, essentially specifies formats of
           messages exchanged between ORBs. It has only a few message
@@ -26,30 +26,30 @@
           different protocols. The framework,though not complete in
           itself, has been used for implementing GIOP and
           GIOPlite. The framework would be re-factored and reworked
-          depending on the use cases our users come across. 
-	  
-	  <h2>Idea</h2>
+          depending on the use cases our users come across.
+
+    <h2>Idea</h2>
           We wanted to give a flexibility to the user to load the message
           formatting protocol by selecting a protocol during the
-          bootstrapping process. So, we tried to leverage the work 
+          bootstrapping process. So, we tried to leverage the work
           that has already been done for the <a HREF =
-          "pluggable_protocols/index.html"> pluggable_protocols</a>. 
+          "pluggable_protocols/index.html"> pluggable_protocols</a>.
 
           The fundamental idea that we followed was to isolate all of
           the ORB code from the message formatting details. The
           framework is constrained by the type of marshalling
           scheme. The framework now completely relies on CDR
-          formatted streams. 
-          
-          
+          formatted streams.
+
+
           <h2>Implementation of GIOP</h2>
 
           <P>The common interface that has  been defined is the class
           Pluggable_Messaging_Interface forms the core class for the
           implementation of a concrete messaging protocol. We have
-          been able to implement the GIOP & GIOPlite succesfully using
+          been able to implement the GIOP & GIOPlite successfully using
           this minimal interface. The different versions of GIOP have
-          been managed succesfully within this implementation.</P>
+          been managed successfully within this implementation.</P>
 
           <P>When the user loads protocols like IIOP he/she in turn is
           loading the TCP/IP mapping of GIOP formatted message. The
@@ -58,11 +58,11 @@
           the user behind the scene. If an user wants to use GIOPlite
           mapped on to TCP/IP he would load IIOP_Lite using the
           svc.conf file. The format is given below </P>
-          
+
           <P><code>dynamic IIOP_Lite_Factory Service_Object * TAO:_make_TAO_IIOP_Lite_Protocol_Factory() ""</code></P>
           <P><code>static Resource_Factory "-ORBProtocolFactory IIOP_Lite_Factory". </code></P>
 
-          <P>At the moment the TAO Strategies library is used the 
+          <P>At the moment the TAO Strategies library is used the
           svc.conf file should contain: </P>
 
           <P><code>dynamic IIOP_Lite_Factory Service_Object * TAO:_make_TAO_IIOP_Lite_Protocol_Factory() ""</code></P>
@@ -71,7 +71,7 @@
           <P>Please see the documentation of the pluggable protocol
           framework for exact meaning of the above syntax. The same
           applies to GIOPlite mapping on UIOP too.</P>
-          
+
           <P>The class GIOP_Message_Base derives from the
           Pluggable_Messaging_Interface. This class holds most of the
           common code needed for the GIOP classes. GIOP places a
@@ -112,16 +112,16 @@
           <P> Uses only CDR formats. </P>
           <P> Need more ise cases to make the interface more flexible
           and better. </P>
-          
-                                         
-	  <HR>
-	    For more details and questions,
-	    <p>
-	      
-	      <address><a href="mailto:bala@cs.wustl.edu">Balachandran
-	      Natarajan</a></address>
-	      <p>
-		<address><a href="mailto:fredk@cs.wustl.edu">Fred Kuhns</a></address>
+
+
+    <HR>
+      For more details and questions,
+      <p>
+
+        <address><a href="mailto:bala@cs.wustl.edu">Balachandran
+        Natarajan</a></address>
+        <p>
+    <address><a href="mailto:fredk@cs.wustl.edu">Fred Kuhns</a></address>
     </body>
 </html>
 

--- a/TAO/examples/Persistent_Grid/Grid_Client_i.cpp
+++ b/TAO/examples/Persistent_Grid/Grid_Client_i.cpp
@@ -74,7 +74,7 @@ Grid_Client_i::run (const char *name,
                                          height_);
 
       ACE_DEBUG ((LM_DEBUG,
-                  "(%P|%t) Made the grid succesfully\n"));
+                  "(%P|%t) Made the grid successfully\n"));
 
       for (CORBA::Short index_ = 0; index_ < width_; index_++)
         {

--- a/TAO/examples/Persistent_Grid/Persistent_Client_i.cpp
+++ b/TAO/examples/Persistent_Grid/Persistent_Client_i.cpp
@@ -65,7 +65,7 @@ Persistent_Client_i::run (const char *name,
                                          height_);
 
       ACE_DEBUG ((LM_DEBUG,
-                  "(%P|%t) Made the grid succesfully\n"));
+                  "(%P|%t) Made the grid successfully\n"));
 
 
       for (CORBA::Short index_ = 0; index_ < height_; index_++)

--- a/TAO/examples/Simple/grid/Grid_Client_i.cpp
+++ b/TAO/examples/Simple/grid/Grid_Client_i.cpp
@@ -82,7 +82,7 @@ Grid_Client_i::run (const char *name,
                                           height_);
 
       ACE_DEBUG ((LM_DEBUG,
-                  ACE_TEXT ("(%P|%t) Made the grid succesfully\n")));
+                  ACE_TEXT ("(%P|%t) Made the grid successfully\n")));
 
       // Set a value on the grid
       grid->set (setx_,

--- a/TAO/orbsvcs/DevGuideExamples/ImplRepo/README
+++ b/TAO/orbsvcs/DevGuideExamples/ImplRepo/README
@@ -1,5 +1,3 @@
-
-
 DevGuideExamples/ImplRepo/README
 
 This directory contains a CORBA example illustrating use of the TAO
@@ -16,13 +14,13 @@ $TAO_ROOT/orbsvcs/ImplRepo_Service/ImplRepo_Service -o implrepo.ior
 Register the server's POA name and start-up command with the ImplRepo:
 ----------------------------------------------------------------------
 $TAO_ROOT/orbsvcs/ImplRepo_Service/tao_imr -ORBInitRef \
-	ImplRepoService=file://implrepo.ior add MessengerService \
-	-c "MessengerServer -ORBUseIMR 1 -ORBInitRef ImplRepoService=file://implrepo.ior"
+  ImplRepoService=file://implrepo.ior add MessengerService \
+  -c "MessengerServer -ORBUseIMR 1 -ORBInitRef ImplRepoService=file://implrepo.ior"
 
 Generate an IMRified Object Reference for the MessengerService:
 ---------------------------------------------------------------
 $TAO_ROOT/orbsvcs/ImplRepo_Service/tao_imr -ORBInitRef \
-	ImplRepoService=file://implrepo.ior ior MessengerService -f Messenger.ior
+  ImplRepoService=file://implrepo.ior ior MessengerService -f Messenger.ior
 
 Run the client (ImplRepo should automatically start the server):
 ----------------------------------------------------------------

--- a/TAO/orbsvcs/ImplRepo_Service/Activator_Options.h
+++ b/TAO/orbsvcs/ImplRepo_Service/Activator_Options.h
@@ -57,7 +57,7 @@ public:
   bool service (void) const;
 
   /// Notify the ImR when server processes die.
-  /// Note : Currently this only works on Unix.
+  /// @note Currently this only works on Unix.
   bool notify_imr (void) const;
 
   /// When notifying of child death, pause this number of milliseconds
@@ -110,8 +110,12 @@ private:
   /// Should we run as a service?
   bool service_;
 
+  /// Notify the ImR when server processes die.
+  /// @note Currently this only works on Unix.
   bool notify_imr_;
 
+  /// When notifying of child death, pause this number of milliseconds
+  /// to simulate a heavily loaded server.
   unsigned int induce_delay_;
 
   /// SC_NONE, SC_INSTALL, SC_REMOVE, ...

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -776,7 +776,7 @@ AccessLiveListener::~AccessLiveListener (void)
 bool
 AccessLiveListener::start (void)
 {
-  bool started = this->per_client_ ?
+  bool const started = this->per_client_ ?
     this->pinger_.add_per_client_listener (this, srv_ref_.in()) :
     this->pinger_.add_listener (this);
   if (!started)

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -27,8 +27,8 @@ AsyncAccessManager::AsyncAccessManager (UpdateableServerInfo &info,
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::ctor server <%C> pid = %d, %d\n"),
-                      this, info->ping_id (), info->pid, info_->pid));
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::ctor server <%C> pid <%d>\n"),
+                      this, info->ping_id (), info->pid));
     }
   this->prev_pid_ = info_->pid;
 }
@@ -66,7 +66,7 @@ void
 AsyncAccessManager::report (void)
 {
   ORBSVCS_DEBUG ((LM_DEBUG,
-                  ACE_TEXT ("(%P|%t) AsyncAccessManager(%@) - Server: %C, pid: %d, lastpid: %d, status: %C, waiters: %d\n"),
+                  ACE_TEXT ("(%P|%t) AsyncAccessManager(%@) - Server <%C> pid <%d> lastpid <%d> status <%C> waiters <%d>\n"),
                   this, info_->ping_id (), info_->pid, this->prev_pid_, status_name (this->status_), this->rh_list_ .size()));
 }
 
@@ -97,7 +97,7 @@ AsyncAccessManager::add_interest (ImR_ResponseHandler *rh, bool manual)
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::add_interest status <%s>\n"),
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::add_interest status <%C>\n"),
                       this,
                       status_name (this->status_)));
     }
@@ -262,7 +262,7 @@ AsyncAccessManager::notify_waiters (void)
                         ("Server terminating.");
                     default: {
                       ACE_CString reason = ACE_CString ("AAM_Status is ") +
-                        ACE_TEXT_ALWAYS_CHAR (status_name (this->status_));
+                        status_name (this->status_);
                       throw ImplementationRepository::CannotActivate (reason.c_str());
                     }
                     }
@@ -288,44 +288,44 @@ AsyncAccessManager::is_final (ImplementationRepository::AAM_Status s)
           s == ImplementationRepository::AAM_RETRIES_EXCEEDED);
 }
 
-const ACE_TCHAR *
+const char *
 AsyncAccessManager::status_name (ImplementationRepository::AAM_Status s)
 {
   switch (s)
     {
     case ImplementationRepository::AAM_INIT:
-      return ACE_TEXT ("INIT");
+      return "INIT";
     case ImplementationRepository::AAM_SERVER_STARTED_RUNNING:
-      return ACE_TEXT ("SERVER_STARTED_RUNNING");
+      return "SERVER_STARTED_RUNNING";
     case ImplementationRepository::AAM_ACTIVATION_SENT:
-      return ACE_TEXT ("ACTIVATION_SENT");
+      return "ACTIVATION_SENT";
     case ImplementationRepository::AAM_WAIT_FOR_RUNNING:
-      return ACE_TEXT ("WAIT_FOR_RUNNING");
+      return "WAIT_FOR_RUNNING";
     case ImplementationRepository::AAM_WAIT_FOR_PING:
-      return ACE_TEXT ("WAIT_FOR_PING");
+      return "WAIT_FOR_PING";
     case ImplementationRepository::AAM_WAIT_FOR_ALIVE:
-      return ACE_TEXT ("WAIT_FOR_ALIVE");
+      return "WAIT_FOR_ALIVE";
     case ImplementationRepository::AAM_WAIT_FOR_DEATH:
-      return ACE_TEXT ("WAIT_FOR_DEATH");
+      return "WAIT_FOR_DEATH";
     case ImplementationRepository::AAM_SERVER_READY:
-      return ACE_TEXT ("SERVER_READY");
+      return "SERVER_READY";
     case ImplementationRepository::AAM_SERVER_DEAD:
-      return ACE_TEXT ("SERVER_DEAD");
+      return "SERVER_DEAD";
     case ImplementationRepository::AAM_NOT_MANUAL:
-      return ACE_TEXT ("NOT_MANUAL");
+      return "NOT_MANUAL";
     case ImplementationRepository::AAM_NO_ACTIVATOR:
-      return ACE_TEXT ("NO_ACTIVATOR");
+      return "NO_ACTIVATOR";
     case ImplementationRepository::AAM_NO_COMMANDLINE:
-      return ACE_TEXT ("NO_COMMANDLINE");
+      return "NO_COMMANDLINE";
     case ImplementationRepository::AAM_RETRIES_EXCEEDED:
-      return ACE_TEXT ("RETRIES_EXCEEDED");
+      return "RETRIES_EXCEEDED";
     case ImplementationRepository::AAM_UPDATE_FAILED:
-      return ACE_TEXT ("UPDATE_FAILED");
+      return "UPDATE_FAILED";
     case ImplementationRepository::AAM_ACTIVE_TERMINATE:
-      return ACE_TEXT ("ACTIVE_TERMINATE");
+      return "ACTIVE_TERMINATE";
 
     }
-  return ACE_TEXT ("<undefined status>");
+  return "<undefined status>";
 }
 
 ImplementationRepository::AAM_Status
@@ -367,7 +367,7 @@ AsyncAccessManager::activator_replied (bool success, int pid)
             {
               ORBSVCS_DEBUG ((LM_DEBUG,
                               ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::activator_replied with ")
-                              ACE_TEXT ("pid = %d this pid = %d, status = %s\n"),
+                              ACE_TEXT ("pid <%d> this pid <%d> status <%C>\n"),
                               this, pid, this->info_->pid, status_name (this->status_)));
             }
           this->update_status (ImplementationRepository::AAM_SERVER_READY);
@@ -389,7 +389,7 @@ AsyncAccessManager::shutdown_initiated (void)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::shutdown_initiated ")
-                      ACE_TEXT ("on server <%C> pid <%d> current status <%s>\n"),
+                      ACE_TEXT ("on server <%C> pid <%d> current status <%C>\n"),
                       this, this->info_->ping_id(), this->info_->pid, status_name (this->status_)));
     }
   this->prev_pid_ = this->info_->pid;
@@ -409,7 +409,7 @@ AsyncAccessManager::server_is_shutting_down (void)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::server_is_shutting_down ")
-                      ACE_TEXT ("on server <%C> pid <%d> prev_pid <%d> current status <%s>\n"),
+                      ACE_TEXT ("on server <%C> pid <%d> prev_pid <%d> current status <%C>\n"),
                       this, this->info_->ping_id(), this->info_->pid, this->prev_pid_, status_name (this->status_)));
     }
   this->prev_pid_ = this->info_->pid;
@@ -468,8 +468,8 @@ AsyncAccessManager::notify_child_death (int pid)
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@), child death, pid = %d, status = %s ")
-                      ACE_TEXT ("this info_.pid = %d, prev_pid = %d, waiter count = %d\n"),
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@), child death, pid <%d>, status <%C> ")
+                      ACE_TEXT ("this info_.pid <%d> prev_pid <%d> waiter count <%d>\n"),
                       this, pid, status_name (status_),
                       this->info_->pid, this->prev_pid_, this->rh_list_.size() ));
     }
@@ -495,7 +495,7 @@ AsyncAccessManager::listener_disconnected (void)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::listener_disconnected,")
-                      ACE_TEXT (" this status %s\n"),
+                      ACE_TEXT (" this status <%C>\n"),
                       this, status_name (this->status_)));
     }
 
@@ -509,8 +509,8 @@ AsyncAccessManager::ping_replied (LiveStatus server)
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::ping_replied %s,")
-                      ACE_TEXT (" this status %s\n"),
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::ping_replied <%C>,")
+                      ACE_TEXT (" this status <%C>\n"),
                       this, LiveEntry::status_name (server), status_name (this->status_)));
     }
 

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -580,7 +580,7 @@ AsyncAccessManager::send_start_request (void)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::send_start_request, manual_start_ %d\n"),
-                      this->manual_start_));
+                      this, this->manual_start_));
     }
 
   if ((this->locator_.opts ()->lockout () && !this->info_.edit ()->start_allowed ()) ||

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -67,7 +67,7 @@ AsyncAccessManager::report (void)
 {
   ORBSVCS_DEBUG ((LM_DEBUG,
                   ACE_TEXT ("(%P|%t) AsyncAccessManager(%@) - Server <%C> pid <%d> lastpid <%d> status <%C> waiters <%d>\n"),
-                  this, info_->ping_id (), info_->pid, this->prev_pid_, status_name (this->status_), this->rh_list_ .size()));
+                  this, info_->ping_id (), info_->pid, this->prev_pid_, status_name (this->status_), this->rh_list_.size()));
 }
 
 void
@@ -424,8 +424,9 @@ AsyncAccessManager::server_is_running (const char *partial_ior,
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::server_is_running\n"),
-                      this));
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::server_is_running ")
+                      ACE_TEXT("for server <%C> pid <%d> prev_pid <%d> current status <%C>\n"),
+                      this, this->info_->ping_id(), this->info_->pid, this->prev_pid_, status_name (this->status_)));
     }
 
   this->update_status (ImplementationRepository::AAM_WAIT_FOR_ALIVE);

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -389,7 +389,7 @@ AsyncAccessManager::shutdown_initiated (void)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::shutdown_initiated ")
-                      ACE_TEXT ("on server <%C> pid=%d current status = %s\n"),
+                      ACE_TEXT ("on server <%C> pid <%d> current status <%s>\n"),
                       this, this->info_->ping_id(), this->info_->pid, status_name (this->status_)));
     }
   this->prev_pid_ = this->info_->pid;
@@ -409,7 +409,7 @@ AsyncAccessManager::server_is_shutting_down (void)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::server_is_shutting_down ")
-                      ACE_TEXT ("on server <%C> pid = %d prev_pid = %d, current status = %s\n"),
+                      ACE_TEXT ("on server <%C> pid <%d> prev_pid <%d> current status <%s>\n"),
                       this, this->info_->ping_id(), this->info_->pid, this->prev_pid_, status_name (this->status_)));
     }
   this->prev_pid_ = this->info_->pid;

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -27,7 +27,7 @@ AsyncAccessManager::AsyncAccessManager (UpdateableServerInfo &info,
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::ctor server = %C pid = %d, %d\n"),
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::ctor server <%C> pid = %d, %d\n"),
                       this, info->ping_id (), info->pid, info_->pid));
     }
   this->prev_pid_ = info_->pid;
@@ -38,7 +38,7 @@ AsyncAccessManager::~AsyncAccessManager (void)
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::dtor server = %C\n"),
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::dtor server <%C>\n"),
                       this, info_->ping_id ()));
     }
 }
@@ -97,7 +97,7 @@ AsyncAccessManager::add_interest (ImR_ResponseHandler *rh, bool manual)
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::add_interest status = %s\n"),
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::add_interest status <%s>\n"),
                       this,
                       status_name (this->status_)));
     }
@@ -212,7 +212,7 @@ AsyncAccessManager::final_state (bool active)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::final_state ")
-                          ACE_TEXT ("removing this from map, server = <%C>\n"),
+                          ACE_TEXT ("removing this from map, server <%C>\n"),
                           this, info_->ping_id ()));
         }
       if (this->remove_on_death_rh_ != 0)
@@ -579,7 +579,7 @@ AsyncAccessManager::send_start_request (void)
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager::send_start_request, manual_start_ %d\n"),
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@)::send_start_request, manual_start_ %d\n"),
                       this->manual_start_));
     }
 

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -742,8 +742,8 @@ ActivatorReceiver::kill_server_excep (Messaging::ExceptionHolder * )
 //---------------------------------------------------------------------------
 
 AccessLiveListener::AccessLiveListener (const char *server,
-                                      AsyncAccessManager *aam,
-                                      LiveCheck &pinger)
+                                        AsyncAccessManager *aam,
+                                        LiveCheck &pinger)
   :LiveListener (server),
    aam_ (aam->_add_ref ()),
    pinger_ (pinger),
@@ -754,9 +754,9 @@ AccessLiveListener::AccessLiveListener (const char *server,
 }
 
 AccessLiveListener::AccessLiveListener (const char *server,
-                                      AsyncAccessManager *aam,
-                                      LiveCheck &pinger,
-                                      ImplementationRepository::ServerObject_ptr ref)
+                                        AsyncAccessManager *aam,
+                                        LiveCheck &pinger,
+                                        ImplementationRepository::ServerObject_ptr ref)
   :LiveListener (server),
    aam_ (aam->_add_ref ()),
    pinger_ (pinger),

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -700,7 +700,7 @@ ActivatorReceiver::start_server_excep (Messaging::ExceptionHolder *holder)
     {
       if (ACE_OS::strstr (ca.reason.in(),"pid:") == ca.reason.in())
         {
-          int pid = ACE_OS::atoi (ca.reason.in()+4);
+          int const pid = ACE_OS::atoi (ca.reason.in()+4);
           this->aam_->activator_replied (true, pid);
         }
       else

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -135,7 +135,6 @@ private:
   PortableServer::POA_var poa_;
 };
 
-
 //----------------------------------------------------------------------------
 
 class AccessLiveListener : public LiveListener
@@ -162,9 +161,5 @@ class AccessLiveListener : public LiveListener
   bool per_client_;
   ImplementationRepository::ServerObject_var srv_ref_;
 };
-
-
-
-
 
 #endif /* IMR_ASYNCACCESSMANGER_H_  */

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -103,6 +103,11 @@ class Locator_Export AsyncAccessManager
   int refcount_;
   TAO_SYNCH_MUTEX lock_;
   int prev_pid_;
+
+  /// The cached server object in case this is a per client activated AAM
+  ImplementationRepository::ServerObject_var server_;
+  /// Current endpoint used by the server in case this is a per client activated AAM
+  ACE_CString partial_ior_;
 };
 
 typedef TAO_Intrusive_Ref_Count_Handle<AsyncAccessManager> AsyncAccessManager_ptr;

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -77,7 +77,7 @@ class Locator_Export AsyncAccessManager
 
   AsyncAccessManager *_add_ref (void);
   void _remove_ref (void);
-  static const ACE_TCHAR *status_name (ImplementationRepository::AAM_Status s);
+  static const char *status_name (ImplementationRepository::AAM_Status s);
   static bool is_final (ImplementationRepository::AAM_Status s);
   void report (void);
   void update_prev_pid (void);

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -58,8 +58,8 @@ class Locator_Export AsyncAccessManager
 
   void started_running (void);
 
-  bool is_terminating (void);
-  bool has_server (const char *name);
+  bool is_terminating (void) const;
+  bool has_server (const char *name) const ;
   void remote_state (ImplementationRepository::AAM_Status s);
 
   void add_interest (ImR_ResponseHandler *rh, bool manual);
@@ -79,7 +79,7 @@ class Locator_Export AsyncAccessManager
   void _remove_ref (void);
   static const char *status_name (ImplementationRepository::AAM_Status s);
   static bool is_final (ImplementationRepository::AAM_Status s);
-  void report (void);
+  void report (void) const;
   void update_prev_pid (void);
 
  private:

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -59,6 +59,7 @@ class Locator_Export AsyncAccessManager
   void started_running (void);
 
   bool is_terminating (void) const;
+  bool is_running (void) const;
   bool has_server (const char *name) const ;
   void remote_state (ImplementationRepository::AAM_Status s);
 
@@ -79,10 +80,10 @@ class Locator_Export AsyncAccessManager
   void _remove_ref (void);
   static const char *status_name (ImplementationRepository::AAM_Status s);
   static bool is_final (ImplementationRepository::AAM_Status s);
-  void report (void) const;
   void update_prev_pid (void);
 
  private:
+  void report (const char* operation) const;
   void final_state (bool active = true);
   void notify_waiters (void);
   void status (ImplementationRepository::AAM_Status s);

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -142,13 +142,13 @@ class AccessLiveListener : public LiveListener
 {
  public:
   AccessLiveListener (const char * server,
-                     AsyncAccessManager *aam,
-                     LiveCheck &pinger,
-                     ImplementationRepository::ServerObject_ptr ref);
+                      AsyncAccessManager *aam,
+                      LiveCheck &pinger,
+                      ImplementationRepository::ServerObject_ptr ref);
 
   AccessLiveListener (const char * server,
-                     AsyncAccessManager *aam,
-                     LiveCheck &pinger);
+                      AsyncAccessManager *aam,
+                      LiveCheck &pinger);
 
   virtual ~AccessLiveListener (void);
   bool start (void);

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncListManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncListManager.cpp
@@ -300,8 +300,8 @@ AsyncListManager::ping_replied (CORBA::ULong index, LiveStatus status, int pid)
   if (ImR_Locator_i::debug() > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncListManager(%@)::ping_replied, index = %d ")
-                      ACE_TEXT ("status = %C, server pid = %d, waiters = %d\n"),
+                      ACE_TEXT ("(%P|%t) AsyncListManager(%@)::ping_replied, index <%d> ")
+                      ACE_TEXT ("status <%C>, server pid <%d>, waiters <%d>\n"),
                       this,index, LiveEntry::status_name (status), pid, this->waiters_));
     }
   if (evaluate_status (index, status, pid))

--- a/TAO/orbsvcs/ImplRepo_Service/Config_Backing_Store.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Config_Backing_Store.cpp
@@ -87,7 +87,7 @@ void Config_Backing_Store::loadActivators ()
 
           const ACE_CString name_cstr = ACE_TEXT_ALWAYS_CHAR (name.c_str ());
 
-          Activator_Info* ai;
+          Activator_Info* ai = 0;
           ACE_NEW (ai, Activator_Info (name_cstr, token, ior));
 
           Activator_Info_Ptr info (ai);

--- a/TAO/orbsvcs/ImplRepo_Service/Forwarder.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Forwarder.cpp
@@ -206,7 +206,7 @@ ImR_DSI_ResponseHandler::send_ior (const char *pior)
     {
       ORBSVCS_ERROR ((LM_ERROR,
                   ACE_TEXT ("(%P|%t) ImR_ResponseHandler::send_ior (): Invalid corbaloc ior.\n")
-                  ACE_TEXT ("\t<%s>\n"),
+                  ACE_TEXT ("\t<%C>\n"),
                   ior.c_str()));
     }
 

--- a/TAO/orbsvcs/ImplRepo_Service/INS_Locator.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/INS_Locator.cpp
@@ -47,7 +47,7 @@ INS_Locator::async_locate (::IORTable::Locate_ResponseHandler handler,
   ACE_CString full (object_key);
   if (this->imr_locator_.split_key (full, key, si))
     {
-      ImR_ResponseHandler *rh;
+      ImR_ResponseHandler *rh = 0;
       ACE_NEW (rh, INS_Loc_ResponseHandler (key.c_str(), handler));
       this->imr_locator_.activate_server_by_info (si, rh);
     }

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
@@ -81,7 +81,7 @@ ImR_Activator_i::register_with_imr (ImplementationRepository::Activator_ptr acti
   try
     {
       if (this->debug_ > 1)
-        ORBSVCS_DEBUG( (LM_DEBUG, "ImR Activator: Contacting ImplRepoService...\n"));
+        ORBSVCS_DEBUG( (LM_DEBUG, "(%P|%t) ImR Activator: Contacting ImplRepoService...\n"));
 
       // First, resolve the ImR, without this we can go no further
       CORBA::Object_var obj =
@@ -97,7 +97,7 @@ ImR_Activator_i::register_with_imr (ImplementationRepository::Activator_ptr acti
           if (this->debug_ > 9)
             {
               CORBA::String_var ior = orb_->object_to_string (obj.in ());
-              ORBSVCS_DEBUG((LM_DEBUG, "ImR Activator: ImplRepoService ior <%C>\n",
+              ORBSVCS_DEBUG((LM_DEBUG, "(%P|%t) ImR Activator: ImplRepoService ior <%C>\n",
                              ior.in()));
             }
 
@@ -105,22 +105,21 @@ ImR_Activator_i::register_with_imr (ImplementationRepository::Activator_ptr acti
             locator_->register_activator (name_.c_str (), activator);
 
           if (debug_ > 0)
-            ORBSVCS_DEBUG((LM_DEBUG, "ImR Activator: Registered with ImR.\n"));
+            ORBSVCS_DEBUG((LM_DEBUG, "(%P|%t) ImR Activator: Registered with ImR.\n"));
 
           return;
         }
       else if (this->debug_ > 1)
-        ORBSVCS_DEBUG((LM_DEBUG, "ImR Activator: ImplRepoService not found\n"));
+        ORBSVCS_DEBUG((LM_DEBUG, "(%P|%t) ImR Activator: ImplRepoService not found\n"));
     }
   catch (const CORBA::Exception& ex)
     {
       if (debug_ > 1)
-        ex._tao_print_exception (
-                                 "ImR Activator: Can't register with ImR.");
+        ex._tao_print_exception ("ImR Activator: Can't register with ImR.");
     }
 
   if (debug_ > 0)
-    ORBSVCS_DEBUG ((LM_DEBUG, "ImR Activator: Not registered with ImR.\n"));
+    ORBSVCS_DEBUG ((LM_DEBUG, "(%P|%t) ImR Activator: Not registered with ImR.\n"));
 }
 
 int
@@ -170,7 +169,7 @@ ImR_Activator_i::init_with_orb (CORBA::ORB_ptr orb, const Activator_Options& opt
       CORBA::String_var ior = this->orb_->object_to_string (activator.in ());
 
       if (this->debug_ > 0)
-        ORBSVCS_DEBUG((LM_DEBUG, "ImR Activator: Starting %C\n", name_.c_str ()));
+        ORBSVCS_DEBUG((LM_DEBUG, "(%P|%t) ImR Activator: Starting <%C>\n", name_.c_str ()));
 
       // initialize our process manager.
       // This requires a reactor that has signal handling.
@@ -180,7 +179,7 @@ ImR_Activator_i::init_with_orb (CORBA::ORB_ptr orb, const Activator_Options& opt
           if (this->process_mgr_.open (ACE_Process_Manager::DEFAULT_SIZE, reactor) == -1)
             {
               ORBSVCS_ERROR_RETURN ((LM_ERROR,
-                                     "The ACE_Process_Manager didnt get initialized\n"), -1);
+                                     "(%P|%t) ImR Activator: The ACE_Process_Manager didn't get initialized\n"), -1);
             }
         }
 
@@ -193,7 +192,7 @@ ImR_Activator_i::init_with_orb (CORBA::ORB_ptr orb, const Activator_Options& opt
       if (this->debug_ > 1)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          "ImR Activator: The Activator IOR is: <%C>\n", ior.in ()));
+                          "(%P|%t) ImR Activator: The Activator IOR is: <%C>\n", ior.in ()));
         }
 
       // The last thing we do is write out the ior so that a test program can assume
@@ -204,7 +203,7 @@ ImR_Activator_i::init_with_orb (CORBA::ORB_ptr orb, const Activator_Options& opt
           if (fp == 0)
             {
               ORBSVCS_ERROR_RETURN ((LM_ERROR,
-                                     "ImR Activator: Could not open file: %s\n", opts.ior_filename ().c_str ()), -1);
+                                     "(%P|%t) ImR Activator: Could not open file <%s>\n", opts.ior_filename ().c_str ()), -1);
             }
           ACE_OS::fprintf (fp, "%s", ior.in ());
           ACE_OS::fclose (fp);
@@ -212,8 +211,7 @@ ImR_Activator_i::init_with_orb (CORBA::ORB_ptr orb, const Activator_Options& opt
     }
   catch (const CORBA::Exception& ex)
     {
-      ex._tao_print_exception (
-                               "ImR_Activator_i::init_with_orb");
+      ex._tao_print_exception ("ImR_Activator_i::init_with_orb");
       throw;
     }
   return 0;
@@ -229,10 +227,9 @@ ImR_Activator_i::init (Activator_Options& opts)
   ACE_ARGV av (ACE_TEXT_CHAR_TO_TCHAR (cmdline.c_str ()));
   int argc = av.argc ();
 
-  CORBA::ORB_var orb =
-    CORBA::ORB_init (argc, av.argv (), "TAO_ImR_Activator");
+  CORBA::ORB_var orb = CORBA::ORB_init (argc, av.argv (), "TAO_ImR_Activator");
 
-  int ret = this->init_with_orb(orb.in (), opts);
+  int const ret = this->init_with_orb(orb.in (), opts);
 
   return ret;
 }
@@ -243,7 +240,7 @@ ImR_Activator_i::fini (void)
   try
     {
       if (debug_ > 1)
-        ORBSVCS_DEBUG ((LM_DEBUG, "ImR Activator: Shutting down...\n"));
+        ORBSVCS_DEBUG ((LM_DEBUG, "(%P|%t) ImR Activator: Shutting down...\n"));
 
       this->process_mgr_.close ();
 
@@ -259,13 +256,13 @@ ImR_Activator_i::fini (void)
     {
       if (debug_ > 1)
         ORBSVCS_DEBUG ((LM_DEBUG,
-                        ACE_TEXT ("(%P|%t) ImR Activator: Unable to unregister from ImR.\n")));
+                        ACE_TEXT ("(%P|%t) ImR Activator: COMM_FAILURE, unable to unregister from ImR.\n")));
     }
   catch (const CORBA::TRANSIENT&)
     {
       if (debug_ > 1)
         ORBSVCS_DEBUG ((LM_DEBUG,
-                        ACE_TEXT ("(%P|%t) ImR Activator: Unable to unregister from ImR.\n")));
+                        ACE_TEXT ("(%P|%t) ImR Activator: TRANSIENT, unable to unregister from ImR.\n")));
     }
   catch (const CORBA::Exception& ex)
     {
@@ -278,7 +275,7 @@ ImR_Activator_i::fini (void)
       this->orb_->destroy ();
 
       if (debug_ > 0)
-        ORBSVCS_DEBUG ((LM_DEBUG, "ImR Activator: Shut down successfully.\n"));
+        ORBSVCS_DEBUG ((LM_DEBUG, "(%P|%t) ImR Activator: Shut down successfully.\n"));
     }
   catch (const CORBA::Exception& ex)
     {
@@ -322,7 +319,7 @@ ImR_Activator_i::shutdown (bool signaled)
   if (signaled && this->in_upcall ())
     {
       if (debug_ > 0)
-        ORBSVCS_DEBUG ((LM_DEBUG, "ImR Activator: ignoring signal during upcall.\n"));
+        ORBSVCS_DEBUG ((LM_DEBUG, "(%P|%t) ImR Activator: ignoring signal during upcall.\n"));
       return;
     }
   if (! CORBA::is_nil (this->locator_.in ()) && this->registration_token_ != 0)
@@ -347,9 +344,9 @@ ImR_Activator_i::kill_server (const char* name, CORBA::Long lastpid, CORBA::Shor
 {
   if (debug_ > 1)
     ORBSVCS_DEBUG((LM_DEBUG,
-                   "ImR Activator: Killing server <%C>, lastpid = %d\n",
+                   "(%P|%t) ImR Activator: Killing server <%C>, lastpid <%d>\n",
                    name, lastpid));
-  pid_t lpid = static_cast<pid_t>(lastpid);
+  pid_t const lpid = static_cast<pid_t>(lastpid);
   pid_t pid = 0;
   bool found = false;
   int result = -1;
@@ -385,8 +382,8 @@ ImR_Activator_i::kill_server (const char* name, CORBA::Long lastpid, CORBA::Shor
 
       if (debug_ > 1)
         ORBSVCS_DEBUG((LM_DEBUG,
-                       "ImR Activator: Killing server <%C> "
-                       "signal %d to pid %d, found %d, this->notify_imr_ %d,  result = %d\n",
+                       "(%P|%t) ImR Activator: Killing server <%C> "
+                       "signal <%d> to pid <%d> found <%d> this->notify_imr_ <%d> result <%d>\n",
                        name, signum, static_cast<int> (pid), found, this->notify_imr_, result));
       if (!found && result == 0 && this->notify_imr_)
         {
@@ -461,7 +458,7 @@ ImR_Activator_i::start_server(const char* name,
   if (debug_ > 0)
     {
       ORBSVCS_DEBUG((LM_DEBUG,
-                    "ImR Activator: Starting %C <%C>...\n",
+                    "(%P|%t) ImR Activator: Starting %C <%C>...\n",
                     (unique ? "unique server" : "server"), name));
     }
 
@@ -471,7 +468,7 @@ ImR_Activator_i::start_server(const char* name,
       if (debug_ > 0)
         {
           ORBSVCS_DEBUG((LM_DEBUG,
-                        "ImR Activator: Unique instance already running pid <%d>\n",
+                        "(%P|%t) ImR Activator: Unique instance already running pid <%d>\n",
                         static_cast<int> (pid)));
         }
       char reason[32];
@@ -483,7 +480,7 @@ ImR_Activator_i::start_server(const char* name,
   size_t const cmdline_buf_len = ACE_OS::strlen(cmdline);
   if (debug_ > 0)
     ORBSVCS_DEBUG((LM_DEBUG,
-                   "ImR Activator: command line : len=<%d> <%C>\n\tdirectory <%C>\n",
+                   "(%P|%t) ImR Activator: command line len <%d> <%C> directory <%C>\n",
                    cmdline_buf_len, cmdline, dir)  );
 
   ACE_Process_Options proc_opts (
@@ -530,7 +527,7 @@ ImR_Activator_i::start_server(const char* name,
   if (pid == ACE_INVALID_PID)
     {
       ORBSVCS_ERROR ((LM_ERROR,
-                      "ImR Activator: Cannot start server <%C> using <%C>\n", name, cmdline));
+                      "(%P|%t) ImR Activator: Cannot start server <%C> using <%C>\n", name, cmdline));
 
       throw ImplementationRepository::CannotActivate(CORBA::string_dup ("Process Creation Failed"));
     }
@@ -539,7 +536,7 @@ ImR_Activator_i::start_server(const char* name,
       if (debug_ > 1)
         {
           ORBSVCS_DEBUG((LM_DEBUG,
-                         "ImR Activator: register death handler for server <%C> pid <%d>\n",
+                         "(%P|%t) ImR Activator: register death handler for server <%C> pid <%d>\n",
                          name,
                          static_cast<int> (pid)));
         }

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
@@ -458,29 +458,32 @@ ImR_Activator_i::start_server(const char* name,
       name += unique_prefix_len;
     }
 
-  // if (debug_ > 1)
-  ORBSVCS_DEBUG((LM_DEBUG,
-                 "ImR Activator: Starting %C <%C>...\n",
-                 (unique ? "unique server" : "server"), name));
+  if (debug_ > 0)
+    {
+      ORBSVCS_DEBUG((LM_DEBUG,
+                    "ImR Activator: Starting %C <%C>...\n",
+                    (unique ? "unique server" : "server"), name));
+    }
   pid_t pid;
   if (unique && this->still_running_i (name, pid))
     {
-      // if (debug_ > 1)
-      ORBSVCS_DEBUG((LM_DEBUG,
-                     "ImR Activator: Unique instance already running %d\n",
-                     static_cast<int> (pid)));
+      if (debug_ > 0)
+        {
+          ORBSVCS_DEBUG((LM_DEBUG,
+                        "ImR Activator: Unique instance already running %d\n",
+                        static_cast<int> (pid)));
+        }
       char reason[32];
       ACE_OS::snprintf (reason,32,"pid:%d",static_cast<int> (pid));
       throw ImplementationRepository::CannotActivate(
                                                      CORBA::string_dup (reason));
     }
 
-  ACE_TString cmdline_tstr(ACE_TEXT_CHAR_TO_TCHAR(cmdline));
-  size_t cmdline_buf_len = cmdline_tstr.length();
-  if (debug_ > 1)
+  size_t const cmdline_buf_len = ACE_OS::strlen(cmdline);
+  if (debug_ > 0)
     ORBSVCS_DEBUG((LM_DEBUG,
-                   "\tcommand line : len=%d <%s>\n\tdirectory : <%C>\n",
-                   cmdline_buf_len, cmdline_tstr.c_str(), dir)  );
+                   "\tcommand line : len=%d <%C>\n\tdirectory : <%C>\n",
+                   cmdline_buf_len, cmdline, dir)  );
 
   ACE_Process_Options proc_opts (
                                  1,

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
@@ -536,7 +536,7 @@ ImR_Activator_i::start_server(const char* name,
       if (debug_ > 1)
         {
           ORBSVCS_DEBUG((LM_DEBUG,
-                         "(%P|%t) ImR Activator: register death handler for server <%C> pid <%d>\n",
+                         "(%P|%t) ImR Activator: Register death handler for server <%C> pid <%d>\n",
                          name,
                          static_cast<int> (pid)));
         }

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
@@ -464,6 +464,7 @@ ImR_Activator_i::start_server(const char* name,
                     "ImR Activator: Starting %C <%C>...\n",
                     (unique ? "unique server" : "server"), name));
     }
+
   pid_t pid;
   if (unique && this->still_running_i (name, pid))
     {
@@ -607,7 +608,7 @@ ImR_Activator_i::handle_exit_i (pid_t pid)
           if (debug_ > 1)
             {
               ORBSVCS_DEBUG ((LM_DEBUG,
-                              ACE_TEXT ("(%P|%t) ImR Activator: caught %s from locator::child_death_pid\n"),
+                              ACE_TEXT ("(%P|%t) ImR Activator: caught <%C> from locator::child_death_pid\n"),
                               ex._name()));
             }
         }

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -1340,7 +1340,7 @@ ImR_Locator_i::server_is_running
           this->pinger_.add_server (info->ping_id(), true, srvobj.in());
         }
 
-      AsyncAccessManager_ptr aam(this->find_aam (info->ping_id ());)
+      AsyncAccessManager_ptr aam(this->find_aam (info->ping_id ()));
       if (!aam.is_nil())
         {
           if (ImR_Locator_i::debug () > 4)

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -1340,9 +1340,7 @@ ImR_Locator_i::server_is_running
           this->pinger_.add_server (info->ping_id(), true, srvobj.in());
         }
 
-      // In case of a per client activation there could be multiple AAM for a specific server (ping_id)
-      // we need to make sure we take an AAM that has a wait for running state
-      AsyncAccessManager_ptr aam(this->find_aam (info->ping_id ()));
+      AsyncAccessManager_ptr aam(this->find_aam (info->ping_id ());)
       if (!aam.is_nil())
         {
           if (ImR_Locator_i::debug () > 4)
@@ -1708,6 +1706,20 @@ ImR_Locator_i::find_aam (const char *name, bool active)
   for (AAM_Set::ITERATOR i = set.begin(); i != set.end(); ++i)
     {
       if ((*i)->has_server (name))
+        {
+          return (*i)->_add_ref();
+        }
+    }
+  return 0;
+}
+
+AsyncAccessManager *
+ImR_Locator_i::find_not_running_aam (const char *name, bool active)
+{
+  AAM_Set &set = active ? this->aam_active_ : this->aam_terminating_;
+  for (AAM_Set::ITERATOR i = set.begin(); i != set.end(); ++i)
+    {
+      if ((*i)->has_server (name) && (!(*i)->is_running ()))
         {
           return (*i)->_add_ref();
         }

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -1340,6 +1340,8 @@ ImR_Locator_i::server_is_running
           this->pinger_.add_server (info->ping_id(), true, srvobj.in());
         }
 
+      // In case of a per client activation there could be multiple AAM for a specific server (ping_id)
+      // we need to make sure we take an AAM that has a wait for running state
       AsyncAccessManager_ptr aam(this->find_aam (info->ping_id ()));
       if (!aam.is_nil())
         {

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -563,12 +563,12 @@ ImR_Locator_i::spawn_pid
                     pid, name));
 
   UpdateableServerInfo info(this->repository_, name);
-  if (! info.null ())
+  if (!info.null ())
     {
       if (debug_ > 4)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) ImR: Spawn_pid prev pid was %d becoming %d\n"),
+                          ACE_TEXT ("(%P|%t) ImR: Spawn_pid prev pid was <%d> becoming <%d>\n"),
                           info.edit ()->active_info ()->pid, pid));
         }
 
@@ -588,7 +588,8 @@ ImR_Locator_i::spawn_pid
     {
       if (debug_ > 1)
         ORBSVCS_DEBUG ((LM_DEBUG,
-                        ACE_TEXT ("(%P|%t) ImR: Failed to find server in repository.\n")));
+                        ACE_TEXT ("(%P|%t) ImR: Failed to find server <%C> in repository\n"),
+                        name));
     }
   this->pinger_.set_pid (name, pid);
 

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -1338,7 +1338,8 @@ ImR_Locator_i::server_is_running
           if (ImR_Locator_i::debug () > 4)
             {
               ORBSVCS_DEBUG ((LM_DEBUG,
-                              ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_running aam is not nil\n")));
+                              ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_running <%C> aam is not nil\n"),
+                              id));
             }
           aam->server_is_running (partial_ior, srvobj.in());
         }
@@ -1347,7 +1348,8 @@ ImR_Locator_i::server_is_running
           if (ImR_Locator_i::debug () > 4)
             {
               ORBSVCS_DEBUG ((LM_DEBUG,
-                              ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_running aam is nil\n")));
+                              ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_running <<%C>> aam is nil\n"),
+                              id));
             }
           if (!info->is_mode(ImplementationRepository::PER_CLIENT))
             {

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -1269,7 +1269,7 @@ ImR_Locator_i::server_is_running
   if (debug_ > 0)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) ImR: Server %C is running at %C.\n"),
+                      ACE_TEXT ("(%P|%t) ImR: Server <%C> is running at <%C>.\n"),
                       id, partial_ior));
     }
   CORBA::String_var sior = orb_->object_to_string (server_object);
@@ -1277,7 +1277,7 @@ ImR_Locator_i::server_is_running
   if (debug_ > 1)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) ImR: Server %C callback at %C.\n"),
+                      ACE_TEXT ("(%P|%t) ImR: Server <%C> callback at <%C>.\n"),
                       id, sior.in ()));
     }
 

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -779,20 +779,20 @@ ImR_Locator_i::add_or_update_server
     }
 
   if (debug_ > 0)
-    ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Add/Update server <%C>.\n"), server));
+    ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Add/Update server <%C>\n"), server));
 
   UpdateableServerInfo info(this->repository_, server);
   if (info.null ())
     {
       if (debug_ > 1)
-        ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Adding server <%C>.\n"), server));
+        ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Adding server <%C>\n"), server));
 
       this->repository_->add_server (server, options);
     }
   else
     {
       if (debug_ > 1)
-        ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Updating server <%C>.\n"),
+        ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Updating server <%C>\n"),
                         server));
 
       info.edit ()->update_options (options);
@@ -803,12 +803,11 @@ ImR_Locator_i::add_or_update_server
     {
       // Note : The info var may be null, so we use options.
       ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Server: %C\n")
-                      ACE_TEXT ("\tActivator: %C\n")
-                      ACE_TEXT ("\tCommand Line: %C\n")
-                      ACE_TEXT ("\tWorking Directory: %C\n")
-                      ACE_TEXT ("\tActivation: %C\n")
-                      ACE_TEXT ("\tStart Limit: %d\n")
-                      ACE_TEXT ("\n"),
+                      ACE_TEXT ("\tActivator: <%C>\n")
+                      ACE_TEXT ("\tCommand Line: <%C>\n")
+                      ACE_TEXT ("\tWorking Directory: <%C>\n")
+                      ACE_TEXT ("\tActivation: <%C>\n")
+                      ACE_TEXT ("\tStart Limit: <%d>\n"),
                       server,
                       options.activator.in (),
                       options.command_line.in (),
@@ -818,7 +817,7 @@ ImR_Locator_i::add_or_update_server
                       ));
 
       for (CORBA::ULong i = 0; i < options.environment.length (); ++i)
-        ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("Environment variable %C=%C\n"),
+        ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("Environment variable <%C>=<%C>\n"),
                         options.environment[i].name.in (),
                         options.environment[i].value.in ()));
     }
@@ -1269,7 +1268,7 @@ ImR_Locator_i::server_is_running
   if (debug_ > 0)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) ImR: Server <%C> is running at <%C>.\n"),
+                      ACE_TEXT ("(%P|%t) ImR: Server <%C> is running at <%C>\n"),
                       id, partial_ior));
     }
   CORBA::String_var sior = orb_->object_to_string (server_object);
@@ -1277,7 +1276,7 @@ ImR_Locator_i::server_is_running
   if (debug_ > 1)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) ImR: Server <%C> callback at <%C>.\n"),
+                      ACE_TEXT ("(%P|%t) ImR: Server <%C> callback at <%C>\n"),
                       id, sior.in ()));
     }
 
@@ -1294,7 +1293,7 @@ ImR_Locator_i::server_is_running
       if (debug_ > 0)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) ImR: Auto adding NORMAL server <%C>.\n"),
+                          ACE_TEXT ("(%P|%t) ImR: Auto adding NORMAL server <%C>\n"),
                           id));
         }
 
@@ -1372,7 +1371,7 @@ ImR_Locator_i::server_is_shutting_down
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_shutting_down: ")
-                          ACE_TEXT ("Unknown server: %C\n"),
+                          ACE_TEXT ("Unknown server <%C>\n"),
                           fqname));
         }
       _tao_rh->server_is_shutting_down ();
@@ -1381,7 +1380,7 @@ ImR_Locator_i::server_is_shutting_down
 
   if (debug_ > 0)
     ORBSVCS_DEBUG ((LM_DEBUG,
-                    ACE_TEXT ("(%P|%t) ImR: Server <%C> is shutting down.\n"),
+                    ACE_TEXT ("(%P|%t) ImR: Server <%C> is shutting down\n"),
                     fqname));
 
   if (!info->is_mode(ImplementationRepository::PER_CLIENT))
@@ -1417,7 +1416,7 @@ ImR_Locator_i::find
           imr_info = si->createImRServerInfo ();
 
           if (debug_ > 1)
-            ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Found server %C.\n"), id));
+            ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Found server <%C>\n"), id));
         }
       else
         {

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -1332,15 +1332,23 @@ ImR_Locator_i::server_is_running
                           id, ImR_Utils::activationModeToString(info->mode ())));
         }
 
+      AsyncAccessManager_ptr aam;
       if (!info->is_mode(ImplementationRepository::PER_CLIENT))
         {
           info.edit ()->set_contact (partial_ior, sior.in(), srvobj.in());
 
           info.update_repo();
           this->pinger_.add_server (info->ping_id(), true, srvobj.in());
+
+          aam = this->find_aam (info->ping_id ());
+        }
+      else
+        {
+          // In case of a per client activation there could be multiple AAM for a specific server (ping_id)
+          // we need to make sure we take an AAM that is not running yet
+          aam = this->find_not_running_aam  (info->ping_id ());
         }
 
-      AsyncAccessManager_ptr aam(this->find_aam (info->ping_id ()));
       if (!aam.is_nil())
         {
           if (ImR_Locator_i::debug () > 4)

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -559,7 +559,7 @@ ImR_Locator_i::spawn_pid
  const char* name, CORBA::Long pid)
 {
   if (debug_ > 1)
-    ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Server[%d] spawned <%C>.\n"),
+    ORBSVCS_DEBUG ((LM_DEBUG, ACE_TEXT ("(%P|%t) ImR: Server<%d> spawned <%C>.\n"),
                     pid, name));
 
   UpdateableServerInfo info(this->repository_, name);
@@ -1325,6 +1325,13 @@ ImR_Locator_i::server_is_running
     }
   else
     {
+      if (ImR_Locator_i::debug () > 4)
+        {
+          ORBSVCS_DEBUG ((LM_DEBUG,
+                          ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_running <%C> has mode <%C>\n"),
+                          id, ImR_Utils::activationModeToString(info->mode ())));
+        }
+
       if (!info->is_mode(ImplementationRepository::PER_CLIENT))
         {
           info.edit ()->set_contact (partial_ior, sior.in(), srvobj.in());
@@ -1349,7 +1356,7 @@ ImR_Locator_i::server_is_running
           if (ImR_Locator_i::debug () > 4)
             {
               ORBSVCS_DEBUG ((LM_DEBUG,
-                              ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_running <<%C>> aam is nil\n"),
+                              ACE_TEXT ("(%P|%t) ImR_Locator_i::server_is_running <%C> aam is nil\n"),
                               id));
             }
           if (!info->is_mode(ImplementationRepository::PER_CLIENT))
@@ -1715,9 +1722,7 @@ ImR_Locator_i::create_aam (UpdateableServerInfo &info, bool running)
     {
       aam->started_running ();
     }
-  {
-    this->aam_active_.insert_tail (aam);
-  }
+  this->aam_active_.insert_tail (aam);
   return aam._retn ();
 }
 

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.h
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.h
@@ -173,6 +173,7 @@ public:
   void remove_aam (AsyncAccessManager_ptr &aam);
   void remove_aam (const char *name);
   AsyncAccessManager *find_aam (const char *name, bool active = true);
+  AsyncAccessManager *find_not_running_aam (const char *name, bool active = true);
   AsyncAccessManager *create_aam (UpdateableServerInfo &info, bool running = false);
   void make_terminating (AsyncAccessManager_ptr &aam, const char *name, int pid);
   /// Receiving an update from remote peer
@@ -182,9 +183,7 @@ public:
   CORBA::Object_ptr set_timeout_policy(CORBA::Object_ptr obj,
                                        const ACE_Time_Value& to);
 
-
 private:
-
   bool get_info_for_name (const char *name, Server_Info_Ptr &si);
 
   void  activate_server_i (UpdateableServerInfo& info,

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_ResponseHandler.h
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_ResponseHandler.h
@@ -29,7 +29,7 @@ public:
   ImR_ResponseHandler (void);
   virtual ~ImR_ResponseHandler (void);
 
-  // dummy implementations used for internal operations
+  // Dummy implementations used for internal operations
   virtual void send_ior (const char *pior);
   virtual void send_exception (CORBA::Exception *ex);
 };

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -35,7 +35,7 @@ LiveListener::_add_ref (void)
   if (ImR_Locator_i::debug () > 5)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("LiveListener::add_ref, %s, count = %d\n"),
+                      ACE_TEXT ("LiveListener::add_ref, %C, count = %d\n"),
                       server_.c_str(), refcount_));
     }
   return this;
@@ -51,7 +51,7 @@ LiveListener::_remove_ref (void)
     if (ImR_Locator_i::debug () > 5)
       {
         ORBSVCS_DEBUG ((LM_DEBUG,
-                        ACE_TEXT  ("LiveListener::remove_ref, %s, count = %d\n"),
+                        ACE_TEXT  ("LiveListener::remove_ref, %C, count = %d\n"),
                         server_.c_str(), count));
       }
   }

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -448,7 +448,8 @@ LiveEntry::do_ping (PortableServer::POA_ptr poa)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::do_ping, ")
-                          ACE_TEXT ("sendc_ping returned OK\n")));
+                          ACE_TEXT ("sendc_ping for server <%C> returned OK\n"),
+                          this->server_.c_str()));
         }
     }
   catch (const CORBA::Exception &ex)
@@ -457,7 +458,8 @@ LiveEntry::do_ping (PortableServer::POA_ptr poa)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::do_ping, ")
-                          ACE_TEXT ("sendc_ping threw <%C>\n"), ex._name()));
+                          ACE_TEXT ("sendc_ping for server <%C> threw <%C>\n"),
+                          this->server_.c_str(), ex._name()));
         }
       this->status (LS_DEAD);
     }

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -174,7 +174,14 @@ LiveEntry::add_listener (LiveListener *ll)
 {
   ACE_GUARD (TAO_SYNCH_MUTEX, mon, this->lock_);
   LiveListener_ptr llp(ll->_add_ref());
-  this->listeners_.insert (llp);
+  int const result = this->listeners_.insert (llp);
+  if (ImR_Locator_i::debug() > 4)
+    {
+      ORBSVCS_DEBUG ((LM_DEBUG,
+                      ACE_TEXT ("(%P|%t) LiveEntry::add_listener server <%C> result <%d>\n"),
+                      this->server_.c_str(),
+                      result));
+    }
 }
 
 void
@@ -182,11 +189,11 @@ LiveEntry::remove_listener (LiveListener *ll)
 {
   ACE_GUARD (TAO_SYNCH_MUTEX, mon, this->lock_);
   LiveListener_ptr llp(ll->_add_ref());
-  int result = this->listeners_.remove (llp);
+  int const result = this->listeners_.remove (llp);
   if (ImR_Locator_i::debug() > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) LiveEntry::remove_listener server <%C> result <%d?\n"),
+                      ACE_TEXT ("(%P|%t) LiveEntry::remove_listener server <%C> result <%d>\n"),
                       this->server_.c_str(),
                       result));
     }
@@ -624,7 +631,7 @@ LC_TimeoutGuard::~LC_TimeoutGuard (void)
       ACE_Time_Value delay = ACE_Time_Value::zero;
       if (owner_->deferred_timeout_ != ACE_Time_Value::zero)
         {
-          ACE_Time_Value now (ACE_OS::gettimeofday());
+          ACE_Time_Value const now (ACE_OS::gettimeofday());
           if (owner_->deferred_timeout_ > now)
             delay = owner_->deferred_timeout_ - now;
         }
@@ -739,7 +746,7 @@ LiveCheck::handle_timeout (const ACE_Time_Value &,
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) LiveCheck::handle_timeout(%d), ")
-                      ACE_TEXT ("running = %d\n"),
+                      ACE_TEXT ("running <%d>\n"),
                       token, this->running_));
     }
   if (!this->running_)
@@ -790,7 +797,7 @@ LiveCheck::handle_timeout (const ACE_Time_Value &,
             {
               entry->do_ping (poa_.in ());
             }
-          LiveStatus status = entry->status ();
+          LiveStatus const status = entry->status ();
           if (status != LS_PING_AWAY && status != LS_TRANSIENT)
             {
               this->per_client_.remove (entry);
@@ -807,7 +814,7 @@ LiveCheck::has_server (const char *server)
 {
   ACE_CString s (server);
   LiveEntry *entry = 0;
-  int result = entry_map_.find (s, entry);
+  int const result = entry_map_.find (s, entry);
   return (result == 0 && entry != 0);
 }
 
@@ -816,6 +823,14 @@ LiveCheck::add_server (const char *server,
                        bool may_ping,
                        ImplementationRepository::ServerObject_ptr ref)
 {
+  if (ImR_Locator_i::debug () > 2)
+    {
+      ORBSVCS_DEBUG ((LM_DEBUG,
+                      ACE_TEXT ("(%P|%t) LiveCheck::add_server <%C> ")
+                      ACE_TEXT ("running <%d>\n"),
+                      server, this->running_));
+    }
+
   if (!this->running_)
     return;
 
@@ -840,7 +855,7 @@ LiveCheck::set_pid (const char *server, int pid)
 {
   ACE_CString s(server);
   LiveEntry *entry = 0;
-  int result = entry_map_.find (s, entry);
+  int const result = entry_map_.find (s, entry);
   if (result != -1 && entry != 0)
     {
       entry->set_pid (pid);
@@ -958,7 +973,7 @@ LiveCheck::add_poll_listener (LiveListener *l)
 
   LiveEntry *entry = 0;
   ACE_CString key (l->server());
-  int result = entry_map_.find (key, entry);
+  int const result = entry_map_.find (key, entry);
   if (result == -1 || entry == 0)
     {
       return false;
@@ -978,7 +993,7 @@ LiveCheck::add_listener (LiveListener *l)
 
   LiveEntry *entry = 0;
   ACE_CString key (l->server());
-  int result = entry_map_.find (key, entry);
+  int const result = entry_map_.find (key, entry);
   if (result == -1 || entry == 0)
     {
       return false;
@@ -996,7 +1011,7 @@ LiveCheck::remove_listener (LiveListener *l)
 
   LiveEntry *entry = 0;
   ACE_CString key (l->server());
-  int result = entry_map_.find (key, entry);
+  int const result = entry_map_.find (key, entry);
   if (result != -1 && entry != 0)
     {
       entry->remove_listener (l);
@@ -1089,7 +1104,7 @@ LiveCheck::is_alive (const char *server)
 
   ACE_CString s(server);
   LiveEntry *entry = 0;
-  int result = entry_map_.find (s, entry);
+  int const result = entry_map_.find (s, entry);
   if (result == 0 && entry != 0)
     {
       return entry->status ();

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -146,7 +146,7 @@ LiveEntry::LiveEntry (LiveCheck *owner,
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) LiveEntry::ctor server = <%C>, may_ping = %d\n"),
+                      ACE_TEXT ("(%P|%t) LiveEntry::ctor server <%C>, may_ping <%d>\n"),
                       server, may_ping));
     }
 }
@@ -289,7 +289,7 @@ LiveEntry::status (LiveStatus l)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::status change, ")
-                          ACE_TEXT ("server = %C status = %s\n"),
+                          ACE_TEXT ("server <%C> status <%s>\n"),
                           this->server_.c_str(),
                           status_name (this->liveliness_)));
         }
@@ -339,7 +339,7 @@ LiveEntry::validate_ping (bool &want_reping, ACE_Time_Value& next)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::validate_ping, status ")
-                          ACE_TEXT ("= %s, listeners = %d server %C\n"),
+                          ACE_TEXT ("<%s>, listeners <%d> server <%C>\n"),
                           status_name (this->liveliness_), this->listeners_.size (),
                           this->server_.c_str()));
         }
@@ -359,8 +359,8 @@ LiveEntry::validate_ping (bool &want_reping, ACE_Time_Value& next)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::validate_ping, ")
-                          ACE_TEXT ("status = %s, listeners = %d, ")
-                          ACE_TEXT ("msec = %d server %C\n"),
+                          ACE_TEXT ("status <%s>, listeners <%d>, ")
+                          ACE_TEXT ("msec <%d> server <%C>\n"),
                           status_name (this->liveliness_), this->listeners_.size (),
                           msec, this->server_.c_str()));
         }
@@ -395,8 +395,8 @@ LiveEntry::validate_ping (bool &want_reping, ACE_Time_Value& next)
               {
                 ORBSVCS_DEBUG ((LM_DEBUG,
                                 ACE_TEXT ("(%P|%t) LiveEntry::validate_ping, ")
-                                ACE_TEXT ("transient, reping in %d ms, ")
-                                ACE_TEXT ("server %C\n"),
+                                ACE_TEXT ("transient, reping in <%d> ms, ")
+                                ACE_TEXT ("server <%C>\n"),
                                 ms, this->server_.c_str()));
               }
           }
@@ -412,7 +412,7 @@ LiveEntry::validate_ping (bool &want_reping, ACE_Time_Value& next)
                 ORBSVCS_DEBUG ((LM_DEBUG,
                                 ACE_TEXT ("(%P|%t) LiveEntry::validate_ping, ")
                                 ACE_TEXT ("transient, no more repings, ")
-                                ACE_TEXT ("server %C\n"),
+                                ACE_TEXT ("server <%C>\n"),
                                 this->server_.c_str()));
               }
             if (this->listeners_.size() > 0)
@@ -456,7 +456,7 @@ LiveEntry::do_ping (PortableServer::POA_ptr poa)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::do_ping, ")
-                          ACE_TEXT ("sendc_ping threw %C\n"), ex._name()));
+                          ACE_TEXT ("sendc_ping threw <%C>\n"), ex._name()));
         }
       this->status (LS_DEAD);
     }
@@ -515,7 +515,7 @@ PingReceiver::ping (void)
       if (ImR_Locator_i::debug () > 5)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) PingReceiver::ping received from %C\n"),
+                          ACE_TEXT ("(%P|%t) PingReceiver::ping received from <%C>\n"),
                           this->entry_->server_name ()));
         }
       this->entry_->release_callback ();
@@ -534,7 +534,7 @@ PingReceiver::ping_excep (Messaging::ExceptionHolder * excep_holder)
       if (ImR_Locator_i::debug () > 5)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) PingReceiver::ping_excep received from %C\n"),
+                          ACE_TEXT ("(%P|%t) PingReceiver::ping_excep received from <%C>\n"),
                           this->entry_->server_name ()));
         }
       excep_holder->raise_exception ();

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -849,7 +849,7 @@ LiveCheck::remove_server (const char *server, int pid)
 {
   ACE_CString s(server);
   LiveEntry *entry = 0;
-  int result = entry_map_.find (s, entry);
+  int const result = entry_map_.find (s, entry);
   if (result != -1 && entry->has_pid (pid))
     {
       if (!this->in_handle_timeout ())
@@ -900,7 +900,7 @@ LiveCheck::remove_deferred_servers (void)
                           ACE_TEXT ("removing %s\n"), (*re).c_str()));
         }
       LiveEntry *entry = 0;
-      int result = entry_map_.unbind (*re, entry);
+      int const result = entry_map_.unbind (*re, entry);
       if (result == 0)
         {
           delete entry;

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -67,31 +67,31 @@ LiveListener::_remove_ref (void)
 const int LiveEntry::reping_msec_[] = {10, 100, 500, 1000, 1000, 2000, 2000, 5000, 5000};
 int LiveEntry::reping_limit_ = sizeof (LiveEntry::reping_msec_) / sizeof (int);
 
-const ACE_TCHAR *
+const char *
 LiveEntry::status_name (LiveStatus s)
 {
   switch (s)
     {
     case LS_INIT:
-      return ACE_TEXT ("INIT");
+      return "INIT";
     case LS_UNKNOWN:
-      return ACE_TEXT ("UNKNOWN");
+      return "UNKNOWN";
     case LS_PING_AWAY:
-      return ACE_TEXT ("PING_AWAY");
+      return "PING_AWAY";
     case LS_DEAD:
-      return ACE_TEXT ("DEAD");
+      return "DEAD";
     case LS_ALIVE:
-      return ACE_TEXT ("ALIVE");
+      return "ALIVE";
     case LS_TRANSIENT:
-      return ACE_TEXT ("TRANSIENT");
+      return "TRANSIENT";
     case LS_LAST_TRANSIENT:
-      return ACE_TEXT ("LAST_TRANSIENT");
+      return "LAST_TRANSIENT";
     case LS_TIMEDOUT:
-      return ACE_TEXT ("TIMEDOUT");
+      return "TIMEDOUT";
     case LS_CANCELED:
-      return ACE_TEXT ("CANCELED");
+      return "CANCELED";
     }
-  return ACE_TEXT ("<undefined status>");
+  return "<undefined status>";
 }
 
 void
@@ -208,7 +208,7 @@ LiveEntry::reset_status (void)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("(%P|%t) LiveEntry::reset_status this <%x>, ")
-                      ACE_TEXT ("server <%C> status <%s>\n"),
+                      ACE_TEXT ("server <%C> status <%C>\n"),
                       this, this->server_.c_str(),
                       status_name (this->liveliness_)));
     }
@@ -290,7 +290,7 @@ LiveEntry::status (LiveStatus l)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::status change, ")
-                          ACE_TEXT ("server <%C> status <%s>\n"),
+                          ACE_TEXT ("server <%C> status <%C>\n"),
                           this->server_.c_str(),
                           status_name (this->liveliness_)));
         }
@@ -340,7 +340,7 @@ LiveEntry::validate_ping (bool &want_reping, ACE_Time_Value& next)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::validate_ping, status ")
-                          ACE_TEXT ("<%s>, listeners <%d> server <%C>\n"),
+                          ACE_TEXT ("<%C>, listeners <%d> server <%C>\n"),
                           status_name (this->liveliness_), this->listeners_.size (),
                           this->server_.c_str()));
         }
@@ -360,7 +360,7 @@ LiveEntry::validate_ping (bool &want_reping, ACE_Time_Value& next)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveEntry::validate_ping, ")
-                          ACE_TEXT ("status <%s>, listeners <%d>, ")
+                          ACE_TEXT ("status <%C>, listeners <%d>, ")
                           ACE_TEXT ("msec <%d> server <%C>\n"),
                           status_name (this->liveliness_), this->listeners_.size (),
                           msec, this->server_.c_str()));

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -894,7 +894,7 @@ LiveCheck::remove_server (const char *server, int pid)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveCheck::remove_server <%C> ")
-                          ACE_TEXT ("pid %d does not match entry\n"),
+                          ACE_TEXT ("pid <%d> does not match entry\n"),
                           server, pid));
         }
     }
@@ -915,7 +915,7 @@ LiveCheck::remove_deferred_servers (void)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveCheck::remove_deferred_entries ")
-                          ACE_TEXT ("removing %s\n"), (*re).c_str()));
+                          ACE_TEXT ("removing <%C>\n"), (*re).c_str()));
         }
       LiveEntry *entry = 0;
       int const result = entry_map_.unbind (*re, entry);

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -942,7 +942,7 @@ LiveCheck::add_per_client_listener (LiveListener *l,
     return false;
 
   LiveEntry *entry = 0;
-  ACE_NEW_RETURN (entry, LiveEntry (this, 0, true, ref), false);
+  ACE_NEW_RETURN (entry, LiveEntry (this, l->server (), true, ref), false);
 
   if (this->per_client_.insert_tail(entry) == 0)
     {

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -490,7 +490,7 @@ PingReceiver::cancel (void)
 {
   if (ImR_Locator_i::debug () > 4)
     {
-      const char *server = "<not available>";
+      const char *server = "not available";
       if (this->entry_ != 0)
         {
           server = this->entry_->server_name ();

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -35,7 +35,7 @@ LiveListener::_add_ref (void)
   if (ImR_Locator_i::debug () > 5)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("LiveListener::add_ref, %C, count = %d\n"),
+                      ACE_TEXT ("(%P|%t) LiveListener::add_ref <%C> count <%d>\n"),
                       server_.c_str(), refcount_));
     }
   return this;
@@ -51,7 +51,7 @@ LiveListener::_remove_ref (void)
     if (ImR_Locator_i::debug () > 5)
       {
         ORBSVCS_DEBUG ((LM_DEBUG,
-                        ACE_TEXT  ("LiveListener::remove_ref, %C, count = %d\n"),
+                        ACE_TEXT  ("(%P|%t) LiveListener::remove_ref <%C> count <%d>\n"),
                         server_.c_str(), count));
       }
   }
@@ -146,7 +146,7 @@ LiveEntry::LiveEntry (LiveCheck *owner,
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) LiveEntry::ctor server <%C>, may_ping <%d>\n"),
+                      ACE_TEXT ("(%P|%t) LiveEntry::ctor server <%C> may_ping <%d>\n"),
                       server, may_ping));
     }
 }
@@ -186,7 +186,8 @@ LiveEntry::remove_listener (LiveListener *ll)
   if (ImR_Locator_i::debug() > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) LiveEntry::remove_listener, result = %d\n"),
+                      ACE_TEXT ("(%P|%t) LiveEntry::remove_listener server <%C> result <%d?\n"),
+                      this->server_.c_str(),
                       result));
     }
 }
@@ -206,8 +207,8 @@ LiveEntry::reset_status (void)
   if (ImR_Locator_i::debug () > 2)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) LiveEntry::reset_status this = %x, ")
-                      ACE_TEXT ("server = %C status = %s\n"),
+                      ACE_TEXT ("(%P|%t) LiveEntry::reset_status this <%x>, ")
+                      ACE_TEXT ("server <%C> status <%s>\n"),
                       this, this->server_.c_str(),
                       status_name (this->liveliness_)));
     }
@@ -486,7 +487,7 @@ PingReceiver::cancel (void)
           server = this->entry_->server_name ();
         }
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) PingReceiver::cancel server = <%C>\n"),
+                      ACE_TEXT ("(%P|%t) PingReceiver::cancel server <%C>\n"),
                       server));
     }
 
@@ -501,7 +502,7 @@ PingReceiver::cancel (void)
       if (ImR_Locator_i::debug () > 4)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) PingReceiver::cancel caught %C\n"),
+                          ACE_TEXT ("(%P|%t) PingReceiver::cancel caught <%C>\n"),
                           ex._name ()));
         }
     }

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
@@ -125,7 +125,7 @@ class Locator_Export LiveEntry
   void reset_status (void);
 
   /// the current state value as text
-  static const ACE_TCHAR *status_name (LiveStatus s);
+  static const char *status_name (LiveStatus s);
 
   void update_listeners (void);
   bool validate_ping (bool &want_reping, ACE_Time_Value &next);

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
@@ -71,7 +71,7 @@ enum LiveStatus {
 class Locator_Export LiveListener
 {
  public:
-  /// Construct a new listener. The server name suppled is used to
+  /// Construct a new listener. The server name supplied is used to
   /// look up a listener entry in the LiveCheck map.
   LiveListener (const char *server);
 

--- a/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
@@ -64,7 +64,7 @@ Locator_Repository::report_ior (PortableServer::POA_ptr )
 
   if (this->opts_.debug () > 0)
     {
-      ORBSVCS_DEBUG ((LM_INFO, ACE_TEXT ("(%P|%t) report_ior <%C>\n"),
+      ORBSVCS_DEBUG ((LM_INFO, ACE_TEXT ("(%P|%t) ImR: report_ior <%C>\n"),
         this->imr_ior_.in ()));
     }
 
@@ -165,7 +165,7 @@ Locator_Repository::recover_ior (void)
   }
   catch (const CORBA::Exception& ex)
     {
-      ex._tao_print_exception ("Attempting to read combined_ior for ImR_Locator\n");
+      ex._tao_print_exception ("ImR: Attempting to read combined_ior for ImR_Locator\n");
       return -1;
     }
 
@@ -282,8 +282,8 @@ Locator_Repository::unregister_if_address_reused (const ACE_CString& fqname,
   if (this->opts_.debug() > 0)
   {
     ORBSVCS_DEBUG ((LM_DEBUG,
-                    ACE_TEXT ("(%P|%t)ImR: checking reuse address ")
-                    ACE_TEXT ("for server \"%C\" ior \"%C\"\n"),
+                    ACE_TEXT ("(%P|%t) ImR: checking reuse address ")
+                    ACE_TEXT ("for server <%C> ior <%C>\n"),
                     fqname.c_str(),
                     partial_ior));
   }
@@ -314,8 +314,8 @@ Locator_Repository::unregister_if_address_reused (const ACE_CString& fqname,
     if (this->opts_.debug() > 0)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t)ImR: iterating - registered server")
-                      ACE_TEXT ("\"%C:%C\" key = <%C> ior \"%C\"\n"), info->server_id.c_str(),
+                      ACE_TEXT ("(%P|%t) ImR: iterating - registered server")
+                      ACE_TEXT ("<%C:%C> key <%C> ior <%C>\n"), info->server_id.c_str(),
                       info->poa_name.c_str (), info->key_name_.c_str(), info->partial_ior.c_str ()));
     }
     bool same_server = info->server_id == server_id;
@@ -328,7 +328,7 @@ Locator_Repository::unregister_if_address_reused (const ACE_CString& fqname,
         if (this->opts_.debug() > 0)
           {
             ORBSVCS_DEBUG ((LM_DEBUG,
-                            ACE_TEXT ("(%P|%t)ImR: reuse address %C so remove server %C \n"),
+                            ACE_TEXT ("(%P|%t) ImR: reuse address <%C> so remove server <%C>\n"),
                             info->partial_ior.c_str (), info->poa_name.c_str ()));
           }
         imr_locator->pinger ().remove_server (info->key_name_.c_str());
@@ -474,7 +474,7 @@ Locator_Repository::get_active_server (const ACE_CString& name, int pid)
       if (this->opts_.debug() > 5)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) get_active_server could not find %C\n"),
+                          ACE_TEXT ("(%P|%t) ImR: get_active_server could not find <%C>\n"),
                           name.c_str()));
         }
       si = find_by_poa (key);
@@ -508,8 +508,8 @@ Locator_Repository::get_active_server (const ACE_CString& name, int pid)
       if (this->opts_.debug() > 5)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) get_active_server could not")
-                          ACE_TEXT (" find %C, %d != %d\n"),
+                          ACE_TEXT ("(%P|%t) ImR: get_active_server could not")
+                          ACE_TEXT (" find <%C>, pid <%d> != <%d>\n"),
                           name.c_str(), pid, si->pid));
         }
       si.reset ();
@@ -590,7 +590,7 @@ Locator_Repository::link_peers (Server_Info_Ptr base,
   for (CORBA::ULong i = 0; i < p.length(); i++)
     {
       base->peers[len + i] =  p[i];
-      Server_Info *si;
+      Server_Info *si = 0;
       ACE_CString peer(p[i]);
       ACE_NEW_RETURN (si,
                       Server_Info (base->server_id, peer, base->is_jacorb, base),

--- a/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
@@ -538,7 +538,7 @@ Locator_Repository::remove_server (const ACE_CString& name,
     }
   Server_Info_Ptr si;
   this->servers().find (name, si);
-  int ret = this->servers().unbind (name);
+  int const ret = this->servers().unbind (name);
   if (ret != 0)
     {
       return ret;
@@ -634,7 +634,7 @@ Locator_Repository::remove_activator (const ACE_CString& name)
       return err;
     }
 
-  int ret = activators().unbind (lcase(name));
+  int const ret = activators().unbind (lcase(name));
   if (ret != 0)
     {
       return ret;

--- a/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
@@ -517,16 +517,6 @@ Locator_Repository::get_active_server (const ACE_CString& name, int pid)
   return si;
 }
 
-Server_Info_Ptr
-Locator_Repository::get_info (const ACE_CString& name)
-{
-  sync_load ();
-
-  Server_Info_Ptr si;
-  servers ().find (name, si);
-  return si;
-}
-
 int
 Locator_Repository::remove_server (const ACE_CString& name,
                                    ImR_Locator_i* imr_locator)
@@ -585,7 +575,7 @@ Locator_Repository::link_peers (Server_Info_Ptr base,
                                 const CORBA::StringSeq p)
 {
   sync_load ();
-  CORBA::ULong len = base->peers.length();
+  CORBA::ULong const len = base->peers.length();
   base->peers.length (len + p.length());
   for (CORBA::ULong i = 0; i < p.length(); i++)
     {
@@ -628,7 +618,7 @@ Locator_Repository::has_activator (const ACE_CString& name)
 int
 Locator_Repository::remove_activator (const ACE_CString& name)
 {
-  int err = sync_load ();
+  int const err = sync_load ();
   if (err != 0)
     {
       return err;

--- a/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.h
+++ b/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.h
@@ -75,8 +75,8 @@ public:
                   ImplementationRepository::ServerObject_ptr svrobj);
   int add_server_i (Server_Info *si);
 
-  /// create new records for poas that share a server instance. This is
-  /// a two step process, first the base poa must be registered then a
+  /// create new records for POAs that share a server instance. This is
+  /// a two step process, first the base POA must be registered then a
   /// list of peers may be added.
   int link_peers (Server_Info_Ptr base,
                   const CORBA::StringSeq peers);
@@ -100,7 +100,7 @@ public:
 
   /// Returns information related to startup.
   Server_Info_Ptr get_active_server (const ACE_CString& name, int pid = 0);
-  Server_Info_Ptr get_info (const ACE_CString& name);
+
   /// Returns information related to startup.
   Activator_Info_Ptr get_activator (const ACE_CString& name);
 
@@ -119,10 +119,10 @@ public:
   AIMap& activators(void);
   const AIMap& activators(void) const;
 
-  /// indicate the persistence mode for the repository
+  /// Indicate the persistence mode for the repository
   virtual const ACE_TCHAR* repo_mode(void) const = 0;
 
-  /// convert to lower case
+  /// Convert to lower case
   static ACE_CString lcase (const ACE_CString& s);
 
   /// Initialize the repo

--- a/TAO/orbsvcs/ImplRepo_Service/README
+++ b/TAO/orbsvcs/ImplRepo_Service/README
@@ -90,7 +90,7 @@ Commandline Arguments that can be passed to tao_imr_locator
 -o <filename>      write the ior to the file.
 -t <timeout>       specify a startup timeout value (default 60 seconds)
 -i                 periodically ping servers to check liveness.
--v                 the minimum succcessful ping interval. (default 10 seconds)
+-v                 the minimum successful ping interval. (default 10 seconds)
 -g                 the timeout for ping attempts. (default 1 second)
 -s                 run as a winNT service
 -c <command>       execute the named service command: install, remove

--- a/TAO/orbsvcs/ImplRepo_Service/Replicator.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Replicator.cpp
@@ -341,7 +341,7 @@ Replicator::send_registration (char *&imr_ior)
   catch (const ImplementationRepository::InvalidPeer& ip)
     {
       ORBSVCS_ERROR_RETURN ((LM_ERROR,
-        ACE_TEXT("Error: Replicator::send_registration invalid ImR replica because %s\n"),
+        ACE_TEXT("Error: Replicator::send_registration invalid ImR replica because %C\n"),
         ip.reason.in()), -1);
     }
 
@@ -362,7 +362,7 @@ Replicator::init_peer (const ACE_CString &replica_ior_file)
   if (this->debug_ > 1)
     {
       ORBSVCS_DEBUG ((LM_INFO,
-                      ACE_TEXT("Resolving ImR replica %s\n"),
+                      ACE_TEXT("Resolving ImR replica %C\n"),
                       replica_ior_file.c_str()));
     }
 

--- a/TAO/orbsvcs/ImplRepo_Service/Server_Info.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Server_Info.cpp
@@ -119,6 +119,12 @@ Server_Info::is_mode (ImplementationRepository::ActivationMode m) const
   return this->active_info ()->activation_mode_ == m;
 }
 
+ImplementationRepository::ActivationMode
+Server_Info::mode (void) const
+{
+  return this->active_info ()->activation_mode_;
+}
+
 bool
 Server_Info::has_peer (const char *name) const
 {

--- a/TAO/orbsvcs/ImplRepo_Service/Server_Info.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Server_Info.cpp
@@ -13,25 +13,28 @@ Server_Info::Server_Info (const Server_Info &other)
 Server_Info&
 Server_Info::operator= (const Server_Info &other)
 {
-  server_id = other.server_id;
-  poa_name = other.poa_name;
-  is_jacorb = other.is_jacorb;
-  key_name_ = other.key_name_;
-  activator = other.activator;
-  cmdline = other.cmdline;
-  dir = other.dir;
-  activation_mode_ = other.activation_mode_;
-  start_limit_ = other.start_limit_;
-  start_count_ = other.start_count_;
-  partial_ior = other.partial_ior;
-  ior = other.ior;
-  last_ping = other.last_ping;
-  server = other.server;
-  alt_info_ = other.alt_info_;
-  pid = other.pid;
-  death_notify = other.death_notify;
-  peers = other.peers;
-  env_vars = other.env_vars;
+  if (this != &other)
+  {
+    server_id = other.server_id;
+    poa_name = other.poa_name;
+    is_jacorb = other.is_jacorb;
+    key_name_ = other.key_name_;
+    activator = other.activator;
+    cmdline = other.cmdline;
+    dir = other.dir;
+    activation_mode_ = other.activation_mode_;
+    start_limit_ = other.start_limit_;
+    start_count_ = other.start_count_;
+    partial_ior = other.partial_ior;
+    ior = other.ior;
+    last_ping = other.last_ping;
+    server = other.server;
+    alt_info_ = other.alt_info_;
+    pid = other.pid;
+    death_notify = other.death_notify;
+    peers = other.peers;
+    env_vars = other.env_vars;
+  }
   return *this;
 }
 

--- a/TAO/orbsvcs/ImplRepo_Service/Server_Info.h
+++ b/TAO/orbsvcs/ImplRepo_Service/Server_Info.h
@@ -60,6 +60,8 @@ struct Server_Info
   bool is_server (const char *name) const;
   bool has_peer (const char *name) const;
   bool is_mode (ImplementationRepository::ActivationMode m) const;
+  ImplementationRepository::ActivationMode mode (void) const;
+
   bool is_running (void) const;
   bool start_allowed (void);
   void started (bool success);

--- a/TAO/orbsvcs/ImplRepo_Service/Shared_Backing_Store.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Shared_Backing_Store.cpp
@@ -90,7 +90,7 @@ namespace {
         ((flags_ & O_RDWR) != 0) ? ACE_TEXT ("r+") :
         (((flags_ & O_WRONLY) != 0) ? ACE_TEXT ("w") : ACE_TEXT ("r"));
       this->filename_ = file;
-#ifdef ACE_WIN32
+#if defined (ACE_WIN32)
       this->file_ = ACE_OS::fopen (file.c_str(), flags_str);
 #else
       this->file_lock_.reset
@@ -111,7 +111,7 @@ namespace {
       ACE_OS::fflush (this->file_);
       ACE_OS::fclose (this->file_);
       this->file_ = 0;
-#ifdef ACE_WIN32
+#if defined (ACE_WIN32)
       if (this->unlink_in_destructor_)
         {
           ACE_OS::unlink (this->filename_.c_str ());
@@ -122,7 +122,7 @@ namespace {
 
     void lock (void)
     {
-#ifndef ACE_WIN32
+#if defined (ACE_WIN32)
       if (this->locked_)
         return;
 
@@ -1042,7 +1042,7 @@ Shared_Backing_Store::process_updates (void)
             if (this->opts_.debug() > 4)
               {
                 ORBSVCS_DEBUG ((LM_INFO,
-                                ACE_TEXT("(%P|%t) notify_access_state_update, %C now %s\n"),
+                                ACE_TEXT("(%P|%t) notify_access_state_update, <%C> now <%C>\n"),
                                 entity.name.in (),
                                 AsyncAccessManager::status_name (entity.action.state ())));
               }

--- a/TAO/orbsvcs/ImplRepo_Service/Shared_Backing_Store.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Shared_Backing_Store.cpp
@@ -1263,11 +1263,11 @@ Shared_Backing_Store::LocatorListings_XMLHandler::remove_unmatched(
   Locator_Repository::SIMap::CONST_ITERATOR siit (this->unmatched_servers_);
   for (; siit.next (sientry); siit.advance() )
     {
-      int ret = repo.servers().unbind (sientry->ext_id_);
+      int const ret = repo.servers().unbind (sientry->ext_id_);
       if (ret != 0)
         {
           ORBSVCS_ERROR((LM_ERROR,
-            ACE_TEXT ("ERROR: could not remove server: %s\n"),
+            ACE_TEXT ("ERROR: could not remove server: %C\n"),
             sientry->int_id_->key_name_.c_str()));
         }
     }
@@ -1280,7 +1280,7 @@ Shared_Backing_Store::LocatorListings_XMLHandler::remove_unmatched(
       if (ret != 0)
         {
           ORBSVCS_ERROR((LM_ERROR,
-            ACE_TEXT ("ERROR: could not remove activator: %s\n"),
+            ACE_TEXT ("ERROR: could not remove activator: %C\n"),
             aientry->int_id_->name.c_str()));
         }
     }

--- a/TAO/orbsvcs/ImplRepo_Service/Shared_Backing_Store.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Shared_Backing_Store.cpp
@@ -1146,7 +1146,7 @@ Shared_Backing_Store::gen_ior (char*& ft_imr_ior)
       // give back the original pointer and don't clean it up
       ft_imr_ior = ior._retn();
       ORBSVCS_ERROR((LM_ERROR,
-        "ERROR: Failed to create Fault Tolerant ImR, reason=%s\n",
+        "ERROR: Failed to create Fault Tolerant ImR, reason=%C\n",
         reason.in()));
       throw ImplementationRepository::InvalidPeer(reason.in());
     }

--- a/TAO/orbsvcs/ImplRepo_Service/UpdateableServerInfo.h
+++ b/TAO/orbsvcs/ImplRepo_Service/UpdateableServerInfo.h
@@ -25,7 +25,7 @@ typedef ACE_Strong_Bound_Ptr<Locator_Repository, ACE_Null_Mutex> Repository_Ptr;
 class UpdateableServerInfo
 {
 public:
-  /// constructor
+  /// Constructor
   /// @param repo the repo to report updates to
   /// @param name the name of the server to retrieve
   /// @param pid an optional process id to further discriminate the server
@@ -33,7 +33,7 @@ public:
                        const ACE_CString& name,
                        int pid = 0);
 
-  /// constructor
+  /// Constructor
   /// @param repo the repo to report updates to
   /// @param si an already retrieved Server_Info_Ptr
   /// @param reset_start_count controls the reset of the start count value
@@ -43,16 +43,16 @@ public:
 
   UpdateableServerInfo(UpdateableServerInfo& other );
 
-  /// destructor (updates repo if needed)
+  /// Destructor (updates repo if needed)
   ~UpdateableServerInfo(void);
 
-  /// explicitly update repo if needed
+  /// Explicitly update repo if needed
   void update_repo(void);
 
-  /// update remote access state
+  /// Update remote access state
   void notify_remote_access (ImplementationRepository::AAM_Status state);
 
-  /// assign a server info
+  /// Assign a server info
   void server_info (const Server_Info_Ptr& si);
 
   /// const Server_Info access
@@ -61,23 +61,23 @@ public:
   /// const Server_Info& access
   const Server_Info& operator*() const;
 
-  /// retrieve smart pointer to non-const Server_Info
+  /// Retrieve smart pointer to non-const Server_Info
   /// and indicate repo update required
   const Server_Info_Ptr& edit(bool active = true);
 
-  /// indicate it Server_Info_Ptr is null
+  /// Indicate it Server_Info_Ptr is null
   bool null(void) const;
 
 private:
   const UpdateableServerInfo& operator=(const UpdateableServerInfo& );
 
-  /// the repo
+  /// The repo
   Repository_Ptr repo_;
 
-  /// the retrieved, passed, or non-stored server info
+  /// The retrieved, passed, or non-stored server info
   Server_Info_Ptr si_;
 
-  /// the server info has changes and needs to be updated to the repo
+  /// The server info has changes and needs to be updated to the repo
   bool needs_update_;
 };
 

--- a/TAO/orbsvcs/ImplRepo_Service/XML_Backing_Store.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/XML_Backing_Store.cpp
@@ -320,7 +320,7 @@ XML_Backing_Store::load_activator (const ACE_CString& activator_name,
                                    const ACE_CString& ior,
                                    const NameValues& )
 {
-  Activator_Info *ai;
+  Activator_Info *ai = 0;
   ACE_NEW (ai,
            Activator_Info (activator_name, token, ior));
 

--- a/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
@@ -1365,7 +1365,7 @@ TAO_IMR_Op_Register::run (void)
               if (!this->quiet_)
                 {
                   ORBSVCS_DEBUG((LM_DEBUG,
-                                 "Server <%C> already registered.\n",
+                                 "(%P|%t) ImR: Server <%C> already registered.\n",
                                  this->server_name_.c_str ()));
                 }
               return ALREADY_REGISTERED;
@@ -1379,7 +1379,7 @@ TAO_IMR_Op_Register::run (void)
             if (!this->quiet_)
               {
                 ORBSVCS_DEBUG((LM_DEBUG,
-                               "Adding Server <%C> on update command.\n",
+                               "(%P|%t) Adding Server <%C> on update command.\n",
                                this->server_name_.c_str ()));
               }
             is_add_ = true;
@@ -1415,8 +1415,8 @@ TAO_IMR_Op_Register::run (void)
           if (!this->quiet_)
             {
               ORBSVCS_DEBUG ((LM_DEBUG,
-                              "Updating Server <%C> with default "
-                              "activator of <%C>.\n",
+                              "(%P|%t) ImR: Updating Server <%C> with default "
+                              "activator of <%C>\n",
                               this->server_name_.c_str (),
                               options->activator.in ()));
             }
@@ -1426,13 +1426,13 @@ TAO_IMR_Op_Register::run (void)
       if (!this->quiet_)
         {
           ORBSVCS_DEBUG((LM_DEBUG,
-                         "Successfully registered <%C>.\n",
+                         "(%P|%t) ImR: Successfully registered <%C>\n",
                          this->server_name_.c_str ()));
         }
     }
   catch (const CORBA::NO_PERMISSION&)
     {
-      ORBSVCS_ERROR ((LM_ERROR, "No Permission: ImplRepo is in Locked mode\n"));
+      ORBSVCS_ERROR ((LM_ERROR, "(%P|%t) ImR: No Permission: ImplRepo is in Locked mode\n"));
       return TAO_IMR_Op::NO_PERMISSION;
     }
   catch (const CORBA::Exception& ex)

--- a/TAO/orbsvcs/tests/AVStreams/Asynch_Three_Stage/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Asynch_Three_Stage/sender.cpp
@@ -252,7 +252,7 @@ Sender::pace_data (void)
             }
 
           ACE_DEBUG ((LM_DEBUG,
-                      "Sender::pace_data frame %d was sent succesfully\n",
+                      "Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           // Reset the message block.

--- a/TAO/orbsvcs/tests/AVStreams/Bidirectional_Flows/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Bidirectional_Flows/sender.cpp
@@ -377,7 +377,7 @@ Sender::pace_data (void)
                               -1);
 
           ACE_DEBUG ((LM_DEBUG,
-                      "Sender::pace_data frame %d was sent succesfully\n",
+                      "Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           // Reset the message block.

--- a/TAO/orbsvcs/tests/AVStreams/Component_Switching/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Component_Switching/sender.cpp
@@ -392,7 +392,7 @@ Sender::pace_data (void)
             }
 
           ACE_DEBUG ((LM_DEBUG,
-                      "Sender::pace_data frame %d was sent succesfully\n",
+                      "Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           /// Reset the message block.

--- a/TAO/orbsvcs/tests/AVStreams/Full_Profile/ftp.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Full_Profile/ftp.cpp
@@ -62,7 +62,7 @@ FTP_Client_Callback::handle_timeout (void *)
       int result = this->protocol_object_->send_frame (&mb);
       if (result < 0)
         ACE_ERROR_RETURN ((LM_ERROR,"send failed:%p","FTP_Client_Flow_Handler::send\n"),-1);
-      ACE_DEBUG ((LM_DEBUG,"handle_timeout::buffer sent succesfully\n"));
+      ACE_DEBUG ((LM_DEBUG,"handle_timeout::buffer sent successfully\n"));
     }
   catch (const CORBA::Exception& ex)
     {

--- a/TAO/orbsvcs/tests/AVStreams/Modify_QoS/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Modify_QoS/sender.cpp
@@ -326,7 +326,7 @@ Sender::pace_data (void)
                               -1);
 
           ACE_DEBUG ((LM_DEBUG,
-                      "Sender::pace_data frame %d was sent succesfully\n",
+                      "Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           // Reset the message block.

--- a/TAO/orbsvcs/tests/AVStreams/Multicast/ftp.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Multicast/ftp.cpp
@@ -76,7 +76,7 @@ FTP_Client_Callback::handle_timeout (void *)
   int result = this->protocol_object_->send_frame (&mb);
   if (result < 0)
     ACE_ERROR_RETURN ((LM_ERROR,"send failed:%p","FTP_Client_Flow_Handler::send\n"),-1);
-  ACE_DEBUG ((LM_DEBUG,"handle_timeout::buffer sent succesfully\n"));
+  ACE_DEBUG ((LM_DEBUG,"handle_timeout::buffer sent successfully\n"));
   return 0;
 }
 

--- a/TAO/orbsvcs/tests/AVStreams/Multicast_Full_Profile/ftp.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Multicast_Full_Profile/ftp.cpp
@@ -68,7 +68,7 @@ FTP_Client_Callback::handle_timeout (void *)
   int result = this->protocol_object_->send_frame (&mb);
   if (result < 0)
     ACE_ERROR_RETURN ((LM_ERROR,"send failed:%p","FTP_Client_Flow_Handler::send\n"),-1);
-  ACE_DEBUG ((LM_DEBUG,"handle_timeout::buffer sent succesfully\n"));
+  ACE_DEBUG ((LM_DEBUG,"handle_timeout::buffer sent successfully\n"));
   return 0;
 }
 

--- a/TAO/orbsvcs/tests/AVStreams/Multiple_Flows/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Multiple_Flows/sender.cpp
@@ -330,7 +330,7 @@ Sender::pace_data (void)
 
 
           ACE_DEBUG ((LM_DEBUG,
-                      "Sender::pace_data frame %d was sent succesfully\n",
+                      "Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           // Reset the message block.

--- a/TAO/orbsvcs/tests/AVStreams/Pluggable/ftp.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Pluggable/ftp.cpp
@@ -373,7 +373,7 @@ Client::pace_data (void)
             ACE_ERROR_RETURN ((LM_ERROR,
                                "send failed:%p","FTP_Client_Flow_Handler::send\n"),
                               -1);
-          ACE_DEBUG ((LM_DEBUG,"Client::pace_data buffer sent succesfully\n"));
+          ACE_DEBUG ((LM_DEBUG,"Client::pace_data buffer sent successfully\n"));
 
           // Reset the mb.
           this->mb.reset ();

--- a/TAO/orbsvcs/tests/AVStreams/Pluggable_Flow_Protocol/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Pluggable_Flow_Protocol/sender.cpp
@@ -300,7 +300,7 @@ Sender::pace_data (void)
                               -1);
 
           ACE_DEBUG ((LM_DEBUG,
-                      "Sender::pace_data frame %d was sent succesfully\n",
+                      "Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           // Reset the message block.

--- a/TAO/orbsvcs/tests/AVStreams/Simple_Three_Stage/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Simple_Three_Stage/sender.cpp
@@ -275,7 +275,7 @@ Sender::pace_data (void)
                                -1);
 
           ACE_DEBUG ((LM_DEBUG,
-                      "Sender::pace_data frame %d was sent succesfully\n",
+                      "Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           // Reset the message block.

--- a/TAO/orbsvcs/tests/AVStreams/Simple_Two_Stage/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Simple_Two_Stage/sender.cpp
@@ -388,7 +388,7 @@ Sender::pace_data (void)
                               -1);
 
             ACE_DEBUG ((LM_DEBUG,
-                        "Sender::pace_data frame %d was sent succesfully %d\n",
+                        "Sender::pace_data frame %d was sent successfully %d\n",
                         ++this->frame_count_,
                         buffer_size));
 

--- a/TAO/orbsvcs/tests/AVStreams/Simple_Two_Stage_With_QoS/sender.cpp
+++ b/TAO/orbsvcs/tests/AVStreams/Simple_Two_Stage_With_QoS/sender.cpp
@@ -434,7 +434,7 @@ Sender::pace_data (void)
                               -1);
 
           ACE_DEBUG ((LM_DEBUG,
-                      " Sender::pace_data frame %d was sent succesfully\n",
+                      " Sender::pace_data frame %d was sent successfully\n",
                       ++this->frame_count_));
 
           // Reset the message block.

--- a/TAO/orbsvcs/tests/ImplRepo/double_start/README
+++ b/TAO/orbsvcs/tests/ImplRepo/double_start/README
@@ -1,8 +1,5 @@
-
-
 This test demonstrates that a client may safely obtain a new reference to a
 previously crashed server by connecting to either a primary or backup ImR.
 
 Additionally, a secondary restart script is used to request a server restart
 when the server exits with a non-zero value.
-

--- a/TAO/orbsvcs/tests/ImplRepo/manual_start/README
+++ b/TAO/orbsvcs/tests/ImplRepo/manual_start/README
@@ -1,5 +1,3 @@
-
-
 This test demonstrates that a client attempting to contact a stopped MANUAL server will
 not lock up the ImR. The test starts primary and backup Locators, then registers and
 starts a server with MANUAL activation mode. The server connects to the locator then

--- a/TAO/orbsvcs/tests/ImplRepo/scale/client.conf
+++ b/TAO/orbsvcs/tests/ImplRepo/scale/client.conf
@@ -1,4 +1,3 @@
-
 # This file is here just in case you want to run some of the tests manually
 # and don't want the client to jump back in the reactor during the
 # invocation.

--- a/TAO/orbsvcs/tests/ImplRepo/scale/server_i.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/scale/server_i.cpp
@@ -196,7 +196,6 @@ Server_i::run (void)
     throw;
   }
 
-
   return 0;
 }
 

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
@@ -11,7 +11,6 @@ run_test.pl [-clients <num>]
       [-max_rt_tries <max-client-requests>]
       [-no_imr]
 
-
 2. Description of command line arguments
 
 - clients <num>

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
@@ -4,7 +4,8 @@ to a server registered with the ImplRepo and launched using the activator.
 1. Syntax
 
 run_test.pl [-clients <num>]
-      [-imrdebug <level>
+      [-imrdebug <level>]
+      [-activationmode <mode>]
       [-msecs_between_clients <msecs>]
       [-server_init_delay <seconds>]
       [-server_reply_delay <seconds>]
@@ -19,6 +20,9 @@ run_test.pl [-clients <num>]
 
 - imrdebug <level>
         The debug level for the ImR Locator/Activator, default of 1
+
+- activationmode <mode>
+        The server activation mode, normal|manual|per_client|auto_start
 
 - msecs_between_clients <msecs>
         The number of milliseconds to wait between client spawns.

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
@@ -1,17 +1,15 @@
-
-
 This is a test of the ImplRepo being accessed by a variable number of clients trying to send a request
 to a server registered with the ImplRepo and launched using the activator.
 
 1. Syntax
 
 run_test.pl [-clients <num>]
-	    [-msecs_between_clients <msecs>]
-	    [-server_init_delay <seconds>]
-	    [-server_reply_delay <seconds>]
-	    [-rt_timeout <round-trip-timeout-msecs>]
-	    [-max_rt_tries <max-client-requests>]
-	    [-no_imr]
+      [-msecs_between_clients <msecs>]
+      [-server_init_delay <seconds>]
+      [-server_reply_delay <seconds>]
+      [-rt_timeout <round-trip-timeout-msecs>]
+      [-max_rt_tries <max-client-requests>]
+      [-no_imr]
 
 
 2. Description of command line arguments
@@ -41,8 +39,8 @@ run_test.pl [-clients <num>]
         the client will attempt to try the request again. This
         argument controls the maximum number of requests that the
         client will make.
-	You can use this argument along with low value of rt_timeout
-	to cause a rapid number of request attempts.
+        You can use this argument along with low value of rt_timeout
+        o cause a rapid number of request attempts.
 
 - no_imr
        Passing this argument will assume the ImplRepo is already

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/README
@@ -4,6 +4,7 @@ to a server registered with the ImplRepo and launched using the activator.
 1. Syntax
 
 run_test.pl [-clients <num>]
+      [-imrdebug <level>
       [-msecs_between_clients <msecs>]
       [-server_init_delay <seconds>]
       [-server_reply_delay <seconds>]
@@ -15,6 +16,9 @@ run_test.pl [-clients <num>]
 
 - clients <num>
         The number of clients to spawn.
+
+- imrdebug <level>
+        The debug level for the ImR Locator/Activator, default of 1
 
 - msecs_between_clients <msecs>
         The number of milliseconds to wait between client spawns.

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/Test_i.h
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/Test_i.h
@@ -13,7 +13,6 @@
 class  Test_i : public virtual POA_Test
 {
 public:
-
   Test_i (CORBA::Short num_requests_expected);
 
   virtual ~Test_i ();
@@ -24,8 +23,7 @@ public:
   static bool expected_requests_made ();
 
 private:
-
-  CORBA::Short num_requests_expected_;
+  CORBA::Short const num_requests_expected_;
   CORBA::Short num_requests_made_;
 
   static bool expected_requests_made_;

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/client.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/client.cpp
@@ -39,7 +39,7 @@ parse_args (int argc, ACE_TCHAR *argv[])
         ACE_ERROR_RETURN ((LM_ERROR,
                            "usage:  %s "
                            "-d <request delay in seconds> "
-                           "-r <rount trip timeout in milliseconds> "
+                           "-r <round trip timeout in milliseconds> "
                            "-m <max tries if RT timeout failures> "
                            "\n",
                            argv [0]),
@@ -65,35 +65,32 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
     if (rt_timeout_msecs > 0)
       {
+        // Timeout specified in hundreds of nanoseconds which is
+        // 10000 milliseconds.
+        TimeBase::TimeT relative_rt_timeout = rt_timeout_msecs * 10000;
 
-    // Timeout specified in hundreds of nanoseconds which is
-    // 10000 milliseconds.
-    TimeBase::TimeT relative_rt_timeout = rt_timeout_msecs * 10000;
+        CORBA::Any relative_rt_timeout_as_any;
+        relative_rt_timeout_as_any <<= relative_rt_timeout;
+        CORBA::PolicyList policy_list(1);
+        policy_list.length(1);
+        policy_list[0] =
+          orb->create_policy(Messaging::RELATIVE_RT_TIMEOUT_POLICY_TYPE,
+          relative_rt_timeout_as_any);
 
-    CORBA::Any relative_rt_timeout_as_any;
-    relative_rt_timeout_as_any <<= relative_rt_timeout;
-    CORBA::PolicyList policy_list(1);
-    policy_list.length(1);
-    policy_list[0] =
-      orb->create_policy(Messaging::RELATIVE_RT_TIMEOUT_POLICY_TYPE,
-      relative_rt_timeout_as_any);
+        // Apply the policy at the ORB level.
+        obj = orb->resolve_initial_references("ORBPolicyManager");
+        CORBA::PolicyManager_var policy_manager =
+          CORBA::PolicyManager::_narrow(obj.in());
+        policy_manager->set_policy_overrides (policy_list, CORBA::ADD_OVERRIDE);
 
-    // Apply the policy at the ORB level.
-    obj = orb->resolve_initial_references("ORBPolicyManager");
-    CORBA::PolicyManager_var policy_manager =
-      CORBA::PolicyManager::_narrow(obj.in());
-    policy_manager->set_policy_overrides (policy_list, CORBA::ADD_OVERRIDE);
-
-    // Destroy the Policy objects.
-    for (CORBA::ULong i = 0; i < policy_list.length(); ++i) {
-      policy_list[i]->destroy ();
-    }
-    policy_list.length(0);
-
+        // Destroy the Policy objects.
+        for (CORBA::ULong i = 0; i < policy_list.length(); ++i) {
+          policy_list[i]->destroy ();
+        }
+        policy_list.length(0);
       }
 
     ///// Get object reference /////
-
     obj = orb->resolve_initial_references("Test");
     ACE_ASSERT (!CORBA::is_nil(obj.in()));
     Test_var test = Test::_narrow( obj.in() );

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/client.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/client.cpp
@@ -61,8 +61,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
     CORBA::Object_var obj;
 
-    ///// Specify the relative round trip policy /////
-
+    //Specify the relative round trip policy
     if (rt_timeout_msecs > 0)
       {
         // Timeout specified in hundreds of nanoseconds which is
@@ -99,7 +98,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     if (max_tries > 1)
       {
         ACE_DEBUG ((LM_DEBUG,
-                    "Maximum number of tries = %d\n",
+                    "(%P|%t) Maximum number of tries = %d\n",
                     max_tries));
       }
 
@@ -121,17 +120,22 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     if (n == 0)
       {
         ACE_ERROR_RETURN ((LM_ERROR,
-                           "ERROR: Expected number of requests from "
-                           "server to by > 0\n"),
+                           "(%P|%t) ERROR: Expected number of requests from "
+                           "server to be > 0\n"),
                           -1);
       }
-
+    else
+      {
+        ACE_DEBUG ((LM_DEBUG,
+                    "(%P|%t) Client got back <%d>\n",
+                    n));
+      }
 
     return 0;
 
   }
   catch(const CORBA::Exception& ex) {
-    ex._tao_print_exception ("client:");
+    ex._tao_print_exception ("Client:");
   }
 
   return -1;

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
@@ -138,7 +138,7 @@ sub scale_clients_test
     my $result = 0;
     my $start_time = time();
 
-    $IMR->Arguments ("-d $imr_debug_level -o $imr_imriorfile -orbendpoint iiop://:$port $asynch_loc ");
+    $IMR->Arguments ("-d $imr_debug_level -o $imr_imriorfile -orbendpoint iiop://:$port $asynch_loc -ORBDebugLevel $debug_level");
 
     if ($no_imr) {
       print STDERR "IMR assumed to be manually launched in way that is ".

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
@@ -22,6 +22,7 @@ my $server_reply_delay = 0;
 my $rt_timeout_msecs = 0;
 my $max_rt_tries = 1;
 my $asynch_loc = "";
+my $activationmode = "normal";
 
 if ($#ARGV >= 0) {
     for (my $i = 0; $i <= $#ARGV; $i++) {
@@ -32,6 +33,10 @@ if ($#ARGV >= 0) {
       elsif ($ARGV[$i] eq "-imrdebug") {
         $i++;
         $imr_debug_level = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-activationmode") {
+        $i++;
+        $activationmode = $ARGV[$i];
       }
       elsif ($ARGV[$i] eq "-clients") {
         $i++;
@@ -198,7 +203,7 @@ sub scale_clients_test
     $srv->DeleteFile ($srv_status_file);
 
     $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
-        "add $objprefix" . " -c \"".
+        "add $objprefix" . " -a $activationmode -c \"".
         $srv_server_cmd . " ".
         "-ORBUseIMR 1 -d $server_init_delay -n $clients_count ".
         "-ORBInitRef ImplRepoService=file://$imr_imriorfile\"");
@@ -291,6 +296,7 @@ sub usage() {
       "[-max_rt_tries <max-client-requests=$max_rt_tries>] ".
       "[-no_imr] ".
       "[-imrdebug <level=$imr_debug_level>]" .
+      "[-activationmode <activationmode=$activationmode]" .
       "\n";
 }
 

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
@@ -182,7 +182,7 @@ sub scale_clients_test
         return 1;
     }
 
-    $ACT->Arguments ("-d $imr_debug_level -l -o $act_actiorfile -ORBInitRef ImplRepoService=file://$act_imriorfile");
+    $ACT->Arguments ("-d $imr_debug_level -o $act_actiorfile -ORBInitRef ImplRepoService=file://$act_imriorfile");
     print ">>> " . $ACT->CommandLine () . "\n";
 
     $ACT_status = $ACT->Spawn ();

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
@@ -243,8 +243,7 @@ sub scale_clients_test
     ##### Stop clients #####
     print STDERR "Waiting for clients to stop\n";
     for(my $i = 0; $i < $clients_count; $i++ ) {
-        my $CLI_status = $CLI[$i]->WaitKill ($cli[$i]->ProcessStartWaitInterval() +
-              $server_init_delay + $server_reply_delay);
+        my $CLI_status = $CLI[$i]->WaitKill ($cli[$i]->ProcessStartWaitInterval() + $server_init_delay + $server_reply_delay);
         if ($CLI_status != 0) {
             print STDERR "ERROR: Client $i returned $CLI_status\n";
             return 1;
@@ -256,13 +255,15 @@ sub scale_clients_test
     $srv->DeleteFile ($status_file_name);
 
     # Shutting down any server object within the server will shutdown the whole server
-    $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
-       "shutdown $objprefix");
-    print ">>> " . $TI->CommandLine () . "\n";
-    $TI_status = $TI->SpawnWaitKill ($ti->ProcessStartWaitInterval());
-    if ($TI_status != 0) {
-      print STDERR "ERROR: tao_imr shutdown returned $TI_status\n";
-      $status = 1;
+    # This can not be done with per client activation mode
+    if ($activationmode != "per_client") {
+      $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile shutdown $objprefix");
+      print ">>> " . $TI->CommandLine () . "\n";
+      $TI_status = $TI->SpawnWaitKill ($ti->ProcessStartWaitInterval());
+      if ($TI_status != 0) {
+        print STDERR "ERROR: tao_imr shutdown returned $TI_status\n";
+        $status = 1;
+      }
     }
 
     my $ACT_status = $ACT->TerminateWaitKill ($act->ProcessStopWaitInterval());

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
@@ -182,7 +182,7 @@ sub scale_clients_test
         return 1;
     }
 
-    $ACT->Arguments ("-d $imr_debug_level -o $act_actiorfile -ORBInitRef ImplRepoService=file://$act_imriorfile");
+    $ACT->Arguments ("-d $imr_debug_level -l -o $act_actiorfile -ORBInitRef ImplRepoService=file://$act_imriorfile");
     print ">>> " . $ACT->CommandLine () . "\n";
 
     $ACT_status = $ACT->Spawn ();

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/run_test.pl
@@ -9,9 +9,10 @@ use lib "$ENV{ACE_ROOT}/bin";
 use PerlACE::TestTarget;
 
 $status = 0;
-$debug_level = '0';
+my $debug_level = '0';
+my $imr_debug_level = '1';
 
-# Allow for manually launching ImpleRepo for debugging purposes.
+# Allow for manually launching ImplRepo for debugging purposes.
 my $no_imr = 0;
 
 my $clients_count = 6;
@@ -24,48 +25,52 @@ my $asynch_loc = "";
 
 if ($#ARGV >= 0) {
     for (my $i = 0; $i <= $#ARGV; $i++) {
-	if ($ARGV[$i] eq '-debug') {
-	    $debug_level = '10';
-	    $i++;
-	}
-	elsif ($ARGV[$i] eq "-clients") {
-	    $i++;
-	    $clients_count = $ARGV[$i];
-	}
-	elsif ($ARGV[$i] eq "-rt_timeout") {
-	    $i++;
-	    $rt_timeout_msecs = $ARGV[$i];
-	}
-	elsif ($ARGV[$i] eq "-secs_between_clients") {
-	    $i++;
-	    $secs_between_clients = $ARGV[$i];
-	}
-	elsif ($ARGV[$i] eq "-server_init_delay") {
-	    $i++;
-	    $server_init_delay = $ARGV[$i];
-	}
-	elsif ($ARGV[$i] eq "-server_reply_delay") {
-	    $i++;
-	    $server_reply_delay = $ARGV[$i];
-	}
-	elsif ($ARGV[$i] eq "-rt_timeout") {
-	    $i++;
-	    $rt_timeout_msecs = $ARGV[$i];
-	}
-	elsif ($ARGV[$i] eq "-max_rt_tries") {
-	    $i++;
-	    $max_rt_tries = $ARGV[$i];
-	}
-	elsif ($ARGV[$i] eq "-no_imr") {
-	    $no_imr = 1;
-	}
-        elsif ($ARGV[$i] eq "-asynch") {
-            $asynch_loc = "--use_dsi";
-        }
-	else {
-	    usage();
-	    exit 1;
-	}
+      if ($ARGV[$i] eq '-debug') {
+        $debug_level = '10';
+        $i++;
+      }
+      elsif ($ARGV[$i] eq "-imrdebug") {
+        $i++;
+        $imr_debug_level = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-clients") {
+        $i++;
+        $clients_count = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-rt_timeout") {
+        $i++;
+        $rt_timeout_msecs = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-secs_between_clients") {
+        $i++;
+        $secs_between_clients = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-server_init_delay") {
+        $i++;
+        $server_init_delay = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-server_reply_delay") {
+        $i++;
+        $server_reply_delay = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-rt_timeout") {
+        $i++;
+        $rt_timeout_msecs = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-max_rt_tries") {
+        $i++;
+        $max_rt_tries = $ARGV[$i];
+      }
+      elsif ($ARGV[$i] eq "-no_imr") {
+        $no_imr = 1;
+      }
+      elsif ($ARGV[$i] eq "-asynch") {
+        $asynch_loc = "--use_dsi";
+      }
+      else {
+        usage();
+        exit 1;
+      }
     }
 }
 
@@ -128,34 +133,32 @@ sub scale_clients_test
     my $result = 0;
     my $start_time = time();
 
-    $IMR->Arguments ("-d 1 -o $imr_imriorfile -orbendpoint iiop://:$port $asynch_loc ");
-#		     "-ORBDebugLevel 10 -ORBVerboseLogging");
+    $IMR->Arguments ("-d $imr_debug_level -o $imr_imriorfile -orbendpoint iiop://:$port $asynch_loc ");
 
     if ($no_imr) {
-	print STDERR "IMR assumed to be manually launched in way that is ".
-	    "compatbile with:\n";
-	print STDERR $IMR->CommandLine () . "\n";
+      print STDERR "IMR assumed to be manually launched in way that is ".
+        "compatible with:\n";
+      print STDERR $IMR->CommandLine () . "\n";
     } else {
+      print ">>> " . $IMR->CommandLine () . "\n";
 
-	print ">>> " . $IMR->CommandLine () . "\n";
+      ##### Start ImplRepo #####
+      $IMR_status = $IMR->Spawn ();
+      if ($IMR_status != 0) {
+        print STDERR "ERROR: ImplRepo Service returned $IMR_status\n";
+        return 1;
+      }
+      if ($imr->WaitForFileTimed ($imriorfile, $imr->ProcessStartWaitInterval()) == -1) {
+        print STDERR "ERROR: cannot find file <$imr_imriorfile>\n";
+        $IMR->Kill (); $IMR->TimedWait (1);
+        return 1;
+      }
 
-	##### Start ImplRepo #####
-	$IMR_status = $IMR->Spawn ();
-	if ($IMR_status != 0) {
-	    print STDERR "ERROR: ImplRepo Service returned $IMR_status\n";
-	    return 1;
-	}
-	if ($imr->WaitForFileTimed ($imriorfile, $imr->ProcessStartWaitInterval()) == -1) {
-	    print STDERR "ERROR: cannot find file <$imr_imriorfile>\n";
-	    $IMR->Kill (); $IMR->TimedWait (1);
-	    return 1;
-	}
-
-	if ($imr->GetFile ($imriorfile) == -1) {
-	    print STDERR "ERROR: cannot retrieve file <$imr_imriorfile>\n";
-	    $IMR->Kill (); $IMR->TimedWait (1);
-	    return 1;
-	}
+      if ($imr->GetFile ($imriorfile) == -1) {
+        print STDERR "ERROR: cannot retrieve file <$imr_imriorfile>\n";
+        $IMR->Kill (); $IMR->TimedWait (1);
+        return 1;
+      }
     }
 
     if ($act->PutFile ($imriorfile) == -1) {
@@ -174,19 +177,19 @@ sub scale_clients_test
         return 1;
     }
 
-    $ACT->Arguments ("-d 1 -o $act_actiorfile -ORBInitRef ImplRepoService=file://$act_imriorfile");
+    $ACT->Arguments ("-d $imr_debug_level -o $act_actiorfile -ORBInitRef ImplRepoService=file://$act_imriorfile");
     print ">>> " . $ACT->CommandLine () . "\n";
 
     $ACT_status = $ACT->Spawn ();
     if ($ACT_status != 0) {
-	print STDERR "ERROR: ImR Activator returned $ACT_status\n";
-	return 1;
+      print STDERR "ERROR: ImR Activator returned $ACT_status\n";
+      return 1;
     }
     if ($act->WaitForFileTimed ($actiorfile,$act->ProcessStartWaitInterval()) == -1) {
-	print STDERR "ERROR: cannot find file <$act_imriorfile>\n";
-	$ACT->Kill (); $ACT->TimedWait (1);
-	$IMR->Kill (); $IMR->TimedWait (1);
-	return 1;
+      print STDERR "ERROR: cannot find file <$act_imriorfile>\n";
+      $ACT->Kill (); $ACT->TimedWait (1);
+      $IMR->Kill (); $IMR->TimedWait (1);
+      return 1;
     }
 
     ##### Add server to activator #####
@@ -195,18 +198,18 @@ sub scale_clients_test
     $srv->DeleteFile ($srv_status_file);
 
     $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
-		    "add $objprefix" . " -c \"".
-		    $srv_server_cmd . " ".
-		    "-ORBUseIMR 1 -d $server_init_delay -n $clients_count ".
-		    "-ORBInitRef ImplRepoService=file://$imr_imriorfile\"");
+        "add $objprefix" . " -c \"".
+        $srv_server_cmd . " ".
+        "-ORBUseIMR 1 -d $server_init_delay -n $clients_count ".
+        "-ORBInitRef ImplRepoService=file://$imr_imriorfile\"");
 
     print ">>> " . $TI->CommandLine () . "\n";
     $TI_status = $TI->SpawnWaitKill ($ti->ProcessStartWaitInterval());
     if ($TI_status != 0) {
-	print STDERR "ERROR: tao_imr returned $TI_status\n";
-	$ACT->Kill (); $ACT->TimedWait (1);
-	$IMR->Kill (); $IMR->TimedWait (1);
-	return 1;
+      print STDERR "ERROR: tao_imr returned $TI_status\n";
+      $ACT->Kill (); $ACT->TimedWait (1);
+      $IMR->Kill (); $IMR->TimedWait (1);
+      return 1;
     }
 
     # Why is this sleep needed?
@@ -214,20 +217,20 @@ sub scale_clients_test
 
     ##### Run clients #####
     for(my $i = 0; $i < $clients_count; $i++ ) {
-	# Make sure server has started by looking for its status file
+      # Make sure server has started by looking for its status file
 
-	$CLI[$i]->Arguments ("-ORBInitRef Test=corbaloc::localhost:$port/$objprefix" .
-			     " -d $server_reply_delay".
-                             " -r $rt_timeout_msecs".
-			     " -m $max_rt_tries");
-	print ">>> " . $CLI[$i]->CommandLine () . "\n";
-	$CLI_status = $CLI[$i]->Spawn ();
-	if ($CLI_status != 0) {
-	    print STDERR "ERROR: client returned $CLI_status during spawn\n";
-	    $status = 1;
-	    last;
-	}
-	sleep($secs_between_clients);
+      $CLI[$i]->Arguments ("-ORBInitRef Test=corbaloc::localhost:$port/$objprefix" .
+            " -d $server_reply_delay".
+            " -r $rt_timeout_msecs".
+            " -m $max_rt_tries");
+      print ">>> " . $CLI[$i]->CommandLine () . "\n";
+      $CLI_status = $CLI[$i]->Spawn ();
+      if ($CLI_status != 0) {
+        print STDERR "ERROR: client returned $CLI_status during spawn\n";
+        $status = 1;
+        last;
+      }
+      sleep($secs_between_clients);
     }
 
     sleep (server_request_delay);
@@ -236,7 +239,7 @@ sub scale_clients_test
     print STDERR "Waiting for clients to stop\n";
     for(my $i = 0; $i < $clients_count; $i++ ) {
         my $CLI_status = $CLI[$i]->WaitKill ($cli[$i]->ProcessStartWaitInterval() +
-					     $server_init_delay + $server_reply_delay);
+              $server_init_delay + $server_reply_delay);
         if ($CLI_status != 0) {
             print STDERR "ERROR: Client $i returned $CLI_status\n";
             return 1;
@@ -249,26 +252,26 @@ sub scale_clients_test
 
     # Shutting down any server object within the server will shutdown the whole server
     $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
-		    "shutdown $objprefix");
+       "shutdown $objprefix");
     print ">>> " . $TI->CommandLine () . "\n";
     $TI_status = $TI->SpawnWaitKill ($ti->ProcessStartWaitInterval());
     if ($TI_status != 0) {
-	print STDERR "ERROR: tao_imr shutdown returned $TI_status\n";
-	$status = 1;
+      print STDERR "ERROR: tao_imr shutdown returned $TI_status\n";
+      $status = 1;
     }
 
     my $ACT_status = $ACT->TerminateWaitKill ($act->ProcessStopWaitInterval());
     if ($ACT_status != 0) {
-	print STDERR "ERROR: IMR Activator returned $ACT_status\n";
-	$status = 1;
+      print STDERR "ERROR: IMR Activator returned $ACT_status\n";
+      $status = 1;
     }
 
     if (!$no_imr) {
-	my $IMR_status = $IMR->TerminateWaitKill ($imr->ProcessStopWaitInterval());
-	if ($IMR_status != 0) {
-	    print STDERR "ERROR: IMR returned $IMR_status\n";
-	    $status = 1;
-	}
+      my $IMR_status = $IMR->TerminateWaitKill ($imr->ProcessStopWaitInterval());
+      if ($IMR_status != 0) {
+        print STDERR "ERROR: IMR returned $IMR_status\n";
+        $status = 1;
+      }
     }
 
     my $test_time = time() - $start_time;
@@ -280,14 +283,15 @@ sub scale_clients_test
 
 sub usage() {
     print "Usage: run_test.pl ".
-	"[-clients <num=$clients_count>] ".
-	"[-secs_between_clients <seconds=$secs_between_clients>] ".
-	"[-server_init_delay <seconds=$server_init_delay>] ".
-	"[-server_reply_delay <seconds=$server_reply_delay] ".
-	"[-rt_timeout <round-trip-timeout-msecs=$rt_timeout_msecs>] ".
-	"[-max_rt_tries <max-client-requests=$max_rt_tries>] ".
-	"[-no_imr] ".
-	"\n";
+      "[-clients <num=$clients_count>] ".
+      "[-secs_between_clients <seconds=$secs_between_clients>] ".
+      "[-server_init_delay <seconds=$server_init_delay>] ".
+      "[-server_reply_delay <seconds=$server_reply_delay] ".
+      "[-rt_timeout <round-trip-timeout-msecs=$rt_timeout_msecs>] ".
+      "[-max_rt_tries <max-client-requests=$max_rt_tries>] ".
+      "[-no_imr] ".
+      "[-imrdebug <level=$imr_debug_level>]" .
+      "\n";
 }
 
 ###############################################################################

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/server.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/server.cpp
@@ -127,11 +127,10 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     //
     //
     // Stop discarding requests.
-    //
     mgr->activate();
 
     ACE_DEBUG ((LM_DEBUG,
-      "\n  Started Server %s \n",
+      "(%P|%t) Server: Started <%C>\n",
       poa_name.c_str()));
 
     {
@@ -151,14 +150,14 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     return 1;
   }
 
-  bool expected_requests_made = Test_i::expected_requests_made ();
+  bool const expected_requests_made = Test_i::expected_requests_made ();
   if (!expected_requests_made)
     {
       ACE_ERROR ((LM_ERROR,
                   "ERROR: Expected number of requests were not made\n"));
     }
 
-  int status = expected_requests_made ? 0 : -1;
+  int const status = expected_requests_made ? 0 : -1;
 
   return status;
 }

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/server.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/server.cpp
@@ -1,4 +1,3 @@
-// server.cpp
 // This version uses the Implementation Repository.
 
 #include "Test_i.h"
@@ -58,7 +57,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           break;
         case '?':
           ACE_DEBUG ((LM_DEBUG,
-                      "usage: %s "
+                      "Server: usage: %s "
                       "-d <seconds to delay before initializing POA> ",
                       "-n <number of expected requests> \n",
                       argv[0]));
@@ -67,11 +66,11 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         }
 
     ACE_DEBUG ((LM_DEBUG,
-                "Delaying in initialization for %d seconds\n",
+                "(%P|%t) Server: delaying in initialization for <%d> seconds\n",
                 init_delay_secs));
     ACE_OS::sleep (init_delay_secs);
     ACE_DEBUG ((LM_DEBUG,
-                "Done with delay\n"));
+                "(%P|%t) Server: done with delay\n"));
 
     CORBA::Object_var obj = orb->resolve_initial_references("RootPOA");
     PortableServer::POA_var root_poa = PortableServer::POA::_narrow(obj.in());
@@ -89,24 +88,20 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     PortableServer::ObjectId_var object_id =
       PortableServer::string_to_ObjectId("test_object");
 
-    //
     // Activate the servant with the test POA,
     // obtain its object reference, and get a
     // stringified IOR.
-    //
     test_poa->activate_object_with_id(object_id.in(), test_servant.in());
 
-    //
     // Create binding between "TestService" and
     // the test object reference in the IOR Table.
     // Use a TAO extension to get the non imrified poa
     // to avoid forwarding requests back to the ImR.
-
     TAO_Root_POA* tpoa = dynamic_cast<TAO_Root_POA*>(test_poa.in());
     if (!tpoa)
       {
         ACE_ERROR ((LM_ERROR,
-                    ACE_TEXT ("Could not cast POA to root POA")
+                    ACE_TEXT ("(%P|%t) Server: Could not cast POA to root POA")
                     ));
         return -1;
       }
@@ -130,7 +125,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     mgr->activate();
 
     ACE_DEBUG ((LM_DEBUG,
-      "(%P|%t) Server: Started <%C>\n",
+      "(%P|%t) Server: started <%C>\n",
       poa_name.c_str()));
 
     {
@@ -154,7 +149,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
   if (!expected_requests_made)
     {
       ACE_ERROR ((LM_ERROR,
-                  "ERROR: Expected number of requests were not made\n"));
+                  "(%P|%t) Server: ERROR: Expected number of requests were not made\n"));
     }
 
   int const status = expected_requests_made ? 0 : -1;

--- a/TAO/orbsvcs/tests/ImplRepo/scale_clients/server.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/scale_clients/server.cpp
@@ -112,14 +112,12 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     IORTable::Table_var table = IORTable::Table::_narrow(obj.in());
     table->bind(poa_name.c_str (), test_ior.in());
 
-    //
     // This server is now ready to run.
     // This version does not create an IOR
     // file as demonstrated in the
     // Developer's Guide.  It assumes that
     // users create IORs for the client using
     // the tao_imr utility.
-    //
     //
     // Stop discarding requests.
     mgr->activate();

--- a/TAO/tao/ImR_Client/ImR_Client.cpp
+++ b/TAO/tao/ImR_Client/ImR_Client.cpp
@@ -38,7 +38,7 @@ namespace
     if (TAO_debug_level > 0)
       {
         TAOLIB_DEBUG ((LM_DEBUG,
-                       ACE_TEXT ("TAO_ImR_Client (%P|%t) - IMR partial IOR =\n%C\n"),
+                       ACE_TEXT ("TAO_ImR_Client (%P|%t) - IMR partial IOR <%C>\n"),
                        profile_str.in ()));
       }
     char* const pos = find_delimiter (profile_str.inout (),
@@ -63,7 +63,7 @@ namespace
     if (TAO_debug_level > 0)
       {
         TAOLIB_DEBUG ((LM_DEBUG,
-                       ACE_TEXT ("TAO_ImR_Client (%P|%t) - ImR-ified IOR =\n%C\n\n"),
+                       ACE_TEXT ("TAO_ImR_Client (%P|%t) - ImR-ified IOR <%C>\n"),
                        ior.c_str ()));
       }
     CORBA::Object_ptr obj = orb_core.orb ()->string_to_object (ior.c_str ());
@@ -225,16 +225,14 @@ namespace TAO
 
       if (TAO_debug_level > 0)
         {
-          ACE_CString imr_info;
           if (TAO_debug_level > 1)
             {
               CORBA::ORB_ptr orb = poa->orb_core ().orb ();
               CORBA::String_var ior = orb->object_to_string (imr.in ());
-              imr_info = ACE_CString (", IMR IOR=") + ior.in ();
+              TAOLIB_DEBUG ((LM_DEBUG,
+                            ACE_TEXT ("TAO_ImR_Client (%P|%t) - Notifying ImR of startup IMR IOR <%C>\n"),
+                            ior.in ()));
             }
-          TAOLIB_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("TAO_ImR_Client (%P|%t) - Notifying ImR of startup <%C>\n"),
-                      imr_info.c_str ()));
         }
 
       ImplementationRepository::Administration_var imr_locator;
@@ -299,7 +297,7 @@ namespace TAO
       if (TAO_debug_level > 0)
         {
           TAOLIB_DEBUG((LM_INFO,
-                        "TAO_ImR_Client (%P|%t) - full_ior=<%C>\n\nior=<%C>\n\n",
+                        "TAO_ImR_Client (%P|%t) - full_ior <%C>\nior <%C>\n",
                         full_ior.in(),
                         ior.in()));
         }

--- a/TAO/tao/ImR_Client/ImR_Client.cpp
+++ b/TAO/tao/ImR_Client/ImR_Client.cpp
@@ -307,9 +307,12 @@ namespace TAO
       const ACE_CString partial_ior (ior.in (), (pos - ior.in ()) + 1);
 
       if (TAO_debug_level > 0)
+      {
+        CORBA::String_var poaname = poa->the_name ();
         TAOLIB_DEBUG ((LM_DEBUG,
-                    ACE_TEXT ("TAO_ImR_Client (%P|%t) - Informing IMR that we are running at: <%C>\n"),
-                    partial_ior.c_str ()));
+                    ACE_TEXT ("TAO_ImR_Client (%P|%t) - Informing IMR that <%C> is running at: <%C>\n"),
+                    poaname.in(), partial_ior.c_str ()));
+      }
 
       try
         {
@@ -317,7 +320,7 @@ namespace TAO
           TAO::Portable_Server::Non_Servant_Upcall non_servant_upcall (*poa);
           ACE_UNUSED_ARG (non_servant_upcall);
 
-          ACE_CString serverId = poa->orb_core ().server_id ();
+          ACE_CString const serverId = poa->orb_core ().server_id ();
           ACE_CString name;
           if (serverId.empty ())
             {

--- a/TAO/tao/ImR_Client/ImR_Client.cpp
+++ b/TAO/tao/ImR_Client/ImR_Client.cpp
@@ -310,7 +310,7 @@ namespace TAO
       {
         CORBA::String_var poaname = poa->the_name ();
         TAOLIB_DEBUG ((LM_DEBUG,
-                    ACE_TEXT ("TAO_ImR_Client (%P|%t) - Informing IMR that <%C> is running at: <%C>\n"),
+                    ACE_TEXT ("TAO_ImR_Client (%P|%t) - Informing IMR that <%C> is running at <%C>\n"),
                     poaname.in(), partial_ior.c_str ()));
       }
 

--- a/TAO/tao/ImR_Client/ImplRepo.idl
+++ b/TAO/tao/ImR_Client/ImplRepo.idl
@@ -1,8 +1,5 @@
 // -*- IDL -*-
 
-/**
- */
-
 #ifndef TAO_IMRCLIENT_IMPLREPO_PIDL
 #define TAO_IMRCLIENT_IMPLREPO_PIDL
 
@@ -73,7 +70,7 @@ module ImplementationRepository
     /// No attempt as been made to determine status.
     ACTIVE_MAYBE,
 
-    /// Server has been succesfully pinged within ping interval.
+    /// Server has been successfully pinged within ping interval.
     ACTIVE_YES,
 
     /// Server was not able to be pinged within ping interval.


### PR DESCRIPTION
For a per client activate server we need to store the state within the AAM because at the moment multiple clients at the same moment invoke an operation for the same server multiple instances of the server are spawned and they share the Shared_Info state between them. Storing the started server details within the Shared_Info will result in the situation that only the first server started is reported back to the client, the other clients hang