### PR TITLE
clang 7

### DIFF
--- a/ACE/tests/Compiler_Features_32_Test.cpp
+++ b/ACE/tests/Compiler_Features_32_Test.cpp
@@ -43,12 +43,12 @@ void A::clear ()
 {
 #if defined __clang__ && \
     (defined __apple_build_version__ && __apple_build_version__ < 9100000 \
-     || __clang_major__ <= 6)
+     || __clang_major__ <= 7)
 #define CLANG_WORKAROUND
 #endif
 
 #ifdef CLANG_WORKAROUND
-  // As of 5.0, clang requires one of two workarounds:
+  // clang requires one of two workarounds:
   // 1. the name after ~ must be in scope
   using std::string;
 #endif


### PR DESCRIPTION
Updating ACE's "compiler features test" to apply the same workaround from clang 6 to 7.