### PR TITLE
Fix Android Linking Errors

### DIFF
--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -209,13 +209,6 @@
   // this must appear before its #include.
 # define ACE_HAS_STRING_CLASS
 # include "ace/config-g++-common.h"
-
-# define ACE_HAS_CUSTOM_EXPORT_MACROS
-# define ACE_Proper_Export_Flag
-# define ACE_IMPORT_SINGLETON_DECLARATION(T) __extension__ extern template class T
-# define ACE_IMPORT_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK) __extension__ extern template class SINGLETON_TYPE<CLASS, LOCK>;
-# define ACE_HAS_EXPLICIT_TEMPLATE_CLASS_INSTANTIATION
-
 #elif defined (__GNUC__)
 /**
  * GNU C compiler.


### PR DESCRIPTION
Fixes linking errors caused by enabling hidden visibility in #858 which I unfortunately must have done without testing. This does build on NDK 19 and I'm [testing it OpenDDS-Android as well](https://travis-ci.org/iguessthislldo/OpenDDS-Android/builds/506532752).

I changed it to match `config-linux.h` below and let `config-g++-common.h` do its job. For me this confirms the fact that there should be a `config-linux-common.h` like there is a `platform_linux_common.GNU`. I would like to do that in the future but I need to sort out what's necessary to keep for Android and what is leftover from the `config-linux.h` when they diverged.