### PR TITLE
Let ACE_MEM_Connector timeout parameters const.

### DIFF
--- a/ACE/ace/MEM_Connector.cpp
+++ b/ACE/ace/MEM_Connector.cpp
@@ -32,7 +32,7 @@ ACE_MEM_Connector::ACE_MEM_Connector (void)
 // Establish a connection.
 ACE_MEM_Connector::ACE_MEM_Connector (ACE_MEM_Stream &new_stream,
                                       const ACE_INET_Addr &remote_sap,
-                                      ACE_Time_Value *timeout,
+                                      const ACE_Time_Value *timeout,
                                       const ACE_Addr &local_sap,
                                       int reuse_addr,
                                       int flags,
@@ -55,7 +55,7 @@ ACE_MEM_Connector::ACE_MEM_Connector (ACE_MEM_Stream &new_stream,
 int
 ACE_MEM_Connector::connect (ACE_MEM_Stream &new_stream,
                             const ACE_INET_Addr &remote_sap,
-                            ACE_Time_Value *timeout,
+                            const ACE_Time_Value *timeout,
                             const ACE_Addr &local_sap,
                             int reuse_addr,
                             int flags,

--- a/ACE/ace/MEM_Connector.h
+++ b/ACE/ace/MEM_Connector.h
@@ -78,7 +78,7 @@ public:
    */
   ACE_MEM_Connector (ACE_MEM_Stream &new_stream,
                      const ACE_INET_Addr &remote_sap,
-                     ACE_Time_Value *timeout = 0,
+                     const ACE_Time_Value *timeout = 0,
                      const ACE_Addr &local_sap = ACE_Addr::sap_any,
                      int reuse_addr = 0,
                      int flags = 0,
@@ -127,7 +127,7 @@ public:
    */
   int connect (ACE_MEM_Stream &new_stream,
                const ACE_INET_Addr &remote_sap,
-               ACE_Time_Value *timeout = 0,
+               const ACE_Time_Value *timeout = 0,
                const ACE_Addr &local_sap = ACE_Addr::sap_any,
                int reuse_addr = 0,
                int flags = 0,


### PR DESCRIPTION
To keep consistent with ACE_SOCK_Connector similar member functions.