### PR TITLE
Fix AIX and Solaris linking rpath errors.

### DIFF
--- a/ACE/include/makeinclude/platform_aix_g++.GNU
+++ b/ACE/include/makeinclude/platform_aix_g++.GNU
@@ -83,6 +83,7 @@ endif
 LIBS           += -lxti -ldl
 ARFLAGS        += cruv
 RANLIB          = ranlib
+LD_RPATH        = -Wl,-R,
 
 # Test for template instantiation, add to SOFLAGS if versioned_so set,
 # add -E to LDFLAGS if using GNU ld

--- a/ACE/include/makeinclude/platform_sunos5_g++.GNU
+++ b/ACE/include/makeinclude/platform_sunos5_g++.GNU
@@ -44,6 +44,7 @@ RANLIB          = @true
 SOFLAGS         += -shared $(CPPFLAGS)
 SOBUILD         = $(COMPILE.cc) $(PIC) -o $(VSHDIR)$*.so $<
 PRELIB          = @true
+LD_RPATH        = -Wl,-R,
 
 # Get common Solaris settings
 include $(ACE_ROOT)/include/makeinclude/platform_sunos5_common.GNU


### PR DESCRIPTION
In AIX and Solaris, linking rpath is `-Wl,-R` rather than `-Wl,--rpath`.