### PR TITLE
Additions related to rpmbuild

### DIFF
--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -1220,7 +1220,7 @@ install ${ACE_ROOT}/bin/ace_gperf %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_idl %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_imr %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_ifr %{buildroot}%{_bindir}
-install ${ACE_ROOT}/bin/tao_ifr_service %{buildroot}%{_bindir}
+install ${ACE_ROOT}/TAO/orbsvcs/IFR_Service/tao_ifr_service %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_catior %{buildroot}%{_bindir}/tao_catior
 install ${ACE_ROOT}/bin/tao_nsadd %{buildroot}%{_bindir}/tao_nsadd
 install ${ACE_ROOT}/bin/tao_nsdel %{buildroot}%{_bindir}/tao_nsdel

--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -1220,6 +1220,7 @@ install ${ACE_ROOT}/bin/ace_gperf %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_idl %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_imr %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_ifr %{buildroot}%{_bindir}
+install ${ACE_ROOT}/bin/tao_ifr_service %{buildroot}%{_bindir}
 install ${ACE_ROOT}/bin/tao_catior %{buildroot}%{_bindir}/tao_catior
 install ${ACE_ROOT}/bin/tao_nsadd %{buildroot}%{_bindir}/tao_nsadd
 install ${ACE_ROOT}/bin/tao_nsdel %{buildroot}%{_bindir}/tao_nsdel
@@ -2277,6 +2278,7 @@ fi
 
 %{_bindir}/tao_imr
 %{_bindir}/tao_ifr
+%{_bindir}/tao_ifr_service
 %{_datadir}/tao/MPC
 %{_bindir}/tao_idl
 %attr(0644,root,root) %doc %{_mandir}/man1/tao_idl.1%{_extension}

--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -84,7 +84,7 @@ BuildRoot:    %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 %define _extension .gz
 
 %if 0%{?fedora} || 0%{?rhel}
-BuildRequires: redhat-rpm-config elfutils sendmail
+BuildRequires: redhat-rpm-config elfutils
 %endif
 
 %if !0%{?suse_version}

--- a/TAO/orbsvcs/IFR_Service/IFR_Service.mpc
+++ b/TAO/orbsvcs/IFR_Service/IFR_Service.mpc
@@ -3,6 +3,7 @@
 // necessary to add minimum_corba to 'avoids' here.
 project(IFR_Service) : orbsvcsexe, install, ifrservice, ifr_client, imr_client, svc_utils {
   exename = tao_ifr_service
+  install = $(ACE_ROOT)/bin
 
   IDL_Files {
   }

--- a/TAO/orbsvcs/IFR_Service/IFR_Service.mpc
+++ b/TAO/orbsvcs/IFR_Service/IFR_Service.mpc
@@ -3,7 +3,6 @@
 // necessary to add minimum_corba to 'avoids' here.
 project(IFR_Service) : orbsvcsexe, install, ifrservice, ifr_client, imr_client, svc_utils {
   exename = tao_ifr_service
-  install = $(ACE_ROOT)/bin
 
   IDL_Files {
   }


### PR DESCRIPTION
These are the updates I need to do to build after a new version of ACE-TAO is released:
- BuildRequires: has a dependency on sendmail. Not sure why, but I don't have a mail server on my build machine and this makes it impossible to run `rpmbuild -tb ACE-TAO-src.tar.gz`
- We have legacy code that uses combat-tcl for CORBA. To compile idl into tcl, it uses both `tao_ifr` and `tao_ifr_service`.