### PR TITLE
With CPP17 or newer provide our auto_ptr implementation to not break …

### DIFF
--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -74,6 +74,7 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 // in ACE and TAO tests so for the moment we are providing
 // our own auto_ptr implementation
 # define ACE_LACKS_AUTO_PTR
+# include <memory>
 #endif /* ACE_HAS_CPP17 */
 
 #if !defined (ACE_LACKS_AUTO_PTR) && \

--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -69,15 +69,20 @@ protected:
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 
+#if defined (ACE_HAS_CPP17)
+// C++17 has removed std::auto_ptr but this is heavily used
+// in ACE and TAO tests so for the moment we are providing
+// our own auto_ptr implementation
+# define ACE_LACKS_AUTO_PTR
+#endif /* ACE_HAS_CPP17 */
+
 #if !defined (ACE_LACKS_AUTO_PTR) && \
      defined (ACE_HAS_STANDARD_CPP_LIBRARY) && \
             (ACE_HAS_STANDARD_CPP_LIBRARY != 0)
 #include <memory>
 #if defined (ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB) && \
             (ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB != 0)
-#if !defined (ACE_HAS_CPP17)
 using std::auto_ptr;
-#endif /* !ACE_HAS_CPP17 */
 #endif /* ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB */
 #else /* ACE_HAS_STANDARD_CPP_LIBRARY */
 


### PR DESCRIPTION
…all ACE/TAO tests