### PR TITLE
gnuace: declare makefile_name.local to be phony

### DIFF
--- a/ACE/include/makeinclude/rules.local.GNU
+++ b/ACE/include/makeinclude/rules.local.GNU
@@ -49,6 +49,7 @@ ifeq ($(use_pwd_call),)
   endif
 endif
 
+.PHONY: makefile_name.local
 ifneq ($(use_pwd_call),1)
 makefile_name.local:
 	@echo


### PR DESCRIPTION
I wanted to use `make --touch` on OpenDDS, which worked but it created all these `makefile_name.local` files everywhere. To stop that, `makefile_name.local` has to be declared as phony because it's not a real file. Props to @mitza-oci for making this more clear to me.