### PR TITLE
Fixed incorrect order of arguments to logging macro

### DIFF
--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
@@ -592,7 +592,7 @@ ImR_Activator_i::handle_exit_i (pid_t pid)
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) ImR Activator: Notifying ImR that ")
                           ACE_TEXT ("server <%C> pid <%d> has exited.\n"),
-                          static_cast<int> (pid), name.c_str()));
+                          name.c_str(), static_cast<int> (pid)));
         }
       try
         {


### PR DESCRIPTION
    * TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp: