### PR TITLE
Add support for Embarcadero C++ Builder 10.4 Sydney

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,16 @@
 USER VISIBLE CHANGES BETWEEN ACE-6.5.9 and ACE-6.5.10
 =====================================================
 
+. Add support for Embarcadero C++ Builder 10.4 Sydney using the
+  classic compiler. ACE/TAO compile with the new 32/64 bit clang
+  compilers but runtime tests show several runtime problems which
+  makes them not safe to use
+
+. Make a change in the ACE Process Manager to resolve an internal
+  compiler error with Visual Studio 2019 16.5.x compilers
+
+. Android enhancements for if_nameindex
+
 USER VISIBLE CHANGES BETWEEN ACE-6.5.8 and ACE-6.5.9
 ====================================================
 

--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -30,7 +30,6 @@
 #  pragma warning(disable: 4284)
 #endif /* _MSC_VER */
 
-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /**

--- a/ACE/ace/Compression/rle/RLECompressor.cpp
+++ b/ACE/ace/Compression/rle/RLECompressor.cpp
@@ -1,7 +1,7 @@
 #include "RLECompressor.h"
 #include "ace/OS_NS_string.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x740)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 #  pragma option push -w-8072
 #endif
 
@@ -140,6 +140,6 @@ ACE_SINGLETON_TEMPLATE_INSTANTIATE(ACE_Singleton, ACE_RLECompressor, ACE_SYNCH_M
 // Close versioned namespace, if enabled by the user.
 ACE_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x740)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 # pragma option pop
 #endif

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -27,7 +27,6 @@ ACE_MUTEX_LOCK_CLEANUP_ADAPTER_NAME (void *args)
   ACE_VERSIONED_NAMESPACE_NAME::ACE_OS::mutex_lock_cleanup (args);
 }
 
-
 #if !defined(ACE_WIN32) && defined (__IBMCPP__) && (__IBMCPP__ >= 400)
 # define ACE_BEGINTHREADEX(STACK, STACKSIZE, ENTRY_POINT, ARGS, FLAGS, THR_ID) \
        (*THR_ID = ::_beginthreadex ((void(_Optlink*)(void*))ENTRY_POINT, STACK, STACKSIZE, ARGS), *THR_ID)

--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -193,20 +193,7 @@
 # define ACE_HAS_BUILTIN_BSWAP32
 # define ACE_HAS_BUILTIN_BSWAP64
 # define ACE_LACKS_INLINE_ASSEMBLY
-# if __cplusplus >= 201103L
-#  define ACE_HAS_CPP11
-# endif
-# if __cplusplus >= 201402L
-#  define ACE_HAS_CPP14
-# endif
-# if __cplusplus >= 201703L
-#  define ACE_HAS_CPP17
-# endif
-# if __cplusplus >= 202002L
-#  define ACE_HAS_CPP20
-# endif
 #endif /* __clang__ */
-
 
 #include /**/ "ace/post.h"
 #endif /* ACE_CONFIG_WIN32_BORLAND_H */

--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -145,18 +145,21 @@
 # endif /* !__MT__ */
 #endif /* ACE_MT_SAFE && ACE_MT_SAFE != 0 */
 
-#if (__BORLANDC__ <= 0x740)
+#if (__BORLANDC__ <= 0x750)
 # define ACE_LACKS_ISWCTYPE
 # define ACE_LACKS_ISCTYPE
 #endif
 
-#if (__BORLANDC__ >= 0x640) && (__BORLANDC__ <= 0x740)
+#if (__BORLANDC__ >= 0x640) && (__BORLANDC__ <= 0x750)
 # define ACE_LACKS_STRTOK_R
 #endif
 
 #if (__BORLANDC__ <= 0x740)
 # define ACE_LACKS_LOCALTIME_R
 # define ACE_LACKS_GMTIME_R
+#endif
+
+#if (__BORLANDC__ <= 0x750)
 # define ACE_LACKS_ASCTIME_R
 #endif
 
@@ -190,6 +193,18 @@
 # define ACE_HAS_BUILTIN_BSWAP32
 # define ACE_HAS_BUILTIN_BSWAP64
 # define ACE_LACKS_INLINE_ASSEMBLY
+# if __cplusplus >= 201103L
+#  define ACE_HAS_CPP11
+# endif
+# if __cplusplus >= 201402L
+#  define ACE_HAS_CPP14
+# endif
+# if __cplusplus >= 201703L
+#  define ACE_HAS_CPP17
+# endif
+# if __cplusplus >= 202002L
+#  define ACE_HAS_CPP20
+# endif
 #endif /* __clang__ */
 
 

--- a/ACE/ace/os_include/net/os_if.h
+++ b/ACE/ace/os_include/net/os_if.h
@@ -103,7 +103,7 @@ struct  ifconf {
 #endif /* IFF_BROADCAST */
 
 #if defined (ACE_LACKS_STRUCT_IF_NAMEINDEX)
-struct if_nameindex {};
+struct if_nameindex { int dummy; };
 #endif
 
 #ifdef __cplusplus

--- a/TAO/orbsvcs/orbsvcs/IFRService/IFR_Service_Utils_T.cpp
+++ b/TAO/orbsvcs/orbsvcs/IFRService/IFR_Service_Utils_T.cpp
@@ -340,7 +340,7 @@ TAO_Port_Utils<T>::create_entry (const char *id,
   return T::_narrow (obj.in ());
 }
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 // Borland gives warnings about argument not used on the construct as used
 // for the other compilers. This has been reported to Borland, adding
 // a workaround to suppress these warnings so that the real important ones

--- a/TAO/orbsvcs/orbsvcs/Notify/MonitorControlExt/MC_Default_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/MonitorControlExt/MC_Default_Factory.h
@@ -21,7 +21,7 @@
 
 #if defined (TAO_HAS_MONITOR_FRAMEWORK) && (TAO_HAS_MONITOR_FRAMEWORK == 1)
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 #  pragma option push -w-8022
 #endif
 
@@ -68,7 +68,7 @@ public:
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 # pragma option pop
 #endif
 

--- a/TAO/orbsvcs/orbsvcs/Notify/RT_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/RT_Factory.h
@@ -18,7 +18,7 @@
 
 #include "orbsvcs/Notify/Default_Factory.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 #  pragma option push -w-8022
 #endif
 
@@ -50,7 +50,7 @@ public:
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 # pragma option pop
 #endif
 

--- a/TAO/orbsvcs/tests/Concurrency/CC_command.tab.cpp
+++ b/TAO/orbsvcs/tests/Concurrency/CC_command.tab.cpp
@@ -387,8 +387,8 @@ __ace_cc_yy_memcpy (to, from, count)
      unsigned int count;
 {
   char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -401,9 +401,9 @@ __ace_cc_yy_memcpy (to, from, count)
 static void
 __ace_cc_yy_memcpy (char *to, char *from, unsigned int count)
 {
-  register char *t = to;
-  register char *f = from;
-  register int i = count;
+  char *t = to;
+  char *f = from;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -446,10 +446,10 @@ int
 ace_cc_yyparse(ACE_CC_YYPARSE_PARAM_ARG)
      ACE_CC_YYPARSE_PARAM_DECL
 {
-  register int ace_cc_yystate;
-  register int ace_cc_yyn;
-  register short *ace_cc_yyssp;
-  register ACE_CC_YYSTYPE *ace_cc_yyvsp;
+  int ace_cc_yystate;
+  int ace_cc_yyn;
+  short *ace_cc_yyssp;
+  ACE_CC_YYSTYPE *ace_cc_yyvsp;
   int ace_cc_yyerrstatus; /*  number of tokens to shift before error messages enabled */
   int ace_cc_yychar1 = 0;   /*  lookahead token as an internal (translated) token number */
 

--- a/TAO/orbsvcs/tests/Notify/Bug_3252_Regression/server.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_3252_Regression/server.cpp
@@ -10,7 +10,7 @@
 
 #include "DllOrb.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 #  pragma option push -w-8057
 #endif
 
@@ -231,6 +231,6 @@ ACE_TMAIN(int, ACE_TCHAR **argv)
   return 0;
 }
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 # pragma option pop
 #endif

--- a/TAO/tests/Bug_3574_Regression/test.cpp
+++ b/TAO/tests/Bug_3574_Regression/test.cpp
@@ -1,6 +1,6 @@
 #include "tao/StringSeqC.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 #  pragma option push -w-8011
 #endif
 
@@ -52,6 +52,6 @@ ACE_TMAIN (int, ACE_TCHAR *[])
   return 0;
 }
 
-#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x730)
+#if defined (__BORLANDC__) && (__BORLANDC__ >= 0x660) && (__BORLANDC__ <= 0x750)
 # pragma option pop
 #endif


### PR DESCRIPTION
    * ACE/NEWS:
    * ACE/ace/Compression/rle/RLECompressor.cpp:
    * ACE/ace/OS_NS_Thread.cpp:
    * ACE/ace/config-win32-borland.h:
    * ACE/ace/os_include/net/os_if.h:
    * TAO/orbsvcs/orbsvcs/IFRService/IFR_Service_Utils_T.cpp:
    * TAO/orbsvcs/orbsvcs/Notify/MonitorControlExt/MC_Default_Factory.h:
    * TAO/orbsvcs/orbsvcs/Notify/RT_Factory.h:
    * TAO/orbsvcs/tests/Notify/Bug_3252_Regression/server.cpp:
    * TAO/tests/Bug_3574_Regression/test.cpp: