### PR TITLE
Removed ACE_NO_HEAP_CHECK macro because it is broken, see issue #733

### DIFF
--- a/ACE/ace/Global_Macros.h
+++ b/ACE/ace/Global_Macros.h
@@ -38,40 +38,6 @@
 #   define ACE_DB(X) X
 # endif /* ACE_NDEBUG */
 
-// ACE_NO_HEAP_CHECK macro can be used to suppress false report of
-// memory leaks. It turns off the built-in heap checking until the
-// block is left. The old state will then be restored Only used for
-// Win32 (in the moment).
-# if defined (ACE_WIN32)
-
-#   if defined (_DEBUG) && !defined (ACE_HAS_WINCE) && !defined (__BORLANDC__)
-# include /**/ <crtdbg.h>
-
-// Open versioned namespace, if enabled by the user.
-ACE_BEGIN_VERSIONED_NAMESPACE_DECL
-
-class ACE_Export ACE_No_Heap_Check
-{
-public:
-  ACE_No_Heap_Check (void)
-    : old_state (_CrtSetDbgFlag (_CRTDBG_REPORT_FLAG))
-  { _CrtSetDbgFlag (old_state & ~_CRTDBG_ALLOC_MEM_DF);}
-  ~ACE_No_Heap_Check (void) { _CrtSetDbgFlag (old_state);}
-private:
-  int old_state;
-};
-
-// Close versioned namespace, if enabled by the user.
-ACE_END_VERSIONED_NAMESPACE_DECL
-
-#     define ACE_NO_HEAP_CHECK ACE_No_Heap_Check ____no_heap;
-#   else /* !_DEBUG */
-#     define ACE_NO_HEAP_CHECK
-#   endif /* _DEBUG */
-# else /* !ACE_WIN32 */
-#   define ACE_NO_HEAP_CHECK
-# endif /* ACE_WIN32 */
-
 // Turn a number into a string.
 # define ACE_ITOA(X) #X
 

--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -479,14 +479,13 @@ ACE_Log_Msg::close (void)
          // unload of libACE, by a program not linked with libACE,
          // ACE_TSS_cleanup will be invoked after libACE has been unloaded.
          // See Bugzilla 2980 for lots of details.
-         ACE_Log_Msg *tss_log_msg = 0;
          void *temp = 0;
 
          // Get the tss_log_msg from thread-specific storage.
          if (ACE_Thread::getspecific (*(log_msg_tss_key ()), &temp) != -1
              && temp)
            {
-             tss_log_msg = static_cast <ACE_Log_Msg *> (temp);
+             ACE_Log_Msg *tss_log_msg = static_cast <ACE_Log_Msg *> (temp);
              // we haven't been cleaned up
              ACE_TSS_CLEANUP_NAME(tss_log_msg);
              if (ACE_Thread::setspecific(*(log_msg_tss_key()),

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -125,7 +125,6 @@ ACE_TSS_Emulation::tss_base (void* ts_storage[], u_int *ts_created)
 
       if (!key_created_)
         {
-          ACE_NO_HEAP_CHECK;
           if (ACE_OS::thr_keycreate_native (&native_tss_key_,
                                      &ACE_TSS_Emulation_cleanup) != 0)
             {
@@ -160,8 +159,6 @@ ACE_TSS_Emulation::tss_base (void* ts_storage[], u_int *ts_created)
       // storage array.
       if (ts_storage == 0)
         {
-          ACE_NO_HEAP_CHECK;
-
 #ifdef ACE_HAS_ALLOC_HOOKS
           const size_t n = ACE_TSS_THREAD_KEYS_MAX * sizeof (void *);
           ACE_Allocator *const alloc = ACE_Allocator::instance ();

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -595,7 +595,7 @@ public:
     USE,
     DESTROY
   };
-  TSS_Cleanup_Instance (Purpose purpose = USE);
+  explicit TSS_Cleanup_Instance (Purpose purpose = USE);
   ~TSS_Cleanup_Instance();
 
   bool valid();

--- a/ACE/ace/Service_Gestalt.cpp
+++ b/ACE/ace/Service_Gestalt.cpp
@@ -789,10 +789,6 @@ ACE_Service_Gestalt::process_directives_i (ACE_Svc_Conf_Param *param)
                 : param->source.directive));
 #endif
 
-  // AC 970827 Skip the heap check because yacc allocates a buffer
-  // here which will be reported as a memory leak for some reason.
-  ACE_NO_HEAP_CHECK
-
   // Were we called in the context of the current instance?
   ACE_ASSERT (this == param->config);
 


### PR DESCRIPTION
    * ACE/ace/Global_Macros.h:
    * ACE/ace/Log_Msg.cpp:
    * ACE/ace/OS_NS_Thread.cpp:
    * ACE/ace/Service_Gestalt.cpp: