### PR TITLE
Fix ACE_DLL_Manager error info

### DIFF
--- a/ACE/ace/DLL_Manager.cpp
+++ b/ACE/ace/DLL_Manager.cpp
@@ -148,7 +148,7 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
               // mask it.
               // @TODO: If we've found our DLL _and_ it's
               // broken, should we continue at all?
-              if ((errno != 0) && (errno != ENOENT) && (errors || ACE::debug ()))
+              if ((errno != ENOENT) && (errors || ACE::debug ()))
                 {
                   ACE_TString errtmp;
                   if (errors)
@@ -208,7 +208,7 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
                   //
                   // @TODO: If we've found our DLL _and_ it's broken,
                   // should we continue at all?
-                  if ((errno != 0) && (errno != ENOENT) && (errors || ACE::debug ()))
+                  if ((errno != ENOENT) && (errors || ACE::debug ()))
                     {
                       ACE_TString errtmp;
                       if (errors)


### PR DESCRIPTION
Fix ACE_DLL_Manager without error info when loading a shared object with undefined symbol. 