### PR TITLE
Fix C++11 related warnings given by newer gcc versions

### DIFF
--- a/ACE/ace/OS_NS_unistd.cpp
+++ b/ACE/ace/OS_NS_unistd.cpp
@@ -388,7 +388,7 @@ ACE_OS::fork_exec (ACE_TCHAR *argv[])
               ACE_OS::exit (errno);
             }
 #   endif /* ACE_HAS_WCHAR */
-
+          return result;
         default:
           // Server process.  The fork succeeded.
           return result;

--- a/ACE/netsvcs/lib/Client_Logging_Handler.cpp
+++ b/ACE/netsvcs/lib/Client_Logging_Handler.cpp
@@ -109,7 +109,11 @@ ACE_Client_Logging_Handler::handle_input (ACE_HANDLE handle)
                   ACE_Message_Block (ACE_DEFAULT_CDR_BUFSIZE),
                   -1);
 
+#if defined (ACE_HAS_CPP11)
+  std::unique_ptr <ACE_Message_Block> header (header_p);
+#else
   auto_ptr <ACE_Message_Block> header (header_p);
+#endif /* ACE_HAS_CPP11 */
 
   // Align the Message Block for a CDR stream
   ACE_CDR::mb_align (header.get ());
@@ -217,7 +221,11 @@ ACE_Client_Logging_Handler::handle_input (ACE_HANDLE handle)
   ACE_NEW_RETURN (payload_p,
                   ACE_Message_Block (length),
                   -1);
+#if defined (ACE_HAS_CPP11)
+  std::unique_ptr <ACE_Message_Block> payload (payload_p);
+#else
   auto_ptr <ACE_Message_Block> payload (payload_p);
+#endif /* ACE_HAS_CPP11 */
 
   // Ensure there's sufficient room for log record payload.
   ACE_CDR::grow (payload.get (), 8 + ACE_CDR::MAX_ALIGNMENT + length);

--- a/ACE/netsvcs/lib/Name_Handler.cpp
+++ b/ACE/netsvcs/lib/Name_Handler.cpp
@@ -265,9 +265,9 @@ ACE_Name_Handler::recv_request (void)
   switch (n)
     {
     case -1:
-      /* FALLTHROUGH */
       ACE_DEBUG ((LM_DEBUG,
                   ACE_TEXT ("****************** recv_request returned -1\n")));
+      /* FALLTHROUGH */
     default:
       ACE_ERROR ((LM_ERROR,
                   ACE_TEXT ("%p got %d bytes, expected %d bytes\n"),

--- a/ACE/netsvcs/lib/Server_Logging_Handler_T.cpp
+++ b/ACE/netsvcs/lib/Server_Logging_Handler_T.cpp
@@ -65,7 +65,11 @@ ACE_Server_Logging_Handler_T<ACE_PEER_STREAM_2, COUNTER, ACE_SYNCH_USE, LMR>::ha
                   ACE_Message_Block (ACE_DEFAULT_CDR_BUFSIZE),
                   -1);
 
+#if defined (ACE_HAS_CPP11)
+  std::unique_ptr <ACE_Message_Block> header (header_p);
+#else
   auto_ptr <ACE_Message_Block> header (header_p);
+#endif /* ACE_HAS_CPP11 */
 
   // Align the Message Block for a CDR stream
   ACE_CDR::mb_align (header.get ());
@@ -122,7 +126,11 @@ ACE_Server_Logging_Handler_T<ACE_PEER_STREAM_2, COUNTER, ACE_SYNCH_USE, LMR>::ha
   ACE_NEW_RETURN (payload_p,
                   ACE_Message_Block (length),
                   -1);
+#if defined (ACE_HAS_CPP11)
+  std::unique_ptr <ACE_Message_Block> payload (payload_p);
+#else
   auto_ptr <ACE_Message_Block> payload (payload_p);
+#endif /* ACE_HAS_CPP11 */
 
   // Ensure there's sufficient room for log record payload.
   ACE_CDR::grow (payload.get (), 8 + ACE_CDR::MAX_ALIGNMENT + length);

--- a/ACE/netsvcs/lib/TS_Clerk_Handler.cpp
+++ b/ACE/netsvcs/lib/TS_Clerk_Handler.cpp
@@ -245,8 +245,8 @@ ACE_TS_Clerk_Handler::recv_reply (ACE_Time_Request &reply)
       switch (n)
         {
         case -1:
-          // FALLTHROUGH
           ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("****************** recv_reply returned -1\n")));
+          // FALLTHROUGH
         default:
           ACE_ERROR ((LM_ERROR, ACE_TEXT ("%p got %d bytes, expected %d bytes\n"),
                       ACE_TEXT ("recv failed"), n, bytes_expected));

--- a/ACE/netsvcs/lib/TS_Server_Handler.cpp
+++ b/ACE/netsvcs/lib/TS_Server_Handler.cpp
@@ -192,19 +192,19 @@ ACE_TS_Server_Handler::dispatch (void)
 ACE_TS_Server_Handler::recv_request (void)
 {
   ACE_TRACE ("ACE_TS_Server_Handler::recv_request");
-  ssize_t bytes_expected = this->time_request_.size ();
+  ssize_t const bytes_expected = this->time_request_.size ();
 
   // Since Time_Request messages are fixed size, read the entire
   // message in one go.
-  ssize_t n = this->peer ().recv ((void *) &this->time_request_, bytes_expected);
+  ssize_t const n = this->peer ().recv ((void *) &this->time_request_, bytes_expected);
   if (n != bytes_expected)
     {
       switch (n)
         {
         case -1:
-          /* FALLTHROUGH */
           ACE_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("****************** recv_request returned -1\n")));
+          /* FALLTHROUGH */
         default:
           ACE_ERROR ((LM_ERROR,
                       ACE_TEXT ("%p got %d bytes, expected %d bytes\n"),


### PR DESCRIPTION
    * ACE/netsvcs/lib/Client_Logging_Handler.cpp:
    * ACE/netsvcs/lib/Name_Handler.cpp:
    * ACE/netsvcs/lib/Server_Logging_Handler_T.cpp:
    * ACE/netsvcs/lib/TS_Clerk_Handler.cpp:
    * ACE/netsvcs/lib/TS_Server_Handler.cpp: