### PR TITLE
Only set versioned_so to 0 when it is not set, it is possible to use …

### DIFF
--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -23,7 +23,7 @@ PIE	?= -pie
 rwho = 0
 
 # Android Studio does not seem to recognize so files with versions
-versioned_so=0
+versioned_so ?= 0
 
 # Only try to use clang, unless this is set to 0, then try to use g++
 android_force_clang ?= 1


### PR DESCRIPTION
…this so let the user enable it when necessary

    * ACE/include/makeinclude/platform_android.GNU: