### PR TITLE
Cleanup some last leftovers from old and deprecated tandem support

### DIFF
--- a/ACE/ace/ACE_export.h
+++ b/ACE/ace/ACE_export.h
@@ -42,12 +42,7 @@
 #  define ACE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif     /* ACE_HAS_DLL */
 
-// Added by hand to help with ACE_OS namespace
-#if defined (__TANDEM) && defined (USE_EXPLICIT_EXPORT)
-#define ACE_NAMESPACE_STORAGE_CLASS ACE_EXPORT_MACRO extern
-#else
 #define ACE_NAMESPACE_STORAGE_CLASS extern ACE_EXPORT_MACRO
-#endif
 
 #if defined (__ACE_INLINE__)
 #  define ACE_NAMESPACE_INLINE_FUNCTION inline

--- a/ACE/ace/Basic_Types.h
+++ b/ACE/ace/Basic_Types.h
@@ -429,9 +429,6 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 #  define ACE_UINT64_LITERAL(n) n ## ui64
 #  define ACE_INT64_LITERAL(n) n ## i64
 # endif /* defined (__MINGW32__) */
-#elif defined (__TANDEM)
-#   define ACE_UINT64_LITERAL(n) n ## LL
-#   define ACE_INT64_LITERAL(n) n ## LL
 #else  /* ! ACE_WIN32  */
 #   define ACE_UINT64_LITERAL(n) n ## ull
 #   define ACE_INT64_LITERAL(n) n ## ll

--- a/ACE/ace/config-macros.h
+++ b/ACE/ace/config-macros.h
@@ -256,7 +256,7 @@
 #if !defined (ACE_UNUSED_ARG)
 # if defined (__GNUC__) && ((__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))) || (defined (__BORLANDC__) && defined (__clang__))
 #   define ACE_UNUSED_ARG(a) (void) (a)
-# elif defined (__GNUC__) || defined (ghs) || defined (__hpux) || defined (__DECCXX) || defined (__rational__) || defined (__USLC__) || defined (ACE_RM544) || defined (__DCC__) || defined (__PGI) || defined (__TANDEM)
+# elif defined (__GNUC__) || defined (ghs) || defined (__hpux) || defined (__DECCXX) || defined (__rational__) || defined (__USLC__) || defined (ACE_RM544) || defined (__DCC__) || defined (__PGI)
 // Some compilers complain about "statement with no effect" with (a).
 // This eliminates the warnings, and no code is generated for the null
 // conditional statement.  @note that may only be true if -O is enabled,
@@ -271,7 +271,7 @@
 # endif /* ghs || __GNUC__ || ..... */
 #endif /* !ACE_UNUSED_ARG */
 
-#if defined (_MSC_VER) || defined (ghs) || defined (__DECCXX) || defined(__BORLANDC__) || defined (ACE_RM544) || defined (__USLC__) || defined (__DCC__) || defined (__PGI) || defined (__TANDEM) || (defined (__HP_aCC) && (__HP_aCC < 39000 || __HP_aCC >= 60500)) || defined (__IAR_SYSTEMS_ICC__)
+#if defined (_MSC_VER) || defined (ghs) || defined (__DECCXX) || defined(__BORLANDC__) || defined (ACE_RM544) || defined (__USLC__) || defined (__DCC__) || defined (__PGI) || (defined (__HP_aCC) && (__HP_aCC < 39000 || __HP_aCC >= 60500)) || defined (__IAR_SYSTEMS_ICC__)
 # define ACE_NOTREACHED(a)
 #else  /* ghs || ..... */
 # define ACE_NOTREACHED(a) a

--- a/ACE/ace/os_include/sys/os_types.h
+++ b/ACE/ace/os_include/sys/os_types.h
@@ -76,8 +76,7 @@ typedef double ACE_timer_t;
    typedef __int64  ACE_LOFF_T;
 #elif (defined (ACE_VXWORKS) && (ACE_VXWORKS <= 0x700)) || \
   defined (ACE_LYNXOS_MAJOR) || \
-  (defined (ACE_OPENVMS) && !defined (_LARGEFILE)) || \
-  defined (__TANDEM)
+  (defined (ACE_OPENVMS) && !defined (_LARGEFILE))
    typedef long long ACE_LOFF_T;
 #else
    typedef loff_t ACE_LOFF_T;

--- a/TAO/orbsvcs/orbsvcs/Shutdown_Utilities.cpp
+++ b/TAO/orbsvcs/orbsvcs/Shutdown_Utilities.cpp
@@ -42,16 +42,10 @@ Service_Shutdown::set_signals (ACE_Sig_Set& which_signals)
       {
         if (this->shutdown_.register_handler (i, this) == -1)
           {
-#if defined(__TANDEM)
-// Tandem NSK platform has no signal 10 so do not emit a warning for it
-            if (i != 10)
-#endif
-              {
-                ORBSVCS_DEBUG ((LM_WARNING,
-                            "WARNING: Failed to register signal handler "
-                            "for signal %d: %p\n",
-                            i, ACE_TEXT ("register_handler")));
-              }
+            ORBSVCS_DEBUG ((LM_WARNING,
+                        "WARNING: Failed to register signal handler "
+                        "for signal %d: %p\n",
+                        i, ACE_TEXT ("register_handler")));
           }
         else
           {


### PR DESCRIPTION
    * ACE/ace/ACE_export.h:
    * ACE/ace/Basic_Types.h:
    * ACE/ace/config-macros.h:
    * ACE/ace/os_include/sys/os_types.h:
    * TAO/orbsvcs/orbsvcs/Shutdown_Utilities.cpp: