### PR TITLE
Removed our version of ACE_Time_Value::operator=, the compiler genera…

### DIFF
--- a/ACE/ace/Time_Value.h
+++ b/ACE/ace/Time_Value.h
@@ -271,7 +271,7 @@ public:
   /// Assign @a tv to this
   ACE_Time_Value &operator = (const ACE_Time_Value &) = default;
   ACE_Time_Value &operator = (ACE_Time_Value &&)  = default;
-#endif /* ACE_HAS_CPP11)
+#endif /* ACE_HAS_CPP11 */
 
   /// Assign @a tv to this
   ACE_Time_Value &operator = (time_t tv);

--- a/ACE/ace/Time_Value.h
+++ b/ACE/ace/Time_Value.h
@@ -84,6 +84,9 @@ public:
   explicit ACE_Time_Value (const timespec_t &t);
 
 #if defined (ACE_HAS_CPP11)
+  ACE_Time_Value (const ACE_Time_Value&) = default;
+  ACE_Time_Value (ACE_Time_Value&&) = default;
+
   /// Construct the ACE_Time_Value object from a chrono duration.
   template< class Rep, class Period >
   explicit ACE_Time_Value (const std::chrono::duration<Rep, Period>& duration)
@@ -264,8 +267,11 @@ public:
   /// Add @a tv to this.
   ACE_Time_Value &operator += (time_t tv);
 
+#if defined (ACE_HAS_CPP11)
   /// Assign @a tv to this
-  ACE_Time_Value &operator = (const ACE_Time_Value &tv);
+  ACE_Time_Value &operator = (const ACE_Time_Value &) = default;
+  ACE_Time_Value &operator = (ACE_Time_Value &&)  = default;
+#endif /* ACE_HAS_CPP11)
 
   /// Assign @a tv to this
   ACE_Time_Value &operator = (time_t tv);

--- a/ACE/ace/Time_Value.inl
+++ b/ACE/ace/Time_Value.inl
@@ -344,15 +344,6 @@ ACE_Time_Value::operator+= (time_t tv)
 }
 
 ACE_INLINE ACE_Time_Value &
-ACE_Time_Value::operator= (const ACE_Time_Value &tv)
-{
-  // ACE_OS_TRACE ("ACE_Time_Value::operator=");
-  this->sec (tv.sec ());
-  this->usec (tv.usec ());
-  return *this;
-}
-
-ACE_INLINE ACE_Time_Value &
 ACE_Time_Value::operator= (time_t tv)
 {
   // ACE_OS_TRACE ("ACE_Time_Value::operator=");


### PR DESCRIPTION
…ted one will be enough. When we have C++11 we declare copy constructor and assignment operators as default, fixes warnings with gcc9

    * ACE/ace/Time_Value.h:
    * ACE/ace/Time_Value.inl: