### PR TITLE
orbsvcs tests/examples: removed MPC and Perl files from Documentation_Files, they are already elsewhere in the project

### DIFF
--- a/TAO/orbsvcs/examples/ImR/Advanced/Advanced.mpc
+++ b/TAO/orbsvcs/examples/ImR/Advanced/Advanced.mpc
@@ -16,7 +16,6 @@ project(*Manager): orbsvcsexe, portableserver {
     ManagerC.cpp
   }
   Documentation_Files {
-    run_test.pl
     README
     drivers/*
   }

--- a/TAO/orbsvcs/examples/ImR/Advanced/Advanced.mpc
+++ b/TAO/orbsvcs/examples/ImR/Advanced/Advanced.mpc
@@ -16,7 +16,6 @@ project(*Manager): orbsvcsexe, portableserver {
     ManagerC.cpp
   }
   Documentation_Files {
-    Advanced.mpc
     run_test.pl
     README
     drivers/*

--- a/TAO/orbsvcs/tests/FT_App/FT_App.mpc
+++ b/TAO/orbsvcs/tests/FT_App/FT_App.mpc
@@ -32,14 +32,6 @@ project(*Server): taoserver, fault_tolerance, orbsvcsexe, avoids_minimum_corba, 
 
   Documentation_Files {
     README
-    run_test_basic.pl           // can the client talk to the server
-    run_test_detector.pl        // does a detector notice a server fault
-    run_test_notifier.pl        // does the notification get to an analyzer
-    run_test_fault_consumer.pl  // Is the notification analyzed correctly
-    run_test_registry.pl        // does the stand-along factory registry work
-    run_test_rmregistry.pl      // does the factory registry in the RM work
-    run_test_replication_mgr.pl //
-    run_test_demo.pl            // test it all together
   }
 
   IDL_Files {

--- a/TAO/orbsvcs/tests/FT_App/FT_App.mpc
+++ b/TAO/orbsvcs/tests/FT_App/FT_App.mpc
@@ -32,7 +32,6 @@ project(*Server): taoserver, fault_tolerance, orbsvcsexe, avoids_minimum_corba, 
 
   Documentation_Files {
     README
-    FT_App.mpc
     run_test_basic.pl           // can the client talk to the server
     run_test_detector.pl        // does a detector notice a server fault
     run_test_notifier.pl        // does the notification get to an analyzer


### PR DESCRIPTION
VS2017 and VS2019 require each file to be listed in a single section, no overlaps