### PR TITLE
Fix end() on ACE_Vector

### DIFF
--- a/ACE/ace/Vector_T.h
+++ b/ACE/ace/Vector_T.h
@@ -188,6 +188,16 @@ public:
 
   void swap (ACE_Vector &rhs);
 
+  /*
+   * Implement our own end functions because Array_Base's end functions use the
+   * current capacity, not the Vector's actual element count!
+   */
+  /// C++ Standard End Iterator
+  ///{
+  typename ACE_Array_Base<T>::iterator end ();
+  typename ACE_Array_Base<T>::const_iterator end () const;
+  ///}
+
 protected:
 
   /**

--- a/ACE/ace/Vector_T.inl
+++ b/ACE/ace/Vector_T.inl
@@ -45,6 +45,18 @@ void ACE_Vector<T, DEFAULT_SIZE>::pop_back (void)
     }
 }
 
+template <class T, size_t DEFAULT_SIZE> ACE_INLINE
+typename ACE_Array_Base<T>::iterator ACE_Vector<T, DEFAULT_SIZE>::end ()
+{
+  return ACE_Array_Base<T>::array_ + length_;
+}
+
+template <class T, size_t DEFAULT_SIZE> ACE_INLINE
+typename ACE_Array_Base<T>::const_iterator ACE_Vector<T, DEFAULT_SIZE>::end () const
+{
+  return ACE_Array_Base<T>::array_ + length_;
+}
+
 // Compare this vector with <s> for inequality.
 
 template <class T, size_t DEFAULT_SIZE> ACE_INLINE bool

--- a/ACE/tests/.gitignore
+++ b/ACE/tests/.gitignore
@@ -272,3 +272,7 @@
 /XtAthenaReactor_Test
 /XtMotifReactor_Test
 /XtReactor_Test
+/Compiler_Features_36_Test
+/Compiler_Features_37_Test
+/Compiler_Features_38_Test
+/SOCK_Acceptor_Test

--- a/ACE/tests/Vector_Test.cpp
+++ b/ACE/tests/Vector_Test.cpp
@@ -9,10 +9,9 @@
  */
 //=============================================================================
 
+#include <algorithm>
 
 #include "test_config.h"
-
-
 
 #include "ace/Vector_T.h"
 
@@ -156,6 +155,34 @@ int run_main (int, ACE_TCHAR *[])
   v1.swap (v2);
   if (v2.size () != 3)
     ACE_ERROR ((LM_ERROR, ACE_TEXT ("v2's size should be 3\n")));
+
+  // Assert that vector standard iterators work
+  {
+    VECTOR vector;
+    const size_t size = 200;
+    const size_t offset = 5;
+
+    ACE_TEST_ASSERT (vector.begin () == vector.end ());
+
+    size_t i;
+    for (i = 0; i < size; i++)
+      {
+        vector.push_back (i + offset);
+      }
+
+    i = 0;
+    for (VECTOR::iterator it = vector.begin (); it != vector.end (); ++it)
+      {
+        ACE_TEST_ASSERT (*it == i++ + offset);
+      }
+
+    std::reverse (vector.begin (), vector.end());
+    i = size - 1;
+    for (VECTOR::iterator it = vector.begin (); it != vector.end (); ++it)
+      {
+        ACE_TEST_ASSERT (*it == i-- + offset);
+      }
+  }
 
   ACE_END_TEST;
 


### PR DESCRIPTION
It was based on the the base array, not the actual elements in the array.

This is an example program that would fail:
```C++
#include <ace/Vector_T.h>
typedef ACE_Vector<int> Vector;
int main() {
  Vector v;
  for (Vector::iterator i = v.begin(); i != v.end(); ++i) {
    return 1;
  }
  return 0;
}
```