### PR TITLE
Linux: Refactor config-linux.h and use gettid() for %t for Log_Msg

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,8 +1,8 @@
 USER VISIBLE CHANGES BETWEEN ACE-6.5.5 and ACE-6.5.6
 ====================================================
 
-. Shorten output from `%t` (current thread id) for ACE_Log_Msg on non-Windows
-  systems
+. On Linux, the ACE_Log_Msg format specifier `%t` is now replaced with the
+  system thread id provided by gettid(), instead of the much longer pthread id.
 
 USER VISIBLE CHANGES BETWEEN ACE-6.5.4 and ACE-6.5.5
 ====================================================

--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,9 @@
 USER VISIBLE CHANGES BETWEEN ACE-6.5.5 and ACE-6.5.6
 ====================================================
 
+. Shorten output from `%t` (current thread id) for ACE_Log_Msg on non-Windows
+  systems
+
 USER VISIBLE CHANGES BETWEEN ACE-6.5.4 and ACE-6.5.5
 ====================================================
 

--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -1795,13 +1795,15 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
 
 #  ifdef ACE_HAS_GETTID
 #    define ACE_LOG_MSG_GET_THREAD_ID ACE_OS::thr_gettid
+#    define ACE_LOG_MSG_GET_THREAD_ID_BUFFER_SIZE 8
 #  else
 #    define ACE_LOG_MSG_GET_THREAD_ID ACE_OS::thr_id
+#    define ACE_LOG_MSG_GET_THREAD_ID_BUFFER_SIZE 32
 #  endif
 
 #  if defined ACE_USES_WCHAR
                   {
-                    char tid_buf[32] = {};
+                    char tid_buf[ACE_LOG_MSG_GET_THREAD_ID_BUFFER_SIZE] = {};
                     ACE_LOG_MSG_GET_THREAD_ID (tid_buf, sizeof tid_buf);
                     this_len = ACE_OS::strlen (tid_buf);
                     ACE_OS::strncpy (bp, ACE_TEXT_CHAR_TO_TCHAR (tid_buf),

--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -1791,16 +1791,25 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
                       ACE_OS::sprintf (bp,
                                        format,
                                        static_cast <unsigned> (ACE_Thread::self ()));
-#elif defined ACE_USES_WCHAR
+#else
+
+#  ifdef ACE_HAS_GETTID
+#    define ACE_LOG_MSG_GET_THREAD_ID ACE_OS::thr_gettid
+#  else
+#    define ACE_LOG_MSG_GET_THREAD_ID ACE_OS::thr_id
+#  endif
+
+#  if defined ACE_USES_WCHAR
                   {
                     char tid_buf[32] = {};
-                    ACE_OS::thr_id (tid_buf, sizeof tid_buf);
+                    ACE_LOG_MSG_GET_THREAD_ID (tid_buf, sizeof tid_buf);
                     this_len = ACE_OS::strlen (tid_buf);
                     ACE_OS::strncpy (bp, ACE_TEXT_CHAR_TO_TCHAR (tid_buf),
                                      bspace);
                   }
-#else
-                  this_len = ACE_OS::thr_id (bp, bspace);
+#  else
+                  this_len = ACE_LOG_MSG_GET_THREAD_ID (bp, bspace);
+#  endif /* ACE_USES_WCHAR */
 #endif /* ACE_WIN32 */
                   ACE_UPDATE_COUNT (bspace, this_len);
                   break;

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -4810,7 +4810,7 @@ ACE_OS::unique_name (const void *object,
 pid_t
 ACE_OS::thr_gettid ()
 {
-#if defined (ACE_LINUX) && defined (ACE_HAS_GETTID)
+#ifdef ACE_HAS_GETTID
   return syscall (SYS_gettid);
 #else
   ACE_NOTSUP_RETURN (-1);

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -17,7 +17,9 @@
 #include "ace/Thread_Mutex.h"
 #include "ace/Condition_Thread_Mutex.h"
 #include "ace/Guard_T.h"
-#include "ace/OS_NS_sys_resource.h"
+#ifdef ACE_HAS_GETTID
+#  include "ace/OS_NS_sys_resource.h" // syscall for gettid impl
+#endif
 
 extern "C" void
 ACE_MUTEX_LOCK_CLEANUP_ADAPTER_NAME (void *args)

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -4810,12 +4810,10 @@ ACE_OS::unique_name (const void *object,
 pid_t
 ACE_OS::thr_gettid ()
 {
-#if defined(ACE_LINUX) && defined(ACE_HAS_GETTID)
+#if defined (ACE_LINUX) && defined (ACE_HAS_GETTID)
   return syscall (SYS_gettid);
-#elif !defined(ACE_HAS_OPAQUE_PTHREAD_T)
-  return reinterpret_cast<pid_t> (ACE_OS::thr_self ());
 #else
-  return 0;
+  ACE_NOTSUP_RETURN (-1);
 #endif
 }
 

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -4812,8 +4812,10 @@ ACE_OS::thr_gettid ()
 {
 #if defined(ACE_LINUX) && defined(ACE_HAS_GETTID)
   return syscall (SYS_gettid);
-#else
+#elif !defined(ACE_HAS_OPAQUE_PTHREAD_T)
   return static_cast<pid_t> (ACE_OS::thr_self ());
+#else
+  return 0;
 #endif
 }
 

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -4813,7 +4813,7 @@ ACE_OS::thr_gettid ()
 #if defined(ACE_LINUX) && defined(ACE_HAS_GETTID)
   return syscall (SYS_gettid);
 #elif !defined(ACE_HAS_OPAQUE_PTHREAD_T)
-  return static_cast<pid_t> (ACE_OS::thr_self ());
+  return reinterpret_cast<pid_t> (ACE_OS::thr_self ());
 #else
   return 0;
 #endif

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -17,6 +17,7 @@
 #include "ace/Thread_Mutex.h"
 #include "ace/Condition_Thread_Mutex.h"
 #include "ace/Guard_T.h"
+#include "ace/OS_NS_sys_resource.h"
 
 extern "C" void
 ACE_MUTEX_LOCK_CLEANUP_ADAPTER_NAME (void *args)
@@ -4803,6 +4804,18 @@ ACE_OS::unique_name (const void *object,
   // <object>.
   ACE_OS::snprintf (name, length, ACE_TEXT ("%p%d"), object,
                     static_cast<int> (ACE_OS::getpid ()));
+}
+#endif
+
+#ifdef ACE_HAS_GETTID
+pid_t
+ACE_OS::thr_gettid ()
+{
+#  ifdef ACE_LINUX
+  return syscall (SYS_gettid);
+#  else
+#    error "No implementation for thr_gettid(), please disable ACE_HAS_GETTID"
+#  endif
 }
 #endif
 

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -4807,17 +4807,15 @@ ACE_OS::unique_name (const void *object,
 }
 #endif
 
-#ifdef ACE_HAS_GETTID
 pid_t
 ACE_OS::thr_gettid ()
 {
-#  ifdef ACE_LINUX
+#if defined(ACE_LINUX) && defined(ACE_HAS_GETTID)
   return syscall (SYS_gettid);
-#  else
-#    error "No implementation for thr_gettid(), please disable ACE_HAS_GETTID"
-#  endif
-}
+#else
+  return static_cast<pid_t> (ACE_OS::thr_self ());
 #endif
+}
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/OS_NS_Thread.h
+++ b/ACE/ace/OS_NS_Thread.h
@@ -1754,6 +1754,24 @@ namespace ACE_OS {
   ACE_NAMESPACE_INLINE_FUNCTION
   ssize_t thr_id (char buffer[], size_t buffer_length);
 
+#ifdef ACE_HAS_GETTID
+  /**
+   * Wrapper for pid_t gettid(). For systems that support it (only Linux as of
+   * writing), get the system-wide thread id (TID) for the current thread.
+   *
+   * These are similar to PIDs and, on x86 Linux at least, are much shorter
+   * than the what is returned from thr_id(), which is represents a address.
+   */
+  pid_t thr_gettid ();
+
+  /**
+   * Puts the string representation of pid_t thr_gettid() into the buffer and
+   * returns number of bytes added.
+   */
+  ACE_NAMESPACE_INLINE_FUNCTION
+  ssize_t thr_gettid (char buffer[], size_t buffer_length);
+#endif
+
   /// State is THR_CANCEL_ENABLE or THR_CANCEL_DISABLE
   ACE_NAMESPACE_INLINE_FUNCTION
   int thr_setcancelstate (int new_state, int *old_state);

--- a/ACE/ace/OS_NS_Thread.h
+++ b/ACE/ace/OS_NS_Thread.h
@@ -1755,7 +1755,7 @@ namespace ACE_OS {
   ssize_t thr_id (char buffer[], size_t buffer_length);
 
   /**
-   * For systems that support it (Only Linux as of writing), this is wrapper
+   * For systems that support it (Only Linux as of writing), this is a wrapper
    * for pid_t gettid().
    *
    * It returns the system-wide thread id (TID) for the current thread. These
@@ -1763,7 +1763,7 @@ namespace ACE_OS {
    * what is returned from thr_self(), which is an address.
    *
    * For older Linux (pre 2.4.11) and other systems that don't have gettid(),
-   * this returns thr_self().
+   * this uses ACE_NOTSUP_RETURN (-1).
    */
   pid_t thr_gettid ();
 

--- a/ACE/ace/OS_NS_Thread.h
+++ b/ACE/ace/OS_NS_Thread.h
@@ -1754,13 +1754,16 @@ namespace ACE_OS {
   ACE_NAMESPACE_INLINE_FUNCTION
   ssize_t thr_id (char buffer[], size_t buffer_length);
 
-#ifdef ACE_HAS_GETTID
   /**
-   * Wrapper for pid_t gettid(). For systems that support it (only Linux as of
-   * writing), get the system-wide thread id (TID) for the current thread.
+   * For systems that support it (Only Linux as of writing), this is wrapper
+   * for pid_t gettid().
    *
-   * These are similar to PIDs and, on x86 Linux at least, are much shorter
-   * than the what is returned from thr_id(), which is represents a address.
+   * It returns the system-wide thread id (TID) for the current thread. These
+   * are similar to PIDs and, for x86 Linux at least, are much shorter than
+   * what is returned from thr_self(), which is an address.
+   *
+   * For older Linux (pre 2.4.11) and other systems that don't have gettid(),
+   * this returns thr_self().
    */
   pid_t thr_gettid ();
 
@@ -1770,7 +1773,6 @@ namespace ACE_OS {
    */
   ACE_NAMESPACE_INLINE_FUNCTION
   ssize_t thr_gettid (char buffer[], size_t buffer_length);
-#endif
 
   /// State is THR_CANCEL_ENABLE or THR_CANCEL_DISABLE
   ACE_NAMESPACE_INLINE_FUNCTION

--- a/ACE/ace/OS_NS_Thread.inl
+++ b/ACE/ace/OS_NS_Thread.inl
@@ -3178,20 +3178,18 @@ ACE_OS::thr_id (char buffer[], size_t buffer_length)
 #else /* ACE_HAS_OPAQUE_PTHREAD_T */
   return ACE_OS::snprintf (buffer,
                            buffer_length,
-                           "%lx",
+                           "%lu",
                            (unsigned long) t_id);
 #endif /* ACE_HAS_OPAQUE_PTHREAD_T */
 #endif /* WIN32 */
 }
 
-#ifdef ACE_HAS_GETTID
 ACE_INLINE ssize_t
 ACE_OS::thr_gettid (char buffer[], size_t buffer_length)
 {
   return ACE_OS::snprintf (buffer, buffer_length, "%u",
     static_cast<unsigned> (ACE_OS::thr_gettid()));
 }
-#endif
 
 ACE_INLINE ACE_thread_t
 ACE_OS::thr_self (void)

--- a/ACE/ace/OS_NS_Thread.inl
+++ b/ACE/ace/OS_NS_Thread.inl
@@ -3187,8 +3187,8 @@ ACE_OS::thr_id (char buffer[], size_t buffer_length)
 ACE_INLINE ssize_t
 ACE_OS::thr_gettid (char buffer[], size_t buffer_length)
 {
-  return ACE_OS::snprintf (buffer, buffer_length, "%u",
-    static_cast<unsigned> (ACE_OS::thr_gettid()));
+  return ACE_OS::snprintf (buffer, buffer_length, "%d",
+    static_cast<int> (ACE_OS::thr_gettid ()));
 }
 
 ACE_INLINE ACE_thread_t

--- a/ACE/ace/OS_NS_Thread.inl
+++ b/ACE/ace/OS_NS_Thread.inl
@@ -3178,11 +3178,20 @@ ACE_OS::thr_id (char buffer[], size_t buffer_length)
 #else /* ACE_HAS_OPAQUE_PTHREAD_T */
   return ACE_OS::snprintf (buffer,
                            buffer_length,
-                           "%lu",
+                           "%lx",
                            (unsigned long) t_id);
 #endif /* ACE_HAS_OPAQUE_PTHREAD_T */
 #endif /* WIN32 */
 }
+
+#ifdef ACE_HAS_GETTID
+ACE_INLINE ssize_t
+ACE_OS::thr_gettid (char buffer[], size_t buffer_length)
+{
+  return ACE_OS::snprintf (buffer, buffer_length, "%u",
+    static_cast<unsigned> (ACE_OS::thr_gettid()));
+}
+#endif
 
 ACE_INLINE ACE_thread_t
 ACE_OS::thr_self (void)

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -94,6 +94,13 @@
 #  define ACE_LACKS_SEEKDIR
 #endif
 
+// strbuf was added by r16
+#if ACE_ANDROID_NDK_LESS_THAN(16, 0)
+#  ifdef ACE_HAS_STRBUF_T
+#    undef ACE_HAS_STRBUF_T
+#  endif
+#endif
+
 // fd_mask was added in r17c
 #if ACE_ANDROID_NDK_LESS_THAN(17, 2)
 #  define ACE_LACKS_FD_MASK

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -88,6 +88,13 @@
 #  define ACE_HAS_SEMUN
 #endif
 
+#if ACE_ANDROID_NDK_LESS_THAN(15, 0) && __ANDROID_API__ < 21
+// NOTE: The && is correct, SYS_GETTID is present in API 16 in r15 onwards
+#  ifdef ACE_HAS_GETTID
+#    undef ACE_HAS_GETTID
+#  endif
+#endif
+
 // NDK has telldir() and seekdir() by 15c
 #if ACE_ANDROID_NDK_LESS_THAN(15, 2) || __ANDROID_API__ < 23
 #  define ACE_LACKS_TELLDIR

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -21,6 +21,8 @@
 #define ACE_ANDROID
 #define ACE_PLATFORM_CONFIG config-android.h
 
+#include "ace/config-linux-common.h"
+
 /*
  * Android NDK Revision Macros
  *
@@ -110,11 +112,12 @@
 #  define ACE_LACKS_ENDHOSTENT
 #endif
 
-#define ACE_HAS_SSIZE_T
+#if !defined(ACE_HAS_GLIBC_2_2_3) && (ACE_ANDROID_NDK_AT_LEAST(15, 0) || __ANDROID_API__ >= 21)
+#  define ACE_HAS_CPU_SET_T
+#endif
 
 // system errorno is a volatile int
 #define ACE_HAS_VOLATILE_ERRNO
-
 #define ACE_ERRNO_TYPE volatile int
 
 // Android doesn't check is sig is out of range.
@@ -153,15 +156,6 @@
 // Used in tests/Sequence_Unit_Tests/string_sequence_tester.hpp
 # define TAO_LACKS_WCHAR_CXX_STDLIB
 
-#if !defined (ACE_MT_SAFE)
-#  define ACE_MT_SAFE 1
-#endif
-
-// Needed to differentiate between libc 5 and libc 6 (aka glibc).
-#include <features.h>
-
-#include "ace/config-posix.h"
-
 // @todo JW, test if this works
 // #define ACE_HAS_POSIX_SEM
 // #define ACE_HAS_POSIX_SEM_TIMEOUT
@@ -174,230 +168,16 @@
 #  undef ACE_HAS_AIO_CALLS
 #endif
 
-// First the machine specific part
-#if defined (__powerpc__) || defined (__x86_64__)
-# if !defined (ACE_DEFAULT_BASE_ADDR)
-#   define ACE_DEFAULT_BASE_ADDR ((char *) 0x40000000)
-# endif /* ! ACE_DEFAULT_BASE_ADDR */
-#endif /* ! __powerpc__  && ! __ia64 */
-
 #define ACE_HAS_SIGINFO_T
 #define ACE_HAS_SOCKLEN_T
 #define ACE_HAS_4_4BSD_SENDMSG_RECVMSG
 
-#define ACE_HAS_LSEEK64
-//#define ACE_LACKS_LSEEK64_PROTOTYPE
-
-#define ACE_HAS_P_READ_WRITE
-// Use ACE's alternate cuserid() implementation since the use of the
-// system cuserid() is discouraged.
 #define ACE_LACKS_CUSERID
-#define ACE_HAS_ALT_CUSERID
-
-#if (__GLIBC__  > 2)  || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)
-# define ACE_HAS_ISASTREAM_PROTOTYPE
-# define ACE_HAS_PTHREAD_SIGMASK_PROTOTYPE
-# define ACE_HAS_CPU_SET_T
-#elif ACE_ANDROID_NDK_AT_LEAST(15, 0) || __ANDROID_API__ >= 21
-# define ACE_HAS_CPU_SET_T
-#endif /* __GLIBC__ > 2 || __GLIBC__ === 2 && __GLIBC_MINOR__ >= 3) */
-
-// Then the compiler specific parts
-
-#if defined (__GNUG__)
-  // config-g++-common.h undef's ACE_HAS_STRING_CLASS with -frepo, so
-  // this must appear before its #include.
-# define ACE_HAS_STRING_CLASS
-# include "ace/config-g++-common.h"
-#elif defined (__GNUC__)
-/**
- * GNU C compiler.
- *
- * We need to recognize the GNU C compiler since TAO has at least one
- * C source header and file
- * (TAO/orbsvcs/orbsvcs/SSLIOP/params_dup.{h,c}) that may indirectly
- * include this
- */
-#else  /* ! __GNUG__ && !__DECCXX && !__INTEL_COMPILER && && !__PGI */
-#  ifdef __cplusplus  /* Let it slide for C compilers. */
-#    error unsupported compiler in ace/config-android.h
-#  endif  /* __cplusplus */
-#endif /* ! __GNUG__*/
-
-// Completely common part :-)
-
-// Platform/compiler has the sigwait(2) prototype
-#define ACE_HAS_SIGWAIT
-
-#define ACE_HAS_SIGSUSPEND
-
-#define ACE_HAS_STRSIGNAL
-
-#ifndef ACE_HAS_POSIX_REALTIME_SIGNALS
-# define ACE_HAS_POSIX_REALTIME_SIGNALS
-#endif /* ACE_HAS_POSIX_REALTIME_SIGNALS */
-
-#define ACE_HAS_XPG4_MULTIBYTE_CHAR
-#define ACE_HAS_VFWPRINTF
-
-#define ACE_LACKS_ITOW
-#define ACE_LACKS_WCSICMP
-#define ACE_LACKS_WCSNICMP
-#define ACE_LACKS_ISWASCII
-
-#define ACE_HAS_3_PARAM_WCSTOK
-
-#define ACE_HAS_3_PARAM_READDIR_R
-
-#if !defined (ACE_DEFAULT_BASE_ADDR)
-#  define ACE_DEFAULT_BASE_ADDR ((char *) 0x80000000)
-#endif /* ! ACE_DEFAULT_BASE_ADDR */
-
-#define ACE_HAS_ALLOCA
-
-// Compiler/platform has <alloca.h>
-#define ACE_HAS_ALLOCA_H
-#define ACE_HAS_SYS_SYSINFO_H
-#define ACE_HAS_LINUX_SYSINFO
-
-// Compiler/platform has the getrusage() system call.
-#define ACE_HAS_GETRUSAGE
-#define ACE_HAS_GETRUSAGE_PROTOTYPE
-
-#define ACE_HAS_BYTESWAP_H
-#define ACE_HAS_BSWAP_16
-#define ACE_HAS_BSWAP_32
-#define ACE_HAS_BSWAP_64
-
-#define ACE_HAS_CONSISTENT_SIGNAL_PROTOTYPES
-
-// Optimize ACE_Handle_Set for select().
-#define ACE_HAS_HANDLE_SET_OPTIMIZED_FOR_SELECT
-
-// ONLY define this if you have config'd multicast into a 2.0.34 or
-// prior kernel.  It is enabled by default in 2.0.35 kernels.
-#if !defined (ACE_HAS_IP_MULTICAST)
-# define ACE_HAS_IP_MULTICAST
-#endif /* ! ACE_HAS_IP_MULTICAST */
-
-// At least for IPv4, Linux lacks perfect filtering.
-#if !defined ACE_LACKS_PERFECT_MULTICAST_FILTERING
-# define ACE_LACKS_PERFECT_MULTICAST_FILTERING 1
-#endif /* ACE_LACKS_PERFECT_MULTICAST_FILTERING */
-
-#define ACE_HAS_BIG_FD_SET
-
-// Linux defines struct msghdr in /usr/include/socket.h
-#define ACE_HAS_MSG
-
-// Linux "improved" the interface to select() so that it modifies
-// the struct timeval to reflect the amount of time not slept
-// (see NOTES in Linux's select(2) man page).
-#define ACE_HAS_NONCONST_SELECT_TIMEVAL
-
-#define ACE_DEFAULT_MAX_SOCKET_BUFSIZ 65535
-
-#define ACE_CDR_IMPLEMENT_WITH_NATIVE_DOUBLE 1
-
-#define ACE_HAS_GETPAGESIZE 1
-
-// Platform defines struct timespec but not timespec_t
-#define ACE_LACKS_TIMESPEC_T
-
-// Platform supplies scandir()
-#define ACE_HAS_SCANDIR
 
 #define ACE_MMAP_NO_ZERO
 
-// Compiler/platform contains the <sys/syscall.h> file.
-#define ACE_HAS_SYS_SYSCALL_H
-
-#define ACE_HAS_TIMEZONE_GETTIMEOFDAY
-
-// Compiler supports the ssize_t typedef.
-#define ACE_HAS_SSIZE_T
-
-// Compiler/platform defines the sig_atomic_t typedef.
-#define ACE_HAS_SIG_ATOMIC_T
-
-#define ACE_HAS_POSIX_TIME
-
-#define ACE_HAS_GPERF
-
-#define ACE_HAS_DIRENT
-
-// Starting with FC9 rawhide this file is not available anymore but
-// this define is set
-#if defined _XOPEN_STREAMS && _XOPEN_STREAMS == -1
-# define ACE_LACKS_STROPTS_H
-# define ACE_LACKS_STRRECVFD
-#endif
-
-#if !defined (ACE_LACKS_STROPTS_H)
-# define ACE_HAS_STRBUF_T
-#endif
-
-#if defined (__ia64) || defined(__alpha) || defined (__x86_64__) || defined(__powerpc64__)
-// On 64 bit platforms, the "long" type is 64-bits.  Override the
-// default 32-bit platform-specific format specifiers appropriately.
-# define ACE_UINT64_FORMAT_SPECIFIER_ASCII "%lu"
-# define ACE_SSIZE_T_FORMAT_SPECIFIER_ASCII "%ld"
-# define ACE_SIZE_T_FORMAT_SPECIFIER_ASCII "%lu"
-#endif /* __ia64 */
-
-#define ACE_SIZEOF_WCHAR 4
-
-// Platform has POSIX terminal interface.
-#define ACE_HAS_TERMIOS
-
-// Linux implements sendfile().
-#define ACE_HAS_SENDFILE 1
-
-#define ACE_HAS_VOIDPTR_MMAP
-
-#define ACE_HAS_VASPRINTF
-
-#define ACE_LACKS_PTHREAD_SCOPE_PROCESS
-
-// According to man pages Linux uses different (compared to UNIX systems) types
-// for setting IP_MULTICAST_TTL and IPV6_MULTICAST_LOOP / IP_MULTICAST_LOOP
-// in setsockopt/getsockopt.
-#define ACE_HAS_IP_MULTICAST_TTL_AS_INT 1
-#define ACE_HAS_IPV6_MULTICAST_LOOP_AS_BOOL 1
-#define ACE_HAS_IP_MULTICAST_LOOP_AS_INT 1
-
 #define ACE_HAS_NETLINK
 #define ACE_HAS_SIOCGIFCONF
-
-#if !defined (ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO)
-// Detect if getsockname() and getpeername() returns random values in
-// the sockaddr_in::sin_zero field by evaluation of the kernel
-// version. Since version 2.5.47 this problem is fixed.
-#  if !defined (ACE_LACKS_LINUX_VERSION_H)
-#    include <linux/version.h>
-#  endif /* !ACE_LACKS_LINUX_VERSION_H */
-#  if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,5,47))
-#    define ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO 0
-#  else
-#    define ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO 1
-#  endif  /* (LINUX_VERSION_CODE <= KERNEL_VERSION(2,5,47)) */
-#endif  /* ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO */
-
-#if !defined (ACE_HAS_EVENT_POLL) && !defined (ACE_HAS_DEV_POLL)
-# if !defined (ACE_LACKS_LINUX_VERSION_H)
-#  include <linux/version.h>
-# endif /* !ACE_LACKS_LINUX_VERSION_H */
-#endif
-
-#define ACE_HAS_SVR4_DYNAMIC_LINKING
-#define ACE_HAS_AUTOMATIC_INIT_FINI
-#define ACE_HAS_DLSYM_SEGFAULT_ON_INVALID_HANDLE
-#define ACE_HAS_RECURSIVE_MUTEXES
-#define ACE_HAS_THREAD_SPECIFIC_STORAGE
-#define ACE_HAS_RECURSIVE_THR_EXIT_SEMANTICS
-#define ACE_HAS_2_PARAM_ASCTIME_R_AND_CTIME_R
-#define ACE_HAS_REENTRANT_FUNCTIONS
-#define ACE_HAS_TIMEZONE
 
 #if !defined ACE_DEFAULT_TEMP_DIR
 # define ACE_DEFAULT_TEMP_DIR "/data/tmp"
@@ -406,6 +186,8 @@
 #if !defined TEST_DIR
 # define TEST_DIR "/data"
 #endif
+
+#define ACE_HAS_DLSYM_SEGFAULT_ON_INVALID_HANDLE
 
 #if !defined (ACE_AS_STATIC_LIBS)
 # if (__GNUC__ == 4 && __GNUC_MINOR__ == 4)

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -112,7 +112,7 @@
 #  define ACE_LACKS_WCSTOULL
 #  define ACE_LACKS_CONDATTR_SETCLOCK
 #  ifdef ACE_HAS_EVENT_POLL
-#    undef ACE_HAS_EVEN_POLL
+#    undef ACE_HAS_EVENT_POLL
 #  endif
 #endif
 

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -111,6 +111,9 @@
 #  define ACE_LACKS_WCSTOLL
 #  define ACE_LACKS_WCSTOULL
 #  define ACE_LACKS_CONDATTR_SETCLOCK
+#  ifdef ACE_HAS_EVENT_POLL
+#    undef ACE_HAS_EVEN_POLL
+#  endif
 #endif
 
 // These were available before r18, but in r18 they are restricted to API >= 28 ¯\_(ツ)_/¯

--- a/ACE/ace/config-linux-common.h
+++ b/ACE/ace/config-linux-common.h
@@ -155,11 +155,6 @@
 
 // Platform supplies scandir()
 #define ACE_HAS_SCANDIR
-#if (__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10)
-// Although the scandir man page says otherwise, this setting is correct.
-// The setting was fixed in 2.10, so do not use the hack after that.
-#  define ACE_SCANDIR_CMP_USES_CONST_VOIDPTR
-#endif
 
 // Compiler/platform contains the <sys/syscall.h> file.
 #define ACE_HAS_SYS_SYSCALL_H

--- a/ACE/ace/config-linux-common.h
+++ b/ACE/ace/config-linux-common.h
@@ -1,0 +1,260 @@
+/**
+ * Common configuration for platforms using the Linux Kernel, specifically
+ * ACE_LINUX and ACE_ANDROID as of writing. config-android.h was originally
+ * based off config-linux.h and this file was created from the common parts of
+ * both.
+ */
+#ifndef ACE_CONFIG_LINUX_COMMON_H
+#define ACE_CONFIG_LINUX_COMMON_H
+
+#if !defined (ACE_MT_SAFE)
+#  define ACE_MT_SAFE 1
+#endif
+
+// Compiler supports the ssize_t typedef.
+#define ACE_HAS_SSIZE_T
+
+// Needed to differentiate between libc 5 and libc 6 (aka glibc).
+#include <features.h>
+
+#include "ace/config-posix.h"
+
+#ifndef ACE_DEFAULT_BASE_ADDR
+#  if defined (__powerpc__) || defined (__x86_64__)
+#    define ACE_DEFAULT_BASE_ADDR (reinterpret_cast< char* >(0x40000000))
+#  elif defined (__ia64)
+// Zero base address should work fine for Linux of IA-64: it just lets
+// the kernel to choose the right value.
+#    define ACE_DEFAULT_BASE_ADDR (reinterpret_cast< char*>(0x0000000000000000))
+#  else
+#    define ACE_DEFAULT_BASE_ADDR (reinterpret_cast< char* >(0x80000000))
+#  endif
+#endif /* ! ACE_DEFAULT_BASE_ADDR */
+
+#define ACE_HAS_LSEEK64
+
+#define ACE_HAS_P_READ_WRITE
+// Use ACE's alternate cuserid() implementation since the use of the
+// system cuserid() is discouraged.
+#define ACE_HAS_ALT_CUSERID
+
+#if (__GLIBC__  > 2)  || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)
+#  define ACE_HAS_ISASTREAM_PROTOTYPE
+#  define ACE_HAS_PTHREAD_SIGMASK_PROTOTYPE
+#  define ACE_HAS_CPU_SET_T
+#  define ACE_HAS_GLIBC_2_2_3
+#endif /* __GLIBC__ > 2 || __GLIBC__ === 2 && __GLIBC_MINOR__ >= 3) */
+
+#if defined (__INTEL_COMPILER)
+#  include "ace/config-icc-common.h"
+#elif defined (__GNUG__)
+  // config-g++-common.h undef's ACE_HAS_STRING_CLASS with -frepo, so
+  // this must appear before its #include.
+#  define ACE_HAS_STRING_CLASS
+#  include "ace/config-g++-common.h"
+#elif defined (__SUNCC_PRO) || defined (__SUNPRO_CC)
+#  include "ace/config-suncc-common.h"
+#elif defined (__PGI)
+// Portable group compiler
+#  define ACE_HAS_CPLUSPLUS_HEADERS
+#  define ACE_HAS_STDCPP_STL_INCLUDES
+#  define ACE_HAS_STANDARD_CPP_LIBRARY 1
+#  define ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB 1
+#  define ACE_LACKS_SWAB
+#elif defined (__GNUC__)
+/**
+ * GNU C compiler.
+ *
+ * We need to recognize the GNU C compiler since TAO has at least one
+ * C source header and file
+ * (TAO/orbsvcs/orbsvcs/SSLIOP/params_dup.{h,c}) that may indirectly
+ * include this
+ */
+#else  /* ! __GNUG__ && !__DECCXX && !__INTEL_COMPILER && && !__PGI */
+#  ifdef __cplusplus  /* Let it slide for C compilers. */
+#    error unsupported compiler in ace/config-linux.h
+#  endif  /* __cplusplus */
+#endif /* ! __GNUG__*/
+
+// Platform/compiler has the sigwait(2) prototype
+#define ACE_HAS_SIGWAIT
+
+#define ACE_HAS_SIGSUSPEND
+
+#define ACE_HAS_STRSIGNAL
+
+#ifndef ACE_HAS_POSIX_REALTIME_SIGNALS
+# define ACE_HAS_POSIX_REALTIME_SIGNALS
+#endif /* ACE_HAS_POSIX_REALTIME_SIGNALS */
+
+#define ACE_HAS_XPG4_MULTIBYTE_CHAR
+#define ACE_HAS_VFWPRINTF
+
+#define ACE_LACKS_ITOW
+#define ACE_LACKS_WCSICMP
+#define ACE_LACKS_WCSNICMP
+#define ACE_LACKS_ISWASCII
+
+#define ACE_HAS_3_PARAM_WCSTOK
+
+#define ACE_HAS_3_PARAM_READDIR_R
+
+#define ACE_HAS_ALLOCA
+
+// Compiler/platform has <alloca.h>
+#define ACE_HAS_ALLOCA_H
+#define ACE_HAS_SYS_SYSINFO_H
+#define ACE_HAS_LINUX_SYSINFO
+
+// Compiler/platform has the getrusage() system call.
+#define ACE_HAS_GETRUSAGE
+#define ACE_HAS_GETRUSAGE_PROTOTYPE
+
+#define ACE_HAS_BYTESWAP_H
+#define ACE_HAS_BSWAP_16
+#define ACE_HAS_BSWAP_32
+
+#if defined (__GNUC__)
+#  define ACE_HAS_BSWAP_64
+#endif
+
+#define ACE_HAS_CONSISTENT_SIGNAL_PROTOTYPES
+
+// Optimize ACE_Handle_Set for select().
+#define ACE_HAS_HANDLE_SET_OPTIMIZED_FOR_SELECT
+
+// ONLY define this if you have config'd multicast into a 2.0.34 or
+// prior kernel.  It is enabled by default in 2.0.35 kernels.
+#if !defined (ACE_HAS_IP_MULTICAST)
+#  define ACE_HAS_IP_MULTICAST
+#endif /* ! ACE_HAS_IP_MULTICAST */
+
+// At least for IPv4, Linux lacks perfect filtering.
+#if !defined ACE_LACKS_PERFECT_MULTICAST_FILTERING
+#  define ACE_LACKS_PERFECT_MULTICAST_FILTERING 1
+#endif /* ACE_LACKS_PERFECT_MULTICAST_FILTERING */
+
+#define ACE_HAS_BIG_FD_SET
+
+// Linux defines struct msghdr in /usr/include/socket.h
+#define ACE_HAS_MSG
+
+// Linux "improved" the interface to select() so that it modifies
+// the struct timeval to reflect the amount of time not slept
+// (see NOTES in Linux's select(2) man page).
+#define ACE_HAS_NONCONST_SELECT_TIMEVAL
+
+#define ACE_DEFAULT_MAX_SOCKET_BUFSIZ 65535
+
+#define ACE_CDR_IMPLEMENT_WITH_NATIVE_DOUBLE 1
+
+#define ACE_HAS_GETPAGESIZE 1
+
+// Platform defines struct timespec but not timespec_t
+#define ACE_LACKS_TIMESPEC_T
+
+// Platform supplies scandir()
+#define ACE_HAS_SCANDIR
+#if (__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10)
+// Although the scandir man page says otherwise, this setting is correct.
+// The setting was fixed in 2.10, so do not use the hack after that.
+#  define ACE_SCANDIR_CMP_USES_CONST_VOIDPTR
+#endif
+
+// Compiler/platform contains the <sys/syscall.h> file.
+#define ACE_HAS_SYS_SYSCALL_H
+
+#define ACE_HAS_TIMEZONE
+#define ACE_HAS_TIMEZONE_GETTIMEOFDAY
+
+// Compiler/platform defines the sig_atomic_t typedef.
+#define ACE_HAS_SIG_ATOMIC_T
+
+#define ACE_HAS_POSIX_TIME
+
+#define ACE_HAS_GPERF
+
+#define ACE_HAS_DIRENT
+
+// Starting with FC9 rawhide this file is not available anymore but
+// this define is set
+#if defined _XOPEN_STREAMS && _XOPEN_STREAMS == -1
+#  define ACE_LACKS_STROPTS_H
+#  define ACE_LACKS_STRRECVFD
+#endif
+
+#if !defined (ACE_LACKS_STROPTS_H)
+#  define ACE_HAS_STRBUF_T
+#endif
+
+#if defined (__ia64) || defined(__alpha) || defined (__x86_64__) || defined(__powerpc64__) || (defined(__mips__) && defined(__LP64__)) || defined (__aarch64__)
+// On 64 bit platforms, the "long" type is 64-bits.  Override the
+// default 32-bit platform-specific format specifiers appropriately.
+#  define ACE_UINT64_FORMAT_SPECIFIER_ASCII "%lu"
+#  define ACE_SSIZE_T_FORMAT_SPECIFIER_ASCII "%ld"
+#  define ACE_SIZE_T_FORMAT_SPECIFIER_ASCII "%lu"
+#endif /* __ia64 */
+
+#define ACE_SIZEOF_WCHAR 4
+
+// Platform has POSIX terminal interface.
+#define ACE_HAS_TERMIOS
+
+// Linux implements sendfile().
+#define ACE_HAS_SENDFILE 1
+
+#define ACE_HAS_VOIDPTR_MMAP
+
+#define ACE_HAS_VASPRINTF
+
+#define ACE_LACKS_PTHREAD_SCOPE_PROCESS
+
+// According to man pages Linux uses different (compared to UNIX systems) types
+// for setting IP_MULTICAST_TTL and IPV6_MULTICAST_LOOP / IP_MULTICAST_LOOP
+// in setsockopt/getsockopt.
+// In the current (circa 2012) kernel source however there is an explicit check
+// for IPV6_MULTICAST_LOOP being sizeof(int). Anything else is rejected so it must
+// not be a passed a bool, irrespective of what the man pages (still) say.
+// i.e. #define ACE_HAS_IPV6_MULTICAST_LOOP_AS_BOOL 1 is wrong
+#define ACE_HAS_IP_MULTICAST_TTL_AS_INT 1
+#define ACE_HAS_IP_MULTICAST_LOOP_AS_INT 1
+
+#define ACE_HAS_SVR4_DYNAMIC_LINKING
+#define ACE_HAS_AUTOMATIC_INIT_FINI
+#define ACE_HAS_RECURSIVE_MUTEXES
+#define ACE_HAS_THREAD_SPECIFIC_STORAGE
+#define ACE_HAS_RECURSIVE_THR_EXIT_SEMANTICS
+#define ACE_HAS_2_PARAM_ASCTIME_R_AND_CTIME_R
+#define ACE_HAS_REENTRANT_FUNCTIONS
+
+/* ===========================================================================
+ * By Kernel API Version
+ * ===========================================================================
+ */
+
+#if !defined (ACE_LACKS_LINUX_VERSION_H)
+#  include <linux/version.h>
+#endif /* !ACE_LACKS_LINUX_VERSION_H */
+
+#if !defined (ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO)
+// Detect if getsockname() and getpeername() returns random values in
+// the sockaddr_in::sin_zero field by evaluation of the kernel
+// version. Since version 2.5.47 this problem is fixed.
+#  if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,5,47))
+#    define ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO 0
+#  else
+#    define ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO 1
+#  endif  /* (LINUX_VERSION_CODE <= KERNEL_VERSION(2,5,47)) */
+#endif  /* ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO */
+
+#if !defined (ACE_HAS_EVENT_POLL) && !defined (ACE_HAS_DEV_POLL)
+#  if (LINUX_VERSION_CODE > KERNEL_VERSION (2,6,0))
+#    define ACE_HAS_EVENT_POLL
+#  endif
+#endif
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION (2,4,11))
+#  define ACE_HAS_GETTID // See ACE_OS::thr_gettid()
+#endif
+
+#endif

--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -10,10 +10,6 @@
 #define ACE_LINUX
 #endif /* ACE_LINUX */
 
-#if !defined (ACE_MT_SAFE)
-#  define ACE_MT_SAFE 1
-#endif
-
 #if !defined (__ACE_INLINE__)
 #  define __ACE_INLINE__
 #endif /* ! __ACE_INLINE__ */
@@ -22,16 +18,13 @@
 #define ACE_PLATFORM_CONFIG config-linux.h
 #endif
 
-#define ACE_HAS_BYTESEX_H
+#include "ace/config-linux-common.h"
 
-// Needed to differentiate between libc 5 and libc 6 (aka glibc).
-#include <features.h>
+#define ACE_HAS_BYTESEX_H
 
 #if (defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) >= 500)
 #  define ACE_HAS_PTHREADS_UNIX98_EXT
 #endif /* _XOPEN_SOURCE - 0 >= 500 */
-
-# include "ace/config-posix.h"
 
 #if !defined (ACE_LACKS_LINUX_NPTL)
 
@@ -64,20 +57,6 @@
 #else
 #  undef ACE_HAS_AIO_CALLS
 #endif
-
-// First the machine specific part
-
-#if defined (__powerpc__) || defined (__x86_64__)
-# if !defined (ACE_DEFAULT_BASE_ADDR)
-#   define ACE_DEFAULT_BASE_ADDR (reinterpret_cast< char* >(0x40000000))
-# endif /* ! ACE_DEFAULT_BASE_ADDR */
-#elif defined (__ia64)
-# if !defined (ACE_DEFAULT_BASE_ADDR)
-// Zero base address should work fine for Linux of IA-64: it just lets
-// the kernel to choose the right value.
-#   define ACE_DEFAULT_BASE_ADDR (reinterpret_cast< char*>(0x0000000000000000))
-# endif /* ! ACE_DEFAULT_BASE_ADDR */
-#endif /* ! __powerpc__  && ! __ia64 */
 
 // Then glibc/libc5 specific parts
 
@@ -123,145 +102,9 @@
 #   define ACE_LACKS_MSG_ACCRIGHTS
 #endif /* ! __GLIBC__ */
 
-#define ACE_HAS_LSEEK64
-//#define ACE_LACKS_LSEEK64_PROTOTYPE
-
-#define ACE_HAS_P_READ_WRITE
-// Use ACE's alternate cuserid() implementation since the use of the
-// system cuserid() is discouraged.
-#define ACE_HAS_ALT_CUSERID
-
-#if (__GLIBC__  > 2)  || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)
-# define ACE_HAS_ISASTREAM_PROTOTYPE
-# define ACE_HAS_PTHREAD_SIGMASK_PROTOTYPE
-# define ACE_HAS_CPU_SET_T
-#endif /* __GLIBC__ > 2 || __GLIBC__ === 2 && __GLIBC_MINOR__ >= 3) */
-
-// Then the compiler specific parts
-
-#if defined (__INTEL_COMPILER)
-# include "ace/config-icc-common.h"
-#elif defined (__GNUG__)
-  // config-g++-common.h undef's ACE_HAS_STRING_CLASS with -frepo, so
-  // this must appear before its #include.
-# define ACE_HAS_STRING_CLASS
-# include "ace/config-g++-common.h"
-#elif defined (__SUNCC_PRO) || defined (__SUNPRO_CC)
-# include "ace/config-suncc-common.h"
-#elif defined (__PGI)
-// Portable group compiler
-# define ACE_HAS_CPLUSPLUS_HEADERS
-# define ACE_HAS_STDCPP_STL_INCLUDES
-# define ACE_HAS_STANDARD_CPP_LIBRARY 1
-# define ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB 1
-# define ACE_LACKS_SWAB
-#elif defined (__GNUC__)
-/**
- * GNU C compiler.
- *
- * We need to recognize the GNU C compiler since TAO has at least one
- * C source header and file
- * (TAO/orbsvcs/orbsvcs/SSLIOP/params_dup.{h,c}) that may indirectly
- * include this
- */
-#else  /* ! __GNUG__ && !__DECCXX && !__INTEL_COMPILER && && !__PGI */
-#  ifdef __cplusplus  /* Let it slide for C compilers. */
-#    error unsupported compiler in ace/config-linux.h
-#  endif  /* __cplusplus */
-#endif /* ! __GNUG__*/
-
 // Completely common part :-)
 
-// Platform/compiler has the sigwait(2) prototype
-#define ACE_HAS_SIGWAIT
-
-#define ACE_HAS_SIGSUSPEND
-
 #define ACE_HAS_UALARM
-
-#define ACE_HAS_STRSIGNAL
-
-#ifndef ACE_HAS_POSIX_REALTIME_SIGNALS
-# define ACE_HAS_POSIX_REALTIME_SIGNALS
-#endif /* ACE_HAS_POSIX_REALTIME_SIGNALS */
-
-#define ACE_HAS_XPG4_MULTIBYTE_CHAR
-#define ACE_HAS_VFWPRINTF
-
-#define ACE_LACKS_ITOW
-#define ACE_LACKS_WCSICMP
-#define ACE_LACKS_WCSNICMP
-#define ACE_LACKS_ISWASCII
-
-#define ACE_HAS_3_PARAM_WCSTOK
-
-#define ACE_HAS_3_PARAM_READDIR_R
-
-#if !defined (ACE_DEFAULT_BASE_ADDR)
-#  define ACE_DEFAULT_BASE_ADDR (reinterpret_cast< char* >(0x80000000))
-#endif /* ! ACE_DEFAULT_BASE_ADDR */
-
-#define ACE_HAS_ALLOCA
-
-// Compiler/platform has <alloca.h>
-#define ACE_HAS_ALLOCA_H
-#define ACE_HAS_SYS_SYSINFO_H
-#define ACE_HAS_LINUX_SYSINFO
-
-// Compiler/platform has the getrusage() system call.
-#define ACE_HAS_GETRUSAGE
-#define ACE_HAS_GETRUSAGE_PROTOTYPE
-
-#define ACE_HAS_BYTESWAP_H
-#define ACE_HAS_BSWAP_16
-#define ACE_HAS_BSWAP_32
-
-#if defined (__GNUC__)
-#  define ACE_HAS_BSWAP_64
-#endif
-
-#define ACE_HAS_CONSISTENT_SIGNAL_PROTOTYPES
-
-// Optimize ACE_Handle_Set for select().
-#define ACE_HAS_HANDLE_SET_OPTIMIZED_FOR_SELECT
-
-// ONLY define this if you have config'd multicast into a 2.0.34 or
-// prior kernel.  It is enabled by default in 2.0.35 kernels.
-#if !defined (ACE_HAS_IP_MULTICAST)
-# define ACE_HAS_IP_MULTICAST
-#endif /* ! ACE_HAS_IP_MULTICAST */
-
-// At least for IPv4, Linux lacks perfect filtering.
-#if !defined ACE_LACKS_PERFECT_MULTICAST_FILTERING
-# define ACE_LACKS_PERFECT_MULTICAST_FILTERING 1
-#endif /* ACE_LACKS_PERFECT_MULTICAST_FILTERING */
-
-#define ACE_HAS_BIG_FD_SET
-
-// Linux defines struct msghdr in /usr/include/socket.h
-#define ACE_HAS_MSG
-
-// Linux "improved" the interface to select() so that it modifies
-// the struct timeval to reflect the amount of time not slept
-// (see NOTES in Linux's select(2) man page).
-#define ACE_HAS_NONCONST_SELECT_TIMEVAL
-
-#define ACE_DEFAULT_MAX_SOCKET_BUFSIZ 65535
-
-#define ACE_CDR_IMPLEMENT_WITH_NATIVE_DOUBLE 1
-
-#define ACE_HAS_GETPAGESIZE 1
-
-// Platform defines struct timespec but not timespec_t
-#define ACE_LACKS_TIMESPEC_T
-
-// Platform supplies scandir()
-#define ACE_HAS_SCANDIR
-#if (__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10)
-// Although the scandir man page says otherwise, this setting is correct.
-// The setting was fixed in 2.10, so do not use the hack after that.
-#define ACE_SCANDIR_CMP_USES_CONST_VOIDPTR
-#endif
 
 // A conflict appears when including both <ucontext.h> and
 // <sys/procfs.h> with recent glibc headers.
@@ -270,108 +113,24 @@
 // Platform supports System V IPC (most versions of UNIX, but not Win32)
 #define ACE_HAS_SYSV_IPC
 
-// Compiler/platform contains the <sys/syscall.h> file.
-#define ACE_HAS_SYS_SYSCALL_H
-
-// Platform/compiler supports global timezone variable.
-#define ACE_HAS_TIMEZONE
-
-#define ACE_HAS_TIMEZONE_GETTIMEOFDAY
-
-// Compiler supports the ssize_t typedef.
-#define ACE_HAS_SSIZE_T
-
-// Compiler/platform defines the sig_atomic_t typedef.
-#define ACE_HAS_SIG_ATOMIC_T
-
 // Compiler/platform defines a union semun for SysV shared memory.
 #define ACE_HAS_SEMUN
-
-#define ACE_HAS_POSIX_TIME
-
-#define ACE_HAS_GPERF
-
-#define ACE_HAS_DIRENT
-
-// Starting with FC9 rawhide this file is not available anymore but
-// this define is set
-#if defined _XOPEN_STREAMS && _XOPEN_STREAMS == -1
-# define ACE_LACKS_STROPTS_H
-# define ACE_LACKS_STRRECVFD
-#endif
-
-#if !defined (ACE_LACKS_STROPTS_H)
-# define ACE_HAS_STRBUF_T
-#endif
-
-#if defined (__ia64) || defined(__alpha) || defined (__x86_64__) || defined(__powerpc64__) || (defined(__mips__) && defined(__LP64__)) || defined (__aarch64__)
-// On 64 bit platforms, the "long" type is 64-bits.  Override the
-// default 32-bit platform-specific format specifiers appropriately.
-# define ACE_UINT64_FORMAT_SPECIFIER_ASCII "%lu"
-# define ACE_SSIZE_T_FORMAT_SPECIFIER_ASCII "%ld"
-# define ACE_SIZE_T_FORMAT_SPECIFIER_ASCII "%lu"
-#endif /* __ia64 */
-
-#define ACE_SIZEOF_WCHAR 4
 
 #if defined (__powerpc__) && !defined (ACE_SIZEOF_LONG_DOUBLE)
 // 32bit PowerPC Linux uses 128bit long double
 # define ACE_SIZEOF_LONG_DOUBLE 16
 #endif
 
-#define ACE_LACKS_PTHREAD_SCOPE_PROCESS
-
 #define ACE_LACKS_GETIPNODEBYADDR
 #define ACE_LACKS_GETIPNODEBYNAME
 
-// Platform has POSIX terminal interface.
-#define ACE_HAS_TERMIOS
-
-// Linux implements sendfile().
-#define ACE_HAS_SENDFILE 1
-
-#define ACE_HAS_VOIDPTR_MMAP
-
 #define ACE_HAS_ICMP_SUPPORT 1
-
-#define ACE_HAS_VASPRINTF
-
-// According to man pages Linux uses different (compared to UNIX systems) types
-// for setting IP_MULTICAST_TTL and IPV6_MULTICAST_LOOP / IP_MULTICAST_LOOP
-// in setsockopt/getsockopt.
-// In the current (circa 2012) kernel source however there is an explicit check
-// for IPV6_MULTICAST_LOOP being sizeof(int). Anything else is rejected so it must
-// not be a passed a bool, irrespective of what the man pages (still) say.
-// i.e. #define ACE_HAS_IPV6_MULTICAST_LOOP_AS_BOOL 1 is wrong
-#define ACE_HAS_IP_MULTICAST_TTL_AS_INT 1
-#define ACE_HAS_IP_MULTICAST_LOOP_AS_INT 1
 
 #if defined (ACE_LACKS_NETWORKING)
 # include "ace/config-posix-nonetworking.h"
 #else
 # define ACE_HAS_NETLINK
 # define ACE_HAS_GETIFADDRS
-#endif
-
-#if !defined (ACE_LACKS_LINUX_VERSION_H)
-# include <linux/version.h>
-#endif /* !ACE_LACKS_LINUX_VERSION_H */
-
-#if !defined (ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO)
-// Detect if getsockname() and getpeername() returns random values in
-// the sockaddr_in::sin_zero field by evaluation of the kernel
-// version. Since version 2.5.47 this problem is fixed.
-#  if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,5,47))
-#    define ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO 0
-#  else
-#    define ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO 1
-#  endif  /* (LINUX_VERSION_CODE <= KERNEL_VERSION(2,5,47)) */
-#endif  /* ACE_GETNAME_RETURNS_RANDOM_SIN_ZERO */
-
-#if !defined (ACE_HAS_EVENT_POLL) && !defined (ACE_HAS_DEV_POLL)
-# if (LINUX_VERSION_CODE > KERNEL_VERSION (2,6,0))
-#  define ACE_HAS_EVENT_POLL
-# endif
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,5,8))
@@ -384,21 +143,11 @@
 // we have no choice.
 // RHEL4 fails (2.6.9) while RHEL5 works (2.6.18)
 #if !defined (ACE_LACKS_CONDATTR_SETCLOCK)
-# if !defined (ACE_LACKS_LINUX_VERSION_H)
-#  include <linux/version.h>
-# endif /* !ACE_LACKS_LINUX_VERSION_H */
 # if (LINUX_VERSION_CODE < KERNEL_VERSION (2,6,18))
 #  define ACE_LACKS_CONDATTR_SETCLOCK
 # endif
 #endif
 
-#define ACE_HAS_SVR4_DYNAMIC_LINKING
-#define ACE_HAS_AUTOMATIC_INIT_FINI
-#define ACE_HAS_RECURSIVE_MUTEXES
-#define ACE_HAS_THREAD_SPECIFIC_STORAGE
-#define ACE_HAS_RECURSIVE_THR_EXIT_SEMANTICS
-#define ACE_HAS_2_PARAM_ASCTIME_R_AND_CTIME_R
-#define ACE_HAS_REENTRANT_FUNCTIONS
 #define ACE_HAS_MNTENT
 
 // To support UCLIBC
@@ -448,10 +197,6 @@
 #  endif /* ACE_HAS_SEMUN */
 
 #endif /* __UCLIBC__ */
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION (2,4,11))
-#  define ACE_HAS_GETTID // See ACE_OS::thr_gettid()
-#endif
 
 #include /**/ "ace/post.h"
 

--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -449,6 +449,10 @@
 
 #endif /* __UCLIBC__ */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION (2,4,11))
+#  define ACE_HAS_GETTID // See ACE_OS::thr_gettid()
+#endif
+
 #include /**/ "ace/post.h"
 
 #endif /* ACE_CONFIG_LINUX_H */

--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -106,6 +106,12 @@
 
 #define ACE_HAS_UALARM
 
+#if (__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10)
+// Although the scandir man page says otherwise, this setting is correct.
+// The setting was fixed in 2.10, so do not use the hack after that.
+#  define ACE_SCANDIR_CMP_USES_CONST_VOIDPTR
+#endif
+
 // A conflict appears when including both <ucontext.h> and
 // <sys/procfs.h> with recent glibc headers.
 //#define ACE_HAS_PROC_FS


### PR DESCRIPTION
On Linux systems that support it, use `gettid()` to get a much smaller number for the thread id.

The main motivator for this PR, besides slightly smaller logs for OpenDDS, is the fact that gdb on linux has two identifiers for threads beside the simple thread index; One is LWP (Light Weight Process), which is another name for the TID that `gettid()` returns, and other is the pthread_t value in hex.

Also refactored `config-android.h` and `config-linux.h`, pulling out the common parts into a `config-linux-common.h` so that the check for gettid could go into the common file.