### PR TITLE
Implementation of portspan capability for SSLIOP

### DIFF
--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Acceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Acceptor.cpp
@@ -614,6 +614,20 @@ TAO::SSLIOP::Acceptor::parse_options_i (int &argc, ACE_CString ** argv)
                                value.c_str ()),
                               -1);
         }
+      else if (ACE_OS::strcmp (name.c_str (), "portspan") == 0)
+        {
+          int range = static_cast <int> (ACE_OS::atoi (value.c_str ()));
+          // @@ What's the lower bound on the range?  zero, or one?
+          if (range < 1 || range > ACE_MAX_DEFAULT_PORT)
+                  TAOLIB_ERROR_RETURN ((LM_ERROR,
+                  ACE_TEXT ("TAO (%P|%t) Invalid IIOP/SSL endpoint ")
+                  ACE_TEXT ("portspan: <%C>\n")
+                  ACE_TEXT ("Valid range 1 -- %d\n"),
+                  value.c_str (), ACE_MAX_DEFAULT_PORT),
+                 -1);
+
+          this->port_span_ = static_cast <u_short> (range);
+        }
       else
         {
           // the name is not known, skip to the next option

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Acceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Acceptor.cpp
@@ -619,7 +619,7 @@ TAO::SSLIOP::Acceptor::parse_options_i (int &argc, ACE_CString ** argv)
           int range = static_cast <int> (ACE_OS::atoi (value.c_str ()));
           // @@ What's the lower bound on the range?  zero, or one?
           if (range < 1 || range > ACE_MAX_DEFAULT_PORT)
-                  TAOLIB_ERROR_RETURN ((LM_ERROR,
+                  ORBSVCS_ERROR_RETURN ((LM_ERROR,
                   ACE_TEXT ("TAO (%P|%t) Invalid IIOP/SSL endpoint ")
                   ACE_TEXT ("portspan: <%C>\n")
                   ACE_TEXT ("Valid range 1 -- %d\n"),


### PR DESCRIPTION
It was determined that SSLIOP was not implemented per #1068. 

Please review and consider adding support for this capability that is valuable for implementing SSLIOP in conjunction with port-based firewall rules.

Thanks!