### PR TITLE
Prevent crash

### DIFF
--- a/TAO/TAO_IDL/ast/ast_annotation_appls.cpp
+++ b/TAO/TAO_IDL/ast/ast_annotation_appls.cpp
@@ -102,7 +102,13 @@ AST_Annotation_Appls::find (const char *annotation)
       return 0;
     }
 
-  AST_Decl* decl = idl_global->scopes ().bottom ()->lookup_by_name (annotation);
+  UTL_Scope* bottom = idl_global->scopes ().bottom ();
+  if (!bottom)
+    {
+      return 0;
+    }
+
+  AST_Decl* decl = bottom->lookup_by_name (annotation);
   if (!decl)
     {
       return 0;


### PR DESCRIPTION
Discovered that if there are no scopes, then bottom() will return nullptr. This was discovered in my own tests where the AST was constructed programatically and not by the frontend.