### PR TITLE
Try to Prevent Usage of System SSL on Android

### DIFF
--- a/ACE/ACE-INSTALL.html
+++ b/ACE/ACE-INSTALL.html
@@ -1668,7 +1668,7 @@ defined by two things:</p>
     <p><b>
       It should be noted that starting in August 2019, the Google Play
       Store will require new apps to have 64-bit libraries if they have native
-      libraries. 32-bit native libraries will still supported but they must also
+      libraries. 32-bit native libraries will still be supported but they must also
       have 64-bit libraries. Look up any restrictions that may affect
       apps you want to publish on the Play Store, including minimum API
       level.
@@ -1809,6 +1809,44 @@ directory.  The native application can also be uploaded using the Software
 Development Kit's ADB tool.  This method requires uploading the native
 application to a directory that allows execution and having any output
 directed to a writable directory.</p>
+
+<h3>Logging</h3>
+<p>
+On Android, <code>ACE_Log_Msg</code> (and therefore <code>ACE_DEBUG</code> and
+<code>ACE_ERROR</code>) uses Android's logging system (aka Logcat) by default
+in addition to <code>stderr</code> because <code>stdout</code> and
+<code>stderr</code> are discarded under normal circumstances. To disable this
+at runtime, run:
+</p>
+
+<p class="indent">
+<code>ACE_LOG_MSG-&gt;clr_flags (ACE_Log_Msg::SYSLOG);</code>
+</p>
+
+<p>To disable this at compile time include these lines in <code>config.h</code>:</p>
+
+<code class="indent">
+#define ACE_DEFAULT_LOG_FLAGS ACE_Log_Msg::STDERR<br>
+</code>
+<code class="indent">
+#define ACE_DEFAULT_LOG_BACKEND_FLAGS 0
+</code>
+
+<h3>OpenSSL</h3>
+<p>
+  Depending on the features of ACE, TAO, or other software desired, you might need
+  OpenSSL. On Android, OpenSSL isn't part of the NDK Library and Android
+  preloads the system SSL library (either OpenSSL or BoringSSL) for the Java
+  Android API. This means OpenSSL <b>MUST</b> be statically linked to avoid
+  conflicts with the almost certianly incompatible system SSL library.
+
+  To build OpenSSL for Android, please read <code>NOTES.ANDROID</code> that comes
+  with OpenSSL's source code. The static libraries will used if the shared
+  libraries are not found. This can be accomplished by either disabling the
+  generation of the shared libraries by passing <code>no-shared</code> to
+  OpenSSL's <code>Configure</code> script or just deleting the so files after
+  building OpenSSL.
+</p>
 
 <hr>
 <h1><a name="svcsinstall">Building and Installing ACE Network Services</a></h1>

--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -4,14 +4,19 @@ USER VISIBLE CHANGES BETWEEN ACE-6.5.4 and ACE-6.5.5
 . Fixed several broken links due to the removal of
   Douglas Schmidt website at WashU
 
-. On Android, ACE_Log_Msg (and therefore ACE_DEBUG and ACE_ERROR) now uses
-  Android's logging system (aka Logcat) by default in addition to stderr
-  because stdout and stderr are discarded under normal circumstances.
-  To disable this at runtime, run:
-    ACE_LOG_MSG->clr_flags (ACE_Log_Msg::SYSLOG)
-  To disable this at compile time include these lines in config.h:
-    #define ACE_DEFAULT_LOG_FLAGS ACE_Log_Msg::STDERR
-    #define ACE_DEFAULT_LOG_BACKEND_FLAGS 0
+. On Android:
+
+  . ACE_Log_Msg (and therefore ACE_DEBUG and ACE_ERROR) now uses
+    Android's logging system (aka Logcat) by default in addition to stderr
+    because stdout and stderr are discarded under normal circumstances.
+    To disable this at runtime, run:
+      ACE_LOG_MSG->clr_flags (ACE_Log_Msg::SYSLOG)
+    To disable this at compile time include these lines in config.h:
+      #define ACE_DEFAULT_LOG_FLAGS ACE_Log_Msg::STDERR
+      #define ACE_DEFAULT_LOG_BACKEND_FLAGS 0
+
+  . When statically linking to OpenSSL, prevent usage of the preloaded and
+    unpredictable system SSL library when using ace_openssl.
 
 USER VISIBLE CHANGES BETWEEN ACE-6.5.3 and ACE-6.5.4
 ====================================================

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -67,6 +67,8 @@
 #  define ACE_LACKS_GETHOSTENT
 #  define ACE_LACKS_LOCALECONV
 #  define ACE_LACKS_WCHAR_STD_NAMESPACE
+// Used in tests/Sequence_Unit_Tests/string_sequence_tester.hpp
+#  define TAO_LACKS_WCHAR_CXX_STDLIB
 #endif
 
 #if ACE_ANDROID_NDK_LESS_THAN(12, 1) || __ANDROID_API__ < 18
@@ -157,8 +159,6 @@
 
 // Needed to differentiate between libc 5 and libc 6 (aka glibc).
 #include <features.h>
-
-#define ACE_HAS_PTHREADS_UNIX98_EXT
 
 #include "ace/config-posix.h"
 

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -1,16 +1,13 @@
 # -*- Makefile -*-
 
-# This file should allow ACE to be built for Android 2.3.1 (API Level 9)
-# or greater, by cross compiling on Linux.
+# This file allows ACE and applications using ACE GNU Makefiles to be built for
+# Android by cross compiling on Linux.
 
 # We always include config-android.h on Android platforms.
 ACE_PLATFORM_CONFIG ?= config-android.h
 
 # Common Linux Functionality
 include $(ACE_ROOT)/include/makeinclude/platform_linux_common.GNU
-
-# The standalone gcc compilers in NDK r6-r9 have issues with the visibility.
-no_hidden_visibility ?= 1
 
 # as of NDK r6 inlining is required
 inline ?= 1
@@ -165,12 +162,12 @@ endif
 OCFLAGS ?= -O3
 OCCFLAGS ?= -O3
 
-# Added line below to support "Executable Shared Object" files (as
-# needed by the service configurator).
-# Marius Kjeldahl <mariusk@sn.no, marius@funcom.com>
-ifeq ($(threads),1)
-    ESOBUILD = $(COMPILEESO.cc) $(PIC) -shared -o $(VSHDIR)$*.so $<
-    ifndef PRELIB
-       PRELIB = @true
-    endif # ! PRELIB
+# Android preloads the (almost certainly incompatible) system SSL library
+# (either OpenSSL or BoringSSL) for the Java Android API, so we must:
+#   1. Statically link OpenSSL to this library
+#   2. Keep our OpenSSL symbols internal
+# Number 1 is described in ACE-INSTALL.html.
+# We are doing number 2 here.
+ifeq ($(ssl),1)
+  PLATFORM_SSL_LDFLAGS += --exclude-libs libcrypto.a,libssl.a
 endif

--- a/ACE/include/makeinclude/platform_linux.GNU
+++ b/ACE/include/makeinclude/platform_linux.GNU
@@ -97,16 +97,6 @@ else
   OCCFLAGS ?= -O3
 endif
 
-# Added line below to support "Executable Shared Object" files (as
-# needed by the service configurator).
-# Marius Kjeldahl <mariusk@sn.no, marius@funcom.com>
-ifeq ($(threads),1)
-    ESOBUILD = $(COMPILEESO.cc) $(PIC) -shared -o $(VSHDIR)$*.so $<
-    ifndef PRELIB
-       PRELIB = @true
-    endif # ! PRELIB
-endif
-
 #### GNU gas has a string limit of 4096 characters.  On Alphas,
 #### builds will fail due to running over that limit.  There are
 #### at least two workarounds:

--- a/ACE/include/makeinclude/platform_linux_common.GNU
+++ b/ACE/include/makeinclude/platform_linux_common.GNU
@@ -119,3 +119,13 @@ PIC      = -fPIC
 AR      ?= ar
 ARFLAGS ?= rsuv
 RANLIB   = @true
+
+# Added line below to support "Executable Shared Object" files (as
+# needed by the service configurator).
+# Marius Kjeldahl <mariusk@sn.no, marius@funcom.com>
+ifeq ($(threads),1)
+    ESOBUILD = $(COMPILEESO.cc) $(PIC) -shared -o $(VSHDIR)$*.so $<
+    ifndef PRELIB
+       PRELIB = @true
+    endif # ! PRELIB
+endif


### PR DESCRIPTION
In a regular Android app, the system has preloaded the system SSL library (which can be any version of OpenSSL or BoringSSL) for use in the Android API. Even if OpenSSL is statically linked, the symbols that have already been loaded will take precedence and will be used instead. This change to `ace_openssl` on Android requires that OpenSSL symbols be kept hidden from the global linking, causing the symbols to be fixed to the OpenSSL library being included.