### PR TITLE
platform_clang_common.GNU: redirect stderr for version checks

### DIFF
--- a/ACE/include/makeinclude/platform_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_clang_common.GNU
@@ -75,7 +75,7 @@ ifneq ($(DLD),)
     LD_FOR_VERSION_TEST = $(DLD)
   endif # DLD = CXX_FOR_VERSION_TEST
   # The -E option is GNU ld specific
-  GNU_LD := $(if $(findstring GNU ld,$(shell $(LD_FOR_VERSION_TEST) -v)), 1, 0)
+  GNU_LD := $(if $(findstring GNU ld,$(shell $(LD_FOR_VERSION_TEST) -v 2>&1)), 1, 0)
 endif # DLD
 
 ifeq ($(GNU_LD),1)


### PR DESCRIPTION
This part was changed in PR #1022 caused a lot of extra output using clang on macOS.
This commit redirects stderr from make's $(shell).

Extra output was:
```
@(#)PROGRAM:ld  PROJECT:ld64-530
BUILD 18:57:17 Dec 13 2019
configured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em
LTO support using: LLVM version 11.0.0, (clang-1100.0.33.17) (static support for 23, runtime is 23)
TAPI support using: Apple TAPI version 11.0.0 (tapi-1100.0.11)
```