### PR TITLE
Use RAND_poll instead of RAND_screen that is deprecated in OpenSSL 1.1

### DIFF
--- a/ACE/ace/SSL/SSL_Context.cpp
+++ b/ACE/ace/SSL/SSL_Context.cpp
@@ -172,7 +172,11 @@ ACE_SSL_Context::ssl_library_init (void)
 
 #ifdef WIN32
       // Seed the random number generator by sampling the screen.
+# if OPENSSL_VERSION_NUMBER < 0x10100000L
       ::RAND_screen ();
+# else
+      ::RAND_poll ();
+# endif  /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 #endif  /* WIN32 */
 
 #if OPENSSL_VERSION_NUMBER >= 0x00905100L


### PR DESCRIPTION
when compiling ACE by MinGW, it reports

``` 
SSL_Context.cpp:175:22: warning: ‘void RAND_screen()’ is deprecated (declared at openssl/rand.h:66) [-Wdeprecated-declarations]
```
See also: https://www.openssl.org/docs/man1.1.0/crypto/RAND_screen.html