### PR TITLE
Log all dlopen errors into the error stack coming from ACE_OS::dlopen

### DIFF
--- a/ACE/ace/DLL.cpp
+++ b/ACE/ace/DLL.cpp
@@ -276,7 +276,7 @@ ACE_DLL::set_handle (ACE_SHLIB_HANDLE handle,
 {
   ACE_TRACE ("ACE_DLL::set_handle");
 
-  // Create a unique name.  Note that this name is only quaranteed
+  // Create a unique name.  Note that this name is only guaranteed
   // to be unique for the life of this object.
   ACE_TCHAR temp[ACE_UNIQUE_NAME_LEN];
   ACE_OS::unique_name (this, temp, ACE_UNIQUE_NAME_LEN);

--- a/ACE/ace/DLL_Manager.cpp
+++ b/ACE/ace/DLL_Manager.cpp
@@ -165,6 +165,13 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
 
           if (this->handle_ == ACE_SHLIB_INVALID_HANDLE)
             {
+              ACE_TString errtmp;
+              this->error (errtmp);
+              ACELIB_ERROR ((LM_ERROR,
+                             ACE_TEXT ("ACE (%P|%t) DLL_Handle::open (\"%s\"): ")
+                             ACE_TEXT ("Invalid handle error: %s\n"),
+                             this->dll_name_,
+                             errtmp.c_str ()));
               return -1;
             }
         }

--- a/ACE/ace/DLL_Manager.cpp
+++ b/ACE/ace/DLL_Manager.cpp
@@ -62,7 +62,7 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
           if (ACE::debug ())
             ACELIB_ERROR ((LM_ERROR,
                         ACE_TEXT ("ACE (%P|%t) DLL_Handle::open: error, ")
-                        ACE_TEXT ("tried to reopen %s with name %s\n"),
+                        ACE_TEXT ("tried to reopen <%s> with name <%s>\n"),
                         this->dll_name_,
                         dll_name));
 
@@ -121,10 +121,8 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
           for (ACE_Array_Iterator<ACE_TString> name_iter (dll_names);
                name_iter.next (name); name_iter.advance ())
             {
-              if (this->open_i (name->c_str (), open_mode))
+              if (this->open_i (name->c_str (), open_mode, errors))
                 break;
-
-              this->log_error (name->c_str (), errors);
 
 #if defined (AIX)
 # define SHR_O ACE_TEXT("(shr.o)")
@@ -161,34 +159,12 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
 
                   if (this->open_i (aix_pathname, open_mode))
                     break;
-
-                  this->log_error (aix_pathname, errors);
                 }
 #endif /* AIX */
             }
 
           if (this->handle_ == ACE_SHLIB_INVALID_HANDLE)
             {
-              if (errors || ACE::debug ())
-                {
-                  ACE_TString errtmp;
-                  if (errors)
-                    {
-                      errors->push (this->error (errtmp));
-                    }
-
-                  if (ACE::debug ())
-                    {
-                      if (!errors)
-                        this->error (errtmp);
-                      ACELIB_ERROR ((LM_ERROR,
-                                  ACE_TEXT ("ACE (%P|%t) DLL_Handle::open (\"%s\"): ")
-                                  ACE_TEXT ("Invalid handle error: %s\n"),
-                                  this->dll_name_,
-                                  errtmp.c_str ()));
-                    }
-                }
-
               return -1;
             }
         }
@@ -198,7 +174,7 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
 
   if (ACE::debug ())
     ACELIB_DEBUG ((LM_DEBUG,
-                ACE_TEXT ("ACE (%P|%t) DLL_Handle::open - %s (%d), refcount=%d\n"),
+                ACE_TEXT ("ACE (%P|%t) DLL_Handle::open - <%s> (%d), refcount=%d\n"),
                 this->dll_name_,
                 this->handle_,
                 this->refcount_));
@@ -231,7 +207,7 @@ ACE_DLL_Handle::close (int unload)
     if (ACE::debug ())
       ACELIB_DEBUG ((LM_DEBUG,
                   ACE_TEXT ("ACE (%P|%t) DLL_Handle::close - ")
-                  ACE_TEXT ("%s (handle=%d, refcount=%d)\n"),
+                  ACE_TEXT ("<%s> (handle=%d, refcount=%d)\n"),
                   this->dll_name_,
                   this->handle_,
                   this->refcount_));
@@ -243,7 +219,7 @@ ACE_DLL_Handle::close (int unload)
         if (ACE::debug ())
           ACELIB_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("ACE (%P|%t) DLL_Handle::close: ")
-                      ACE_TEXT ("Unloading %s (handle=%d)\n"),
+                      ACE_TEXT ("Unloading <%s> (handle=%d)\n"),
                       this->dll_name_,
                       this->handle_));
 
@@ -268,7 +244,7 @@ ACE_DLL_Handle::close (int unload)
           ACE_TString err;
           ACELIB_ERROR ((LM_ERROR,
                       ACE_TEXT ("ACE (%P|%t) DLL_Handle::close - ")
-                      ACE_TEXT ("Failed with: \"%s\".\n"),
+                      ACE_TEXT ("Failed with: <%s>\n"),
                       this->error (err).c_str ()));
         }
     }
@@ -316,8 +292,8 @@ ACE_DLL_Handle::symbol (const ACE_TCHAR *sym_name, bool ignore_errors, ACE_TStri
 
           if (ACE::debug ())
             ACELIB_ERROR ((LM_ERROR,
-                        ACE_TEXT ("ACE (%P|%t) DLL_Handle::symbol (\"%s\") ")
-                        ACE_TEXT (" failed with \"%s\".\n"),
+                        ACE_TEXT ("ACE (%P|%t) DLL_Handle::symbol <%s>")
+                        ACE_TEXT (" failed with <%s>\n"),
                         auto_name.get (),
                         error.c_str ()));
 
@@ -364,13 +340,15 @@ ACE_DLL_Handle::get_handle (bool become_owner)
 }
 
 // This method is used return the last error of a library operation.
-
 ACE_TString &
 ACE_DLL_Handle::error (ACE_TString &err)
 {
   ACE_TRACE ("ACE_DLL_Handle::error");
   const ACE_TCHAR *error = ACE_OS::dlerror ();
-  err = (error ? error : ACE_TEXT ("no error"));
+  if (error)
+    {
+      err = error;
+    }
   return err;
 }
 
@@ -472,59 +450,34 @@ ACE_DLL_Handle::get_dll_names (const ACE_TCHAR *dll_name,
 }
 
 bool
-ACE_DLL_Handle::open_i (const ACE_TCHAR *dll_name, int open_mode)
+ACE_DLL_Handle::open_i (const ACE_TCHAR *dll_name, int open_mode, ERROR_STACK* errors)
 {
   // The ACE_SHLIB_HANDLE object is obtained.
   this->handle_ = ACE_OS::dlopen (dll_name, open_mode);
 
-  if (ACE::debug ())
+  if (errors || ACE::debug ())
     {
       ACE_TString err;
-      ACELIB_DEBUG ((LM_DEBUG,
-                  ACE_TEXT ("ACE (%P|%t) DLL_Handle::open ")
-                  ACE_TEXT ("(\"%s\", 0x%x) -> %s: %s\n"),
-                  dll_name,
-                  open_mode,
-                  ((this->handle_ != ACE_SHLIB_INVALID_HANDLE)
-                   ? ACE_TEXT ("succeeded")
-                   : ACE_TEXT ("failed")),
-                  this->error (err).c_str()));
+      this->error (err);
+      if (errors && err.length () > 0)
+        {
+          errors->push (err);
+        }
+      if (ACE::debug ())
+        {
+          ACELIB_DEBUG ((LM_DEBUG,
+                      ACE_TEXT ("ACE (%P|%t) DLL_Handle::open_i ")
+                      ACE_TEXT ("<%s>, 0x%x) -> <%s>: <%s>\n"),
+                      dll_name,
+                      open_mode,
+                      ((this->handle_ != ACE_SHLIB_INVALID_HANDLE)
+                      ? ACE_TEXT ("succeeded")
+                      : ACE_TEXT ("failed")),
+                      err.c_str ()));
+        }
     }
 
   return this->handle_ != ACE_SHLIB_INVALID_HANDLE;
-}
-
-void
-ACE_DLL_Handle::log_error (const ACE_TCHAR *dll_name, ERROR_STACK *errors)
-{
-  // If errno is ENOENT we just skip over this one, anything
-  // else - like an undefined symbol, for instance
-  // must be flagged here or the next error will mask it.
-  //
-  // @TODO: If we've found our DLL _and_ it's broken,
-  // should we continue at all?
-  if (errno != ENOENT && (errors || ACE::debug ()))
-    {
-      ACE_TString errtmp;
-      if (errors)
-        {
-          errors->push (this->error (errtmp));
-        }
-
-      if (ACE::debug ())
-        {
-          if (!errors)
-            this->error (errtmp);
-
-          ACELIB_ERROR ((LM_ERROR,
-                      ACE_TEXT ("ACE (%P|%t) DLL_Handle::open ")
-                      ACE_TEXT ("(\'%s\') failed, errno=")
-                      ACE_TEXT ("%d: <%s>\n"),
-                      dll_name,
-                      ACE_ERRNO_GET,
-                      errtmp.c_str ()));
-        }
-    }
 }
 
 /******************************************************************/
@@ -626,7 +579,7 @@ ACE_DLL_Manager::open_dll (const ACE_TCHAR *dll_name,
           if (ACE::debug ())
             ACELIB_ERROR ((LM_ERROR,
                         ACE_TEXT ("ACE (%P|%t) DLL_Manager::open_dll: Could not ")
-                        ACE_TEXT ("open dll %s.\n"),
+                        ACE_TEXT ("open dll <%s>\n"),
                         dll_name));
 
           delete temp_handle;

--- a/ACE/ace/DLL_Manager.cpp
+++ b/ACE/ace/DLL_Manager.cpp
@@ -165,13 +165,16 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
 
           if (this->handle_ == ACE_SHLIB_INVALID_HANDLE)
             {
-              ACE_TString errtmp;
-              this->error (errtmp);
-              ACELIB_ERROR ((LM_ERROR,
-                             ACE_TEXT ("ACE (%P|%t) DLL_Handle::open (\"%s\"): ")
-                             ACE_TEXT ("Invalid handle error: %s\n"),
-                             this->dll_name_,
-                             errtmp.c_str ()));
+              if (ACE::debug ())
+                {
+                  ACE_TString errtmp;
+                  this->error (errtmp);
+                  ACELIB_ERROR ((LM_ERROR,
+                                ACE_TEXT ("ACE (%P|%t) DLL_Handle::open (\"%s\"): ")
+                                ACE_TEXT ("Invalid handle error: %s\n"),
+                                this->dll_name_,
+                                errtmp.c_str ()));
+                }
               return -1;
             }
         }

--- a/ACE/ace/DLL_Manager.h
+++ b/ACE/ace/DLL_Manager.h
@@ -54,7 +54,7 @@ class ACE_Export ACE_DLL_Handle
 {
 public:
   /// Error stack. Fixed size should suffice. Ignores any errors exceeding the size.
-  typedef ACE_Fixed_Stack < ACE_TString, 10 >  ERROR_STACK;
+  typedef ACE_Fixed_Stack <ACE_TString, 10> ERROR_STACK;
 
   /// Default construtor.
   ACE_DLL_Handle (void);
@@ -164,18 +164,12 @@ private:
    *            @a dll_name is first loaded
    *        @li @c RTLD_GLOBAL: makes symbols available for relocation
    *            processing of any other DLLs.
-   * @retval false On failure
-   * @retval true On success.
-   */
-  bool open_i (const ACE_TCHAR *dll_name, int open_mode);
-
-  /**
-   * This method logs error of opening the DLL.
-   * @param dll_name  The filename or path of the DLL to load.
    * @param errors Optional address of an error stack to collect any errors
    *        encountered.
+   * @retval false On failure
+   * @retval true On success
    */
-  void log_error (const ACE_TCHAR *dll_name, ERROR_STACK *errors);
+  bool open_i (const ACE_TCHAR *dll_name, int open_mode, ERROR_STACK* errors);
 
   /// Disallow copying and assignment since we don't handle them.
   ACE_DLL_Handle (const ACE_DLL_Handle &);


### PR DESCRIPTION
At the moment ACE_OS::dlopen fails we directly log and put the error message into the error stack. We don't check for ENOENT, an unresolved symbol is also causing ENOENT and that error message has certain value. Side effect is that when multiple DLL names are tried (prefix/postfix changes) there could be multiple error messages into the error stack but the real error message is also there.

Because ACE_DLL_Handle::open_i does now the logging and pushing into the error stack the calling code is much simpler.