### PR TITLE
SSL client handshake check not called

### DIFF
--- a/ACE/ace/SSL/SSL_Asynch_Stream.cpp
+++ b/ACE/ace/SSL/SSL_Asynch_Stream.cpp
@@ -513,6 +513,8 @@ ACE_SSL_Asynch_Stream::do_SSL_handshake (void)
     {
     case ST_CLIENT:
       retval = ::SSL_connect (this->ssl_);
+      if (retval == 1) // handshake was successfully completed - ensure that we call post_handshake_check
+        return do_SSL_handshake();
       break;
 
     case ST_SERVER:


### PR DESCRIPTION
With the former ACE 6.1.7, I have observed that a SSL client sometimes fails to establish connection. It looks like a chicken-and-egg problem where the SSL handshake sometimes is completed when SSL_connect returns and sometimes it is not. Resulting in client post_handshake_check first being called later on  when client attempts to read/write some data.
This may be a result of how we use ACE to initiate a connection. 
But I found that when a ACE SSL client calls SSL_connect as part of do_SSL_state_machine and this returns 1 meaning: 
"The TLS/SSL handshake was successfully completed, a TLS/SSL connection has been established."
see https://www.openssl.org/docs/man1.0.2/man3/SSL_connect.html
The do_SSL_handshake will also return 1 which according to the code comments means"SSL handshake is finished already, success". But this is not entirely true from a ACE perspective, as it did not call post_handshake_check.

Ensuring that post_handshake_check is called within the function, resolves the issue I observe.
