### PR TITLE
Replacing use of ::select in favor of ::poll

### DIFF
--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -138,7 +138,7 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
                   fds.events = POLLOUT;
 #else
                   wr_handle.set_bit (handle);
-#endif  /* ACE_HAS_POLL */                  
+#endif  /* ACE_HAS_POLL */
                 }
               else if (SSL_want_read (ssl))
                 {
@@ -147,9 +147,9 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
                   fds.events = POLLIN;
 #else
                   rd_handle.set_bit (handle);
-#endif  /* ACE_HAS_POLL */                  
+#endif  /* ACE_HAS_POLL */
                 }
-              else 
+              else
                 {
                   status = -1;            // Doesn't want anything - bail out
                 }

--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -10,6 +10,11 @@
 #include "ace/Countdown_Time.h"
 #include "ace/Truncate.h"
 
+
+#if defined (ACE_HAS_POLL)
+#  include "ace/OS_NS_poll.h"
+#endif /* ACE_HAS_POLL */
+
 #if !defined (__ACE_INLINE__)
 #include "SSL_SOCK_Acceptor.inl"
 #endif /* __ACE_INLINE__ */
@@ -65,10 +70,16 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
   int status;
   do
     {
+#if defined (ACE_HAS_POLL)
+	    struct pollfd fds;
+ 	    ACE_OS::memset(&fds, 0, sizeof(fds));
+	    fds.revents = 0;
+#else
       // These handle sets are used to set up for whatever SSL_accept
       // says it wants next. They're reset on each pass around the loop.
       ACE_Handle_Set rd_handle;
       ACE_Handle_Set wr_handle;
+#endif /* ACE_HAS_POLL */
 
       status = ::SSL_accept (ssl);
       switch (::SSL_get_error (ssl, status))
@@ -78,12 +89,22 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
           break;                    // Done
 
         case SSL_ERROR_WANT_WRITE:
+#if defined (ACE_HAS_POLL)
+          fds.fd = handle;
+          fds.events = POLLOUT;
+#else
           wr_handle.set_bit (handle);
+#endif /* ACE_HAS_POLL */
           status = 1;               // Wait for more activity
           break;
 
         case SSL_ERROR_WANT_READ:
+#if defined (ACE_HAS_POLL)
+          fds.fd = handle;
+          fds.events = POLLIN;
+#else
           rd_handle.set_bit (handle);
+#endif /* ACE_HAS_POLL */
           status = 1;               // Wait for more activity
           break;
 
@@ -111,11 +132,27 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
               // Use that to decide what to do.
               status = 1;               // Wait for more activity
               if (SSL_want_write (ssl))
-                wr_handle.set_bit (handle);
+                {
+#if defined (ACE_HAS_POLL)
+                  fds.fd = handle;
+                  fds.events = POLLOUT;
+#else
+                  wr_handle.set_bit (handle);
+#endif  /* ACE_HAS_POLL */                  
+                }
               else if (SSL_want_read (ssl))
-                rd_handle.set_bit (handle);
-              else
-                status = -1;            // Doesn't want anything - bail out
+                {
+#if defined (ACE_HAS_POLL)
+                  fds.fd = handle;
+                  fds.events = POLLIN;
+#else
+                  rd_handle.set_bit (handle);
+#endif  /* ACE_HAS_POLL */                  
+                }
+              else 
+                {
+                  status = -1;            // Doesn't want anything - bail out
+                }
             }
           else
             status = -1;
@@ -129,6 +166,10 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
 
       if (status == 1)
         {
+#if defined (ACE_HAS_POLL)
+          ACE_ASSERT(fds.fd != 0);
+          status = ACE_OS::poll(&fds, 1, timeout);
+#else
           // Must have at least one handle to wait for at this point.
           ACE_ASSERT (rd_handle.num_set() == 1 || wr_handle.num_set () == 1);
           status = ACE::select (int (handle) + 1,
@@ -136,6 +177,7 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
                                 &wr_handle,
                                 0,
                                 timeout);
+#endif  /* ACE_HAS_POLL */
 
           (void) countdown.update ();
 

--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -71,9 +71,9 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
   do
     {
 #if defined (ACE_HAS_POLL)
-	    struct pollfd fds;
- 	    ACE_OS::memset(&fds, 0, sizeof(fds));
-	    fds.revents = 0;
+      struct pollfd fds;
+      ACE_OS::memset(&fds, 0, sizeof(fds));
+      fds.revents = 0;
 #else
       // These handle sets are used to set up for whatever SSL_accept
       // says it wants next. They're reset on each pass around the loop.

--- a/ACE/ace/SSL/SSL_SOCK_Connector.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.cpp
@@ -76,9 +76,9 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
   do
     {
 #if defined (ACE_HAS_POLL)
-	  struct pollfd fds;
-	  ACE_OS::memset(&fds, 0, sizeof(fds));
-	  fds.revents = 0;
+      struct pollfd fds;
+      ACE_OS::memset(&fds, 0, sizeof(fds));
+      fds.revents = 0;
 #else
       // These handle sets are used to set up for whatever SSL_connect
       // says it wants next. They're reset on each pass around the loop.

--- a/ACE/ace/SSL/SSL_SOCK_Connector.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.cpp
@@ -145,7 +145,7 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
                   fds.events = POLLOUT;
 #else
                   wr_handle.set_bit (handle);
-#endif  /* ACE_HAS_POLL */                  
+#endif  /* ACE_HAS_POLL */
                 }
               else if (SSL_want_read (ssl))
                 {
@@ -154,7 +154,7 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
                   fds.events = POLLIN;
 #else
                   rd_handle.set_bit (handle);
-#endif  /* ACE_HAS_POLL */                  
+#endif  /* ACE_HAS_POLL */
                 }
               else
                 {


### PR DESCRIPTION
Replacing use of ::select() with ::poll() in SSL_SOCK_Connector and SSL_SOCK_Acceptor - on systems that support ::poll(). This is primarily to allow for more than 1024 connections.