### PR TITLE
Removed AAM_ACTIVATION_SENT status, at the moment we do an AMI start_…

### DIFF
--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -67,7 +67,7 @@ class Locator_Export AsyncAccessManager
   ImplementationRepository::AAM_Status status (void) const;
   bool force_remove_rh (ImR_ResponseHandler *rh);
 
-  void activator_replied (bool success, int pid);
+  void activator_replied_start_running (bool success, int pid);
   void server_is_running (const char *partial_ior,
                           ImplementationRepository::ServerObject_ptr ref);
   void server_is_shutting_down (void);

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp
@@ -497,7 +497,7 @@ ImR_Activator_i::start_server(const char* name,
   // handles. This includes stdin, stdout, logs, etc.
   proc_opts.handle_inheritance (0);
 
-  // We always enable the unicode environmet buffer on Windows.  This works
+  // We always enable the unicode environment buffer on Windows.  This works
   // around a 32kb environment buffer limitation.  This must come before any of
   // the setenv() calls, since the first of those will copy the current
   // process's environment.

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator.idl
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator.idl
@@ -49,7 +49,6 @@ module ImplementationRepository
   {
     AAM_INIT,
     AAM_SERVER_STARTED_RUNNING,
-    AAM_ACTIVATION_SENT,
     AAM_WAIT_FOR_RUNNING,
     AAM_WAIT_FOR_PING,
     AAM_WAIT_FOR_ALIVE,

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -330,6 +330,12 @@ LiveEntry::set_pid (int pid)
   this->pid_ = pid;
 }
 
+int
+LiveEntry::pid (void)
+{
+  return this->pid_;
+}
+
 bool
 LiveEntry::has_pid (int pid)
 {
@@ -660,7 +666,7 @@ LC_TimeoutGuard::~LC_TimeoutGuard (void)
     }
 }
 
-bool LC_TimeoutGuard::blocked (void)
+bool LC_TimeoutGuard::blocked (void) const
 {
   return this->blocked_;
 }
@@ -894,8 +900,8 @@ LiveCheck::remove_server (const char *server, int pid)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
                           ACE_TEXT ("(%P|%t) LiveCheck::remove_server <%C> ")
-                          ACE_TEXT ("pid <%d> does not match entry\n"),
-                          server, pid));
+                          ACE_TEXT ("pid <%d> does not match entry pid <%d>\n"),
+                          server, pid, entry->pid ()));
         }
     }
 }

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -389,7 +389,7 @@ LiveEntry::validate_ping (bool &want_reping, ACE_Time_Value& next)
     case LS_TRANSIENT:
     case LS_LAST_TRANSIENT:
       {
-        int ms = this->next_reping ();
+        int const ms = this->next_reping ();
         if (ms != -1)
           {
             ACE_GUARD_RETURN (TAO_SYNCH_MUTEX, mon, this->lock_, false);

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -102,7 +102,7 @@ LiveEntry::set_reping_limit (int max)
 }
 
 bool
-LiveEntry::reping_available (void)
+LiveEntry::reping_available (void) const
 {
   return this->repings_ < this->max_retry_;
 }
@@ -331,13 +331,13 @@ LiveEntry::set_pid (int pid)
 }
 
 int
-LiveEntry::pid (void)
+LiveEntry::pid (void) const
 {
   return this->pid_;
 }
 
 bool
-LiveEntry::has_pid (int pid)
+LiveEntry::has_pid (int pid) const
 {
   return this->pid_ == 0 || pid == 0 || pid == this->pid_;
 }

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
@@ -132,13 +132,13 @@ class Locator_Export LiveEntry
   void do_ping (PortableServer::POA_ptr poa);
   const ACE_Time_Value &next_check (void) const;
   static void set_reping_limit (int max);
-  bool reping_available (void);
+  bool reping_available (void) const;
   int next_reping (void);
   void max_retry_msec (int max);
   const char *server_name (void) const;
   void set_pid (int pid);
-  bool has_pid (int pid);
-  int pid (void);
+  bool has_pid (int pid) const;
+  int pid (void) const;
 
  private:
   LiveCheck *owner_;
@@ -158,7 +158,6 @@ class Locator_Export LiveEntry
 
   static const int reping_msec_ [];
   static int reping_limit_;
-
 };
 
 //---------------------------------------------------------------------------

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
@@ -138,6 +138,7 @@ class Locator_Export LiveEntry
   const char *server_name (void) const;
   void set_pid (int pid);
   bool has_pid (int pid);
+  int pid (void);
 
  private:
   LiveCheck *owner_;
@@ -223,7 +224,7 @@ class Locator_Export LC_TimeoutGuard
   ~LC_TimeoutGuard (void);
 
   /// Returns true if the busy flag in the owner was already set.
-  bool blocked (void);
+  bool blocked (void) const;
 
  private:
   LiveCheck *owner_;
@@ -294,6 +295,10 @@ class Locator_Export LiveCheck : public ACE_Event_Handler
   int handle_timeout_busy_;
   bool want_timeout_;
   ACE_Time_Value deferred_timeout_;
+  /// Contains a list of servers which got removed during the handle_timeout,
+  /// these will be removed at the end of the handle_timeout. Be aware that
+  /// between the moment the server has been added to the list and the handling
+  /// of this list the server can already be restarted again.
   NameStack removed_entries_;
 };
 

--- a/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp
@@ -483,7 +483,7 @@ Locator_Repository::get_active_server (const ACE_CString& name, int pid)
           if (name.find ("JACORB:") == ACE_CString::npos)
             {
               ACE_CString jo_key ("JACORB:");
-              ACE_CString::size_type pos = name.find (':');
+              ACE_CString::size_type const pos = name.find (':');
               if (pos == ACE_CString::npos)
                 {
                   jo_key += name;
@@ -521,7 +521,7 @@ int
 Locator_Repository::remove_server (const ACE_CString& name,
                                    ImR_Locator_i* imr_locator)
 {
-  int err = sync_load ();
+  int const err = sync_load ();
   if (err != 0)
     {
       return err;
@@ -557,7 +557,7 @@ Locator_Repository::remove_server (const ACE_CString& name,
       for (CORBA::ULong i = 0; i < si->peers.length(); i++)
         {
           ACE_CString key;
-          ACE_CString peer (si->peers[i]);
+          ACE_CString const peer (si->peers[i]);
           Server_Info::gen_key (si->server_id, peer, key);
 
           Server_Info_Ptr si2;


### PR DESCRIPTION
…server we just ignore the successful AMI reply and don't update the status, when the system is very very busy it can be that the server is already running before our AMI reply from start_server gets invoked, putting the pid to 0 at that moment causes the server status to go from running back to wait_for_reply

    * TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp:
    * TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h:
    * TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.cpp:
    * TAO/orbsvcs/ImplRepo_Service/ImR_Locator.idl:
    * TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp:
    * TAO/orbsvcs/ImplRepo_Service/Locator_Repository.cpp: