### PR TITLE
Fix GetExitCodeProcess error log.

### DIFF
--- a/ACE/ace/Process_Manager.cpp
+++ b/ACE/ace/Process_Manager.cpp
@@ -385,7 +385,7 @@ ACE_Process_Manager::handle_signal (int,
     {
       // <GetExitCodeProcess> failed.
       ACELIB_ERROR_RETURN ((LM_ERROR,
-                         ACE_TEXT ("GetExitCodeProcess failed")),
+                         ACE_TEXT ("GetExitCodeProcess failed\n")),
                         -1); // return -1: unregister
     }
 #else /* !ACE_WIN32 */


### PR DESCRIPTION
When failing to GetExitCodeProcess, the error log is written without newline. 