### PR TITLE
Removed user defined copy constructor and declare copy/move construct…

### DIFF
--- a/ACE/ace/Signal.h
+++ b/ACE/ace/Signal.h
@@ -153,8 +153,12 @@ public:
                   sigset_t *sigmask = 0,
                   int flags = 0);
 
-  /// Copy constructor.
-  ACE_Sig_Action (const ACE_Sig_Action &s);
+#if defined (ACE_HAS_CPP11)
+  ACE_Sig_Action (const ACE_Sig_Action&) = default;
+  ACE_Sig_Action (ACE_Sig_Action&&) = default;
+  ACE_Sig_Action& operator = (ACE_Sig_Action const &) = default;
+  ACE_Sig_Action &operator = (ACE_Sig_Action&&)  = default;
+#endif /* ACE_HAS_CPP11 */
 
   /// Default dtor.
   ~ACE_Sig_Action (void);

--- a/ACE/ace/Signal.inl
+++ b/ACE/ace/Signal.inl
@@ -168,14 +168,6 @@ ACE_Sig_Action::operator struct sigaction * ()
   return &this->sa_;
 }
 
-ACE_INLINE
-ACE_Sig_Action::ACE_Sig_Action (const ACE_Sig_Action &s)
-  // : sa_ ()
-{
-  ACE_TRACE ("ACE_Sig_Action::ACE_Sig_Action");
-  *this = s; // structure copy.
-}
-
 ACE_INLINE int
 ACE_Sig_Action::register_action (int signum, ACE_Sig_Action *oaction)
 {

--- a/ACE/ace/Time_Policy.h
+++ b/ACE/ace/Time_Policy.h
@@ -116,8 +116,12 @@ public:
   /// Set delegate
   void set_delegate (ACE_Dynamic_Time_Policy_Base const * delegate);
 
-  /// Copy policy
-  ACE_Delegating_Time_Policy& operator =(ACE_Delegating_Time_Policy const & pol);
+#if defined (ACE_HAS_CPP11)
+  ACE_Delegating_Time_Policy (const ACE_Delegating_Time_Policy&) = default;
+  ACE_Delegating_Time_Policy (ACE_Delegating_Time_Policy&&) = default;
+  ACE_Delegating_Time_Policy& operator = (ACE_Delegating_Time_Policy const &) = default;
+  ACE_Delegating_Time_Policy &operator = (ACE_Delegating_Time_Policy&&)  = default;
+#endif /* ACE_HAS_CPP11 */
 
   /// Noop. Just here to satisfy backwards compatibility demands.
   void set_gettimeofday (ACE_Time_Value (*gettimeofday)(void));

--- a/ACE/ace/Time_Policy.inl
+++ b/ACE/ace/Time_Policy.inl
@@ -82,11 +82,4 @@ ACE_Delegating_Time_Policy::set_delegate (ACE_Dynamic_Time_Policy_Base const * d
     }
 }
 
-ACE_INLINE ACE_Delegating_Time_Policy&
-ACE_Delegating_Time_Policy::operator =(ACE_Delegating_Time_Policy const & pol)
-{
-  this->delegate_ = pol.delegate_;
-  return *this;
-}
-
 ACE_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
…or/assignment as default with C++11

    * ACE/ace/Signal.h:
    * ACE/ace/Signal.inl:
    * ACE/ace/Time_Policy.h:
    * ACE/ace/Time_Policy.inl: