### PR TITLE
tao_idl: pass unknown options to backend to process

### DIFF
--- a/TAO/TAO_IDL/driver/drv_args.cpp
+++ b/TAO/TAO_IDL/driver/drv_args.cpp
@@ -705,10 +705,6 @@ process_long_option(long ac, char **av, long &i)
     }
   else
     {
-      ACE_DEBUG ((LM_ERROR,
-        ACE_TEXT ("Unknown long option: %C\n"),
-        long_option
-        ));
-      idl_global->parse_args_exit (1);
+      be_global->parse_args (i, av);
     }
 }


### PR DESCRIPTION
Long options were added in #723 but unknown options were not being passed to the backend to give it a chance to process them.

To fix a problem with CIAO passing an undocumented long option to opendds_idl.