### PR TITLE
Use const exception data pointer when using invoke, not changed by th…

### DIFF
--- a/TAO/orbsvcs/orbsvcs/SSLIOP/params_dup.c
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/params_dup.c
@@ -2,7 +2,6 @@
 
 #include <openssl/asn1.h>
 
-
 DSA *
 DSAPARAMS_DUP_WRAPPER_NAME (DSA * dsa)
 {

--- a/TAO/tao/DynamicInterface/DII_Invocation_Adapter.cpp
+++ b/TAO/tao/DynamicInterface/DII_Invocation_Adapter.cpp
@@ -49,7 +49,7 @@ namespace TAO
   }
 
   void
-  DII_Invocation_Adapter::invoke (TAO::Exception_Data * /*ex_data*/,
+  DII_Invocation_Adapter::invoke (const TAO::Exception_Data * /*ex_data*/,
                                   unsigned long ex_count)
   {
     // Convert DII exception list to a form the invocation can use
@@ -174,7 +174,7 @@ namespace TAO
 
   void
   DII_Deferred_Invocation_Adapter::invoke (
-      TAO::Exception_Data *ex,
+      const TAO::Exception_Data *ex,
       unsigned long ex_count)
   {
     // New reply dispatcher on the heap, because we will go out of

--- a/TAO/tao/DynamicInterface/DII_Invocation_Adapter.h
+++ b/TAO/tao/DynamicInterface/DII_Invocation_Adapter.h
@@ -93,7 +93,7 @@ namespace TAO
     virtual ~DII_Invocation_Adapter (void);
 
     /// Invoke the target
-    virtual void invoke (TAO::Exception_Data *ex, unsigned long ex_count);
+    virtual void invoke (const TAO::Exception_Data *ex, unsigned long ex_count);
 
   protected:
 
@@ -147,7 +147,7 @@ namespace TAO
         TAO::Invocation_Mode mode = TAO_DII_DEFERRED_INVOCATION);
 
     /// Invoke the target
-    virtual void invoke (TAO::Exception_Data *ex, unsigned long ex_count);
+    virtual void invoke (const TAO::Exception_Data *ex, unsigned long ex_count);
 
   protected:
     virtual Invocation_Status invoke_twoway (

--- a/TAO/tao/Invocation_Adapter.cpp
+++ b/TAO/tao/Invocation_Adapter.cpp
@@ -30,7 +30,7 @@ namespace TAO
   }
 
   void
-  Invocation_Adapter::invoke (TAO::Exception_Data *ex_data,
+  Invocation_Adapter::invoke (const TAO::Exception_Data *ex_data,
                               unsigned long ex_count)
   {
     // Should stub object be refcounted here?

--- a/TAO/tao/Invocation_Adapter.h
+++ b/TAO/tao/Invocation_Adapter.h
@@ -123,7 +123,7 @@ namespace TAO
      *
      * @param ex_count Number of elements in the array.
      */
-    virtual void invoke (TAO::Exception_Data *ex, unsigned long ex_count);
+    virtual void invoke (const TAO::Exception_Data *ex, unsigned long ex_count);
 
     /**
      * @param byte_order The intended byte order for the message output

--- a/TAO/tao/Messaging/Asynch_Invocation_Adapter.cpp
+++ b/TAO/tao/Messaging/Asynch_Invocation_Adapter.cpp
@@ -104,9 +104,8 @@ namespace TAO
 
   void
   Asynch_Invocation_Adapter::invoke (
-    TAO::Exception_Data *ex,
-    unsigned long ex_count
-    )
+    const TAO::Exception_Data *ex,
+    unsigned long ex_count)
   {
     Invocation_Adapter::invoke (ex, ex_count );
   }

--- a/TAO/tao/Messaging/Asynch_Invocation_Adapter.h
+++ b/TAO/tao/Messaging/Asynch_Invocation_Adapter.h
@@ -71,7 +71,7 @@ namespace TAO
     void invoke (Messaging::ReplyHandler_ptr reply_handler_ptr,
                  const TAO_Reply_Handler_Stub &reply_handler_stub);
 
-    virtual void invoke (TAO::Exception_Data *ex, unsigned long ex_count);
+    virtual void invoke (const TAO::Exception_Data *ex, unsigned long ex_count);
   protected:
 
     virtual Invocation_Status invoke_twoway (

--- a/TAO/tao/operation_details.h
+++ b/TAO/tao/operation_details.h
@@ -71,12 +71,12 @@ public:
 
   /// Constructor
   TAO_Operation_Details (const char *name,
-                         CORBA::ULong len,
+                         const CORBA::ULong len,
                          TAO::Argument **args = 0,
-                         CORBA::ULong num_args = 0,
-                         CORBA::Boolean has_in_args = true,
-                         TAO::Exception_Data *ex_data = 0,
-                         CORBA::ULong ex_count = 0);
+                         const CORBA::ULong num_args = 0,
+                         const CORBA::Boolean has_in_args = true,
+                         const TAO::Exception_Data *ex_data = 0,
+                         const CORBA::ULong ex_count = 0);
 
   /// Operation name
   const char* opname (void) const;
@@ -181,7 +181,7 @@ private:
   const char *opname_;
 
   /// Precalculated length of opname_.
-  CORBA::ULong opname_len_;
+  const CORBA::ULong opname_len_;
 
   /// Request ID of this operation.
   CORBA::ULong request_id_;
@@ -207,16 +207,16 @@ private:
   TAO::Argument **args_;
 
   /// Number of arguments including the return value
-  CORBA::ULong num_args_;
+  const CORBA::ULong num_args_;
 
   /// A flag indicating any args are sent with the request
-  CORBA::Boolean has_in_args_;
+  const CORBA::Boolean has_in_args_;
 
   /// The type of exceptions that the operations can throw.
-  TAO::Exception_Data *ex_data_;
+  const TAO::Exception_Data *ex_data_;
 
   /// Count of the exceptions that operations can throw.
-  CORBA::ULong ex_count_;
+  const CORBA::ULong ex_count_;
 
   /// Boolean flag to indicate whether in the skeletons the stub arguments
   /// stored in these operation details should be used or not.

--- a/TAO/tao/operation_details.inl
+++ b/TAO/tao/operation_details.inl
@@ -4,12 +4,12 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_INLINE
 TAO_Operation_Details::TAO_Operation_Details (const char *name,
-                                              CORBA::ULong len,
+                                              const CORBA::ULong len,
                                               TAO::Argument **args,
-                                              CORBA::ULong num,
-                                              CORBA::Boolean has_in_args,
-                                              TAO::Exception_Data *data,
-                                              CORBA::ULong count)
+                                              const CORBA::ULong num,
+                                              const CORBA::Boolean has_in_args,
+                                              const TAO::Exception_Data *data,
+                                              const CORBA::ULong count)
   : opname_ (name)
     , opname_len_ (len)
     , request_id_ (0)


### PR DESCRIPTION
…e implementation, only used

    * TAO/orbsvcs/orbsvcs/SSLIOP/params_dup.c:
    * TAO/tao/DynamicInterface/DII_Invocation_Adapter.cpp:
    * TAO/tao/DynamicInterface/DII_Invocation_Adapter.h:
    * TAO/tao/Invocation_Adapter.cpp:
    * TAO/tao/Invocation_Adapter.h:
    * TAO/tao/Messaging/Asynch_Invocation_Adapter.cpp:
    * TAO/tao/Messaging/Asynch_Invocation_Adapter.h:
    * TAO/tao/operation_details.h:
    * TAO/tao/operation_details.inl: