### PR TITLE
Remove our own default copy constructor, let the compiler generate on…

### DIFF
--- a/TAO/tao/Message_Semantics.h
+++ b/TAO/tao/Message_Semantics.h
@@ -43,8 +43,6 @@ struct TAO_Message_Semantics
       : type_ (type), mode_ (TAO_SYNCH_MODE) {}
     TAO_Message_Semantics (Type type, Mode mode)
       : type_ (type), mode_ (mode) {}
-    TAO_Message_Semantics (const TAO_Message_Semantics& ms)
-      : type_ (ms.type_), mode_ (ms.mode_) {}
 
     Type type_;
     Mode mode_;


### PR DESCRIPTION
…e, will fix a warning with gcc9

    * TAO/tao/Message_Semantics.h: