### PR TITLE
Modify Android link on Windows hosts to avoid error

### DIFF
--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -180,11 +180,10 @@ LIBS += -llog
 
 # link step to avoid 'command line too long' error on Windows
 ifeq ($(OS), Windows_NT)
-  SHOBJS_FILE = $(VSHDIR)tmpfile
+  SHOBJS_FILE = $(VSHDIR)$(MAKEFILE)_object_list.tmp
   CLEANUP_OBJS += $(SHOBJS_FILE)
-  define SHLIBBUILD
-    echo " " > $(SHOBJS_FILE)
-    $(foreach myobj, $(VSHOBJS), echo $(myobj) >> $(SHOBJS_FILE);)
+  define SHLIBBUILD 
+    $(file >$(SHOBJS_FILE), $^)
     $(SHR_FILTER) $(SOLINK.cc) $(SO_OUTPUT_FLAG) $@ @$(SHOBJS_FILE) $(LDFLAGS) $(ACE_SHLIBS) $(LIBS)
   endef
 endif

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -177,3 +177,14 @@ endif
 
 # Link To Android Logging Library for Log_Msg_Android_Logcat
 LIBS += -llog
+
+# link step to avoid 'command line too long' error on Windows
+ifeq ($(OS), Windows_NT)
+  SHOBJS_FILE = $(VSHDIR)tmpfile
+  CLEANUP_OBJS += $(SHOBJS_FILE)
+  define SHLIBBUILD
+    echo " " > $(SHOBJS_FILE)
+    $(foreach myobj, $(VSHOBJS), echo $(myobj) >> $(SHOBJS_FILE);)
+    $(SHR_FILTER) $(SOLINK.cc) $(SO_OUTPUT_FLAG) $@ @$(SHOBJS_FILE) $(LDFLAGS) $(ACE_SHLIBS) $(LIBS)
+  endef
+endif


### PR DESCRIPTION
Modify the Android link step on Windows hosts to avoid a 'command line too long' error when linking a large number of object files.