### PR TITLE
Extend Stack_Trace to support ARM/ARM64 on Windows

### DIFF
--- a/ACE/ace/Stack_Trace.cpp
+++ b/ACE/ace/Stack_Trace.cpp
@@ -663,6 +663,22 @@ cs_operate(int (*func)(struct frame_state const *, void *), void *usrarg,
   fs.sf.AddrFrame.Mode = AddrModeFlat;
   fs.sf.AddrBStore.Mode = AddrModeFlat;
   fs.sf.AddrStack.Mode = AddrModeFlat;
+#  elif defined (_M_ARM)
+  DWORD machine = IMAGE_FILE_MACHINE_ARM;
+  fs.sf.AddrPC.Offset = c.Pc;
+  fs.sf.AddrFrame.Offset = c.R11;
+  fs.sf.AddrStack.Offset = c.Sp;
+  fs.sf.AddrPC.Mode = AddrModeFlat;
+  fs.sf.AddrFrame.Mode = AddrModeFlat;
+  fs.sf.AddrStack.Mode = AddrModeFlat;
+#  elif defined (_M_ARM64)
+  DWORD machine = IMAGE_FILE_MACHINE_ARM64;
+  fs.sf.AddrPC.Offset = c.Pc;
+  fs.sf.AddrFrame.Offset = c.Fp;
+  fs.sf.AddrStack.Offset = c.Sp;
+  fs.sf.AddrPC.Mode = AddrModeFlat;
+  fs.sf.AddrFrame.Mode = AddrModeFlat;
+  fs.sf.AddrStack.Mode = AddrModeFlat;
 #  endif
 
   fs.pSym = (PSYMBOL_INFO) GlobalAlloc (GMEM_FIXED,


### PR DESCRIPTION
(cherry picked from commit f2e5a03abba643eb6da996c5db23ad51bc49b9df)