### PR TITLE
Android NDK13 does ship a senum type, isn't usable, but ACE shouldn't…

### DIFF
--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -88,9 +88,10 @@
 #  define ACE_LACKS_SEEKDIR
 #endif
 
-// semun was added to sys/sem.h in r15
+// semun was added to sys/sem.h in r15 but in r13 it does
+// exist as type but isn't usable
 #if __ANDROID_API__ >= 21
-#  if ACE_ANDROID_NDK_AT_LEAST(15, 0)
+#  if ACE_ANDROID_NDK_AT_LEAST(13, 0)
 #   define ACE_HAS_SEMUN
 #  endif
 #endif

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -88,14 +88,6 @@
 #  define ACE_LACKS_SEEKDIR
 #endif
 
-// semun was added to sys/sem.h in r15 but in r13 it does
-// exist as type but isn't usable
-#if __ANDROID_API__ >= 21
-#  if ACE_ANDROID_NDK_AT_LEAST(13, 0)
-#   define ACE_HAS_SEMUN
-#  endif
-#endif
-
 // fd_mask was added in r17c
 #if ACE_ANDROID_NDK_LESS_THAN(17, 2)
 #  define ACE_LACKS_FD_MASK

--- a/ACE/ace/os_include/sys/os_sem.h
+++ b/ACE/ace/os_include/sys/os_sem.h
@@ -29,7 +29,7 @@
 #  include /**/ <sys/sem.h>
 #else
 #  ifdef ACE_HAS_LINUX_SEM_H
-#    include <linux/sem.h>
+#    include /**/ <linux/sem.h>
 #  endif
 #endif /* !ACE_LACKS_SYS_SEM_H */
 


### PR DESCRIPTION
… define its own version

    * ACE/ace/config-android.h:
    * ACE/ace/os_include/sys/os_sem.h:

See #726 and #741 