### PR TITLE
Remove handling of CORBA::TIMEOUT as part of the sendc_ping exception…

### DIFF
--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -119,7 +119,6 @@ typedef TAO_Intrusive_Ref_Count_Handle<AsyncAccessManager> AsyncAccessManager_pt
  *
  * @brief callback for handling asynch server startup requests
  */
-
 class ActivatorReceiver :
   public virtual POA_ImplementationRepository::AMI_ActivatorHandler
 {

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp
@@ -474,18 +474,6 @@ LiveEntry::do_ping (PortableServer::POA_ptr poa)
                           this->server_.c_str()));
         }
     }
-  catch (const CORBA::TIMEOUT &ex)
-    {
-      if (ImR_Locator_i::debug () > 3)
-        {
-          ORBSVCS_DEBUG ((LM_DEBUG,
-                          ACE_TEXT ("(%P|%t) LiveEntry::do_ping, ")
-                          ACE_TEXT ("sendc_ping for server <%C> threw <%C> marking as timed out\n"),
-                          this->server_.c_str(), ex._info ().c_str ()));
-        }
-      this->release_callback ();
-      this->status (LS_TIMEDOUT);
-    }
   catch (const CORBA::Exception &ex)
     {
       if (ImR_Locator_i::debug () > 3)
@@ -501,8 +489,6 @@ LiveEntry::do_ping (PortableServer::POA_ptr poa)
 }
 
 //---------------------------------------------------------------------------
-//---------------------------------------------------------------------------
-
 PingReceiver::PingReceiver (LiveEntry *entry, PortableServer::POA_ptr poa)
   :poa_ (PortableServer::POA::_duplicate(poa)),
    entry_ (entry)


### PR DESCRIPTION
… handling, breaks Windows

    * TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h:
    * TAO/orbsvcs/ImplRepo_Service/LiveCheck.cpp: