### PR TITLE
Fix ACE_Mem_Addr::get_host_addr by getting external address.

### DIFF
--- a/ACE/ace/MEM_Addr.inl
+++ b/ACE/ace/MEM_Addr.inl
@@ -4,8 +4,7 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-// Set the port number.
-
+/// Set the port number.
 ACE_INLINE void
 ACE_MEM_Addr::set_port_number (u_short port_number,
                                 int encode)
@@ -31,8 +30,7 @@ ACE_MEM_Addr::set (const ACE_TCHAR port_number[])
   return this->string_to_addr (port_number);
 }
 
-// Return the port number.
-
+/// Return the port number.
 ACE_INLINE u_short
 ACE_MEM_Addr::get_port_number (void) const
 {
@@ -40,8 +38,7 @@ ACE_MEM_Addr::get_port_number (void) const
   return this->internal_.get_port_number ();
 }
 
-// Return the "dotted decimal" external address.
-
+/// Return the "dotted decimal" external address.
 ACE_INLINE const char *
 ACE_MEM_Addr::get_host_addr (void) const
 {
@@ -49,8 +46,7 @@ ACE_MEM_Addr::get_host_addr (void) const
   return this->external_.get_host_addr ();
 }
 
-// Return the 4-byte IP address, converting it into host byte order.
-
+/// Return the 4-byte IP address, converting it into host byte order.
 ACE_INLINE ACE_UINT32
 ACE_MEM_Addr::get_ip_address (void) const
 {
@@ -70,8 +66,7 @@ ACE_MEM_Addr::get_remote_addr (void) const
   return this->external_;
 }
 
-// Compare two addresses for equality.
-
+/// Compare two addresses for equality.
 ACE_INLINE bool
 ACE_MEM_Addr::operator == (const ACE_MEM_Addr &sap) const
 {
@@ -89,8 +84,7 @@ ACE_MEM_Addr::operator == (const ACE_INET_Addr &sap) const
   return this->external_ == sap;
 }
 
-// Compare two addresses for inequality.
-
+/// Compare two addresses for inequality.
 ACE_INLINE bool
 ACE_MEM_Addr::operator != (const ACE_MEM_Addr &sap) const
 {

--- a/ACE/ace/MEM_Addr.inl
+++ b/ACE/ace/MEM_Addr.inl
@@ -40,13 +40,13 @@ ACE_MEM_Addr::get_port_number (void) const
   return this->internal_.get_port_number ();
 }
 
-// Return the dotted Internet address.
+// Return the "dotted decimal" external address.
 
 ACE_INLINE const char *
 ACE_MEM_Addr::get_host_addr (void) const
 {
   ACE_TRACE ("ACE_MEM_Addr::get_host_addr");
-  return this->internal_.get_host_addr ();
+  return this->external_.get_host_addr ();
 }
 
 // Return the 4-byte IP address, converting it into host byte order.


### PR DESCRIPTION
The comment of ACE_Mem_Addr::get_host_addr definition:

https://github.com/DOCGroup/ACE_TAO/blob/master/ACE/ace/MEM_Addr.h#L108