### PR TITLE
config-linux-common.h: fix glibc build failure

### DIFF
--- a/ACE/ace/config-linux-common.h
+++ b/ACE/ace/config-linux-common.h
@@ -173,7 +173,7 @@
 
 // Starting with FC9 rawhide this file is not available anymore but
 // this define is set
-#if defined _XOPEN_STREAMS && _XOPEN_STREAMS == -1
+#if !defined(_XOPEN_STREAMS) || (defined _XOPEN_STREAMS && _XOPEN_STREAMS == -1)
 #  define ACE_LACKS_STROPTS_H
 #  define ACE_LACKS_STRRECVFD
 #endif


### PR DESCRIPTION
Recent glibc v2.30 dropped XSI STREAMS declarations,
which causing below build failure.

poky/build/tmp/work/corei7-64-poky-linux/ace/6.5.6-r0/ACE_wrappers/ace/os_include/os_stropts.h:56:17: fatal error: stropts.h: No such file or directory
   56 | #  include /**/ <stropts.h>
      |                 ^~~~~~~~~~~
compilation terminated.

Added GLIBC checks for affected versions.

For more information about glibc v2.30 change, please check:
https://sourceware.org/git/?p=glibc.git;a=commit;h=a0a0dc83173ce11ff45105fd32e5d14356cdfb9c

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>