### PR TITLE
Visual Studio 2017 marks now /Gm (enable minimal rebuild) as deprecat…

### DIFF
--- a/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
@@ -5,6 +5,12 @@ feature (nmake_avoid_Wp64) {
   }
 }
 
+feature (nmake_avoid_Gm) {
+  specific(nmake) {
+    add_compile -= /Gm
+  }
+}
+
 feature(vc_avoid_hides_local_declaration) {
   specific(nmake) {
     DisableSpecificWarnings += 4456

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
 
 jobs:
 - job: VisualStudio2017
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   pool:
     vmImage: vs2017-win2016
   strategy:


### PR DESCRIPTION
…ed so we remove it from the compiler flags

    * ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb: