### PR TITLE
Increase the ACE_LOG_MSG_GET_THREAD_ID_BUFFER_SIZE from 8 to 12 as an…

### DIFF
--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -1794,7 +1794,7 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
 
 #  ifdef ACE_HAS_GETTID
 #    define ACE_LOG_MSG_GET_THREAD_ID ACE_OS::thr_gettid
-#    define ACE_LOG_MSG_GET_THREAD_ID_BUFFER_SIZE 8
+#    define ACE_LOG_MSG_GET_THREAD_ID_BUFFER_SIZE 12
 #  else
 #    define ACE_LOG_MSG_GET_THREAD_ID ACE_OS::thr_id
 #    define ACE_LOG_MSG_GET_THREAD_ID_BUFFER_SIZE 32


### PR DESCRIPTION
… int is used in the implementation of ACE_OS::thr_gettid and could require 11 bytes of text, including a sign, and a byte to null terminate the string.