### PR TITLE
Various fixes for tao_idl built using clang with -fsanitize=undefined,address passed.

### DIFF
--- a/ACE/ace/Synch_Options.cpp
+++ b/ACE/ace/Synch_Options.cpp
@@ -52,7 +52,13 @@ ACE_Synch_Options::set (unsigned long options,
   // function is called during initialization of the statics above.
   // But, ACE_Time_Value::zero is a static object.  Very fortunately,
   // its bits have a value of 0.
-  if (this->timeout_ != ACE_Time_Value::zero)
+  if (timeout_ !=
+#ifdef ACE_INITIALIZE_MEMORY_BEFORE_USE
+      ACE_Time_Value(0) // For satisfying clang's undefined behavior sanitizer
+#else
+      ACE_Time_Value::zero
+#endif
+    )
     ACE_SET_BITS (this->options_, ACE_Synch_Options::USE_TIMEOUT);
 
   this->arg_ = arg;

--- a/ACE/ace/Synch_Options.cpp
+++ b/ACE/ace/Synch_Options.cpp
@@ -54,7 +54,7 @@ ACE_Synch_Options::set (unsigned long options,
   // its bits have a value of 0.
   if (timeout_ !=
 #ifdef ACE_INITIALIZE_MEMORY_BEFORE_USE
-      ACE_Time_Value(0) // For satisfying clang's undefined behavior sanitizer
+      ACE_Time_Value (0) // For satisfying clang's undefined behavior sanitizer
 #else
       ACE_Time_Value::zero
 #endif

--- a/ACE/ace/Synch_Options.cpp
+++ b/ACE/ace/Synch_Options.cpp
@@ -48,17 +48,12 @@ ACE_Synch_Options::set (unsigned long options,
   this->options_ = options;
   this->timeout_ = timeout;
 
-  // Whoa, possible dependence on static initialization here.  This
-  // function is called during initialization of the statics above.
-  // But, ACE_Time_Value::zero is a static object.  Very fortunately,
-  // its bits have a value of 0.
-  if (timeout_ !=
-#ifdef ACE_INITIALIZE_MEMORY_BEFORE_USE
-      ACE_Time_Value (0) // For satisfying clang's undefined behavior sanitizer
-#else
-      ACE_Time_Value::zero
-#endif
-    )
+  /*
+   * Not using ACE_Time_Value::zero because of possible static init order
+   * dependence. It would work fine because the memory would all zeros anyways,
+   * but ubsan complains about it.
+   */
+  if (timeout_ != ACE_Time_Value(0))
     ACE_SET_BITS (this->options_, ACE_Synch_Options::USE_TIMEOUT);
 
   this->arg_ = arg;

--- a/TAO/TAO_IDL/ast/ast_interface.cpp
+++ b/TAO/TAO_IDL/ast/ast_interface.cpp
@@ -350,11 +350,7 @@ AST_Interface::fwd_redefinition_helper (AST_Interface *&i,
 
   // Fwd redefinition should be in the same scope, so local
   // lookup is all that's needed.
-  AST_Decl *d = s->lookup_by_name_local (i->local_name (),
-                                         false);
-
-  AST_Interface *fd = 0;
-
+  AST_Decl *d = s->lookup_by_name_local (i->local_name (), false);
   if (d != 0)
     {
       scope = d->defined_in ();
@@ -375,9 +371,7 @@ AST_Interface::fwd_redefinition_helper (AST_Interface *&i,
           scope = parent->defined_in ();
         }
 
-      fd = AST_Interface::narrow_from_decl (d);
-
-      // Successful?
+      AST_Interface *fd = dynamic_cast<AST_Interface*> (d);
       if (fd == 0)
         {
           AST_Decl::NodeType nt = d->node_type ();
@@ -421,7 +415,6 @@ AST_Interface::fwd_redefinition_helper (AST_Interface *&i,
               fd->redefine (i);
 
               AST_InterfaceFwd *fwd = fd->fwd_decl ();
-
               if (fwd != 0)
                 {
                   fwd->set_as_defined ();
@@ -636,7 +629,6 @@ AST_Interface::redefine (AST_Interface *from)
   this->set_file_name (idl_global->filename ()->get_string ());
   this->ifr_added_ = from->ifr_added_;
   this->ifr_fwd_added_ = from->ifr_fwd_added_;
-  this->fwd_decl_->set_as_defined ();
 }
 
 // Data accessors.

--- a/TAO/TAO_IDL/ast/ast_interface.cpp
+++ b/TAO/TAO_IDL/ast/ast_interface.cpp
@@ -371,7 +371,7 @@ AST_Interface::fwd_redefinition_helper (AST_Interface *&i,
           scope = parent->defined_in ();
         }
 
-      AST_Interface *fd = dynamic_cast<AST_Interface*> (d);
+      AST_Interface *fd = dynamic_cast<AST_Interface *> (d);
       if (fd == 0)
         {
           AST_Decl::NodeType nt = d->node_type ();

--- a/TAO/TAO_IDL/ast/ast_interface_fwd.cpp
+++ b/TAO/TAO_IDL/ast/ast_interface_fwd.cpp
@@ -84,7 +84,8 @@ AST_InterfaceFwd::AST_InterfaceFwd (AST_Interface *dummy,
               n),
     AST_Type (AST_Decl::NT_interface_fwd,
               n),
-    is_defined_ (false)
+    is_defined_ (false),
+    has_ownership_ (true)
 {
   // Create a dummy placeholder for the forward declared interface. This
   // interface node is not yet defined (n_inherits < 0), so some operations
@@ -206,9 +207,13 @@ AST_InterfaceFwd::full_definition (void)
 void
 AST_InterfaceFwd::set_full_definition (AST_Interface *nfd)
 {
-  this->pd_full_definition->destroy ();
-  delete this->pd_full_definition;
-  this->pd_full_definition = nfd;
+  if (pd_full_definition && has_ownership_)
+    {
+      pd_full_definition->destroy ();
+      delete pd_full_definition;
+    }
+  pd_full_definition = nfd;
+  has_ownership_ = false;
 }
 
 bool
@@ -230,11 +235,10 @@ AST_InterfaceFwd::is_defined (void)
             {
               // We could be looking at a superfluous forward decl
               // of an interface already defined.
-              AST_Interface *full = AST_Interface::narrow_from_decl (d);
-
+              AST_Interface *full = dynamic_cast<AST_Interface *> (d);
               if (0 != full)
                 {
-                  this->is_defined_ = true;
+                  set_as_defined ();
                 }
 
               AST_InterfaceFwd *fwd =
@@ -248,7 +252,7 @@ AST_InterfaceFwd::is_defined (void)
               // add_to_scope process.
               if (0 != fwd && fwd->is_defined ())
                 {
-                  this->is_defined_ = true;
+                  set_as_defined ();
                 }
             }
         }
@@ -258,29 +262,21 @@ AST_InterfaceFwd::is_defined (void)
 }
 
 void
-AST_InterfaceFwd::set_as_defined (void)
+AST_InterfaceFwd::set_as_defined (bool disown)
 {
-  this->is_defined_ = true;
+  is_defined_ = true;
+  if (disown)
+    {
+      has_ownership_ = false;
+    }
 }
 
 void
 AST_InterfaceFwd::destroy (void)
 {
-  // The implementation of is_defined() accomodates
-  // code generation issues and doesn't have the
-  // correct semantics here. The older implementation
-  // of is_defined is used in the IF block below to
-  // check if our full definition allocation must be
-  // destroyed.
-  if (!this->is_defined_)
+  if (has_ownership_)
     {
-      // If our full definition is not defined, it
-      // means that there was no full definition
-      // for us in this compilation unit, so we
-      // have to destroy this allocation.
-      this->pd_full_definition->destroy ();
-      delete this->pd_full_definition;
-      this->pd_full_definition = 0;
+      set_full_definition (0);
     }
 
   this->AST_Type::destroy ();

--- a/TAO/TAO_IDL/ast/ast_interface_fwd.cpp
+++ b/TAO/TAO_IDL/ast/ast_interface_fwd.cpp
@@ -262,13 +262,15 @@ AST_InterfaceFwd::is_defined (void)
 }
 
 void
-AST_InterfaceFwd::set_as_defined (bool disown)
+AST_InterfaceFwd::set_as_defined ()
 {
   is_defined_ = true;
-  if (disown)
-    {
-      has_ownership_ = false;
-    }
+}
+
+void
+AST_InterfaceFwd::disown_full_definition ()
+{
+  has_ownership_ = false;
 }
 
 void

--- a/TAO/TAO_IDL/be/be_visitor_context.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_context.cpp
@@ -11,6 +11,7 @@
 
 #include "be_visitor_context.h"
 #include "be_extern.h"
+#include "be_helper.h"
 
 be_visitor_context::be_visitor_context (void)
   : ast_visitor_context (),
@@ -101,7 +102,8 @@ be_visitor_context::stream (TAO_OutStream *os)
 TAO_OutStream *
 be_visitor_context::stream (void)
 {
-  return this->os_;
+  static TAO_OutStream null_stream;
+  return os_ ? os_ : &null_stream;
 }
 
 void

--- a/TAO/TAO_IDL/include/ast_interface_fwd.h
+++ b/TAO/TAO_IDL/include/ast_interface_fwd.h
@@ -80,10 +80,23 @@ public:
   virtual ~AST_InterfaceFwd (void);
 
   AST_Interface *full_definition (void);
+
+  /**
+   * Sets the full definition. If there is an existing dummy definition, it
+   * deletes that first. Ownership of the new definition is NOT assumed.
+   */
   void set_full_definition (AST_Interface *nfd);
 
   virtual bool is_defined (void);
-  void set_as_defined (void);
+
+  /**
+   * Marks this as "defined".
+   *
+   * By default it assumes that ownership of the full definition remains with
+   * this object. If this is not the case, such as if the dummy definition was
+   * redefined and added to a scope, pass true to disown the definition.
+   */
+  void set_as_defined (bool disown = false);
 
   virtual bool is_local (void);
   virtual bool is_valuetype (void);
@@ -120,6 +133,9 @@ private:
 
   bool is_defined_;
   // Checking the member above isn't good enough.
+
+  /// True if we own pd_full_definition, which would be true if it's a dummy.
+  bool has_ownership_;
 };
 
 #endif           // _AST_INTERFACE_FWD_AST_INTERFACE_FWD_HH

--- a/TAO/TAO_IDL/include/ast_interface_fwd.h
+++ b/TAO/TAO_IDL/include/ast_interface_fwd.h
@@ -88,15 +88,15 @@ public:
   void set_full_definition (AST_Interface *nfd);
 
   virtual bool is_defined (void);
+  void set_as_defined ();
 
   /**
-   * Marks this as "defined".
+   * Do not assume memory ownership of the full definition anymore.
    *
-   * By default it assumes that ownership of the full definition remains with
-   * this object. If this is not the case, such as if the dummy definition was
-   * redefined and added to a scope, pass true to disown the definition.
+   * For example, this should be used if the dummy definition was made real and
+   * added to a scope, which always assumes ownership of nodes.
    */
-  void set_as_defined (bool disown = false);
+  void disown_full_definition ();
 
   virtual bool is_local (void);
   virtual bool is_valuetype (void);

--- a/TAO/TAO_IDL/include/utl_scope_T.cpp
+++ b/TAO/TAO_IDL/include/utl_scope_T.cpp
@@ -20,7 +20,6 @@ UTL_Scope::fe_add_full_intf_decl (DECL *t)
     }
 
   AST_Decl *predef = 0;
-  DECL *fwd = 0;
 
   // Already defined?
   if ((predef = this->lookup_for_add (t)) != 0)
@@ -28,8 +27,7 @@ UTL_Scope::fe_add_full_intf_decl (DECL *t)
       // Treat fwd declared interfaces specially
       if (predef->node_type () == DECL::NT)
         {
-          fwd = DECL::narrow_from_decl (predef);
-
+          DECL *fwd = dynamic_cast<DECL *> (predef);
           if (fwd == 0)
             {
               return 0;
@@ -95,10 +93,9 @@ UTL_Scope::fe_add_full_intf_decl (DECL *t)
   // since fwd declared structs and unions must be defined in
   // the same translation unit.
   AST_InterfaceFwd *fd = t->fwd_decl ();
-
   if (0 != fd)
     {
-      fd->set_as_defined ();
+      fd->set_as_defined (true /* transfered ownership to scope */);
     }
 
   // Add it to set of locally referenced symbols
@@ -127,8 +124,7 @@ UTL_Scope::fe_add_fwd_intf_decl (typename FULL_DECL::FWD_TYPE *t)
       // value, but the result is what we want.
       if (nt == FULL_DECL::NT)
         {
-          FULL_DECL *itf = FULL_DECL::narrow_from_decl (d);
-
+          FULL_DECL *itf = dynamic_cast<FULL_DECL *> (d);
           if (itf == 0)
             {
               return 0;
@@ -140,23 +136,13 @@ UTL_Scope::fe_add_fwd_intf_decl (typename FULL_DECL::FWD_TYPE *t)
           // get destroyed twice.
           if (itf->is_defined ())
             {
-              if (!t->is_defined ())
-                {
-                  FULL_DECL *prev_fd =
-                    FULL_DECL::narrow_from_decl (t->full_definition ());
-
-                  prev_fd->destroy ();
-                  // No need to delete prev_fd, the call to
-                  // set_full_definition() below will do it.
-                }
-
               t->set_full_definition (itf);
               t->set_as_defined ();
             }
         }
 
-      if (!FE_Utils::can_be_redefined (d, t)) {
-
+      if (!FE_Utils::can_be_redefined (d, t))
+        {
           idl_global->err ()->error3 (UTL_Error::EIDL_REDEF,
                                       t,
                                       ScopeAsDecl (this),

--- a/TAO/TAO_IDL/include/utl_scope_T.cpp
+++ b/TAO/TAO_IDL/include/utl_scope_T.cpp
@@ -95,7 +95,8 @@ UTL_Scope::fe_add_full_intf_decl (DECL *t)
   AST_InterfaceFwd *fd = t->fwd_decl ();
   if (0 != fd)
     {
-      fd->set_as_defined (true /* transfered ownership to scope */);
+      fd->set_as_defined ();
+      fd->disown_full_definition (); // This scope assumes ownership
     }
 
   // Add it to set of locally referenced symbols

--- a/TAO/TAO_IDL/util/utl_scope.cpp
+++ b/TAO/TAO_IDL/util/utl_scope.cpp
@@ -2247,6 +2247,7 @@ UTL_Scope::lookup_by_name (const char *name)
   AST_Decl *node = 0;
   UTL_ScopedName *scoped_name = FE_Utils::string_to_scoped_name (name);
   node = lookup_by_name (scoped_name);
+  scoped_name->destroy();
   delete scoped_name;
   return node;
 }

--- a/TAO/TAO_IDL/util/utl_scope.cpp
+++ b/TAO/TAO_IDL/util/utl_scope.cpp
@@ -2247,7 +2247,7 @@ UTL_Scope::lookup_by_name (const char *name)
   AST_Decl *node = 0;
   UTL_ScopedName *scoped_name = FE_Utils::string_to_scoped_name (name);
   node = lookup_by_name (scoped_name);
-  scoped_name->destroy();
+  scoped_name->destroy ();
   delete scoped_name;
   return node;
 }


### PR DESCRIPTION
Various fixes for tao_idl built using clang with `-fsanitize=undefined,address` passed.

- Work around static init ub in `ACE_Sync_Options`.
- Fix a memory leak in `UTL_Scope` and a possible null dereference in tao_idl be.
- Fixed a hard to track down memory leak involving `AST_InterfaceFwd` not handling ownership of its placeholder `AST_Interface` correctly under a case when a forward declaration of an interface is made after the interface was already declared.