### PR TITLE
Support IDL output in places other than the IDL file location

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,10 @@
 USER VISIBLE CHANGES BETWEEN ACE-6.5.3 and ACE-6.5.4
 ====================================================
 
+. Fix ACE_Vector::end(), which now correctly
+  represents the end of the elements of the vector
+  instead of the end of the base array.
+
 USER VISIBLE CHANGES BETWEEN ACE-6.5.2 and ACE-6.5.3
 ====================================================
 

--- a/TAO/MPC/config/taobaseidldefaults.mpb
+++ b/TAO/MPC/config/taobaseidldefaults.mpb
@@ -16,6 +16,7 @@ project: build_files {
     libpath              = $(ACE_ROOT)/lib
     inputext             = .idl
     keyword idlflags     = commandflags
+    output_follows_input = 0
 
     optional(header_outputext) {
       commandflags(!-Sch || !-Ssh || -GC) = .h, .hpp, .hxx, .hh

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -7,8 +7,30 @@ USER VISIBLE CHANGES BETWEEN TAO-2.5.3 and TAO-2.5.4
 
 . The TAO_IDL frontend library now parses all IDL4
   annotation-related syntax: using and defining annotations.
-  Use the tao_idl command-line options --idl-version and 
+  Use the tao_idl command-line options --idl-version and
   --unknown-annotations to control annotation parsing.
+  Documentation on this feature is located in
+  TAO/TAO_IDL/docs/annotations.md.
+
+. TAO_IDL now will return an error status code when
+  passing an invalid command line argument.
+  Backends will have to support this behavior
+  explicitly, see TAO/TAO_IDL/include/idl_defines.h
+  for details.
+  TAO_IDL also accepts new options such as -h,
+  --help, --version, and --syntax-only, the latter
+  of which won't generate any files, just check
+  syntax of the IDL file(s).
+  See tao_idl -h for details.
+
+. When using IDL_Files in MPC, generated files will
+  now be placed in the current directory by default,
+  instead of the directory of the IDL file.
+  Use
+    idlflags += -o <IDL_FILE_DIR>
+    gendir = <IDL_FILE_DIR>
+  to output generated files to where the IDL file
+  is.
 
 USER VISIBLE CHANGES BETWEEN TAO-2.5.2 and TAO-2.5.3
 ====================================================

--- a/TAO/orbsvcs/orbsvcs/HTIOP.mpc
+++ b/TAO/orbsvcs/orbsvcs/HTIOP.mpc
@@ -15,6 +15,7 @@ project : htbp, orbsvcslib, orbsvcs_output, install, tao_versioning_idl_defaults
     idlflags += -Sci -Gp -Gd -Sa -Sorb \
                 -o HTIOP
     idlflags -= -St
+    gendir = HTIOP
     HTIOP/htiop_endpoints.pidl
   }
 

--- a/TAO/orbsvcs/orbsvcs/SSLIOP.mpc
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP.mpc
@@ -58,6 +58,7 @@ project(SSLIOP) : orbsvcslib, orbsvcs_output, install, security, ssl, pi_server,
     idlflags += -Sci -Gp -Gd -Sa -Sorb \
                 -o SSLIOP
     idlflags -= -St
+    gendir = SSLIOP
     SSLIOP/ssl_endpoints.pidl
   }
 }


### PR DESCRIPTION
Using `output_follows_input = 0`, set IDL output location to be the current directory when using `IDL_Files` in MPC.