### PR TITLE
Only define ACE_HAS_SEMUN when we have API >= 12 and at least NDK 15

### DIFF
--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -90,11 +90,8 @@
 
 // semun was added to sys/sem.h in r15
 #if __ANDROID_API__ >= 21
-#  define ACE_HAS_SEMUN
-#  if ACE_ANDROID_NDK_LESS_THAN(15, 0)
-#    error \
-This combination of Android NDK < r15 and API >= 21 is not supported. \
-There are conflicting versions of semun between ACE and linux/sem.h.
+#  if ACE_ANDROID_NDK_AT_LEAST(15, 0)
+#   define ACE_HAS_SEMUN
 #  endif
 #endif
 

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -22,7 +22,7 @@ PIE	?= -pie
 #No rwho on Android
 rwho = 0
 
-# Android Studio does not seem to reconize so files with versions
+# Android Studio does not seem to recognize so files with versions
 versioned_so=0
 
 # Only try to use clang, unless this is set to 0, then try to use g++


### PR DESCRIPTION
Giving an error is not user friendly, we just not set ACE_HAS_SEMUN when it is not usable

This is a change related to PR #726 