### PR TITLE
Workaround is still necessary with clang9

### DIFF
--- a/ACE/tests/Compiler_Features_32_Test.cpp
+++ b/ACE/tests/Compiler_Features_32_Test.cpp
@@ -46,7 +46,7 @@ void A::clear ()
 {
 #if defined __clang__ && \
     (defined __apple_build_version__ && __apple_build_version__ < 9100000 \
-     || __clang_major__ <= 8)
+     || __clang_major__ <= 9)
 #define CLANG_WORKAROUND
 #endif
 


### PR DESCRIPTION
    * ACE/tests/Compiler_Features_32_Test.cpp: