### PR TITLE
Add a musl compatible fallback for libc detection on Linux

### DIFF
--- a/ACE/ace/Dev_Poll_Reactor.cpp
+++ b/ACE/ace/Dev_Poll_Reactor.cpp
@@ -1122,10 +1122,10 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
 
   // Define bits to check for while dispatching.
 #if defined (ACE_HAS_EVENT_POLL)
-  const __uint32_t out_event = EPOLLOUT;
-  const __uint32_t exc_event = EPOLLPRI;
-  const __uint32_t in_event  = EPOLLIN;
-  const __uint32_t err_event = EPOLLHUP | EPOLLERR;
+  const ACE_UINT32 out_event = EPOLLOUT;
+  const ACE_UINT32 exc_event = EPOLLPRI;
+  const ACE_UINT32 in_event  = EPOLLIN;
+  const ACE_UINT32 err_event = EPOLLHUP | EPOLLERR;
 #else
   const short out_event = POLLOUT;
   const short exc_event = POLLPRI;
@@ -1138,7 +1138,7 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
   // is invalid, there's no event there. Else process it. In any event, we
   // have the event, so clear event_ for the next thread.
   const ACE_HANDLE handle = this->event_.data.fd;
-  __uint32_t revents      = this->event_.events;
+  ACE_UINT32 revents      = this->event_.events;
   this->event_.data.fd = ACE_INVALID_HANDLE;
   this->event_.events = 0;
   if (handle != ACE_INVALID_HANDLE)

--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -242,6 +242,10 @@
 
 #endif /* ACE_HAS_MUSL */
 
+#if !defined (__GLIBC__) && !defined (__UCLIBC__) && !defined (ACE_HAS_MUSL)
+#  error "Could not determine C Standard Library"
+#endif /* !defined (__GLIBC__) && !defined (__UCLIBC__) && !defined (ACE_HAS_MUSL) */
+
 #include /**/ "ace/post.h"
 
 #endif /* ACE_CONFIG_LINUX_H */

--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -204,6 +204,44 @@
 
 #endif /* __UCLIBC__ */
 
+// To support musl (note: musl devs refuse to add a __MUSL__)
+#if defined (ACE_HAS_MUSL)
+
+// Enable stuff that musl definitly has
+#define ACE_HAS_UCONTEXT_T
+#define ACE_HAS_SIGTIMEDWAIT
+#define ACE_HAS_PTHREADS
+#define ACE_HAS_RECURSIVE_MUTEXES
+#define ACE_HAS_PTHREADS_UNIX98_EXT
+#define ACE_HAS_CPU_SET_T
+#define ACE_HAS_SIGINFO_T
+#define ACE_HAS_SOCKLEN_T
+
+// Mask some features musl lacks
+#define ACE_LACKS_SIGINFO_H
+#define ACE_LACKS_SYS_SYSCTL_H
+#define ACE_LACKS_ISCTYPE
+#define ACE_LACKS_NETDB_REENTRANT_FUNCTIONS
+
+// Following the example set by uclib undef some festures
+#  if defined (ACE_SCANDIR_CMP_USES_VOIDPTR)
+#    undef ACE_SCANDIR_CMP_USES_VOIDPTR
+#  endif /* ACE_SCANDIR_CMP_USES_VOIDPTR */
+
+#  if defined (ACE_SCANDIR_CMP_USES_CONST_VOIDPTR)
+#    undef ACE_SCANDIR_CMP_USES_CONST_VOIDPTR
+#  endif /* ACE_SCANDIR_CMP_USES_CONST_VOIDPTR */
+
+#  if defined(__GLIBC__)
+#    undef __GLIBC__
+#  endif /* __GLIBC__ */
+
+#  if defined(ACE_HAS_SEMUN)
+#    undef ACE_HAS_SEMUN
+#  endif /* ACE_HAS_SEMUN */
+
+#endif /* ACE_HAS_MUSL */
+
 #include /**/ "ace/post.h"
 
 #endif /* ACE_CONFIG_LINUX_H */

--- a/ACE/ace/os_include/sys/os_types.h
+++ b/ACE/ace/os_include/sys/os_types.h
@@ -66,7 +66,7 @@ typedef double ACE_timer_t;
 #if defined (ACE_SIZEOF_LONG) && ACE_SIZEOF_LONG == 8
    typedef off_t ACE_LOFF_T;
 #elif defined (ACE_HAS_RTEMS) || defined (__FreeBSD__) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__APPLE__) || defined(__INTERIX) || \
-  (defined (ACE_OPENVMS) && defined (_LARGEFILE))
+  (defined (ACE_OPENVMS) && defined (_LARGEFILE)) || defined (ACE_HAS_MUSL)
    typedef off_t ACE_LOFF_T;
 #elif defined (AIX) || defined (HPUX) || defined (__QNX__)
    typedef off64_t ACE_LOFF_T;


### PR DESCRIPTION
The libc detection code is very glibc centric. At the end of config-linux.h there was already a uclib fixup. I've added an additional section for musl.

Follow up to #914