### PR TITLE
Fixed typo in config-posix.h

### DIFF
--- a/ACE/ace/config-posix.h
+++ b/ACE/ace/config-posix.h
@@ -58,7 +58,7 @@
 #       define ACE_HAS_PTHREADS
 #     endif /* ACE_HAS_PTHREADS */
 
-#     if defined (_POSIX_CLOCK_SELECTION) && (_POSIX_POSIX_CLOCK_SELECTION-0 != -1)
+#     if defined (_POSIX_CLOCK_SELECTION) && (_POSIX_CLOCK_SELECTION-0 != -1)
 #       if !defined (ACE_HAS_CONDATTR_SETCLOCK) && !defined (ACE_LACKS_CONDATTR_SETCLOCK)
 #         define ACE_HAS_CONDATTR_SETCLOCK
 #       endif


### PR DESCRIPTION
I suspect this was a typo. 