### PR TITLE
Update Compiler_Features_32_Test.cpp for Apple Xcode-11.3.1

### DIFF
--- a/ACE/tests/Compiler_Features_32_Test.cpp
+++ b/ACE/tests/Compiler_Features_32_Test.cpp
@@ -45,7 +45,7 @@ A::u_type_::~u_type_ ()
 void A::clear ()
 {
 #if defined __clang__ && \
-    (defined __apple_build_version__ && __apple_build_version__ < 9100000 \
+    (defined __apple_build_version__ && __apple_build_version__ <= 11000033 \
      || __clang_major__ <= 9)
 #define CLANG_WORKAROUND
 #endif


### PR DESCRIPTION
Make it work with Apple Xcode-11.3.1 Clang compiler. Closes #1042 