### PR TITLE
Replaced QApplication with QCoreApplication for Qt5 (QtQuick applications don't need QApplication)

### DIFF
--- a/ACE/ace/QtReactor/QtReactor.cpp
+++ b/ACE/ace/QtReactor/QtReactor.cpp
@@ -6,7 +6,7 @@ ACE_ALLOC_HOOK_DEFINE (ACE_QtReactor)
 
 // Must be called with lock held
 
-ACE_QtReactor::ACE_QtReactor (QApplication *qapp ,
+ACE_QtReactor::ACE_QtReactor (QAPPLICATION_TYPE *qapp ,
     ACE_Sig_Handler *sh,
     ACE_Timer_Queue *tq,
     int disable_notify_pipe,
@@ -23,7 +23,7 @@ ACE_QtReactor::ACE_QtReactor (QApplication *qapp ,
 
 // Must be called with lock held
 ACE_QtReactor::ACE_QtReactor (size_t size,
-    QApplication *qapp,
+    QAPPLICATION_TYPE *qapp,
     bool restart,
     ACE_Sig_Handler *sh,
     ACE_Timer_Queue *tq,
@@ -108,7 +108,7 @@ ACE_QtReactor::~ACE_QtReactor (void)
 }
 
 void
-ACE_QtReactor::qapplication (QApplication *qapp)
+ACE_QtReactor::qapplication (QAPPLICATION_TYPE *qapp)
 {
   // reparent QSocketNotifiers and QTimer
   qapp_ = qapp ;

--- a/ACE/ace/QtReactor/QtReactor.cpp
+++ b/ACE/ace/QtReactor/QtReactor.cpp
@@ -6,7 +6,7 @@ ACE_ALLOC_HOOK_DEFINE (ACE_QtReactor)
 
 // Must be called with lock held
 
-ACE_QtReactor::ACE_QtReactor (QAPPLICATION_TYPE *qapp ,
+ACE_QtReactor::ACE_QtReactor (ACE_QApplication *qapp ,
     ACE_Sig_Handler *sh,
     ACE_Timer_Queue *tq,
     int disable_notify_pipe,
@@ -23,7 +23,7 @@ ACE_QtReactor::ACE_QtReactor (QAPPLICATION_TYPE *qapp ,
 
 // Must be called with lock held
 ACE_QtReactor::ACE_QtReactor (size_t size,
-    QAPPLICATION_TYPE *qapp,
+    ACE_QApplication *qapp,
     bool restart,
     ACE_Sig_Handler *sh,
     ACE_Timer_Queue *tq,
@@ -108,7 +108,7 @@ ACE_QtReactor::~ACE_QtReactor (void)
 }
 
 void
-ACE_QtReactor::qapplication (QAPPLICATION_TYPE *qapp)
+ACE_QtReactor::qapplication (ACE_QApplication *qapp)
 {
   // reparent QSocketNotifiers and QTimer
   qapp_ = qapp ;

--- a/ACE/ace/QtReactor/QtReactor.h
+++ b/ACE/ace/QtReactor/QtReactor.h
@@ -30,11 +30,11 @@
 // QT toolkit specific includes.
 #ifdef ACE_HAS_QT5
 #include /**/ <QtCore/QCoreApplication>
-#define QAPPLICATION_TYPE QCoreApplication
+typedef QCoreApplication ACE_QApplication;
 #define ACE_QT_HANDLE_TYPE qintptr
 #else
 #include /**/ <QtGui/QApplication>
-#define QAPPLICATION_TYPE QApplication
+typedef QApplication ACE_QApplication;
 #define ACE_QT_HANDLE_TYPE int
 #endif
 #include /**/ <QtCore/QObject>
@@ -99,9 +99,9 @@ class ACE_QtReactor_Export ACE_QtReactor
 
 public:
     /** \brief Constructor follows  @ACE_Select_Reactor
-        \param QAPPLICATION_TYPE *qapp, qapplication which runs events loop
+        \param ACE_QApplication *qapp, qapplication which runs events loop
     */
-    explicit ACE_QtReactor (QAPPLICATION_TYPE *qapp = 0,
+    explicit ACE_QtReactor (ACE_QApplication *qapp = 0,
         ACE_Sig_Handler * = 0,
         ACE_Timer_Queue * = 0,
         int disable_notify_pipe = 0,
@@ -113,7 +113,7 @@ public:
         \param QApplication *qapp, qapplication which runs events loop
     */
     explicit ACE_QtReactor (size_t size,
-        QAPPLICATION_TYPE *qapp = 0,
+        ACE_QApplication *qapp = 0,
         bool restart = false,
         ACE_Sig_Handler * = 0,
         ACE_Timer_Queue * = 0,
@@ -124,7 +124,7 @@ public:
 
     virtual ~ACE_QtReactor (void);
 
-    void qapplication (QAPPLICATION_TYPE *qapp);
+    void qapplication (ACE_QApplication *qapp);
 
     // = Timer operations.
     virtual long schedule_timer (ACE_Event_Handler *handler,
@@ -179,7 +179,7 @@ protected:
     // Wait for Qt events to occur
 
     /// Some Qt stuff that we need to have
-    QAPPLICATION_TYPE *qapp_ ;
+    ACE_QApplication *qapp_ ;
 
     /// Typedef of a map.
     typedef ACE_Map_Manager<ACE_HANDLE, QSocketNotifier *, ACE_Null_Mutex> MAP;

--- a/ACE/ace/QtReactor/QtReactor.h
+++ b/ACE/ace/QtReactor/QtReactor.h
@@ -29,10 +29,12 @@
 
 // QT toolkit specific includes.
 #ifdef ACE_HAS_QT5
-#include /**/ <QtWidgets/QApplication>
+#include /**/ <QtCore/QCoreApplication>
+#define QAPPLICATION_TYPE QCoreApplication
 #define ACE_QT_HANDLE_TYPE qintptr
 #else
 #include /**/ <QtGui/QApplication>
+#define QAPPLICATION_TYPE QApplication
 #define ACE_QT_HANDLE_TYPE int
 #endif
 #include /**/ <QtCore/QObject>
@@ -97,9 +99,9 @@ class ACE_QtReactor_Export ACE_QtReactor
 
 public:
     /** \brief Constructor follows  @ACE_Select_Reactor
-        \param QApplication *qapp, qapplication which runs events loop
+        \param QAPPLICATION_TYPE *qapp, qapplication which runs events loop
     */
-    explicit ACE_QtReactor (QApplication *qapp = 0,
+    explicit ACE_QtReactor (QAPPLICATION_TYPE *qapp = 0,
         ACE_Sig_Handler * = 0,
         ACE_Timer_Queue * = 0,
         int disable_notify_pipe = 0,
@@ -111,7 +113,7 @@ public:
         \param QApplication *qapp, qapplication which runs events loop
     */
     explicit ACE_QtReactor (size_t size,
-        QApplication *qapp = 0,
+        QAPPLICATION_TYPE *qapp = 0,
         bool restart = false,
         ACE_Sig_Handler * = 0,
         ACE_Timer_Queue * = 0,
@@ -122,7 +124,7 @@ public:
 
     virtual ~ACE_QtReactor (void);
 
-    void qapplication (QApplication *qapp);
+    void qapplication (QAPPLICATION_TYPE *qapp);
 
     // = Timer operations.
     virtual long schedule_timer (ACE_Event_Handler *handler,
@@ -177,7 +179,7 @@ protected:
     // Wait for Qt events to occur
 
     /// Some Qt stuff that we need to have
-    QApplication *qapp_ ;
+    QAPPLICATION_TYPE *qapp_ ;
 
     /// Typedef of a map.
     typedef ACE_Map_Manager<ACE_HANDLE, QSocketNotifier *, ACE_Null_Mutex> MAP;

--- a/ACE/bin/MakeProjectCreator/config/ace_qt5.mpb
+++ b/ACE/bin/MakeProjectCreator/config/ace_qt5.mpb
@@ -1,4 +1,4 @@
 // -*- MPC -*-
-project: qt5_gui {
+project: qt5_core {
   macros += ACE_HAS_QT5
 }

--- a/ACE/bin/MakeProjectCreator/config/ace_qt5reactor.mpb
+++ b/ACE/bin/MakeProjectCreator/config/ace_qt5reactor.mpb
@@ -1,5 +1,5 @@
 // -*- MPC -*-
-project : acelib, ace_qt5, qt5_widgets {
+project : acelib, ace_qt5 {
   requires += ace_qt5reactor
   after    += ACE_Qt5Reactor
   libs     += ACE_QtReactor

--- a/ACE/tests/tests.mpc
+++ b/ACE/tests/tests.mpc
@@ -2157,7 +2157,7 @@ project(SOCK_SEQPACK_SCTP_Test) : acetest {
   }
 }
 
-project(QtReactor Test) : acetest, ace_qtreactor {
+project(QtReactor Test) : acetest, ace_qtreactor, qt5_widgets {
   exename   = QtReactor_Test
   MOC_Files {
     QtReactor_Test.h

--- a/TAO/tao/QtResource/QtResource_Factory.cpp
+++ b/TAO/tao/QtResource/QtResource_Factory.cpp
@@ -6,7 +6,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace TAO
 {
-  QtResource_Factory::QtResource_Factory (QApplication *qapp)
+  QtResource_Factory::QtResource_Factory (QAPPLICATION_TYPE *qapp)
     : reactor_impl_ (0)
     , qapp_ (qapp)
   {

--- a/TAO/tao/QtResource/QtResource_Factory.cpp
+++ b/TAO/tao/QtResource/QtResource_Factory.cpp
@@ -6,7 +6,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace TAO
 {
-  QtResource_Factory::QtResource_Factory (QAPPLICATION_TYPE *qapp)
+  QtResource_Factory::QtResource_Factory (ACE_QApplication *qapp)
     : reactor_impl_ (0)
     , qapp_ (qapp)
   {
@@ -18,7 +18,7 @@ namespace TAO
     if (this->qapp_ == 0)
       {
         TAOLIB_ERROR ((LM_ERROR,
-                    "TAO (%P|%t) - QApplication is undefined.",
+                    "TAO (%P|%t) - ACE_QApplication is undefined.",
                     " Cannot create ACE_QtReactor\n"));
         return 0;
       }

--- a/TAO/tao/QtResource/QtResource_Factory.h
+++ b/TAO/tao/QtResource/QtResource_Factory.h
@@ -40,7 +40,7 @@ namespace TAO
   class TAO_QtResource_Export QtResource_Factory : public GUIResource_Factory
   {
   public:
-    QtResource_Factory (QApplication *qapp_);
+    QtResource_Factory (QAPPLICATION_TYPE *qapp_);
 
   protected:
     /// Create or obtain current reactor implementation
@@ -51,7 +51,7 @@ namespace TAO
     ACE_QtReactor *reactor_impl_;
 
     /// QApplication running reactor
-    QApplication *qapp_;
+    QAPPLICATION_TYPE *qapp_;
   };
 }
 

--- a/TAO/tao/QtResource/QtResource_Factory.h
+++ b/TAO/tao/QtResource/QtResource_Factory.h
@@ -40,7 +40,7 @@ namespace TAO
   class TAO_QtResource_Export QtResource_Factory : public GUIResource_Factory
   {
   public:
-    QtResource_Factory (QAPPLICATION_TYPE *qapp_);
+    QtResource_Factory (ACE_QApplication *qapp_);
 
   protected:
     /// Create or obtain current reactor implementation
@@ -51,7 +51,7 @@ namespace TAO
     ACE_QtReactor *reactor_impl_;
 
     /// QApplication running reactor
-    QAPPLICATION_TYPE *qapp_;
+    ACE_QApplication *qapp_;
   };
 }
 

--- a/TAO/tao/QtResource/QtResource_Loader.cpp
+++ b/TAO/tao/QtResource/QtResource_Loader.cpp
@@ -6,7 +6,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace TAO
 {
-  QtResource_Loader::QtResource_Loader (QAPPLICATION_TYPE *qapp)
+  QtResource_Loader::QtResource_Loader (ACE_QApplication *qapp)
   {
     QtResource_Factory *tmp = 0;
 

--- a/TAO/tao/QtResource/QtResource_Loader.cpp
+++ b/TAO/tao/QtResource/QtResource_Loader.cpp
@@ -6,7 +6,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace TAO
 {
-  QtResource_Loader::QtResource_Loader (QApplication *qapp)
+  QtResource_Loader::QtResource_Loader (QAPPLICATION_TYPE *qapp)
   {
     QtResource_Factory *tmp = 0;
 

--- a/TAO/tao/QtResource/QtResource_Loader.h
+++ b/TAO/tao/QtResource/QtResource_Loader.h
@@ -33,6 +33,9 @@
 #endif // !QAPPLICATION_TYPE
 #else
 #include <qapplication.h>
+#ifndef QAPPLICATION_TYPE
+#define QAPPLICATION_TYPE QApplication
+#endif // !QAPPLICATION_TYPE
 #endif
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/QtResource/QtResource_Loader.h
+++ b/TAO/tao/QtResource/QtResource_Loader.h
@@ -22,9 +22,15 @@
 #include "tao/Versioned_Namespace.h"
 
 #ifdef ACE_HAS_QT5
-#include <QtWidgets/QApplication>
+#include <QtCore/QCoreApplication>
+#ifndef QAPPLICATION_TYPE
+#define QAPPLICATION_TYPE QCoreApplication
+#endif // !QAPPLICATION_TYPE
 #elif defined ACE_HAS_QT4
 #include <QtGui/qapplication.h>
+#ifndef QAPPLICATION_TYPE
+#define QAPPLICATION_TYPE QApplication
+#endif // !QAPPLICATION_TYPE
 #else
 #include <qapplication.h>
 #endif
@@ -51,7 +57,7 @@ namespace TAO
   class TAO_QtResource_Export QtResource_Loader
   {
   public:
-    QtResource_Loader (QApplication *qapp);
+    QtResource_Loader (QAPPLICATION_TYPE *qapp);
     virtual ~QtResource_Loader (void);
   };
 }

--- a/TAO/tao/QtResource/QtResource_Loader.h
+++ b/TAO/tao/QtResource/QtResource_Loader.h
@@ -21,22 +21,7 @@
 
 #include "tao/Versioned_Namespace.h"
 
-#ifdef ACE_HAS_QT5
-#include <QtCore/QCoreApplication>
-#ifndef QAPPLICATION_TYPE
-#define QAPPLICATION_TYPE QCoreApplication
-#endif // !QAPPLICATION_TYPE
-#elif defined ACE_HAS_QT4
-#include <QtGui/qapplication.h>
-#ifndef QAPPLICATION_TYPE
-#define QAPPLICATION_TYPE QApplication
-#endif // !QAPPLICATION_TYPE
-#else
-#include <qapplication.h>
-#ifndef QAPPLICATION_TYPE
-#define QAPPLICATION_TYPE QApplication
-#endif // !QAPPLICATION_TYPE
-#endif
+#include "ace/QtReactor/QtReactor.h"
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -60,7 +45,7 @@ namespace TAO
   class TAO_QtResource_Export QtResource_Loader
   {
   public:
-    QtResource_Loader (QAPPLICATION_TYPE *qapp);
+    QtResource_Loader (ACE_QApplication *qapp);
     virtual ~QtResource_Loader (void);
   };
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,6 +151,9 @@ jobs:
   - powershell: |
       '#include "ace/config-macosx.h"' > $(ACE_ROOT)/ace/config.h
     displayName: Create config.h file
+    powershell: |
+      'qt5=1' >> $(ACE_ROOT)/bin/MakeProjectCreator/config/default.features
+    displayName: Create default.features file
   - powershell: |
       'qt5=1' > $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
       'include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU' >> $(ACE_ROOT)/include/makeinclude/platform_macros.GNU;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
   - powershell: |
       New-Item -ItemType "directory" -Path "c:\Temp\Qt5"
       Invoke-WebRequest -Uri "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5130/qt.qt5.5130.win64_msvc2017_64/5.13.0-0-201906171525qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z" -OutFile "C:\Temp\Qt5\qt.7z"
-      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\Qt5\qt.7z -o:C:\Temp\Qt5 -r
+      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\Qt5\qt.7z -o C:\Temp\Qt5 -r
     displayName: Download and extract Qt5 base archive
   - powershell: |
       '#include "ace/config-win32.h"' > $(ACE_ROOT)/ace/config.h

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,8 +54,8 @@ jobs:
     displayName: Install Chocolatey (for 7zip)
   - powershell: |
       New-Item -ItemType "directory" -Path "c:\Temp\Qt5"
-      Invoke-WebRequest -Uri "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5130/qt.qt5.5130.win64_msvc2017_64/5.13.0-0-201906171525qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z" -OutFile "C:\Temp\Qt5\qt.7z"
-      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\Qt5\qt.7z -oC:\Temp\Qt5 -r
+      Invoke-WebRequest -Uri "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5130/qt.qt5.5130.win64_msvc2017_64/5.13.0-0-201906171525qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z" -OutFile "C:\Temp\qt.7z"
+      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\qt.7z -oC:\Temp\Qt5 -r
     displayName: Download and extract Qt5 base archive
   - powershell: |
       '#include "ace/config-win32.h"' > $(ACE_ROOT)/ace/config.h
@@ -151,7 +151,7 @@ jobs:
   - powershell: |
       '#include "ace/config-macosx.h"' > $(ACE_ROOT)/ace/config.h
     displayName: Create config.h file
-    powershell: |
+  - powershell: |
       'qt5=1' >> $(ACE_ROOT)/bin/MakeProjectCreator/config/default.features
     displayName: Create default.features file
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,48 +18,27 @@ resources:
 
 jobs:
 - job: VisualStudio2019
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   pool:
     vmImage: windows-2019
   strategy:
     matrix:
-      WChar:
+      Qt5:
         BuildPlatform: x64
         BuildConfiguration: Debug
         vcpkgarch: x64-windows
         vcpkglibdir: debug\lib
-        vcpkgpackages: 'openssl xerces-c[xmlch_wchar]'
-        OptionalFeatures: uses_wchar=1
-      Debug64:
-        BuildPlatform: x64
-        BuildConfiguration: Debug
-        vcpkgarch: x64-windows
-        vcpkglibdir: debug\lib
-        vcpkgpackages: openssl xerces-c
-      Release64:
-        BuildPlatform: x64
-        BuildConfiguration: Release
-        vcpkgarch: x64-windows
-        vcpkglibdir: lib
-        vcpkgpackages: openssl xerces-c
-      Debug32:
-        BuildPlatform: Win32
-        BuildConfiguration: Debug
-        vcpkgarch: x86-windows
-        vcpkglibdir: debug\lib
-        vcpkgpackages: openssl xerces-c
-      Release32:
-        BuildPlatform: Win32
-        BuildConfiguration: Release
-        vcpkgarch: x86-windows
-        vcpkglibdir: lib
-        vcpkgpackages: openssl xerces-c
+        vcpkgpackages: 'openssl xerces-c qt5-base'
+        OptionalFeatures: qt5=1
   variables:
     VCPKG_ROOT: $(Build.SourcesDirectory)\vcpkg
     XERCESC_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
     XERCESC_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
     SSL_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
     SSL_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
+    QT5_BINDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\tools\qt5\bin
+    QT5_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
+    QT5_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
   steps:
   - powershell: |
       git clone -q --depth 1 git://github.com/Microsoft/vcpkg.git $(VCPKG_ROOT)
@@ -80,9 +59,9 @@ jobs:
     condition: and(succeeded(), ne(variables['OptionalFeatures'], ''))
   - powershell: git clone -q --depth 1 git://github.com/DOCGroup/MPC.git $(MPC_ROOT)
     displayName: git clone MPC
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vs2019 $(TAO_ROOT)/TAO_ACE.mwc -workers 4
+  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vs2019 $(TAO_ROOT)/TAO_ACE.mwc -workers 4 -expand_vars -use_env
     displayName: Run script mwc.pl on $(TAO_ROOT)/TAO_ACE.mwc
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vs2019 $(ACE_ROOT)/tests/tests.mwc -workers 4
+  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vs2019 $(ACE_ROOT)/tests/tests.mwc -workers 4 -expand_vars -use_env
     displayName: Run script mwc.pl on $(ACE_ROOT)/tests/tests.mwc
   - task: VSBuild@1
     displayName: Build solution TAO/TAO_ACE.sln
@@ -95,133 +74,6 @@ jobs:
     displayName: Build solution ACE/tests/tests.sln
     inputs:
       solution: ACE/tests/tests.sln
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
-      maximumCpuCount: true
-
-- job: VisualStudio2017
-  timeoutInMinutes: 120
-  pool:
-    vmImage: vs2017-win2016
-  strategy:
-    matrix:
-      WChar:
-        BuildPlatform: x64
-        BuildConfiguration: Debug
-        vcpkgarch: x64-windows
-        vcpkglibdir: debug\lib
-        vcpkgpackages: 'openssl xerces-c[xmlch_wchar]'
-        OptionalFeatures: uses_wchar=1
-      Debug64:
-        BuildPlatform: x64
-        BuildConfiguration: Debug
-        vcpkgarch: x64-windows
-        vcpkglibdir: debug\lib
-        vcpkgpackages: openssl xerces-c
-      Release64:
-        BuildPlatform: x64
-        BuildConfiguration: Release
-        vcpkgarch: x64-windows
-        vcpkglibdir: lib
-        vcpkgpackages: openssl xerces-c
-  variables:
-    VCPKG_ROOT: $(Build.SourcesDirectory)\vcpkg
-    XERCESC_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
-    XERCESC_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
-    SSL_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
-    SSL_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
-  steps:
-  - powershell: |
-      git clone --depth 1 git://github.com/Microsoft/vcpkg.git $(VCPKG_ROOT)
-      $(VCPKG_ROOT)\bootstrap-vcpkg.bat
-      $(VCPKG_ROOT)\vcpkg install --recurse --triplet $(vcpkgarch) $(vcpkgpackages)
-    displayName: Install additional packages using vcpkg
-  - powershell: |
-      '#include "ace/config-win32.h"' > $(ACE_ROOT)/ace/config.h
-    displayName: Create config.h file
-  - powershell: |
-      echo "xerces3=1" | out-file -encoding ASCII $(ACE_ROOT)\bin\MakeProjectCreator\config\default.features
-      echo "ssl=1" | out-file -append -encoding ASCII $(ACE_ROOT)\bin\MakeProjectCreator\config\default.features
-      echo "versioned_namespace=1" | out-file -append -encoding ASCII $(ACE_ROOT)\bin\MakeProjectCreator\config\default.features
-    displayName: Create default.features file
-  - powershell: |
-      echo $(OptionalFeatures) | out-file -append -encoding ASCII $(ACE_ROOT)\bin\MakeProjectCreator\config\default.features
-    displayName: Add optional features ($(OptionalFeatures))
-    condition: and(succeeded(), ne(variables['OptionalFeatures'], ''))
-  - powershell: git clone --depth 1 git://github.com/DOCGroup/MPC.git $(MPC_ROOT)
-    displayName: git clone MPC
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vs2017 $(TAO_ROOT)/TAO_ACE.mwc -workers 4
-    displayName: Run script mwc.pl on $(TAO_ROOT)/TAO_ACE.mwc
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vs2017 $(ACE_ROOT)/tests/tests.mwc -workers 4
-    displayName: Run script mwc.pl on $(ACE_ROOT)/tests/tests.mwc
-  - task: VSBuild@1
-    displayName: Build solution TAO/TAO_ACE.sln
-    inputs:
-      solution: TAO/TAO_ACE.sln
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
-      maximumCpuCount: true
-  - task: VSBuild@1
-    displayName: Build solution ACE/tests/tests.sln
-    inputs:
-      solution: ACE/tests/tests.sln
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
-      maximumCpuCount: true
-
-- job: VisualStudio2015
-  timeoutInMinutes: 90
-  pool:
-    vmImage: vs2015-win2012r2
-  strategy:
-    matrix:
-      Debug64:
-        BuildPlatform: x64
-        BuildConfiguration: Debug
-        vcpkgarch: x64-windows
-        vcpkglibdir: debug\lib
-      Release64:
-        BuildPlatform: x64
-        BuildConfiguration: Release
-        vcpkgarch: x64-windows
-        vcpkglibdir: lib
-  variables:
-    XERCESCROOT: $(Build.SourcesDirectory)\vcpkg\packages\xerces-c_$(vcpkgarch)
-    SSL_ROOT: $(Build.SourcesDirectory)\vcpkg\packages\openssl-windows_$(vcpkgarch)
-    SSL_LIBDIR: $(SSL_ROOT)\$(vcpkglibdir)
-    XERCESC_LIBDIR: $(XERCESCROOT)\$(vcpkglibdir)
-    VCPKG_ROOT: $(Build.SourcesDirectory)\vcpkg
-  steps:
-  - powershell: |
-      git clone --depth 1 git://github.com/Microsoft/vcpkg.git $(VCPKG_ROOT)
-      $(VCPKG_ROOT)\bootstrap-vcpkg.bat
-      $(VCPKG_ROOT)\vcpkg.exe install --recurse --triplet $(vcpkgarch) openssl xerces-c
-    displayName: vcpkg
-  - powershell: |
-      '#include "ace/config-win32.h"' > $(ACE_ROOT)/ace/config.h
-    displayName: Create config.h file
-  - powershell: |
-      echo "xerces3=1" | out-file -encoding ASCII $(ACE_ROOT)\bin\MakeProjectCreator\config\default.features
-      echo "ssl=1" | out-file -append -encoding ASCII $(ACE_ROOT)\bin\MakeProjectCreator\config\default.features
-      echo "versioned_namespace=1" | out-file -append -encoding ASCII $(ACE_ROOT)\bin\MakeProjectCreator\config\default.features
-    displayName: Create default.features file
-  - powershell: git clone --depth 1 git://github.com/DOCGroup/MPC.git $(MPC_ROOT)
-    displayName: git clone MPC
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vc14 $(TAO_ROOT)/TAO_ACE.mwc -workers 4
-    displayName: Run script mwc.pl on $(TAO_ROOT)/TAO_ACE.mwc
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type vc14 $(ACE_ROOT)/tests/tests.mwc -workers 4
-    displayName: Run script mwc.pl on $(ACE_ROOT)/tests/tests.mwc
-  - task: VSBuild@1
-    displayName: Build solution TAO\TAO_ACE.sln
-    inputs:
-      solution: TAO\TAO_ACE.sln
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
-      maximumCpuCount: true
-  - task: VSBuild@1
-    displayName: Build solution ACE\tests\tests.sln
-    inputs:
-      solution: ACE\tests\tests.sln
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
       maximumCpuCount: true
@@ -236,45 +88,6 @@ jobs:
         CC: gcc
         CXX: g++
         platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU
-      GCC6:
-        CC: gcc-6
-        CXX: g++-6
-        PackageDeps: g++-6
-        platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU
-      GCC7:
-        CC: gcc-7
-        CXX: g++-7
-        PackageDeps: g++-7
-        platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU
-      GCC8:
-        CC: gcc-8
-        CXX: g++-8
-        PackageDeps: g++-8
-        platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU
-      CLANG5:
-        CC: clang-5.0
-        CXX: clang++-5.0
-        PackageDeps: clang-5.0
-        Repo: llvm-toolchain-$(lsb_release -cs)-5.0
-        platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
-      CLANG6:
-        CC: clang-6.0
-        CXX: clang++-6.0
-        PackageDeps: clang-6.0
-        Repo: llvm-toolchain-$(lsb_release -cs)-6.0
-        platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
-      CLANG7:
-        CC: clang-7
-        CXX: clang++-7
-        PackageDeps: clang-7
-        Repo: llvm-toolchain-$(lsb_release -cs)-7
-        platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
-      CLANG8:
-        CC: clang-8
-        CXX: clang++-8
-        PackageDeps: clang-8
-        Repo: llvm-toolchain-$(lsb_release -cs)-8
-        platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
   steps:
   - script: |
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
@@ -284,7 +97,7 @@ jobs:
   - script: |
       sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
       sudo apt-get --yes update
-      sudo apt-get --yes install libxerces-c-dev libssl-dev $(PackageDeps)
+      sudo apt-get --yes install libxerces-c-dev libssl-dev qtbase5-dev qt5-qmake qt5-default $(PackageDeps)
     displayName: install system package dependencies
   - powershell: |
       '#include "ace/config-linux.h"' > $(ACE_ROOT)/ace/config.h
@@ -292,18 +105,20 @@ jobs:
   - powershell: |
       'xerces3=1' > $(ACE_ROOT)/bin/MakeProjectCreator/config/default.features
       'ssl=1' >> $(ACE_ROOT)/bin/MakeProjectCreator/config/default.features
+      'qt5=1' >> $(ACE_ROOT)/bin/MakeProjectCreator/config/default.features
       'versioned_namespace=1' >> $(ACE_ROOT)/bin/MakeProjectCreator/config/default.features
     displayName: Create default.features file
   - powershell: |
       'xerces3=1' > $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
       'ssl=1' >> $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
+      'qt5=1' >> $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
       "$(platform_file)" >> $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
     displayName: Create platform_macros file
   - powershell: git clone --depth 1 git://github.com/DOCGroup/MPC.git $(MPC_ROOT)
     displayName: git clone MPC
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type gnuace $(TAO_ROOT)/TAO_ACE.mwc -workers 4
+  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type gnuace $(TAO_ROOT)/TAO_ACE.mwc -workers 4 -expand_vars -relative QTDIR=/usr
     displayName: Run mwc.pl on $(TAO_ROOT)/TAO_ACE.mwc
-  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type gnuace $(ACE_ROOT)/tests/tests.mwc -workers 4
+  - powershell: perl $(ACE_ROOT)/bin/mwc.pl -type gnuace $(ACE_ROOT)/tests/tests.mwc -workers 4 -expand_vars -relative QTDIR=/usr
     displayName: Run mwc.pl on $(ACE_ROOT)/tests/tests.mwc
   - bash: make -j 6 -C TAO
     displayName: Build TAO project

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,9 +36,6 @@ jobs:
     XERCESC_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
     SSL_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
     SSL_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
-    #QT5_BINDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\tools\qt5\bin
-    #QT5_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
-    #QT5_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
     QTDIR: C:\Temp\Qt5\5.13.0\msvc2017_64
   steps:
   - powershell: |
@@ -47,15 +44,9 @@ jobs:
       $(VCPKG_ROOT)\vcpkg install --recurse --triplet $(vcpkgarch) $(vcpkgpackages)
     displayName: Install additional packages using vcpkg
   - powershell: |
-      $Env:chocolateyUseWindowsCompression = $false
-      iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); choco feature disable --name showDownloadProgress
-      refreshenv
-      choco install -y 7zip
-    displayName: Install Chocolatey (for 7zip)
-  - powershell: |
       New-Item -ItemType "directory" -Path "c:\Temp\Qt5"
       Invoke-WebRequest -Uri "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5130/qt.qt5.5130.win64_msvc2017_64/5.13.0-0-201906171525qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z" -OutFile "C:\Temp\qt.7z"
-      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\qt.7z -oC:\Temp\Qt5 -r
+      7z x C:\Temp\qt.7z -oC:\Temp\Qt5 -r
     displayName: Download and extract Qt5 base archive
   - powershell: |
       '#include "ace/config-win32.h"' > $(ACE_ROOT)/ace/config.h

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
   - powershell: |
       New-Item -ItemType "directory" -Path "c:\Temp\Qt5"
       Invoke-WebRequest -Uri "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5130/qt.qt5.5130.win64_msvc2017_64/5.13.0-0-201906171525qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z" -OutFile "C:\Temp\Qt5\qt.7z"
-      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\Qt5\qt.7z -o C:\Temp\Qt5 -r
+      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\Qt5\qt.7z -oC:\Temp\Qt5 -r
     displayName: Download and extract Qt5 base archive
   - powershell: |
       '#include "ace/config-win32.h"' > $(ACE_ROOT)/ace/config.h
@@ -141,12 +141,19 @@ jobs:
   timeoutInMinutes: 90
   pool:
     vmImage: macOS-10.14
+  variables:
+    QTDIR: /usr/local/opt/qt
   steps:
+  - powershell: |
+      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+      brew install qt
+    displayName: Install Qt5 with homebrew
   - powershell: |
       '#include "ace/config-macosx.h"' > $(ACE_ROOT)/ace/config.h
     displayName: Create config.h file
   - powershell: |
       'include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU' > $(ACE_ROOT)/include/makeinclude/platform_macros.GNU;
+      'qt5=1' >> $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
     displayName: Create platform_macros file
   - powershell: git clone --depth 1 git://github.com/DOCGroup/MPC.git $(MPC_ROOT)
     displayName: git clone MPC

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         BuildConfiguration: Debug
         vcpkgarch: x64-windows
         vcpkglibdir: debug\lib
-        vcpkgpackages: 'openssl xerces-c qt5-base'
+        vcpkgpackages: 'openssl xerces-c'
         OptionalFeatures: qt5=1
   variables:
     VCPKG_ROOT: $(Build.SourcesDirectory)\vcpkg
@@ -36,15 +36,27 @@ jobs:
     XERCESC_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
     SSL_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
     SSL_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
-    QT5_BINDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\tools\qt5\bin
-    QT5_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
-    QT5_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
+    #QT5_BINDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\tools\qt5\bin
+    #QT5_INCDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\include
+    #QT5_LIBDIR: $(VCPKG_ROOT)\installed\$(vcpkgarch)\$(vcpkglibdir)
+    QTDIR: C:\Temp\Qt5\5.13.0\msvc2017_64
   steps:
   - powershell: |
       git clone -q --depth 1 git://github.com/Microsoft/vcpkg.git $(VCPKG_ROOT)
       $(VCPKG_ROOT)\bootstrap-vcpkg.bat
       $(VCPKG_ROOT)\vcpkg install --recurse --triplet $(vcpkgarch) $(vcpkgpackages)
     displayName: Install additional packages using vcpkg
+  - powershell: |
+      $Env:chocolateyUseWindowsCompression = $false
+      iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); choco feature disable --name showDownloadProgress
+      refreshenv
+      choco install -y 7zip
+    displayName: Install Chocolatey (for 7zip)
+  - powershell: |
+      New-Item -ItemType "directory" -Path "c:\Temp\Qt5"
+      Invoke-WebRequest -Uri "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5130/qt.qt5.5130.win64_msvc2017_64/5.13.0-0-201906171525qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z" -OutFile "C:\Temp\Qt5\qt.7z"
+      C:\ProgramData\chocolatey\bin\7z.exe x C:\Temp\Qt5\qt.7z -o:C:\Temp\Qt5 -r
+    displayName: Download and extract Qt5 base archive
   - powershell: |
       '#include "ace/config-win32.h"' > $(ACE_ROOT)/ace/config.h
     displayName: Create config.h file

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,8 +152,8 @@ jobs:
       '#include "ace/config-macosx.h"' > $(ACE_ROOT)/ace/config.h
     displayName: Create config.h file
   - powershell: |
-      'include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU' > $(ACE_ROOT)/include/makeinclude/platform_macros.GNU;
-      'qt5=1' >> $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
+      'qt5=1' > $(ACE_ROOT)/include/makeinclude/platform_macros.GNU
+      'include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU' >> $(ACE_ROOT)/include/makeinclude/platform_macros.GNU;
     displayName: Create platform_macros file
   - powershell: git clone --depth 1 git://github.com/DOCGroup/MPC.git $(MPC_ROOT)
     displayName: git clone MPC


### PR DESCRIPTION
With this change linking against Qt5Widgets isn't required anymore.
