### PR TITLE
Support instantiating ACE_Arg_Shifter_T<char> in wchar builds.

### DIFF
--- a/ACE/ace/Arg_Shifter.cpp
+++ b/ACE/ace/Arg_Shifter.cpp
@@ -130,33 +130,20 @@ template <typename CHAR_TYPE>
 int
 ACE_Arg_Shifter_T<CHAR_TYPE>::cur_arg_strncasecmp (const CHAR_TYPE *flag)
 {
-  // Check for a current argument
-  if (this->is_anything_left())
-    {
-      size_t const flag_length = ACE_OS::strlen (flag);
+  if (!this->is_anything_left ())
+    return -1;
 
-      // Check for presence of the flag
-      if (ACE_OS::strncasecmp(this->temp_[current_index_],
-                              flag,
-                              flag_length) == 0)
-        {
-          if (ACE_OS::strlen(temp_[current_index_]) == flag_length)
-            {
-              // match and lengths are equal
-              return 0;
-            }
-          else
-            {
-              // matches, with more info to boot!
-              size_t const remaining = ACE_OS::strspn
-                (this->temp_[current_index_] + flag_length,
-                ACE_TEXT (" ")) + flag_length;
-              return static_cast<int> (remaining);
-            }
-        }
-    }
-  // failure
-  return -1;
+  const size_t flag_length = ACE_OS::strlen (flag);
+  const CHAR_TYPE *arg = this->temp_[this->current_index_];
+
+  if (ACE_OS::strncasecmp (arg, flag, flag_length) != 0)
+    return -1;
+
+  const size_t arg_length = ACE_OS::strlen (arg);
+  size_t remaining = flag_length;
+  while (remaining < arg_length && arg[remaining] == CHAR_TYPE (' '))
+    ++remaining;
+  return (arg_length == flag_length) ? 0 : static_cast<int> (remaining);
 }
 
 template <typename CHAR_TYPE>

--- a/ACE/ace/Arg_Shifter.h
+++ b/ACE/ace/Arg_Shifter.h
@@ -75,13 +75,13 @@ public:
    *    (the default) the object will allocate and free the temporary
    *    vector transparently.
    */
-  ACE_Arg_Shifter_T (int& argc,
+  ACE_Arg_Shifter_T (int &argc,
                      const CHAR_TYPE **argv,
                      const CHAR_TYPE **temp = 0);
 
   /// Same behavior as the preceding constructor, but without the
   /// "const" qualifier.
-  ACE_Arg_Shifter_T (int& argc,
+  ACE_Arg_Shifter_T (int &argc,
                      CHAR_TYPE **argv,
                      CHAR_TYPE **temp = 0);
 
@@ -98,12 +98,12 @@ public:
    *
    * Safe to call without checking that a current arg exists
    *
-   * In the following examples, a pointer to the char* "value" is ret
+   * In the following examples, a pointer to the char* "value" is returned
    *
    * eg: main -foobar value, main -FooBar value
    *     main -FOOBARvalue
    *
-   *     all of the above will all match the @a flag == -FooBar
+   *     all of the above will match the @a flag == -FooBar
    *     and will return a char* to "value"
    *
    *     main -foobar 4 would succeed and return a char* to "4"
@@ -123,7 +123,7 @@ public:
    * together '-foobarflagVALUE', the flag is NOT consumed
    * and the cur arg is left pointing to the entire flag/value pair
    */
-  const CHAR_TYPE *get_the_parameter (const CHAR_TYPE* flag);
+  const CHAR_TYPE *get_the_parameter (const CHAR_TYPE *flag);
 
   /**
    * Check if the current argument matches (case insensitive) @a flag
@@ -134,7 +134,7 @@ public:
    * 0 is returned.
    *
    *     ie: when current_arg = "-foobar" or "-FOOBAR" or "-fooBAR"
-   *         this->cur_arg_strncasecmp ("-FooBar);
+   *         this->cur_arg_strncasecmp ("-FooBar");
    *         will return 0
    *
    * ------------------------------------------------------------
@@ -142,10 +142,18 @@ public:
    * Case B: Perfect Match (case insensitive) but the current_arg
    * is longer than the flag. Returns a number equal to the index
    * in the char* indicating the start of the extra characters
+   * after any initial spaces (see below).
    *
    *     ie: when current_arg = "-foobar98023"
-   *         this->cur_arg_strncasecmp ("-FooBar);
+   *         this->cur_arg_strncasecmp ("-FooBar");
    *         will return 7
+   *
+   * Spaces separating the flag from its value (that are still part
+   * of the same argv element) are counted as part of the return value
+   *
+   *     ie: when current_arg = "-foobar 98023"
+   *         this->cur_arg_strncasecmp ("-FooBar");
+   *         will return 8
    *
    * Notice: this number will always be > 0
    *
@@ -180,16 +188,16 @@ public:
 
 private:
   /// Copy Constructor should not be used.
-  ACE_UNIMPLEMENTED_FUNC (ACE_Arg_Shifter_T (const ACE_Arg_Shifter_T<CHAR_TYPE>&))
+  ACE_UNIMPLEMENTED_FUNC (ACE_Arg_Shifter_T (const ACE_Arg_Shifter_T<CHAR_TYPE> &))
 
   /// Assignment '=' operator should not be used.
-  ACE_UNIMPLEMENTED_FUNC (ACE_Arg_Shifter_T operator= (const ACE_Arg_Shifter_T<CHAR_TYPE>&))
+  ACE_UNIMPLEMENTED_FUNC (ACE_Arg_Shifter_T operator= (const ACE_Arg_Shifter_T<CHAR_TYPE> &))
 
   /// Refactor the constructor logic.
   void init (void);
 
   /// The size of the argument vector.
-  int& argc_;
+  int &argc_;
 
   /// The size of argv_.
   int total_size_;

--- a/ACE/tests/Arg_Shifter_Test.cpp
+++ b/ACE/tests/Arg_Shifter_Test.cpp
@@ -68,6 +68,20 @@ run_main (int, ACE_TCHAR *[])
       ACE_ERROR_RETURN ((LM_ERROR, ACE_TEXT ("argshifter 2 test failed\n")), -1);
     }
 
+#ifdef ACE_USES_WCHAR
+  const char *args3[] = {
+    "-ORBDebugLevel 0",
+    "-o",
+    "server.ior",
+  };
+  int argc3 = sizeof args3 / sizeof args3[0];
+  ACE_Arg_Shifter_T<char> arg_shifter_char (argc3, args3);
+  if (15 != arg_shifter_char.cur_arg_strncasecmp ("-ORBDebugLevel"))
+    {
+      ACE_ERROR_RETURN ((LM_ERROR, ACE_TEXT ("argshifter<char> failed\n")), -1);
+    }
+#endif
+
   ACE_END_TEST;
   return 0;
 }


### PR DESCRIPTION
Also cleaned up some comments and style guidelines violations.