### PR TITLE
Rewrote auto_run_tests.pl Arg Parsing

### DIFF
--- a/ACE/bin/auto_run_tests.pl
+++ b/ACE/bin/auto_run_tests.pl
@@ -3,8 +3,10 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
     if 0;
 
 # -*- perl -*-
-# This file is for running the run_test.pl scripts listed in
-# auto_run_tests.lst.
+# Executes test list files (*.lst), which contain commands with conditions
+# called configurations under which the commands are run.
+
+use strict;
 
 use lib "$ENV{ACE_ROOT}/bin";
 if (defined $ENV{srcdir}) {
@@ -12,8 +14,7 @@ if (defined $ENV{srcdir}) {
 }
 use PerlACE::Run_Test;
 
-use English;
-use Getopt::Std;
+use Getopt::Long;
 use Cwd;
 
 use Env qw(ACE_ROOT PATH TAO_ROOT CIAO_ROOT DANCE_ROOT DDS_ROOT);
@@ -31,20 +32,24 @@ if (!defined $DDS_ROOT && -d "$ACE_ROOT/TAO/DDS") {
     $DDS_ROOT = "$ACE_ROOT/TAO/DDS";
 }
 
-sub run_command ($$) {
+sub run_command {
+  my $test = shift;
   my $command = shift;
   my $print_error = shift;
+
   my $result = 0;
-  if (system($command)) {
+  if (system ($command)) {
     $result = $? >> 8;
     if ($print_error) {
+      my $signal = $? & 127;
+      my $coredump = $? & 128;
       my $error_message;
       if ($? == -1) {
         $error_message = "failed to run: $!";
       }
-      elsif ($? & 127) {
-        $error_message = sprintf("exited on signal %d", ($? & 127));
-        $error_message .= " and created coredump" if ($? & 128);
+      elsif ($signal) {
+        $error_message = sprintf ("exited on signal %d", ($signal));
+        $error_message .= " and created coredump" if ($coredump);
       }
       else {
         $error_message = sprintf ("returned with status %d", $result);
@@ -55,110 +60,136 @@ sub run_command ($$) {
   return $result;
 }
 
+sub print_help {
+  my $fd = shift;
+  print $fd
+    "auto_run_tests.pl [<options> ...] [<list_file> ...]\n" .
+    "\n" .
+    "Executes test list files (*.lst), which contain commands with conditions called\n" .
+    "configurations under which the commands are run.\n" .
+    "\n" .
+    "Test lists files can be specified using the -l option or as non-option\n" .
+    "arguments. The standard test list files for ACE/TAO and related software are\n" .
+    "built-in and can be included via the listed options before. If not test list\n" .
+    "files are specified, the script tries to use all the standard test list files\n" .
+    "that can be found.\n" .
+    "\n" .
+    "Options:\n" .
+    "    --help | -h              Display this help\n" .
+
+    "    --ace | -a               Include the ACE tests\n" .
+    "    --orb | -o               Include the TAO ORB tests\n" .
+    "    --tao | -t               Include the TAO non-ORB tests\n" .
+    "    --ciao-dance | -C        Include the CIAO and DAnCE tests\n" .
+    "    --opendds | -d           Include the OpenDDS tests\n" .
+
+    "    -l <list_file>           Include the tests from <list_file>\n" .
+
+    "    --sandbox | -s <sandbox> Runs each program using a sandbox program\n" .
+    "    --root | -r <dir>        Root directory for running the tests\n" .
+    "    --dry-run | -z           Just print the commands that would be ran\n" .
+    "    --show-configs           Just print possible values for -Config\n" .
+
+    # These two are processed by PerlACE/ConfigList.pm
+    "    -Config <cfg>            Include tests with <cfg> configuration\n" .
+    "    -Exclude <cfg>           Exclude tests with <cfg> configuration\n" .
+
+    # This one is processed by PerlACE/Process.pm
+    "    -ExeSubDir <dir>         Subdirectory for finding the executables\n";
+}
+
 ################################################################################
 
-if (!getopts ('adl:os:r:tCd') || $opt_h) {
-    print "auto_run_tests.pl [-a] [-h] [-s sandbox] [-o] [-t]\n";
-    print "\n";
-    print "Runs the tests listed in auto_run_tests.lst\n";
-    print "\n";
-    print "Options:\n";
-    print "    -a             ACE tests only\n";
-    print "    -c config      Run the tests for the <config> configuration\n";
-    print "    -h             Display this help\n";
-    print "    -s sandbox     Runs each program using a sandbox program\n";
-    print "    -o             ORB test only\n";
-    print "    -t             TAO tests (other than ORB tests) only\n";
-    print "    -C             CIAO and DAnCE tests only\n";
-    print "    -d             Run OpenDDS tests only\n";
-    print "    -z             Run debug mode, no tests executed\n";
-    print "    -Config cfg    Run the tests for the <cfg> configuration\n";
-    print "    -l list        Load the list and run only those tests\n";
-    print "    -r dir         Root directory for running the tests\n";
-    print "    -ExeSubDir dir Subdirectory for finding the executables,\n";
+# Parse Options
+my $help = 0;
+my $ace_tests = 0;
+my $tao_orb_tests = 0;
+my $tao_tests = 0;
+my $ciao_dance_tests = 0;
+my $opendds_tests = 0;
+my @l_options = ();
+my $sandbox = '';
+my $dry_run = 0;
+my $startdir = '';
+my $show_configs = 0;
+Getopt::Long::Configure ('bundling', 'no_auto_abbrev');
+my $invalid_arguments = !GetOptions (
+  'help|h' => \$help,
+  'ace|a' => \$ace_tests,
+  'orb|o' => \$tao_orb_tests,
+  'tao|t' => \$tao_tests,
+  'ciao-dance|C' => \$ciao_dance_tests,
+  'opendds|d' => \$opendds_tests,
+  'l=s' => \@l_options,
+  'sandbox|s=s' => \$sandbox,
+  'dry-run|z' => \$dry_run,
+  'root|r=s' => \$startdir,
+  'show-configs' => \$show_configs,
+);
+if ($invalid_arguments || $help) {
+  print_help ($invalid_arguments ? *STDERR : *STDOUT);
+  exit ($invalid_arguments ? 1 : 0);
+}
 
-    print "\n";
-    $ace_config_list = new PerlACE::ConfigList;
-    $ace_config_list->load ($ACE_ROOT."/bin/ace_tests.lst");
-    print "ACE Test Configs: " . $ace_config_list->list_configs () . "\n";
-    if (defined $TAO_ROOT) {
-        $orb_config_list = new PerlACE::ConfigList;
-        $orb_config_list->load ($TAO_ROOT."/bin/tao_orb_tests.lst");
-        print "ORB Test Configs: " . $orb_config_list->list_configs () . "\n";
-        $tao_config_list = new PerlACE::ConfigList;
-        $tao_config_list->load ($TAO_ROOT."/bin/tao_other_tests.lst");
-        print "TAO Test Configs: " . $tao_config_list->list_configs () . "\n";
+# Determine what test list files to use
+my @main_test_lists = (
+  [\$ace_tests, $ACE_ROOT, "bin/ace_tests.lst", "ACE"],
+  [\$tao_orb_tests, $TAO_ROOT, "bin/tao_orb_tests.lst", "TAO ORB"],
+  [\$tao_tests, $TAO_ROOT, "bin/tao_other_tests.lst", "TAO non-ORB"],
+  [\$ciao_dance_tests, $CIAO_ROOT, "bin/ciao_tests.lst", "CIAO"],
+  [\$ciao_dance_tests, $DANCE_ROOT, "bin/dance_tests.lst", "DANCE"],
+  [\$opendds_tests, $DDS_ROOT, "bin/dcps_tests.lst", "OpenDDS"],
+);
+my @file_list = ();
+my $list_error = 0;
+foreach my $i (@main_test_lists) {
+  my $enabled_ref = $i->[0];
+  my $root = $i->[1];
+  my $list_file = $i->[2];
+  my $name = $i->[3];
+  my $list_file_path = "$root/$list_file";
+  if (defined $root && $$enabled_ref) {
+    push (@file_list, $list_file_path);
+  }
+  elsif ($$enabled_ref) {
+    $list_error = "option for $name tests passed, but the root enviroment variable isn't set";
+  }
+}
+push (@file_list, @l_options);
+push (@file_list, @ARGV);
+if (!scalar (@file_list)) {
+  foreach my $i (@main_test_lists) {
+    my $root = $i->[1];
+    my $list_file = $i->[2];
+    my $list_file_path = "$root/$list_file";
+    if (defined $root && -f $list_file_path) {
+      push (@file_list, $list_file_path);
     }
-    if (defined $CIAO_ROOT) {
-        $ciao_config_list = new PerlACE::ConfigList;
-        $ciao_config_list->load ($CIAO_ROOT."/bin/ciao_tests.lst");
-        print "CIAO Test Configs: " . $ciao_config_list->list_configs ()
-            . "\n";
-    }
-    if (defined $DANCE_ROOT) {
-        $dance_config_list = new PerlACE::ConfigList;
-        $dance_config_list->load ($DANCE_ROOT."/bin/dance_tests.lst");
-        print "DAnCE Test Configs: " . $dance_config_list->list_configs ()
-            . "\n";
-    }
-    if (defined $DDS_ROOT) {
-        $dds_config_list = new PerlACE::ConfigList;
-        $dds_config_list->load ($DDS_ROOT."/bin/dcps_tests.lst");
-        print "DDS Test Configs: " . $dds_config_list->list_configs ()
-            . "\n";
-    }
-    exit (1);
+  }
+  if (!scalar (@file_list)) {
+    $list_error = "no default test lists could be found";
+  }
+}
+if ($list_error) {
+  print STDERR "ERROR: $list_error\n";
+  exit (1);
 }
 
-my @file_list;
-
-if ($opt_a) {
-push (@file_list, "bin/ace_tests.lst");
+if ($show_configs) {
+  foreach my $test_list (@file_list) {
+    my $config_list = new PerlACE::ConfigList;
+    $config_list->load ($test_list);
+    print "$test_list: " . $config_list->list_configs () . "\n";
+  }
+  exit (0);
 }
 
-if ($opt_o) {
-push (@file_list, "$TAO_ROOT/bin/tao_orb_tests.lst");
-}
-
-if ($opt_t) {
-push (@file_list, "$TAO_ROOT/bin/tao_other_tests.lst");
-}
-
-if ($opt_C) {
-push (@file_list, "$CIAO_ROOT/bin/ciao_tests.lst");
-push (@file_list, "$DANCE_ROOT/bin/dance_tests.lst");
-}
-
-if ($opt_d) {
-push (@file_list, "$DDS_ROOT/bin/dcps_tests.lst");
-}
-
-if ($opt_r) {
-  $startdir = $opt_r;
+my $explicit_startdir = 0;
+if ($startdir) {
+  $explicit_startdir = 1;
 }
 else {
   $startdir = "$ACE_ROOT";
-}
-
-if ($opt_l) {
-push (@file_list, "$opt_l");
-}
-
-if (scalar(@file_list) == 0) {
-    push (@file_list, "bin/ace_tests.lst");
-    if (-d $TAO_ROOT) {
-        push (@file_list, "$TAO_ROOT/bin/tao_orb_tests.lst");
-        push (@file_list, "$TAO_ROOT/bin/tao_other_tests.lst");
-    }
-    if (-d $CIAO_ROOT) {
-        push (@file_list, "$CIAO_ROOT/bin/ciao_tests.lst");
-    }
-    if (-d $DANCE_ROOT) {
-        push (@file_list, "$DANCE_ROOT/bin/dance_tests.lst");
-    }
-    if (-d $DDS_ROOT) {
-        push (@file_list, "$DDS_ROOT/bin/dcps_tests.lst");
-    }
 }
 
 foreach my $test_lst (@file_list) {
@@ -177,7 +208,7 @@ foreach my $test_lst (@file_list) {
     # Insures that we search for stuff in the current directory.
     $PATH .= $Config::Config{path_sep} . '.';
 
-    foreach $test ($config_list->valid_entries ()) {
+    foreach my $test ($config_list->valid_entries ()) {
         my $directory = ".";
         my $program = ".";
 
@@ -220,16 +251,15 @@ foreach my $test_lst (@file_list) {
           $directory = $1;
         }
 
-        $status = undef;
+        my $status;
         my @dirlist = ($ACE_ROOT."/$directory",
                        $TAO_ROOT."/$directory",
                        $CIAO_ROOT."/$directory",
                        $DANCE_ROOT."/$directory",
                        $DDS_ROOT."/$directory");
-        # when $opt_r is set make sure to *first* check the explicitly
-        # specified directory and only when nothing found there check
-        # the default dirs
-        if ($opt_r) {
+        # make sure to *first* check the explicitly specified directory and
+        # only when nothing found there check the default dirs
+        if ($explicit_startdir) {
           unshift (@dirlist, $startdir."/$directory");
           unshift (@dirlist, $startdir."/$orig_dir");
         }
@@ -240,7 +270,7 @@ foreach my $test_lst (@file_list) {
         }
 
         if (!$status) {
-          if ($opt_r) {
+          if ($explicit_startdir) {
             print STDERR "ERROR: Cannot chdir to $startdir/$directory\n";
           } else {
             print STDERR "ERROR: Cannot chdir to $directory\n";
@@ -268,26 +298,25 @@ foreach my $test_lst (@file_list) {
              $inherited_options .= " -Config $config ";
         }
 
-        $cmd = '';
-        if ($opt_s) {
+        my $cmd = '';
+        if ($sandbox) {
             #The Win32 sandbox takes the program and options in quotes, but the
             #posix sandbox takes the program and options as separate args.
             my($q) = ($^O eq 'MSWin32') ? '"' : '';
-            $cmd = "$opt_s ${q}perl $program $inherited_options${q}";
+            $cmd = "$sandbox ${q}perl $program $inherited_options${q}";
         }
         else {
             $cmd = "perl $program$inherited_options";
         }
 
-        my $result = 0;
-
-        if (defined $opt_z) {
-            print "Running: $cmd\n";
+        if ($dry_run) {
+            my $cwd = getcwd ();
+            print "In \"$cwd\" would run:\n    $cmd\n";
         }
         else {
-            $start_time = time();
-            $result = run_command($cmd, !$is_ace_test);
-            $time = time() - $start_time;
+            my $start_time = time ();
+            my $result = run_command ($test, $cmd, !$is_ace_test);
+            my $time = time () - $start_time;
 
             # see note about tests/run_test.pl printing reports for ace tests individually
             if (!$is_ace_test) {

--- a/ACE/bin/auto_run_tests.pl
+++ b/ACE/bin/auto_run_tests.pl
@@ -38,7 +38,7 @@ sub run_command {
   my $print_error = shift;
 
   my $result = 0;
-  if (system ($command)) {
+  if (system($command)) {
     $result = $? >> 8;
     if ($print_error) {
       my $signal = $? & 127;
@@ -48,11 +48,11 @@ sub run_command {
         $error_message = "failed to run: $!";
       }
       elsif ($signal) {
-        $error_message = sprintf ("exited on signal %d", ($signal));
+        $error_message = sprintf("exited on signal %d", ($signal));
         $error_message .= " and created coredump" if ($coredump);
       }
       else {
-        $error_message = sprintf ("returned with status %d", $result);
+        $error_message = sprintf("returned with status %d", $result);
       }
       print "Error: $test $error_message\n";
     }
@@ -112,8 +112,8 @@ my $sandbox = '';
 my $dry_run = 0;
 my $startdir = '';
 my $show_configs = 0;
-Getopt::Long::Configure ('bundling', 'no_auto_abbrev');
-my $invalid_arguments = !GetOptions (
+Getopt::Long::Configure('bundling', 'no_auto_abbrev');
+my $invalid_arguments = !GetOptions(
   'help|h' => \$help,
   'ace|a' => \$ace_tests,
   'orb|o' => \$tao_orb_tests,
@@ -127,8 +127,8 @@ my $invalid_arguments = !GetOptions (
   'show-configs' => \$show_configs,
 );
 if ($invalid_arguments || $help) {
-  print_help ($invalid_arguments ? *STDERR : *STDOUT);
-  exit ($invalid_arguments ? 1 : 0);
+  print_help($invalid_arguments ? *STDERR : *STDOUT);
+  exit($invalid_arguments ? 1 : 0);
 }
 
 # Determine what test list files to use
@@ -149,15 +149,15 @@ foreach my $i (@main_test_lists) {
   my $name = $i->[3];
   my $list_file_path = "$root/$list_file";
   if (defined $root && $$enabled_ref) {
-    push (@file_list, $list_file_path);
+    push(@file_list, $list_file_path);
   }
   elsif ($$enabled_ref) {
     $list_error = "option for $name tests passed, but the root enviroment variable isn't set";
   }
 }
-push (@file_list, @l_options);
-push (@file_list, @ARGV);
-if (!scalar (@file_list)) {
+push(@file_list, @l_options);
+push(@file_list, @ARGV);
+if (!scalar(@file_list)) {
   foreach my $i (@main_test_lists) {
     my $root = $i->[1];
     my $list_file = $i->[2];
@@ -166,20 +166,20 @@ if (!scalar (@file_list)) {
       push (@file_list, $list_file_path);
     }
   }
-  if (!scalar (@file_list)) {
+  if (!scalar(@file_list)) {
     $list_error = "no default test lists could be found";
   }
 }
 if ($list_error) {
   print STDERR "ERROR: $list_error\n";
-  exit (1);
+  exit(1);
 }
 
 if ($show_configs) {
   foreach my $test_list (@file_list) {
     my $config_list = new PerlACE::ConfigList;
-    $config_list->load ($test_list);
-    print "$test_list: " . $config_list->list_configs () . "\n";
+    $config_list->load($test_list);
+    print "$test_list: " . $config_list->list_configs() . "\n";
   }
   exit (0);
 }
@@ -196,19 +196,19 @@ foreach my $test_lst (@file_list) {
 
     my $config_list = new PerlACE::ConfigList;
     if (-r $ACE_ROOT.$test_lst) {
-      $config_list->load ($ACE_ROOT.$test_lst);
+      $config_list->load($ACE_ROOT.$test_lst);
     }
     elsif (-r "$startdir/$test_lst") {
-      $config_list->load ("$startdir/$test_lst");
+      $config_list->load("$startdir/$test_lst");
     }
     else {
-      $config_list->load ($test_lst);
+      $config_list->load($test_lst);
     }
 
     # Insures that we search for stuff in the current directory.
     $PATH .= $Config::Config{path_sep} . '.';
 
-    foreach my $test ($config_list->valid_entries ()) {
+    foreach my $test ($config_list->valid_entries()) {
         my $directory = ".";
         my $program = ".";
 
@@ -230,7 +230,7 @@ foreach my $test_lst (@file_list) {
 
         if (! $is_ace_test) {
             print "auto_run_tests: $test\n";
-            if ($config_list->check_config ('Coverity')) {
+            if ($config_list->check_config('Coverity')) {
               $ENV{COVERITY_TEST_NAME} = $test;
               $ENV{COVERITY_SUITE_NAME} = $test_lst;
               $ENV{COVERITY_TEST_SOURCE} = "$directory/$program";
@@ -264,7 +264,7 @@ foreach my $test_lst (@file_list) {
           unshift (@dirlist, $startdir."/$orig_dir");
         }
         foreach my $path (@dirlist) {
-          if (-d $path && ($status = chdir ($path))) {
+          if (-d $path && ($status = chdir($path))) {
             last;
           }
         }
@@ -294,7 +294,7 @@ foreach my $test_lst (@file_list) {
         ### Generate the -ExeSubDir and -Config options
         my $inherited_options = " -ExeSubDir $PerlACE::Process::ExeSubDir ";
 
-        foreach my $config ($config_list->my_config_list ()) {
+        foreach my $config ($config_list->my_config_list()) {
              $inherited_options .= " -Config $config ";
         }
 
@@ -310,13 +310,13 @@ foreach my $test_lst (@file_list) {
         }
 
         if ($dry_run) {
-            my $cwd = getcwd ();
+            my $cwd = getcwd();
             print "In \"$cwd\" would run:\n    $cmd\n";
         }
         else {
-            my $start_time = time ();
-            my $result = run_command ($test, $cmd, !$is_ace_test);
-            my $time = time () - $start_time;
+            my $start_time = time();
+            my $result = run_command($test, $cmd, !$is_ace_test);
+            my $time = time() - $start_time;
 
             # see note about tests/run_test.pl printing reports for ace tests individually
             if (!$is_ace_test) {


### PR DESCRIPTION
I've been wanting to do this since at least #943, because I remember being confused by some of this stuff then.

- Help message:
  - It said test list options, like `-l` or `-a`, "only" do the tests from that option. That isn't true, they include the tests in the run in addition to other ones.
  - Removed reference to non-existent `-c` option which is supposed to be an alias to `-Config`.
  - Removed outdated synopsis and try to give a slightly more detailed explanation of the script.
  - Documented `-Exclude`
  - Moved configuration listing to its own option and made it do it for all test list files that would ran otherwise.
- Argument Parsing:
  - Switched to using `GetOpt::Long` and added long options.
  - Fixed dry run `-z` option which wasn't being parsed.
  - Fixed that when using `-l` to specify multiple files it only uses the last one. Also made it so it takes non-option arguments as test lists.
- Documented what arguments are being parsed by `PerlACE` modules.
- Added 'use strict' and fixes for that.
- Removed seemingly unused `use English;`.