### PR TITLE
Avoid the use of unmanaged strings in ACE_Env_Helper

### DIFF
--- a/ACE/ace/XML_Utils/XML_Schema_Resolver.cpp
+++ b/ACE/ace/XML_Utils/XML_Schema_Resolver.cpp
@@ -6,6 +6,7 @@
 #include "XercesString.h"
 
 #include "ace/Env_Value_T.h"
+#include "ace/SString.h"
 
 #include <iostream>
 
@@ -41,10 +42,10 @@ namespace XML
   Environment_Resolver::add_path (const ACE_TCHAR *variable,
                                   const ACE_TCHAR *relpath)
   {
-    ACE_Env_Value <const ACE_TCHAR *> path_env (variable,
-                                                ACE_TEXT(""));
+    ACE_Env_Value <ACE_TString> path_env (variable,
+                                          ACE_TEXT(""));
 
-    XStr xpath (path_env);
+    XStr xpath (static_cast<ACE_TString>(path_env).c_str());
     XStr xrelpath (relpath);
 
     xpath.append (xrelpath);

--- a/ACE/protocols/ace/INet/INet_Log.cpp
+++ b/ACE/protocols/ace/INet/INet_Log.cpp
@@ -22,7 +22,7 @@ namespace ACE
         ACE_Env_Value<int> trace_env (ACE_TEXT("INET_TRACE_ENABLE"), 0);
         trace = (trace_env != 0);
 
-        ACE_Env_Value<const ACE_TCHAR *> filename_env (ACE_TEXT("INET_LOG_FILE"), filename.c_str ());
+        ACE_Env_Value<ACE_TString> filename_env (ACE_TEXT("INET_LOG_FILE"), filename.c_str ());
         filename = filename_env;
 
         if (trace)

--- a/ACE/tests/Env_Value_Test.cpp
+++ b/ACE/tests/Env_Value_Test.cpp
@@ -17,6 +17,7 @@
 #include "ace/OS_NS_string.h"
 #include "ace/Process.h"
 #include "ace/Env_Value_T.h"
+#include "ace/SString.h"
 
 #define TEST_THIS(type, varname, defval, expval) \
 do { \
@@ -61,13 +62,25 @@ run_main (int, ACE_TCHAR* [])
       TEST_THIS (short, ACE_TEXT ("TEST_VALUE_NEGATIVE"), 0, -10);
       TEST_THIS (unsigned short, ACE_TEXT ("TEST_VALUE_NEGATIVE"), 0, (unsigned short) -10);
 
-      const ACE_TCHAR *defstr = ACE_TEXT ("Sarah Cleeland is Two!");
-      ACE_Env_Value<const ACE_TCHAR *> sval (ACE_TEXT ("This_Shouldnt_Be_Set_Hopefully"),
-                                  defstr);
-      if (ACE_OS::strcmp (sval, defstr) != 0)
+      const ACE_TCHAR* const defstr = ACE_TEXT ("Sarah Cleeland is Two!");
+
+      ACE_Env_Value<ACE_TString> sval1 (ACE_TEXT ("This_Shouldnt_Be_Set_Hopefully"),
+                                        defstr);
+      if (ACE_OS::strcmp (static_cast<ACE_TString>(sval1).c_str(), defstr) != 0) {
         ACE_ERROR ((LM_ERROR,
                     ACE_TEXT ("Mismatch: %s should be %s\n"),
-                    (const ACE_TCHAR *)sval, defstr));
+                    static_cast<ACE_TString>(sval1).c_str(), defstr));
+      }
+
+      const ACE_TString strval(ACE_TEXT("-10.2"));
+
+      ACE_Env_Value<ACE_TString> sval2 (ACE_TEXT ("TEST_VALUE_NEGATIVE"),
+                                        defstr);
+      if (ACE_OS::strcmp (static_cast<ACE_TString>(sval2).c_str(), strval.c_str()) != 0) {
+        ACE_ERROR ((LM_ERROR,
+                    ACE_TEXT ("Mismatch: %s should be %s\n"),
+                    static_cast<ACE_TString>(sval2).c_str(), strval.c_str()));
+      }
       ACE_END_TEST;
     }
 #endif // ACE_LACKS_PUTENV


### PR DESCRIPTION
Inline conversion of character pointer types can leave pointers to temporary buffers in value_ and cause subsequent read access violations.

See #999 