### PR TITLE
Support for Clang based Android NDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ ipch/
 /setenv.cmd
 /setenv.sh
 /build
+/ACE/build
+/TAO/build
 
 *.o
 *.res

--- a/ACE/ACE-INSTALL.html
+++ b/ACE/ACE-INSTALL.html
@@ -2,9 +2,33 @@
 <html><head><!--  -->
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type"><title>Building and Installing ACE and Its Auxiliary Libraries and Services</title>
 
-  <link rev="made" href="mailto:d.schmidt@vanderbilt.edu"></head>
+  <link rev="made" href="mailto:d.schmidt@vanderbilt.edu">
 
-<body bgcolor="#ffffff" link="#000fff" text="#000000" vlink="#ff0f0f">
+<style>
+body {
+  background-color: #ffffff;
+  color: #000000;
+}
+table, th, td {
+  border: 1px solid black;
+}
+.indent {
+  margin-left: 2em;
+}
+.boxed {
+  border: 1px solid black;
+  margin: .5em;
+  padding: .5em;
+}
+pre, code {
+  background-color: #e3e3e3;
+  padding: .1em;
+  margin: .1em;
+}
+</style>
+</head>
+
+<body>
 
 <hr>
 <h1>Building and Installing ACE and Its Auxiliary Libraries and Services</h1>
@@ -112,7 +136,7 @@ detailed information.  For information on TAO's platform coverage and
 support, please also see <a href="TAO/TAO-INSTALL.html">TAO's install
 document</a>.</p><p>
 
-<table border="1" width="75%">
+<table width="75%">
 <caption><b>Groups Involved in ACE Development and Support<br></b></caption>
 <thead>
   <tr valign="top">
@@ -147,8 +171,10 @@ document</a>.</p><p>
     <td>Maintains ACE on certain platforms required for their TAO
         software and service offerings.
     </td>
-    <td>OCI's <a href="http://www.theaceorb.com/">web site</a> and
-        the TAO <a href="TAO/TAO-INSTALL.html">install document</a></td>
+    <td>
+      <a href="http://www.objectcomputing.com/">OCI's web site</a>,
+      <a href="https://objectcomputing.com/products/tao">TAO page</a>,
+      and the <a href="../TAO/TAO-INSTALL.html">TAO install document</a></td>
   </tr>
   <tr>
     <th>Remedy IT</th>
@@ -198,8 +224,6 @@ document</a>.</p><p>
         For up-to-date listings on platform that are deprecated and pending
         removal from ACE, please see the <a href="NEWS">NEWS file</a>.
     </td>
-  </tr>
-    <tr><td></td>
   </tr>
 </tbody></table></p><p>
 
@@ -460,7 +484,7 @@ that are for VC8 / VC9 also apply to the express edition.  MFC, 64-bit, and
 CE/mobile options are not available with the express edition.  64-bit binaries
 can be built with the compiler and linker included in the <a href="http://www.microsoft.com/downloads/details.aspx?FamilyID=E6E1C3DF-A74F-4207-8586-711EBE331CDC&displaylang=en">Windows SDK</a>, using nmake as the build system (generate nmake makefiles with mwc.pl -type nmake).</p>
 
-<table border="1" width="400">
+<table width="400">
 <caption><b>Mapping of Platform to Solution/Project File Name</b></caption>
 <thead>
   <tr valign="top">
@@ -771,13 +795,13 @@ For our build we require the packages
   </li><li> Open a MSYS shell. Set your <tt>PATH</tt> environment variable so
        your MinGW's <tt>bin</tt> directory is first:
 
-       <blockquote><code></code><pre>       % export PATH=/c/mingw/bin:$PATH
+       <blockquote><pre>       % export PATH=/c/mingw/bin:$PATH
        </pre></blockquote>
 
   </li><li> Add an <tt>ACE_ROOT</tt> environment variable pointing to the
        root of your ACE wrappers source tree:
 
-       <blockquote><code></code><pre>       % export ACE_ROOT=/c/work/mingw/ACE_wrappers
+       <blockquote><pre>       % export ACE_ROOT=/c/work/mingw/ACE_wrappers
        </pre></blockquote>
 
        From now on, we will refer to the root directory of the ACE
@@ -787,13 +811,13 @@ For our build we require the packages
   </li><li> Create a file called <tt>config.h</tt> in the
        <tt>$ACE_ROOT/ace</tt> directory that contains:
 
-       <blockquote><code></code><pre>       #include "ace/config-win32.h"
+       <blockquote><pre>       #include "ace/config-win32.h"
        </pre></blockquote>
 
   </li><li> Create a file called <tt>platform_macros.GNU</tt> in the
        <tt>$ACE_ROOT/include/makeinclude</tt> directory containing:
 
-       <blockquote><code></code><pre>       include $(ACE_ROOT)/include/makeinclude/platform_mingw32.GNU
+       <blockquote><pre>       include $(ACE_ROOT)/include/makeinclude/platform_mingw32.GNU
        </pre></blockquote>
 
        In the above text, don't replace <tt>$(ACE_ROOT)</tt> with the
@@ -803,7 +827,7 @@ For our build we require the packages
        <p>
        If you lack Winsock 2, add the line
 
-       </p><blockquote><code></code><pre>       winsock2 = 0
+       </p><blockquote><pre>       winsock2 = 0
        </pre></blockquote>
 
        before the previous one.
@@ -812,7 +836,7 @@ For our build we require the packages
      <p>
        If you want to install ACE (using "make install") and want all the <tt>.pc</tt> files generated,
      set the installation prefix in platform_macros.GNU.
-       </p><blockquote><code></code><pre>      INSTALL_PREFIX=/c/ACE
+       </p><blockquote><pre>      INSTALL_PREFIX=/c/ACE
        </pre></blockquote>
      Headers will be installed to $INSTALL_PREFIX/include, documentation and
      build system files to $INSTALL_PREFIX/share and libraries to $INSTALL_PREFIX/lib. With INSTALL_PREFIX set, RPATH will be enabled.
@@ -825,7 +849,7 @@ For our build we require the packages
   </li><li> In the MSYS shell, change to the $ACE_ROOT/ace directory and
        run make:
 
-       <blockquote><code></code><pre>       % cd $ACE_ROOT/ace
+       <blockquote><pre>       % cd $ACE_ROOT/ace
        % make
        </pre></blockquote>
 
@@ -838,12 +862,12 @@ For our build we require the packages
        </p><p>
        If you want static libs also, you may run:
 
-       </p><blockquote><code></code><pre>       % make static_libs_only=1
+       </p><blockquote><pre>       % make static_libs_only=1
        </pre></blockquote>
 
   </li><li> Run make install:
 
-    <blockquote><code></code><pre>       % make install
+    <blockquote><pre>       % make install
        </pre></blockquote>
      <p>
        This should create <tt>ACE.pc</tt> to use with pkg-config.
@@ -854,7 +878,7 @@ For our build we require the packages
        want to run some ACE programs from the MSYS shell, you may
        need to add the directory for <tt>libACE.dll</tt> to your PATH:
 
-       </a><blockquote><code></code><pre><a name="mingwrunpath">       % export PATH=/c/work/mingw/ACE_wrappers/ace:$PATH
+       </a><blockquote><pre><a name="mingwrunpath">       % export PATH=/c/work/mingw/ACE_wrappers/ace:$PATH
        </a></pre></blockquote>
 
 </li></ol>
@@ -865,7 +889,7 @@ For our build we require the packages
 After building the library, you can change to that directory and run
 make:
 
-       </a></p><blockquote><code></code><pre><a name="mingwrunpath">       % cd $ACE_ROOT/tests
+       </a></p><blockquote><pre><a name="mingwrunpath">       % cd $ACE_ROOT/tests
        % make
        </a></pre></blockquote>
 
@@ -874,7 +898,7 @@ make:
 <code>run_tests.pl</code> in the
 <code>tests</code> directory to try all the tests:
 
-       </a></p><blockquote><code></code><pre><a name="mingwrunpath">       % perl run_test.pl
+       </a></p><blockquote><pre><a name="mingwrunpath">       % perl run_test.pl
        </a></pre></blockquote>
 
 <p>
@@ -919,12 +943,12 @@ setup selects by default:
   <li> Open a Cygwin shell. Set your <tt>PATH</tt> environment variable so
        your Cygwin <tt>bin</tt> directory is first:
 
-       <blockquote><code></code><pre>       % export PATH=//c/cygwin/bin:$PATH
+       <blockquote><pre>       % export PATH=//c/cygwin/bin:$PATH
        </pre></blockquote>
 
        or
 
-       <blockquote><code></code><pre>       % export PATH=/cygdrive/c/cygwin/bin:$PATH
+       <blockquote><pre>       % export PATH=/cygdrive/c/cygwin/bin:$PATH
        </pre></blockquote>
 
        <p>
@@ -938,7 +962,7 @@ setup selects by default:
   </p></li><li> Add an <tt>ACE_ROOT</tt> environment variable pointing to the
        root of your ACE wrappers source tree (in this example c:/work/cygwin/ACE_wrappers):
 
-       <blockquote><code></code><pre>       % export ACE_ROOT=/cygdrive/c/work/cygwin/ACE_wrappers
+       <blockquote><pre>       % export ACE_ROOT=/cygdrive/c/work/cygwin/ACE_wrappers
        </pre></blockquote>
 
        <p>
@@ -955,13 +979,13 @@ setup selects by default:
   </p></li><li> Create a file called <tt>config.h</tt> in the
        <tt>$ACE_ROOT/ace</tt> directory that contains:
 
-       <blockquote><code></code><pre>       #include "ace/config-cygwin32.h"
+       <blockquote><pre>       #include "ace/config-cygwin32.h"
        </pre></blockquote>
 
   </li><li> Create a file called <tt>platform_macros.GNU</tt> in the
        <tt>$ACE_ROOT/include/makeinclude</tt> directory containing:
 
-       <blockquote><code></code><pre>       include $(ACE_ROOT)/include/makeinclude/platform_cygwin32.GNU
+       <blockquote><pre>       include $(ACE_ROOT)/include/makeinclude/platform_cygwin32.GNU
        </pre></blockquote>
 
        In the above text, don't replace <tt>$(ACE_ROOT)</tt> with the
@@ -971,7 +995,7 @@ setup selects by default:
   </li><li> On the Cygwin shell, change to the $ACE_ROOT/ace directory and
        run make:
 
-       <blockquote><code></code><pre>       % cd $ACE_ROOT/ace
+       <blockquote><pre>       % cd $ACE_ROOT/ace
        % make
        </pre></blockquote>
 
@@ -984,7 +1008,7 @@ setup selects by default:
        </p><p>
        If you want static libs also, you may run:
 
-       </p><blockquote><code></code><pre>       % make static_libs_only=1
+       </p><blockquote><pre>       % make static_libs_only=1
        </pre></blockquote>
 
   </li><li> <a name="cygwinrunpath">
@@ -992,14 +1016,14 @@ setup selects by default:
        want to run some ACE programs from the Cygwin shell, you may
        need to add the directory for <tt>libACE.dll</tt> to your PATH:
 
-       </a><blockquote><code></code><pre><a name="cygwinrunpath">       # export PATH=//c/work/cygwin/ACE_wrappers/ace:$PATH
+       </a><blockquote><pre><a name="cygwinrunpath">       # export PATH=//c/work/cygwin/ACE_wrappers/ace:$PATH
        </a></pre></blockquote>
 
 <a name="cygwinrunpath">       If you are using MPC-generated Makefiles, then the DLLs have been
        placed in the lib directory instead of ace and thus your PATH
        addition would need to look like this:
 
-       </a><blockquote><code></code><pre><a name="cygwinrunpath">       # export PATH=//c/work/mingw/ACE_wrappers/lib:$PATH
+       </a><blockquote><pre><a name="cygwinrunpath">       # export PATH=//c/work/mingw/ACE_wrappers/lib:$PATH
        </a></pre></blockquote>
 
 
@@ -1011,7 +1035,7 @@ setup selects by default:
 After building the library, you can change to that directory and run
 make:
 
-       </a></p><blockquote><code></code><pre><a name="cygwinrunpath">       % cd $ACE_ROOT/tests
+       </a></p><blockquote><pre><a name="cygwinrunpath">       % cd $ACE_ROOT/tests
        % make
        </a></pre></blockquote>
 
@@ -1020,7 +1044,7 @@ make:
 <code>run_tests.pl</code> in the
 <code>tests</code> directory to try all the tests:
 
-       </a></p><blockquote><code></code><pre><a name="cygwinrunpath">       % perl run_test.pl
+       </a></p><blockquote><pre><a name="cygwinrunpath">       % perl run_test.pl
        </a></pre></blockquote>
 
 <p>
@@ -1061,7 +1085,7 @@ $(ACE_ROOT)/include/makeinclude/platform_win32_interix.GNU</TT></P>
 other options may not work.</P>
 <P><b>ACE TESTS</B> </P>
 <p>The tests are located in <TT>$ACE_ROOT/tests</TT>. After building the library, you can
-change to that directory and run make: </P><code></CODE>
+change to that directory and run make: </P>
 <P><TT>% cd $ACE_ROOT/tests </TT><BR><TT>% make </TT>
 <p>Once you build all the tests, you can run <code>run_test.pl</CODE> in the <code>tests</CODE> directory to try all the tests: </P>
 <P><TT>% run_test.pl </TT></P>
@@ -1289,7 +1313,7 @@ Makefile.  Then, build the kernel using <code>make exe</code>.<p>
 </p><h3><a name="VxWorksTestScript">Using the one-button ACE tests with VxWorks</a>.</h3>
 
 It is possible to generate a script to execute all ACE tests. You can do this by executing
-</a></p><blockquote><code></code><pre><a name="vxworksscript">% perl run_test.pl -v -o > run_test.vxworks
+</a></p><blockquote><pre><a name="vxworksscript">% perl run_test.pl -v -o > run_test.vxworks
 </a></pre></blockquote>
 
 The ACE tests write their output files in a directory named
@@ -1627,73 +1651,187 @@ symbols are necessary when you want to debug your code.</p>
 <p></p><hr align="left" width="50%">
 
 <p></p><h2><a name="android">Building and Installing ACE on Android</a></h2>
-<p>ACE can be built for Android by using the <a href="http://developer.android.com/tools/sdk/ndk/index.html">Android Native Development
-Kit's</a> standalone toolchain. Testing has been performed with
-NDK6 and NDK8e. The compilation creates native binaries,
-not the standard Android Java applications.  The native binary applications
-that use ACE can be run by either a shell or using the Java Runtime exec
-operation.</p>
-
-<p>The standalone toolchain must configured for a platform of android API level 8, 9, or 14. From your NDK root directory you can use their
-<code>make-standalone-toolchain.sh</code> script to set this up. For example:</p>
-<code>./build/tools/make-standalone-toolchain.sh --toolchain=arm-linux-androideabi-4.4.3 --arch=arm --platform=android-9 --install-dir=../arm_tools</code>
-<p>To set up an arm-specific tool chain. With the release of NDK r6, x86 targets are supported, so the setup command for that would be:</p>
-<code>./build/tools/make-standalone-toolchain.sh --toolchain=x86-4.4.3 --arch=x86 --platform=android-9 --install-dir=../x86_tools</code>
-<p>
-The bin directory under the installed standalone toolchain dir must be added to your $PATH</p>
-<p>
-When using the Android NDK on a 64bit Linux system you have to install the
-following 32bit packages: <code>libstdc++.i686 glibc.i686 ncurses-libs.i686 zlib.i686</code>
+<p>ACE can be built for Android by using the <a
+href="https://developer.android.com/ndk/">Android Native Development Kit
+(NDK)</a>. This is different than the standard way of writing Android
+applications in Java which run the on Android Runtime or the older Dalvik
+Virtual Machine. Applications built using the NDK are native Linux applications
+written in C or C++ specifically compiled to run on Android systems. In
+addition, applications built using the NDK have access to Android-specific APIs
+much like on Java-based Android applications.
 </p>
-<p>Starting with NDK8e it is possible to use shared libraries on Android.</p>
 
-<p>Compilation requires using the NDK's standalone toolchain for it's
-exception and RTTI support.  The standard NDK compiler is not identified
-as supporting exceptions or RTTI, as of NDK r5c.</p>
+<h3>Generating a Toolchain</h3>
 
-<p>It is not recommended to perform the build on a Windows host.  Using the
-NDK r5c, compilation issues were encountered on Windows XP, when the compiler
-failed to recognize the name difference between the ACE file Signal.h and
-the system file signal.h.</p>
+<p>To build ACE for Android you need to download the NDK and generate a
+toolchain for the specific Android target you want. The specific target is
+defined by two things:</p>
 
-<p>You should be able to follow the instructions above to build ACE
-and applications that use it.  Use the
-<a href="#unix_traditional">Unix  traditional instructions</a> above to build
-ACE and the applications that use it.  Building TAO for Android requires
-cross compiling the code.<p>
+<dl class="indent">
+  <dt>- The minimal API level to target.</dt>
+    <dd>A lower level means larger amount of potential users but also
+    potentially less features. Android has <a
+    href="https://source.android.com/setup/start/build-numbers">many API levels
+    to target</a>. They roughly correspond to the versions of Android.
+    </dd>
+  <dt>- The CPU architecture to target (Also called the Application Binary
+    Interface or ABI by the NDK documentation).</dt>
+    <dd>In addition to ARM, Android also supports x86 and MIPS,
+    although support for MIPS has been dropped from the NDK. <a
+    href="https://developer.android.com/ndk/guides/abis">This is the official
+    documentation on the ABIs</a>. These are the ABIs that ACE supports at the
+    time of writing and must be passed to ACE as <code>ANDROID_ABI</code>:
+    <!-- Check to see if any architectures have been added or removed. If so
+      update this list and the table below as well-->
+    <dl>
+      <dt><code>armeabi-v7a</code></dt>
+        <dd>32-bit ARM, The default ABI for both the NDK and ACE.</dd>
+      <dt><code>armeabi-v7a-with-neon</code></dt>
+        <dd><code>armeabi-v7a</code> with NEON extentions enabled.</dd>
+      <dt><code>arm64-v8a</code></dt>
+        <dd>64-bit ARM, Sometimes referred to as <code>aarch64</code>.</dd>
+      <dt><code>x86</code></dt>
+        <dd>32-bit x86</dd>
+      <dt><code>x86_64</code></dt>
+        <dd>64-bit x86</dd>
+    </dl>
+    <p><b>
+      It should be noted that starting in August 2019, the Google Play
+      Store will require new apps to have 64-bit libraries if they have native
+      libraries. 32-bit native libraries will still supported but they must also
+      have 64-bit libraries. Look up any restrictions that may affect
+      apps you want to publish on the Play Store, including minimum API
+      level.
+    </b></p>
+    </dd>
+  </li>
+</dl>
 
-<p>Basic steps to build
+
+<p>To generate a toolchain, one use must use
+<code>build/tools/make_standalone_toolchain.py</code> in the NDK. A destination must be
+chosen and is denoted here as <code>$TOOLCHAIN</code>. For example, to generate a
+toolchain targeting 32-bit ARM Android 7.0 "Nougat" (API Level 24) and later: </p>
+<p class="indent">
+<code>./make_standalone_toolchain.py --arch arm --api 24 --install-dir $TOOLCHAIN</code>
+</p>
+<p><code>$TOOLCHAIN/bin</code> must be in your <code>$PATH</code> when building ACE and
+applications using ACE.</p>
+
+<p>This table shows how the <code>ANDROID_ABI</code> variable and the <code>--arch</code> argument correlate:</p>
+<table class="indent">
+  <tr>
+    <th><code>ANDROID_ABI</code></th>
+    <th><code>--arch</code></th>
+  </tr>
+  <tr>
+    <td><code>armeabi-v7a</code></td>
+    <td><code>arm</code></td>
+  </tr>
+  <tr>
+    <td><code>armeabi-v7a-with-neon</code></td>
+    <td><code>arm</code></td>
+  </tr>
+  <tr>
+    <td><code>arm64-v8a</code></td>
+    <td><code>arm64</code></td>
+  </tr>
+  <tr>
+    <td><code>x86</code></td>
+    <td><code>x86</code></td>
+  </tr>
+  <tr>
+    <td><code>x86_64</code></td>
+    <td><code>x86_64</code></td>
+  </tr>
+</table>
+
+<!-- Remove this section if these NDKs can be considered not supported anymore -->
+<h3>Using Older NDKs (Skip if Using NDK r18 or Later)</h3>
+<p>
+It is <b>highly recommended</b> to use the latest NDK available assuming
+that it works with ACE. It is possible to use NDKs older than r18, but these
+have caveats:
+</p>
 <ul>
-  <li>Setup up the standalone compiler toolchain by following the
- instructions provided with the Android NDK.</li>
-  <li>If building TAO, build the ACE and TAO tools (<code>ace_gperf</code> and
- <code>tao_idl</code>) for the compiling host.  Follow the cross compilation setup instructions provide
- in $TAO_ROOT/TAO-INSTALL.html.  Search for "Using cross compilation".</li>
-  <ul>
-    <li>Setup the Android build<ul>
-      <li>Create <code>ace/config.h</code>:  <i>#include "ace/config-android.h"</i></li>
-      <li>Create <code>include/makeinclude/platform_macros.GNU</code>:
-        <ul>
-          <li>set options for debug and optimized builds</li>
-          <li>inline is forced on and no-hidden-visibility</li>
-          <li>if you want to compile static, add <code>static_libs_only=1</code></li>
-          <li>Include the <code>include/makeinclude/platform_android.GNU</code> file.</li>
+  <li>
+    In NDK r16, a file called <code>ndk-version.h</code> was added that
+    contains the version of the NDK. If using an earlier NDK, you <b>must</b>
+    define the macros <code>__NDK_MAJOR__</code> and <code>__NDK_MINOR__</code>
+    in <code>ace/config.h</code> before
+    <code>#include "ace/config-android.h"</code>.
+    The scheme works like this:
+    <table class="indent" style="margin-top: .5em; margin-bottom: .5em;">
+      <tr>
+        <th>Revision</th>
+        <th><code>__NDK_MAJOR__</code></th>
+        <th><code>__NDK_MINOR__</code></th>
+      </tr>
+      <tr>
+        <td>r16</td>
+        <td>16</td>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td>r16a</td>
+        <td>16</td>
+        <td>1</td>
+      </tr>
+      <tr>
+        <td>r16b</td>
+        <td>16</td>
+        <td>2</td>
+      </tr>
+    </table>
+  </li>
+  <li>
+    As of NDK r18, the only compiler that comes with the NDK is clang and by
+    default the build system assumes that clang is available and will use it.
+    However there was a transitional period between r12 and r17 where GCC and
+    clang both exist in the NDK. In some cases GCC should be used if linking
+    errors occur with these NDKs (For example missing references to
+    <code>stderr</code>). To let the build system decide between them, set
+    <code>android_force_clang:=0</code> in
+    <code>include/makeinclude/platform_macros.GNU</code> before including
+    <code>platform_android.GNU</code>. <b>This should be set for NDKs before r15.</b>
+  </li>
+  <li>
+    There is an unresolved name conflict involving the <code>semun</code> union
+    when using NDK's r14 or earlier and Android API Levels 21 or greater. These
+    combinations are not supported.
+  </li>
+  <li>
+    There are probably unknown conflicts, especially in the minor revisions
+    before the last minor revision.
+  </li>
+</ul>
+
+<h3>Building</h3>
+
+<ul>
+  <li>
+    If building TAO, build the ACE and TAO tools (<code>ace_gperf</code> and
+    <code>tao_idl</code>) for the host. Follow the <a
+    href="../TAO/TAO-INSTALL.html">cross compilation setup instructions provide
+    in TAO-INSTALL.html</a>.</li>
+  <li>Setup the Android build<ul>
+    <li>Create <code>ace/config.h</code>: <code>#include "ace/config-android.h"</code></li>
+    <li>Create <code>include/makeinclude/platform_macros.GNU</code>:
+      <ul>
+        <li>
+          Set <code>ANDROID_ABI</code> to one of the options above. This
+          must match the toolchain <code>--arch</code> argument used according to the table above.
+        </li>
+        <li>Set options for debug and optimization options as desired.</li>
+          <li>If you want to compile static, add <code>static_libs_only:=1</code></li>
+          <li>Must include <code>include $(ACE_ROOT)/include/makeinclude/platform_android.GNU</code>.</li>
           <li>If building TAO, set the tao idl options specified in the cross compiling instructions in <code>TAO-INSTALL.html</code></li>
-        </ul>
-      <li>Ensure the following environment variables are set:
-        <ul>
-          <li>$ANDROID_ARCH - either arm or x86. Note that x86 is only available in r6 and greater, and is still experimental. ANDROID_ARCH will be set to arm by default.</li>
-          <li>$NDK - the path to the android native development kit</li>
-          <li>$SYSROOT - the platform/arch directory. This defaults to <code>$NDK/platforms/android-9/arch-$ANDROID_ARCH</code>. </li>
-          <li>$HOST_ROOT - the path to the native TAO_IDL & gperf tools</li>
-          <li>$PATH - must include <code>$NDK_TOOLS/bin</code>.</li>
         </ul>
       </ul>
     </li>
     </li>
     <li>Generate makefiles (if necessary).</li>
     <li>Build with GNU make.</li>
-  </ul>
 </ul>
 </p>
 
@@ -1707,8 +1845,6 @@ Development Kit's ADB tool.  This method requires uploading the native
 application to a directory that allows execution and having any output
 directed to a writable directory.</p>
 
-<p></p><hr align="left" width="50%">
-<br/>
 <hr>
 <h1><a name="svcsinstall">Building and Installing ACE Network Services</a></h1>
 
@@ -2598,46 +2734,58 @@ well, try 'make realclean'.</p><p>
 </p></li></ul>
 
 <p></p><hr><p>
-</p><h1><a name="MPC">General MPC information</a></h1>
+</p><h1 name="MPC">General MPC information</a></h1>
 
+<p>
 The <A HREF="
-http://downloads.ociweb.com/MPC/docs/html/MakeProjectCreator.html</A>
+http://downloads.ociweb.com/MPC/docs/html/MakeProjectCreator.html">
 Makefile Project Creator (MPC)</A> is a tool that takes platform and
 building tool generic files (mpc files) as input, which describe basic
 information needed to generate a "project" file for various build
 tools, including Make, NMake, Visual C++ 6, Visual C++ 7, etc.  Please
 see <a href="MPC/docs/USAGE">USAGE</a>, <a
-href="MPC/docs/README">README</a> for documentation on MPC.<P>
+href="MPC/docs/README">README</a> for documentation on MPC.
+</p>
 
+<p>
 A common usage for creating a Windows workspace containing just the
 core ACE and TAO libraries and executables is the following:
+</p>
 
 <pre><code>
 C:> cd %TAO_ROOT%
 C:> %ACE_ROOT%\bin\mwc.pl -type vc71 TAO_ACE.mwc
 </pre></code>
 
+<p>
 Replace vc71 with whatever project type you want to use.  On Linux and
-other UNIX platform use the gnuace type: <P>
+other UNIX platform use the gnuace type:
+</p>
 
 <pre><code>
 % cd $TAO_ROOT
 % $ACE_ROOT/bin/mwc.pl -type gnuace TAO_ACE.mwc
 </pre></code>
 
-this creates the appropriate GNUmakefiles.  Additional information on
+<p>
+This creates the appropriate GNUmakefiles.  Additional information on
 how to obtain, configuration, and build ACE+TAO using MPC appear at
 the OCI <A
-HREF="http://www.theaceorb.com/faq/index.html#HowToBuildACEandTAOonWindows">FAQ</A>.<P>
+HREF="http://www.theaceorb.com/faq/index.html#HowToBuildACEandTAOonWindows">FAQ</A>.
+</p>
 
+<p>
 If you are attempting to generate project files using MPC, and you get
-the following error message:<br>
+the following error message:
+</p>
 
 <pre>ERROR: Unable to find the MPC modules in /builds/ACE_wrappers/MPC.
 You can set the MPC_ROOT environment variable to the location of MPC.
 </pre>
 
+<p>
 You need to do one of the following:
+</p>
 
 <ol>
 <li>If you have already obtained MPC, either move it underneath the
@@ -2647,17 +2795,22 @@ to the full path of MPC.</li>
 and set your MPC_ROOT environment variable.</li>
 </ol>
 
+<p>
 You can check
 out MPC from the DOCGroup git repository using the following command.
+</p>
 
 <pre>git clone https://github.com/DOCGroup/MPC.git MPC
 </pre>
 
+<p>
 The <A HREF="MPC/docs/README">README</A> and <A HREF="MPC/docs/USAGE">USAGE</A> files in the MPC/docs directory are an up-to-date
 source of documentation, however it is not a complete set of
 documentation. The TAO Developer's Guide from OCI starting with the
-1.3a version contains more information about MPC.<p>
+1.3a version contains more information about MPC.
+</p>
 
+<p>
 The MPC chapter from the TAO Developer's Guide is available at <a
 href="http://downloads.ociweb.com/MPC/">
 http://downloads.ociweb.com/MPC/</a>.  Some of MPC has changed since
@@ -2665,8 +2818,8 @@ this version, but it is largely accurate.  An updated version will be
 available as newer versions of the TAO Developer's Guide are released.
 In the meantime, please see the README and USAGE files in the MPC
 directory.
-
 </p>
+
 <p>
 </p><h1><a name="eclipse">Working with ACE in Eclipse</a></h1>
 

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -92,7 +92,7 @@
 #if __ANDROID_API__ >= 21
 #  define ACE_HAS_SEMUN
 #  if ACE_ANDROID_NDK_LESS_THAN(15, 0)
-#    define ACE_HAS_LINUX_SEM_H
+#    error "This combination of Android NDK < r15 and API >= 21 does is not supported. There are conflicting versions of semun"
 #  endif
 #endif
 

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -1,10 +1,14 @@
 // -*- C++ -*-
-// The following configuration file is designed to work for Android
-// platforms using GNU C++.
+// Config Header file for Android NDK
 
 #ifndef ACE_CONFIG_ANDROID_H
 #define ACE_CONFIG_ANDROID_H
 #include /**/ "ace/pre.h"
+
+// NOTE: We must be careful from now on to distinguish between the API level
+// and NDK version.
+// There is a large number of combinations of these two that can lead to
+// problems.
 
 // Location of the __ANDROID_API__ define
 // #include $NDK_ROOT/sysroot/usr/include/android/api-level.h
@@ -15,6 +19,91 @@
 #endif
 
 #define ACE_ANDROID
+#define ACE_PLATFORM_CONFIG config-android.h
+
+/*
+ * Android NDK Revision Macros
+ *
+ * Revsions Scheme Work Like This:
+ * Revision | __NDK_MAJOR__ | __NDK_MINOR__
+ * r16      | 16            | 0
+ * r16b     | 16            | 1
+ * r16c     | 16            | 2
+ *
+ * After r16, NDK version macros are defined in android/ndk-version.h Before
+ * that they must be defined in platform_macros.GNU before the include of
+ * platform_android.GNU.
+ */
+#define ACE_ANDROID_NDK_AT_LEAST(MAJ, MIN) \
+  (__NDK_MAJOR__ > (MAJ) || (__NDK_MAJOR__ == (MAJ) && __NDK_MINOR__ >= (MIN)))
+
+#define ACE_ANDROID_NDK_EXACTLY(MAJ, MIN) \
+  (__NDK_MAJOR__ == (MAJ) && __NDK_MINOR__ == (MIN))
+
+#define ACE_ANDROID_NDK_LESS_THAN(MAJ, MIN) \
+  (__NDK_MAJOR__ < (MAJ) || (__NDK_MAJOR__ == (MAJ) && __NDK_MINOR__ < (MIN)))
+
+#ifdef ACE_ANDROID_NDK_HAS_NDK_VERSION_H
+#  include "android/ndk-version.h"
+#else
+#  ifndef __NDK_MAJOR__
+#    error ndk-version.h is missing, __NDK_MAJOR__ for Android NDK must be defined!
+#  endif
+#  ifndef __NDK_MINOR__
+#    error ndk-version.h is missing, __NDK_MINOR__ for Android NDK must be defined!
+#  endif
+#endif
+
+// ucontext.h and clock_settime() were added in r10c
+#if ACE_ANDROID_NDK_AT_LEAST(10, 2)
+#  define ACE_HAS_UCONTEXT_T
+#  define ACE_HAS_CLOCK_SETTIME
+#else
+#  define ACE_LACKS_UCONTEXT_H
+#endif
+
+// NDK has these by r12b
+#if ACE_ANDROID_NDK_LESS_THAN(12, 1)
+#  define ACE_LACKS_GETHOSTENT
+#  define ACE_LACKS_LOCALECONV
+#  define ACE_LACKS_WCHAR_STD_NAMESPACE
+#endif
+
+#if ACE_ANDROID_NDK_LESS_THAN(12, 1) || __ANDROID_API__ < 18
+#  define ACE_LACKS_LOG2
+#endif
+
+#if ACE_ANDROID_NDK_LESS_THAN(12, 1) || __ANDROID_API__ < 21
+#  define ACE_LACKS_SEARCH_H
+#  define ACE_LACKS_SYS_SEM_H
+#  define ACE_LACKS_SEMBUF_T
+#  define ACE_LACKS_SYS_MSG_H
+#  define ACE_LACKS_SYS_SHM_H
+#  define ACE_LACKS_SYSV_SHMEM
+#endif
+
+// NDK has telldir() and seekdir() by 15c
+#if ACE_ANDROID_NDK_LESS_THAN(15, 2) || __ANDROID_API__ < 23
+#  define ACE_LACKS_TELLDIR
+#  define ACE_LACKS_SEEKDIR
+#endif
+
+// semun was added to sys/sem.h in r15
+#if ACE_ANDROID_NDK_AT_LEAST(15, 0) ||  __ANDROID_API__ >= 21
+#  define ACE_HAS_SEMUN
+#endif
+
+// fd_mask was added in r17c
+#if ACE_ANDROID_NDK_LESS_THAN(17, 2)
+#  define ACE_LACKS_FD_MASK
+#endif
+
+#if __ANDROID_API__ < 21
+#  define ACE_LACKS_RAND_R
+#  define ACE_LACKS_WCSTOLL
+#  define ACE_LACKS_WCSTOULL
+#  define ACE_LACKS_CONDATTR_SETCLOCK
+#endif
 
 #define ACE_HAS_SSIZE_T
 
@@ -38,35 +127,18 @@
 #define ACE_USES_ULONG_FOR_STAT_TIME
 
 #define ACE_LACKS_NEW_H
-#define ACE_LACKS_SEARCH_H
 #define ACE_LACKS_SIGINFO_H
 #define ACE_LACKS_STROPTS_H
-#define ACE_LACKS_SYS_SEM_H
-#define ACE_LACKS_SYS_MSG_H
-#define ACE_LACKS_SYS_SHM_H
 #define ACE_LACKS_SYS_SYSCTL_H
 
-#define ACE_LACKS_CUSERID
-#define ACE_LACKS_GETHOSTENT
 #define ACE_LACKS_GETLOADAVG
 #define ACE_LACKS_ISCTYPE
-#define ACE_LACKS_LOG2
-#define ACE_LACKS_LOCALECONV
 #define ACE_LACKS_NETDB_REENTRANT_FUNCTIONS
 #define ACE_LACKS_PWD_FUNCTIONS
-#define ACE_LACKS_PTHREAD_CANCEL
-#define ACE_LACKS_SEEKDIR
-#define ACE_LACKS_SEMBUF_T
-#define ACE_LACKS_SETINHERITSCHED
 #define ACE_LACKS_STRRECVFD
+#define ACE_LACKS_PTHREAD_CANCEL // posix_limits.h explicitly says this
+#define ACE_LACKS_SETINHERITSCHED // posix_limits.h explicitly says this
 #define ACE_LACKS_SWAB
-#define ACE_LACKS_SYSV_SHMEM
-#define ACE_LACKS_TELLDIR
-#define ACE_LACKS_WCHAR_STD_NAMESPACE
-#define ACE_LACKS_WCSTOLL
-#define ACE_LACKS_WCSTOULL
-
-#define ACE_LACKS_RAND_R
 
 // Android seems to have 64 keys of which Android itself use 5
 #define ACE_DEFAULT_THREAD_KEYS 59
@@ -79,8 +151,6 @@
 #if !defined (ACE_MT_SAFE)
 #  define ACE_MT_SAFE 1
 #endif
-
-#define ACE_PLATFORM_CONFIG config-android.h
 
 // Needed to differentiate between libc 5 and libc 6 (aka glibc).
 #include <features.h>
@@ -118,13 +188,14 @@
 #define ACE_HAS_P_READ_WRITE
 // Use ACE's alternate cuserid() implementation since the use of the
 // system cuserid() is discouraged.
+#define ACE_LACKS_CUSERID
 #define ACE_HAS_ALT_CUSERID
 
 #if (__GLIBC__  > 2)  || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)
 # define ACE_HAS_ISASTREAM_PROTOTYPE
 # define ACE_HAS_PTHREAD_SIGMASK_PROTOTYPE
 # define ACE_HAS_CPU_SET_T
-#elif __ANDROID_API__ >= 21
+#elif ACE_ANDROID_NDK_AT_LEAST(16, 0) || __ANDROID_API__ >= 21
 # define ACE_HAS_CPU_SET_T
 #endif /* __GLIBC__ > 2 || __GLIBC__ === 2 && __GLIBC_MINOR__ >= 3) */
 
@@ -330,32 +401,7 @@
 #define ACE_HAS_RECURSIVE_THR_EXIT_SEMANTICS
 #define ACE_HAS_2_PARAM_ASCTIME_R_AND_CTIME_R
 #define ACE_HAS_REENTRANT_FUNCTIONS
-
-#if __ANDROID_API__ < 21
-# define ACE_LACKS_UCONTEXT_H
-#else
-# define ACE_HAS_CLOCK_SETTIME
-# define ACE_HAS_UCONTEXT_T
-#endif
-
-#define ACE_LACKS_FD_MASK
-
-#if __ANDROID_API__ >= 9
-# define ACE_HAS_TIMEZONE
-#endif
-
-#if __ANDROID_API__ < 14
-# define ACE_LACKS_STD_WSTRING
-# define ACE_LACKS_GETIPNODEBYADDR
-# define ACE_LACKS_GETIPNODEBYNAME
-#endif
-
-#if __ANDROID_API__ == 3
-# error Unsupported Android release 3
-#elif __ANDROID_API__ == 8
-# define ACE_LACKS_REGEX_H 1
-# define ACE_LACKS_CONDATTR 1
-#endif
+#define ACE_HAS_TIMEZONE
 
 #if !defined ACE_DEFAULT_TEMP_DIR
 # define ACE_DEFAULT_TEMP_DIR "/data/tmp"

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -200,7 +200,7 @@ There are conflicting versions of semun between ACE and linux/sem.h.
 # define ACE_HAS_ISASTREAM_PROTOTYPE
 # define ACE_HAS_PTHREAD_SIGMASK_PROTOTYPE
 # define ACE_HAS_CPU_SET_T
-#elif ACE_ANDROID_NDK_AT_LEAST(16, 0) || __ANDROID_API__ >= 21
+#elif ACE_ANDROID_NDK_AT_LEAST(15, 0) || __ANDROID_API__ >= 21
 # define ACE_HAS_CPU_SET_T
 #endif /* __GLIBC__ > 2 || __GLIBC__ === 2 && __GLIBC_MINOR__ >= 3) */
 

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -92,7 +92,9 @@
 #if __ANDROID_API__ >= 21
 #  define ACE_HAS_SEMUN
 #  if ACE_ANDROID_NDK_LESS_THAN(15, 0)
-#    error "This combination of Android NDK < r15 and API >= 21 does is not supported. There are conflicting versions of semun"
+#    error \
+This combination of Android NDK < r15 and API >= 21 is not supported. \
+There are conflicting versions of semun between ACE and linux/sem.h.
 #  endif
 #endif
 

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -89,8 +89,11 @@
 #endif
 
 // semun was added to sys/sem.h in r15
-#if ACE_ANDROID_NDK_AT_LEAST(15, 0) ||  __ANDROID_API__ >= 21
+#if __ANDROID_API__ >= 21
 #  define ACE_HAS_SEMUN
+#  if ACE_ANDROID_NDK_LESS_THAN(15, 0)
+#    define ACE_HAS_LINUX_SEM_H
+#  endif
 #endif
 
 // fd_mask was added in r17c

--- a/ACE/ace/os_include/sys/os_sem.h
+++ b/ACE/ace/os_include/sys/os_sem.h
@@ -27,6 +27,10 @@
 
 #if !defined (ACE_LACKS_SYS_SEM_H)
 #  include /**/ <sys/sem.h>
+#else
+#  ifdef ACE_HAS_LINUX_SEM_H
+#    include <linux/sem.h>
+#  endif
 #endif /* !ACE_LACKS_SYS_SEM_H */
 
 // Place all additions (especially function declarations) within extern "C" {}

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -131,6 +131,18 @@ else
   include $(ACE_ROOT)/include/makeinclude/platform_g++_common.GNU
 endif
 
+ifeq ($(shell echo '\#include "android/ndk-version.h"' | $(CXX) -E - > /dev/null 2>&1; echo $$?), 0)
+  CPPFLAGS += -DACE_ANDROID_NDK_HAS_NDK_VERSION_H
+endif
+
+ifdef __NDK_MAJOR__
+  CPPFLAGS += -D__NDK_MAJOR__=$(__NDK_MAJOR__)
+endif
+
+ifdef __NDK_MINOR__
+  CPPFLAGS += -D__NDK_MINOR__=$(__NDK_MINOR__)
+endif
+
 OCFLAGS ?= -O3
 OCCFLAGS ?= -O3
 

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -22,6 +22,9 @@ PIE	?= -pie
 #No rwho on Android
 rwho = 0
 
+# Android Studio does not seem to reconize so files with versions
+versioned_so=0
+
 # This section deals with selecting the architecture/compiler
 # As of writing information on ABIs can be found at https://developer.android.com/ndk/guides/abis
 

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -6,197 +6,90 @@
 # We always include config-android.h on Android platforms.
 ACE_PLATFORM_CONFIG ?= config-android.h
 
+# Common Linux Functionality
+include $(ACE_ROOT)/include/makeinclude/platform_linux_common.GNU
+
 # The standalone gcc compilers in NDK r6-r9 have issues with the visibility.
 no_hidden_visibility ?= 1
 
 # as of NDK r6 inlining is required
 inline ?= 1
 
-debug ?= 1
-optimize ?= 1
-threads ?= 1
-insure ?= 0
-
-LSB_RELEASE_ID := $(shell lsb_release -i 2> /dev/null || echo Distributor ID: Unknown)
-LSB_RELEASE_RELEASE := $(shell lsb_release -r 2> /dev/null || echo Release: Unknown)
-
-PLATFORM_XT_CPPFLAGS=
-PLATFORM_XT_LIBS=-lXt
-PLATFORM_XT_LDFLAGS=
-
-PLATFORM_FL_CPPFLAGS=
-PLATFORM_FL_LIBS=-lfltk -lfltk_forms -lfltk_gl
-PLATFORM_FL_LDFLAGS=
-
-PLATFORM_X11_CPPFLAGS=-I/usr/X11R6/include
-PLATFORM_X11_LIBS=-lX11
-PLATFORM_X11_LDFLAGS=-L/usr/X11R6/lib
-
-PLATFORM_GL_CPPFLAGS=-I/usr/X11R6/include
-PLATFORM_GL_LIBS    =-lGL
-PLATFORM_GL_LDFLAGS =-L/usr/X11R6/lib
-
-PLATFORM_GTK_CPPFLAGS=$(shell gtk-config --cflags)
-PLATFORM_GTK_LIBS    =$(shell gtk-config --libs)
-PLATFORM_GTK_LDFLAGS =
-
-PLATFORM_FOX_CPPFLAGS ?= -I/usr/include/fox
-PLATFORM_FOX_LIBS     ?= -lFOX
-PLATFORM_FOX_LDFLAGS  ?=
-
-# NOTE: we only support wxWindows over GTK
-PLATFORM_WX_CPPFLAGS= $(shell wx-config --cxxflags) $(PLATFORM_GTK_CPPFLAGS)
-PLATFORM_WX_LIBS    = $(shell wx-config --libs)     $(PLATFORM_GTK_LIBS)
-PLATFORM_WX_LDFLAGS = $(shell wx-config --ldflags)  $(PLATFORM_GTK_LDFLAGS)
-
-PLATFORM_BOOST_CPPFLAGS ?=
-PLATFORM_BOOST_LDLAGS ?=
-PLATFORM_BOOST_UTF_LIBS ?= -lboost_unit_test_framework
-
-ifeq ($(buildbits),64)
-PLATFORM_TK_CPPFLAGS=$(shell . /usr/lib64/tkConfig.sh && echo -n $$TK_INCLUDE_SPEC $$TK_DEFS)
-PLATFORM_TK_LIBS=$(shell . /usr/lib64/tkConfig.sh && echo -n $$TK_LIB_FLAG)
-else
-PLATFORM_TK_CPPFLAGS=$(shell . /usr/lib/tkConfig.sh && echo -n $$TK_INCLUDE_SPEC $$TK_DEFS)
-PLATFORM_TK_LIBS=$(shell . /usr/lib/tkConfig.sh && echo -n $$TK_LIB_FLAG)
-endif
-PLATFORM_TK_LDFLAGS=
-
-ifeq ($(buildbits),64)
-PLATFORM_TCL_CPPFLAGS=$(shell . /usr/lib64/tclConfig.sh && echo -n $$TCL_INCLUDE_SPEC $$TCL_DEFS)
-PLATFORM_TCL_LIBS=$(shell . /usr/lib64/tclConfig.sh && echo -n $$(eval echo $$TCL_LIB_FLAG))
-else
-PLATFORM_TCL_CPPFLAGS=$(shell . /usr/lib/tclConfig.sh && echo -n $$TCL_INCLUDE_SPEC $$TCL_DEFS)
-PLATFORM_TCL_LIBS=$(shell . /usr/lib/tclConfig.sh && echo -n $$(eval echo $$TCL_LIB_FLAG))
-endif
-PLATFORM_TCL_LDFLAGS=
-
-PLATFORM_QT_CPPFLAGS ?= -I$(QTDIR)/include
-PLATFORM_QT_LIBS ?= -lqt-mt
-PLATFORM_QT_LDFLAGS ?= -L$(QTDIR)/lib
-
-sctp ?=
-# support for OpenSS7 SCTP
-ifeq ($(sctp),openss7)
-  PLATFORM_SCTP_CPPFLAGS+= -DACE_HAS_OPENSS7_SCTP
-  PLATFORM_SCTP_LDFLAGS?=
-  PLATFORM_SCTP_LIBS?=
-endif
-
-# support for LKSCTP (Linux Kernel 2.5)
-ifeq ($(sctp),lksctp)
-  PLATFORM_SCTP_CPPFLAGS+= -DACE_HAS_LKSCTP
-  PLATFORM_SCTP_LDFLAGS?= -L/usr/local/lib
-  PLATFORM_SCTP_LIBS?= -lsctp
-endif
-
-GNU_LIBPTHREAD_VERSION := $(shell getconf GNU_LIBPTHREAD_VERSION 2> /dev/null || echo Unknown)
-ifeq (NPTL, $(word 1,$(GNU_LIBPTHREAD_VERSION)))
-  NPTL_VERS := $(subst ., ,$(word 2,$(GNU_LIBPTHREAD_VERSION)))
-  ifneq (0, $(word 1,$(NPTL_VERS)))
-    nptl ?= 1
-  endif
-endif
-nptl ?= 0
-ifeq ($(nptl),0)
-  CPPFLAGS += -DACE_LACKS_LINUX_NPTL
-endif
-
-ssl ?= 0
-ifeq ($(ssl),1)
-  # Some Linux OpenSSL installations compile in Kerberos support.  Add
-  # the Kerberos include path to preprocessor include path.
-  #
-  # We should probably also add the Kerberos libraries to
-  # PLATFORM_SSL_LIBS but we can't be sure if they are needed without
-  # a more sophisticated check.  This will only be a problem when
-  # statically linking the OpenSSL library.  The majority of
-  # installations use shared OpenSSL libraries so we should be okay,
-  # at least until we migrate to Autoconf.
-  PLATFORM_SSL_CPPFLAGS += -I/usr/kerberos/include
-endif # ssl
-
-SYSARCH := $(shell uname -m)
-
 # as of API level 16 executables can be linked as Position Independent Executables
 # as of API level 21 PIE is mandatory
-PIE		?= -pie
-PIC      = -fPIC
-AR      ?= ar
-ARFLAGS ?= rsuv
-RANLIB   = @true
-
-# end of: include most of platform_linux_common.GNU
+PIE	?= -pie
 
 #No rwho on Android
 rwho = 0
 
-#Standalone toolchain required.
-#Required environment variables are
-#$NDK - install directory for android NDK, at least r5c
-#$SDK - install directory for android SDK
-#$SYSROOT - $NDK/platform/android-9
-#$TOOLCHAIN/bin in path, $TOOLCHAIN is root of standalone toolchain
-#
-#Optionally ANDROID_ABI can be set to select specific architecture ABIs like armeabi-v7a or neon
-#ANDROID_ABI ?= arm64-v8a
-#
-#Toolchain defaults to arm architecture
-ANDROID_ARCH ?= arm
+# This section deals with selecting the architecture/compiler
+# As of writing information on ABIs can be found at https://developer.android.com/ndk/guides/abis
 
-#SYSROOT ?= $(NDK)/platforms/android-9/arch-$(ANDROID_ARCH)
-
-ifeq (,$(CROSS_COMPILE))
-  ifeq ($(ANDROID_ARCH),arm)
-    CROSS_COMPILE=arm-linux-androideabi-
-  else
-    ifeq ($(ANDROID_ARCH),x86)
-      CROSS_COMPILE=i686-linux-android-
+ifndef ANDROID_ABI
+  ifdef ANDROID_ARCH # Handle Possiblity of ANDROID_ARCH being passed
+    ifeq ($(ANDROID_ARCH),arm)
+      ANDROID_ABI := armeabi-v7a
     else
-      CROSS_COMPILE=unknown-android-arch-
+      ANDROID_ABI := $(ANDROID_ARCH)
     endif
+  else # Else default to ARMv7
+    ANDROID_ABI := armeabi-v7a
   endif
 endif
 
-# fix this
-pipes ?= 1
-
-# set architecture specific build flags
-ifeq (arm,$(findstring arm,$(ANDROID_ARCH)))
-  # NDK says -Wl,--fix-cortex-a8 is required for working around a CPU bug 
-  # in some Cortex-A8 implementations
-  
-  # Set ABI specific flags
-  ifeq ($(ANDROID_ABI),armeabi-v7a)
-    FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
-    LDFLAGS    += -march=armv7-a -Wl,--fix-cortex-a8
-  endif
-
-  ifeq ($(ANDROID_ABI),arm64-v8a)
-    CROSS_COMPILE=aarch64-linux-android-
-    FLAGS_C_CC += -march=armv8-a 
-    LDFLAGS    += -march=armv8-a 
-  endif 
-
-  ifeq ($(ANDROID_ABI),neon)
-    FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp -mfpu=neon
-    LDFLAGS    += -march=armv7-a -Wl,--fix-cortex-a8
-  endif
-
+# Alias neon
+ifeq ($(ANDROID_ABI), neon)
+  ANDROID_ABI := armeabi-v7a-with-neon
 endif
 
-FLAGS_C_CC += -W -Wall -Wpointer-arith -Wno-psabi
+# NDK says -Wl,--fix-cortex-a8 is required for working around a CPU bug
+# in some Cortex-A8 implementations
+
+ifeq ($(ANDROID_ABI),armeabi-v7a)
+  CROSS_COMPILE := arm-linux-androideabi-
+  FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
+  LDFLAGS    += -march=armv7-a -Wl,--fix-cortex-a8
+endif
+
+ifeq ($(ANDROID_ABI),arm64-v8a)
+  CROSS_COMPILE := aarch64-linux-android-
+  FLAGS_C_CC += -march=armv8-a
+  LDFLAGS    += -march=armv8-a
+endif
+
+ifeq ($(ANDROID_ABI),armeabi-v7a-with-neon)
+  CROSS_COMPILE := arm-linux-androideabi-
+  FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp -mfpu=neon
+  LDFLAGS    += -march=armv7-a -Wl,--fix-cortex-a8
+endif
+
+ifeq ($(ANDROID_ABI),x86)
+  CROSS_COMPILE := i686-linux-android-
+endif
+
+ifeq ($(ANDROID_ABI),x86_64)
+  CROSS_COMPILE := x86_64-linux-android-
+endif
+
+ifndef CROSS_COMPILE
+  $(error ANDROID_ABI passed (set to: $(ANDROID_ABI)) is not valid)
+endif
+
+# Determine if the g++ compiler is GCC or Clang.
+# There are at least 3 assumptions being made here:
+#  - There is a g++ command to get the version from
+#  - Clang will have "clang" in the version string
+#  - If g++ is actually clang, then we can replace that with clang++
+gplusplus_version = $(shell $(CROSS_COMPILE)g++$(CROSS_COMPILE_SUFFIX) --version)
+actually_is_clang := $(strip $(findstring clang,$(gplusplus_version)))
+
+FLAGS_C_CC += -W -Wall -Wpointer-arith
 ifeq ($(threads),1)
     CPPFLAGS  += -D_REENTRANT $(PLATFORM_AIO_SUPPORT)
 endif # threads
 
-ifeq ($(buildbits),32)
-  FLAGS_C_CC += -m32
-  LDFLAGS    += -m32
-endif
-ifeq ($(buildbits),64)
-  FLAGS_C_CC += -m64
-endif
+# Use -pipes by default
+pipes ?= 1
 
 # DT_RUNPATH is preferred over DT_RPATH, but the linker will only use it when
 # this extra flag option (enable-new-dtags) is present
@@ -211,13 +104,16 @@ DCFLAGS  += -ggdb
 DCCFLAGS += -ggdb
 DLD      = $(CXX)
 LD       = $(CXX) $(PIE)
-# make sure to add the required libs for RTTI and exceptions (libsupc++)
-# and a shared STL lib (libgnustl_shared by default)
-static_libs_only ?=
-ANDROID_STL_DLL ?= gnustl_shared
-LIBS     += -ldl -lsupc++
-ifneq ($(static_libs_only),1)
-  LIBS   += -l$(ANDROID_STL_DLL)
+
+ifndef actually_is_clang
+  # make sure to add the required libs for RTTI and exceptions (libsupc++)
+  # and a shared STL lib (libgnustl_shared by default)
+  static_libs_only ?=
+  ANDROID_STL_DLL ?= gnustl_shared
+  LIBS     += -ldl -lsupc++
+  ifneq ($(static_libs_only),1)
+    LIBS   += -l$(ANDROID_STL_DLL)
+  endif
 endif
 
 ifeq ($(optimize),1)
@@ -229,10 +125,11 @@ SOBUILD = $(COMPILE.cc) $(PIC) -o $(VSHDIR)$*.so $<; \
           $(SOLINK.cc) -o $@ $(LDFLAGS) $(VSHDIR)$*.o
 PRELIB  = @true
 
-# Test for template instantiation, add to SOFLAGS if SONAME set,
-# add -E to LDFLAGS if using GNU ld
-#
-include $(ACE_ROOT)/include/makeinclude/platform_g++_common.GNU
+ifdef actually_is_clang
+  include $(ACE_ROOT)/include/makeinclude/platform_clang_common.GNU
+else
+  include $(ACE_ROOT)/include/makeinclude/platform_g++_common.GNU
+endif
 
 OCFLAGS ?= -O3
 OCCFLAGS ?= -O3

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -50,7 +50,7 @@ endif
 
 android_neon ?= 0
 ifeq ($(ANDROID_ABI),armeabi-v7a-with-neon)
-  ANDROID_ABI = armeabi-v7a
+  ANDROID_ABI := armeabi-v7a
   android_neon := 1
 endif
 
@@ -60,7 +60,7 @@ endif
 ifeq ($(ANDROID_ABI),armeabi-v7a)
   CROSS_COMPILE := arm-linux-androideabi-
   FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp
-  ifeq ($(android_neon),0)
+  ifeq ($(android_neon),1)
     FLAGS_C_CC += -mfpu=neon
   else
     FLAGS_C_CC += -mfpu=vfpv3-d16

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -25,6 +25,9 @@ rwho = 0
 # Android Studio does not seem to reconize so files with versions
 versioned_so=0
 
+# Only try to use clang, unless this is set to 0, then try to use g++
+android_force_clang ?= 1
+
 # This section deals with selecting the architecture/compiler
 # As of writing information on ABIs can be found at https://developer.android.com/ndk/guides/abis
 
@@ -78,13 +81,21 @@ ifndef CROSS_COMPILE
   $(error ANDROID_ABI passed (set to: $(ANDROID_ABI)) is not valid)
 endif
 
-# Determine if the g++ compiler is GCC or Clang.
-# There are at least 3 assumptions being made here:
-#  - There is a g++ command to get the version from
-#  - Clang will have "clang" in the version string
-#  - If g++ is actually clang, then we can replace that with clang++
-gplusplus_version = $(shell $(CROSS_COMPILE)g++$(CROSS_COMPILE_SUFFIX) --version)
-actually_is_clang := $(strip $(findstring clang,$(gplusplus_version)))
+ifeq ($(android_force_clang),0)
+  # Determine if the g++ compiler is GCC or Clang.
+  # There are at least 3 assumptions being made here:
+  #  - There is a g++ command to get the version from
+  #  - Clang will have "clang" in the version string
+  #  - If g++ is actually clang, then we can replace that with clang++
+  gplusplus_version = $(shell $(CROSS_COMPILE)g++$(CROSS_COMPILE_SUFFIX) --version)
+  actually_is_clang := $(strip $(findstring clang,$(gplusplus_version)))
+else
+  ifeq ($(android_force_clang),1)
+    actually_is_clang := 1
+  else
+    $(error Invalid value for android_force_clang: $(android_force_clang))
+  endif
+endif
 
 FLAGS_C_CC += -W -Wall -Wpointer-arith
 ifeq ($(threads),1)

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -48,12 +48,23 @@ ifeq ($(ANDROID_ABI), neon)
   ANDROID_ABI := armeabi-v7a-with-neon
 endif
 
+android_neon ?= 0
+ifeq ($(ANDROID_ABI),armeabi-v7a-with-neon)
+  ANDROID_ABI = armeabi-v7a
+  android_neon := 1
+endif
+
 # NDK says -Wl,--fix-cortex-a8 is required for working around a CPU bug
 # in some Cortex-A8 implementations
 
 ifeq ($(ANDROID_ABI),armeabi-v7a)
   CROSS_COMPILE := arm-linux-androideabi-
-  FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
+  FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp
+  ifeq ($(android_neon),0)
+    FLAGS_C_CC += -mfpu=neon
+  else
+    FLAGS_C_CC += -mfpu=vfpv3-d16
+  endif
   LDFLAGS    += -march=armv7-a -Wl,--fix-cortex-a8
 endif
 
@@ -61,12 +72,6 @@ ifeq ($(ANDROID_ABI),arm64-v8a)
   CROSS_COMPILE := aarch64-linux-android-
   FLAGS_C_CC += -march=armv8-a
   LDFLAGS    += -march=armv8-a
-endif
-
-ifeq ($(ANDROID_ABI),armeabi-v7a-with-neon)
-  CROSS_COMPILE := arm-linux-androideabi-
-  FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp -mfpu=neon
-  LDFLAGS    += -march=armv7-a -Wl,--fix-cortex-a8
 endif
 
 ifeq ($(ANDROID_ABI),x86)

--- a/ACE/include/makeinclude/platform_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_clang_common.GNU
@@ -1,6 +1,30 @@
 # -*- Makefile -*-
-#
-# Common file help turn on/off explicit template instantiation
+
+# Compiling TAO requires relaxing strict 2-phase name lookup rules:
+CCFLAGS += -fdelayed-template-parsing
+
+ifneq ($(CROSS_COMPILE),)
+  CROSS-COMPILE = 1
+  # Build using the cross-tools
+  CC  = ${CROSS_COMPILE}clang${CROSS_COMPILE_SUFFIX}
+  CXX = ${CROSS_COMPILE}clang++${CROSS_COMPILE_SUFFIX}
+  AR  = ${CROSS_COMPILE}ar${CROSS_COMPILE_SUFFIX}
+  # Cross-linker requires this for linked in shared libs that depend
+  # themselves on other shared libs (not directly linked in)
+  LDFLAGS += -Wl,-rpath-link,$(ACE_ROOT)/lib
+  ifneq (,$(HOST_ROOT))
+    TAO_IDLFLAGS += -g $(HOST_ROOT)/bin/ace_gperf
+    TAO_IDL = $(HOST_ROOT)/bin/tao_idl
+    TAO_IDL_DEP = $(TAO_IDL)
+    TAO_IDL3_TO_IDL2 = $(HOST_ROOT)/bin/tao_idl3_to_idl2
+    TAO_IDL3_TO_IDL2_DEP = $(TAO_IDL3_TO_IDL2)
+    TAO_IDL3_TO_XMI = $(HOST_ROOT)/bin/tao_idl3_to_xmi
+    TAO_IDL3_TO_XMI_DEP = $(TAO_IDL3_TO_XMI)
+    # make sure to use the target compiler, not the cross-compiler
+    # as preprocessor for the cross-compiled idl tools
+    TAO_IDL_PREPROCESSOR = clang
+  endif
+endif
 
 ifeq ($(openmp),1)
 FLAGS_C_CC += -fopenmp

--- a/TAO/TAO-INSTALL.html
+++ b/TAO/TAO-INSTALL.html
@@ -50,7 +50,7 @@ to run TAO on:<P>
     <td></td>
   </tr>
   <tr valign=top>
-    <td><b>Support were dropped recently</b></td>
+    <td><b>Formally Supported Platforms</b></td>
     <td> Embarcadero C++ Builder, Sun/C++ 5.1 through 5.4, g++
          prior to 2.95.x, HP/UX 10.x, pSoS, Chorus, DEC UNIX, SCO, UnixWare, MVS,
          Windows 9x/ME, Chorus, Tandem NS, OpenVMS 8.3 IA64

--- a/TAO/TAO-INSTALL.html
+++ b/TAO/TAO-INSTALL.html
@@ -50,7 +50,7 @@ to run TAO on:<P>
     <td></td>
   </tr>
   <tr valign=top>
-    <td><b>Formally Supported Platforms</b></td>
+    <td><b>Formerly Supported Platforms</b></td>
     <td> Embarcadero C++ Builder, Sun/C++ 5.1 through 5.4, g++
          prior to 2.95.x, HP/UX 10.x, pSoS, Chorus, DEC UNIX, SCO, UnixWare, MVS,
          Windows 9x/ME, Chorus, Tandem NS, OpenVMS 8.3 IA64


### PR DESCRIPTION
This PR addresses #676 by allowing ACE and TAO to compile against Android NDK r18+, which uses Clang instead of GCC. This is still a work in progress as support for older NDKs is spotty. In addition these changes intentionally break builds using NDKs older than r16 because these are missing  `ndk_version.h` which is needed to determine what macros for ACE are needed. This can to fixed by supplying the correct values `__NDK_MAJOR__` and `__NDK_MINOR__` in `platform_macros.GNU`. In exchange for this, assuming `config-android.h` is written correctly, ACE should be backwards compatible with NDKs from now on.