### PR TITLE
SOCK_Dgram_Test: remove hardcoded buffer length

### DIFF
--- a/ACE/tests/SOCK_Dgram_Test.cpp
+++ b/ACE/tests/SOCK_Dgram_Test.cpp
@@ -140,7 +140,7 @@ client (void *arg)
       iovec iov[1];
       // Some platforms define iov_base as char* instead of void*.
       iov[0].iov_base = (char *)buf;
-      iov[0].iov_len = 20;
+      iov[0].iov_len = sizeof buf;
 
       ssize_t rcv_cnt = cli_dgram.recv (iov,
                                         1,


### PR DESCRIPTION
Fixes wchar