### PR TITLE
Extend Annotation Support

### DIFF
--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,10 +1,10 @@
 USER VISIBLE CHANGES BETWEEN TAO-2.5.9 and TAO-2.5.10
 =====================================================
 
-- TAO IDL Frontend annotation support extended: (#1125)
-  - All the contents of interfaces
-  - The porttypes, eventtypes, components and all their contents
-  - Valuetypes and most of their contents
+. TAO IDL Frontend annotation support extended: (#1125)
+  . All the direct contents of interfaces
+  . Porttypes, eventtypes, components, and all their direct contents
+  . Valuetypes and most of their direct contents
 
 USER VISIBLE CHANGES BETWEEN TAO-2.5.8 and TAO-2.5.9
 ====================================================

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,6 +1,11 @@
 USER VISIBLE CHANGES BETWEEN TAO-2.5.9 and TAO-2.5.10
 =====================================================
 
+- TAO IDL Frontend annotation support extended: (#1125)
+  - All the contents of interfaces
+  - The porttypes, eventtypes, components and all their contents
+  - Valuetypes and most of their contents
+
 USER VISIBLE CHANGES BETWEEN TAO-2.5.8 and TAO-2.5.9
 ====================================================
 

--- a/TAO/TAO_IDL/ast/ast_decl.cpp
+++ b/TAO/TAO_IDL/ast/ast_decl.cpp
@@ -62,27 +62,27 @@ trademarks or registered trademarks of Sun Microsystems, Inc.
 
 */
 
-#include "ast_interface.h"
-#include "ast_module.h"
-#include "ast_array.h"
-#include "ast_field.h"
-#include "ast_structure.h"
-#include "ast_sequence.h"
-#include "ast_string.h"
-#include "ast_typedef.h"
-#include "ast_visitor.h"
-#include "global_extern.h"
-#include "nr_extern.h"
-#include "utl_identifier.h"
-#include "utl_string.h"
-#include "utl_scope.h"
-#include "utl_err.h"
-#include "ace/OS_NS_stdio.h"
-#include "ast_annotation_appl.h"
-#include "utl_indenter.h"
+#include <ast_interface.h>
+#include <ast_module.h>
+#include <ast_array.h>
+#include <ast_field.h>
+#include <ast_structure.h>
+#include <ast_sequence.h>
+#include <ast_string.h>
+#include <ast_typedef.h>
+#include <ast_visitor.h>
+#include <global_extern.h>
+#include <nr_extern.h>
+#include <utl_identifier.h>
+#include <utl_string.h>
+#include <utl_scope.h>
+#include <utl_err.h>
+#include <ast_annotation_appl.h>
+#include <utl_indenter.h>
 
 // FUZZ: disable check_for_streams_include
-#include "ace/streams.h"
+#include <ace/streams.h>
+#include <ace/OS_NS_stdio.h>
 
 COMMON_Base::COMMON_Base (bool local,
                           bool abstract)
@@ -1643,7 +1643,7 @@ operator<< (ACE_OSTREAM_TYPE &o, AST_Decl &d)
 bool
 AST_Decl::annotatable () const
 {
-  return false;
+  return true;
 }
 
 bool

--- a/TAO/TAO_IDL/docs/annotations.md
+++ b/TAO/TAO_IDL/docs/annotations.md
@@ -614,6 +614,6 @@ annotation member names with `_cxx_` if they are also a C++ keyword.
 ### TAO 2.5.10
 
 - Annotation support extended:
-  - All the contents of interfaces
-  - The porttypes, eventtypes, components and all their contents
-  - Valuetypes and most of their contents
+  - All the direct contents of interfaces
+  - The porttypes, eventtypes, components and all their direct contents
+  - Valuetypes and most of their direct contents

--- a/TAO/TAO_IDL/docs/annotations.md
+++ b/TAO/TAO_IDL/docs/annotations.md
@@ -27,6 +27,7 @@ compiler that uses `tao_idl`.**
   * [TAO 2.5.5](#tao-255)
   * [TAO 2.5.6](#tao-256)
   * [TAO 2.5.7](#tao-257)
+  * [TAO 2.5.10](#tao-2510)
 
 ## IDL Annotations
 
@@ -87,7 +88,7 @@ of what can be annotated and how, annotations for specific IDL elements have to
 be added on a as-needed basis.
 
 You can put annotations before the following things in IDL and a backend using
-TAO IDLs front-end library can read them:
+TAO IDL's front-end library can read them:
 
 - modules
 - `typedef`s
@@ -95,11 +96,12 @@ TAO IDLs front-end library can read them:
 - structures and their member values
 - unions and their cases
 - enumerations and their enumerators
-- interfaces, porttypes, eventtypes, components and all their contents
-- valuetypes and most of their contents with the exception of these kinds
-  valuetype statements:
+- interfaces, porttypes, eventtypes, components and all of their direct
+  contents
+- valuetypes and most of their direct contents with the exception of these
+  kinds of valuetype statements:
   - import: not supported by TAO
-  - typeid: not supported by TAO on valuetypes
+  - typeid: not supported by TAO within valuetypes
   - typeprefix: No corresponding AST Node to attach annotations to
 
 These are the general cases. The rest of the cases are defined in the next

--- a/TAO/TAO_IDL/docs/annotations.md
+++ b/TAO/TAO_IDL/docs/annotations.md
@@ -87,7 +87,7 @@ of what can be annotated and how, annotations for specific IDL elements have to
 be added on a as-needed basis.
 
 You can put annotations before the following things in IDL and a backend using
-TAO IDL's front-end library can read them:
+TAO IDLs front-end library can read them:
 
 - modules
 - `typedef`s
@@ -95,7 +95,12 @@ TAO IDL's front-end library can read them:
 - structures and their member values
 - unions and their cases
 - enumerations and their enumerators
-- interfaces and their operations and attributes
+- interfaces, porttypes, eventtypes, components and all their contents
+- valuetypes and most of their contents with the exception of these kinds
+  valuetype statements:
+  - import: not supported by TAO
+  - typeid: not supported by TAO on valuetypes
+  - typeprefix: No corresponding AST Node to attach annotations to
 
 These are the general cases. The rest of the cases are defined in the next
 section. If an annotation application isn't listed in the general case list or
@@ -603,3 +608,10 @@ annotation member names with `_cxx_` if they are also a C++ keyword.
 
 - Expanded documentation on what can be annotated and how to extend annotation
   support.
+
+### TAO 2.5.10
+
+- Annotation support extended:
+  - All the contents of interfaces
+  - The porttypes, eventtypes, components and all their contents
+  - Valuetypes and most of their contents

--- a/TAO/TAO_IDL/fe/idl.tab.cpp
+++ b/TAO/TAO_IDL/fe/idl.tab.cpp
@@ -1254,55 +1254,55 @@ static const yytype_int16 yyrline[] =
     1103,  1104,  1108,  1113,  1118,  1163,  1167,  1117,  1196,  1239,
     1243,  1194,  1262,  1260,  1300,  1299,  1311,  1315,  1322,  1327,
     1334,  1359,  1387,  1453,  1472,  1476,  1480,  1481,  1493,  1492,
-    1510,  1514,  1521,  1540,  1541,  1545,  1560,  1565,  1564,  1573,
-    1572,  1581,  1580,  1589,  1588,  1597,  1596,  1605,  1604,  1613,
-    1612,  1621,  1620,  1633,  1645,  1643,  1668,  1675,  1685,  1684,
-    1710,  1708,  1733,  1743,  1754,  1798,  1825,  1857,  1861,  1865,
-    1869,  1856,  1931,  1932,  1933,  1934,  1935,  1936,  1937,  1941,
-    1945,  2013,  2015,  2017,  2018,  2030,  2031,  2043,  2044,  2056,
-    2057,  2066,  2078,  2079,  2088,  2100,  2101,  2110,  2119,  2131,
-    2132,  2141,  2150,  2162,  2219,  2220,  2227,  2231,  2236,  2243,
-    2250,  2254,  2259,  2263,  2267,  2271,  2278,  2347,  2346,  2375,
-    2376,  2380,  2381,  2382,  2384,  2383,  2392,  2393,  2397,  2453,
-    2457,  2464,  2477,  2487,  2495,  2494,  2582,  2586,  2593,  2602,
-    2609,  2617,  2623,  2630,  2643,  2642,  2651,  2655,  2659,  2663,
-    2691,  2699,  2698,  2769,  2770,  2774,  2781,  2782,  2808,  2809,
-    2810,  2811,  2812,  2813,  2814,  2815,  2819,  2820,  2821,  2822,
-    2826,  2827,  2828,  2832,  2833,  2837,  2849,  2847,  2872,  2879,
-    2880,  2884,  2896,  2894,  2919,  2926,  2942,  2960,  2961,  2965,
-    2969,  2973,  2980,  2984,  2988,  2995,  2999,  3003,  3010,  3017,
-    3021,  3028,  3035,  3042,  3049,  3057,  3056,  3070,  3101,  3105,
-    3069,  3122,  3125,  3126,  3130,  3148,  3152,  3147,  3210,  3209,
-    3222,  3221,  3234,  3238,  3271,  3275,  3334,  3338,  3233,  3360,
-    3367,  3380,  3389,  3396,  3397,  3506,  3509,  3510,  3515,  3519,
-    3514,  3555,  3554,  3566,  3576,  3594,  3602,  3601,  3615,  3619,
-    3614,  3635,  3634,  3684,  3709,  3733,  3737,  3768,  3772,  3732,
-    3796,  3801,  3799,  3805,  3809,  3849,  3853,  3847,  3941,  4012,
-    4021,  4011,  4035,  4045,  4049,  4043,  4094,  4120,  4129,  4133,
-    4127,  4169,  4195,  4203,  4202,  4249,  4259,  4277,  4285,  4289,
-    4284,  4349,  4350,  4355,  4359,  4363,  4367,  4354,  4426,  4430,
-    4434,  4438,  4425,  4506,  4510,  4542,  4546,  4505,  4563,  4567,
-    4628,  4632,  4562,  4669,  4674,  4679,  4686,  4687,  4698,  4703,
-    4746,  4697,  4768,  4767,  4776,  4775,  4786,  4791,  4789,  4795,
-    4800,  4804,  4799,  4843,  4842,  4851,  4850,  4861,  4866,  4864,
-    4870,  4875,  4879,  4874,  4924,  4931,  4932,  4933,  5040,  5044,
-    5048,  5056,  5060,  5055,  5069,  5077,  5081,  5076,  5090,  5098,
-    5102,  5097,  5111,  5119,  5123,  5118,  5132,  5139,  5151,  5149,
-    5172,  5179,  5209,  5248,  5249,  5253,  5284,  5325,  5329,  5283,
-    5348,  5352,  5346,  5393,  5392,  5400,  5407,  5422,  5423,  5428,
-    5427,  5437,  5436,  5446,  5445,  5455,  5454,  5464,  5463,  5473,
-    5472,  5482,  5481,  5492,  5585,  5591,  5616,  5723,  5732,  5736,
-    5743,  5818,  5890,  5966,  5965,  6015,  6019,  6023,  6027,  6031,
-    6035,  6014,  6088,  6087,  6095,  6102,  6107,  6115,  6119,  6114,
-    6129,  6130,  6134,  6136,  6135,  6144,  6143,  6156,  6179,  6154,
-    6205,  6232,  6203,  6256,  6257,  6258,  6262,  6263,  6267,  6296,
-    6328,  6372,  6376,  6326,  6393,  6402,  6420,  6431,  6430,  6468,
-    6518,  6522,  6466,  6539,  6543,  6550,  6554,  6558,  6562,  6566,
-    6570,  6574,  6578,  6582,  6586,  6594,  6625,  6638,  6645,  6670,
-    6688,  6695,  6710,  6717,  6727,  6731,  6750,  6758,  6726,  6773,
-    6788,  6792,  6793,  6797,  6798,  6800,  6799,  6810,  6877,  6925,
-    6941,  6954,  6961,  7020,  7028,  7032,  7027,  7093,  7097,  7092,
-    7110,  7111,  7116,  7115,  7124,  7123,  7132,  7131,  7140,  7139
+    1510,  1514,  1521,  1542,  1543,  1547,  1562,  1567,  1566,  1575,
+    1574,  1583,  1582,  1591,  1590,  1599,  1598,  1607,  1606,  1615,
+    1614,  1623,  1622,  1635,  1647,  1645,  1670,  1677,  1687,  1686,
+    1712,  1710,  1735,  1745,  1756,  1800,  1827,  1859,  1863,  1867,
+    1871,  1858,  1933,  1934,  1935,  1936,  1937,  1938,  1939,  1943,
+    1947,  2015,  2017,  2019,  2020,  2032,  2033,  2045,  2046,  2058,
+    2059,  2068,  2080,  2081,  2090,  2102,  2103,  2112,  2121,  2133,
+    2134,  2143,  2152,  2164,  2221,  2222,  2229,  2233,  2238,  2245,
+    2252,  2256,  2261,  2265,  2269,  2273,  2280,  2349,  2348,  2377,
+    2378,  2382,  2383,  2384,  2386,  2385,  2394,  2395,  2399,  2455,
+    2459,  2466,  2479,  2489,  2497,  2496,  2584,  2588,  2595,  2604,
+    2611,  2619,  2625,  2632,  2645,  2644,  2653,  2657,  2661,  2665,
+    2693,  2701,  2700,  2771,  2772,  2776,  2783,  2784,  2810,  2811,
+    2812,  2813,  2814,  2815,  2816,  2817,  2821,  2822,  2823,  2824,
+    2828,  2829,  2830,  2834,  2835,  2839,  2851,  2849,  2874,  2881,
+    2882,  2886,  2898,  2896,  2921,  2928,  2944,  2962,  2963,  2967,
+    2971,  2975,  2982,  2986,  2990,  2997,  3001,  3005,  3012,  3019,
+    3023,  3030,  3037,  3044,  3051,  3059,  3058,  3072,  3103,  3107,
+    3071,  3124,  3127,  3128,  3132,  3150,  3154,  3149,  3212,  3211,
+    3224,  3223,  3236,  3240,  3273,  3277,  3336,  3340,  3235,  3362,
+    3369,  3382,  3391,  3398,  3399,  3508,  3511,  3512,  3517,  3521,
+    3516,  3557,  3556,  3568,  3578,  3596,  3604,  3603,  3617,  3621,
+    3616,  3637,  3636,  3686,  3711,  3735,  3739,  3770,  3774,  3734,
+    3798,  3803,  3801,  3807,  3811,  3851,  3855,  3849,  3943,  4014,
+    4023,  4013,  4037,  4047,  4051,  4045,  4096,  4122,  4131,  4135,
+    4129,  4171,  4197,  4205,  4204,  4251,  4261,  4279,  4287,  4291,
+    4286,  4351,  4352,  4357,  4361,  4365,  4369,  4356,  4428,  4432,
+    4436,  4440,  4427,  4508,  4512,  4544,  4548,  4507,  4565,  4569,
+    4630,  4634,  4564,  4671,  4676,  4681,  4688,  4689,  4700,  4705,
+    4748,  4699,  4770,  4769,  4778,  4777,  4788,  4793,  4791,  4797,
+    4802,  4806,  4801,  4845,  4844,  4853,  4852,  4863,  4868,  4866,
+    4872,  4877,  4881,  4876,  4926,  4933,  4934,  4935,  5042,  5046,
+    5050,  5058,  5062,  5057,  5071,  5079,  5083,  5078,  5092,  5100,
+    5104,  5099,  5113,  5121,  5125,  5120,  5134,  5141,  5153,  5151,
+    5174,  5181,  5211,  5250,  5251,  5255,  5286,  5327,  5331,  5285,
+    5350,  5354,  5348,  5395,  5394,  5402,  5409,  5424,  5425,  5430,
+    5429,  5439,  5438,  5448,  5447,  5457,  5456,  5466,  5465,  5475,
+    5474,  5484,  5483,  5494,  5587,  5593,  5618,  5725,  5734,  5738,
+    5745,  5820,  5892,  5968,  5967,  6017,  6021,  6025,  6029,  6033,
+    6037,  6016,  6090,  6089,  6097,  6104,  6109,  6117,  6121,  6116,
+    6131,  6132,  6136,  6138,  6137,  6146,  6145,  6158,  6181,  6156,
+    6207,  6234,  6205,  6258,  6259,  6260,  6264,  6265,  6269,  6298,
+    6330,  6374,  6378,  6328,  6395,  6404,  6422,  6433,  6432,  6470,
+    6520,  6524,  6468,  6541,  6545,  6552,  6556,  6560,  6564,  6568,
+    6572,  6576,  6580,  6584,  6588,  6596,  6627,  6640,  6647,  6672,
+    6690,  6697,  6712,  6719,  6729,  6733,  6752,  6760,  6728,  6775,
+    6790,  6794,  6795,  6799,  6800,  6802,  6801,  6812,  6879,  6927,
+    6943,  6956,  6963,  7022,  7030,  7034,  7029,  7095,  7099,  7094,
+    7112,  7113,  7118,  7117,  7126,  7125,  7134,  7133,  7142,  7141
 };
 #endif
 
@@ -4131,25 +4131,27 @@ yyreduce:
   case 112:
 #line 1522 "fe/idl.ypp"
         {
-          if ((yyvsp[0].decls_val))
+          AST_Field::Visibility &visibility = (yyvsp[-1].vival);
+          AST_Decls *&decls_ptr = (yyvsp[0].decls_val);
+          if (decls_ptr)
             {
-              AST_Decls &decls = *(yyvsp[0].decls_val);
+              AST_Decls &decls = *decls_ptr;
               for (size_t i = 0; i < decls.size (); i++)
                 {
-                  AST_Field * field = dynamic_cast<AST_Field*> (decls[i]);
+                  AST_Field *field = dynamic_cast<AST_Field *> (decls[i]);
                   if (field)
                     {
-                      field->visibility ((yyvsp[-1].vival));
+                      field->visibility (visibility);
                     }
                 }
             }
-          (yyval.decls_val) = (yyvsp[0].decls_val);
+          (yyval.decls_val) = decls_ptr;
         }
-#line 4149 "fe/idl.tab.cpp"
+#line 4151 "fe/idl.tab.cpp"
     break;
 
   case 115:
-#line 1546 "fe/idl.ypp"
+#line 1548 "fe/idl.ypp"
         {
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
           AST_Decl *d = (yyvsp[0].dcval);
@@ -4164,160 +4166,160 @@ yyreduce:
             }
           delete annotations;
         }
-#line 4168 "fe/idl.tab.cpp"
+#line 4170 "fe/idl.tab.cpp"
     break;
 
   case 117:
-#line 1565 "fe/idl.ypp"
+#line 1567 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypeDeclSeen);
         }
-#line 4176 "fe/idl.tab.cpp"
+#line 4178 "fe/idl.tab.cpp"
     break;
 
   case 118:
-#line 1569 "fe/idl.ypp"
+#line 1571 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4184 "fe/idl.tab.cpp"
+#line 4186 "fe/idl.tab.cpp"
     break;
 
   case 119:
-#line 1573 "fe/idl.ypp"
+#line 1575 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypeIdDeclSeen);
         }
-#line 4192 "fe/idl.tab.cpp"
+#line 4194 "fe/idl.tab.cpp"
     break;
 
   case 120:
-#line 1577 "fe/idl.ypp"
+#line 1579 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4200 "fe/idl.tab.cpp"
+#line 4202 "fe/idl.tab.cpp"
     break;
 
   case 121:
-#line 1581 "fe/idl.ypp"
+#line 1583 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypePrefixDeclSeen);
         }
-#line 4208 "fe/idl.tab.cpp"
+#line 4210 "fe/idl.tab.cpp"
     break;
 
   case 122:
-#line 1585 "fe/idl.ypp"
+#line 1587 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4216 "fe/idl.tab.cpp"
+#line 4218 "fe/idl.tab.cpp"
     break;
 
   case 123:
-#line 1589 "fe/idl.ypp"
+#line 1591 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConstDeclSeen);
         }
-#line 4224 "fe/idl.tab.cpp"
+#line 4226 "fe/idl.tab.cpp"
     break;
 
   case 124:
-#line 1593 "fe/idl.ypp"
+#line 1595 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4232 "fe/idl.tab.cpp"
+#line 4234 "fe/idl.tab.cpp"
     break;
 
   case 125:
-#line 1597 "fe/idl.ypp"
+#line 1599 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptDeclSeen);
         }
-#line 4240 "fe/idl.tab.cpp"
+#line 4242 "fe/idl.tab.cpp"
     break;
 
   case 126:
-#line 1601 "fe/idl.ypp"
+#line 1603 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4248 "fe/idl.tab.cpp"
+#line 4250 "fe/idl.tab.cpp"
     break;
 
   case 127:
-#line 1605 "fe/idl.ypp"
+#line 1607 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
         }
-#line 4256 "fe/idl.tab.cpp"
+#line 4258 "fe/idl.tab.cpp"
     break;
 
   case 128:
-#line 1609 "fe/idl.ypp"
+#line 1611 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4264 "fe/idl.tab.cpp"
+#line 4266 "fe/idl.tab.cpp"
     break;
 
   case 129:
-#line 1613 "fe/idl.ypp"
+#line 1615 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpDeclSeen);
         }
-#line 4272 "fe/idl.tab.cpp"
+#line 4274 "fe/idl.tab.cpp"
     break;
 
   case 130:
-#line 1617 "fe/idl.ypp"
+#line 1619 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4280 "fe/idl.tab.cpp"
+#line 4282 "fe/idl.tab.cpp"
     break;
 
   case 131:
-#line 1621 "fe/idl.ypp"
+#line 1623 "fe/idl.ypp"
         {
           idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
-#line 4288 "fe/idl.tab.cpp"
+#line 4290 "fe/idl.tab.cpp"
     break;
 
   case 132:
-#line 1625 "fe/idl.ypp"
+#line 1627 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           yyerrok;
           (yyval.dcval) = 0;
         }
-#line 4298 "fe/idl.tab.cpp"
+#line 4300 "fe/idl.tab.cpp"
     break;
 
   case 133:
-#line 1634 "fe/idl.ypp"
+#line 1636 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.nlval),
                           UTL_NameList ((yyvsp[-1].idlist),
                                         (yyvsp[0].nlval)),
                           1);
         }
-#line 4309 "fe/idl.tab.cpp"
+#line 4311 "fe/idl.tab.cpp"
     break;
 
   case 134:
-#line 1645 "fe/idl.ypp"
+#line 1647 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SNListCommaSeen);
         }
-#line 4317 "fe/idl.tab.cpp"
+#line 4319 "fe/idl.tab.cpp"
     break;
 
   case 135:
-#line 1649 "fe/idl.ypp"
+#line 1651 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ScopedNameSeen);
 
@@ -4337,19 +4339,19 @@ yyreduce:
               (yyval.nlval) = (yyvsp[-3].nlval);
             }
         }
-#line 4341 "fe/idl.tab.cpp"
+#line 4343 "fe/idl.tab.cpp"
     break;
 
   case 136:
-#line 1669 "fe/idl.ypp"
+#line 1671 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 4349 "fe/idl.tab.cpp"
+#line 4351 "fe/idl.tab.cpp"
     break;
 
   case 137:
-#line 1676 "fe/idl.ypp"
+#line 1678 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SN_IDSeen);
 
@@ -4358,19 +4360,19 @@ yyreduce:
                                       0),
                           1);
         }
-#line 4362 "fe/idl.tab.cpp"
+#line 4364 "fe/idl.tab.cpp"
     break;
 
   case 138:
-#line 1685 "fe/idl.ypp"
+#line 1687 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ScopeDelimSeen);
         }
-#line 4370 "fe/idl.tab.cpp"
+#line 4372 "fe/idl.tab.cpp"
     break;
 
   case 139:
-#line 1689 "fe/idl.ypp"
+#line 1691 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SN_IDSeen);
 
@@ -4390,11 +4392,11 @@ yyreduce:
                                       sn),
                           1);
         }
-#line 4394 "fe/idl.tab.cpp"
+#line 4396 "fe/idl.tab.cpp"
     break;
 
   case 140:
-#line 1710 "fe/idl.ypp"
+#line 1712 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ScopeDelimSeen);
 
@@ -4404,11 +4406,11 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 4408 "fe/idl.tab.cpp"
+#line 4410 "fe/idl.tab.cpp"
     break;
 
   case 141:
-#line 1720 "fe/idl.ypp"
+#line 1722 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SN_IDSeen);
 
@@ -4420,11 +4422,11 @@ yyreduce:
           (yyvsp[-3].idlist)->nconc (sn);
           (yyval.idlist) = (yyvsp[-3].idlist);
         }
-#line 4424 "fe/idl.tab.cpp"
+#line 4426 "fe/idl.tab.cpp"
     break;
 
   case 142:
-#line 1734 "fe/idl.ypp"
+#line 1736 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.idval),
                           Identifier ((yyvsp[0].strval)),
@@ -4432,11 +4434,11 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 4436 "fe/idl.tab.cpp"
+#line 4438 "fe/idl.tab.cpp"
     break;
 
   case 143:
-#line 1744 "fe/idl.ypp"
+#line 1746 "fe/idl.ypp"
         {
           /* defining_id is a defining identifier
              whereas id is usually a reference to a defining identifier */
@@ -4444,11 +4446,11 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 4448 "fe/idl.tab.cpp"
+#line 4450 "fe/idl.tab.cpp"
     break;
 
   case 144:
-#line 1755 "fe/idl.ypp"
+#line 1757 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval), 0);
@@ -4491,11 +4493,11 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 4495 "fe/idl.tab.cpp"
+#line 4497 "fe/idl.tab.cpp"
     break;
 
   case 145:
-#line 1799 "fe/idl.ypp"
+#line 1801 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -4521,11 +4523,11 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 4525 "fe/idl.tab.cpp"
+#line 4527 "fe/idl.tab.cpp"
     break;
 
   case 146:
-#line 1826 "fe/idl.ypp"
+#line 1828 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -4553,43 +4555,43 @@ yyreduce:
 
           (yyval.dcval) = dynamic_cast<AST_Decl*> (f);
         }
-#line 4557 "fe/idl.tab.cpp"
+#line 4559 "fe/idl.tab.cpp"
     break;
 
   case 147:
-#line 1857 "fe/idl.ypp"
+#line 1859 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConstSeen);
         }
-#line 4565 "fe/idl.tab.cpp"
+#line 4567 "fe/idl.tab.cpp"
     break;
 
   case 148:
-#line 1861 "fe/idl.ypp"
+#line 1863 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConstTypeSeen);
         }
-#line 4573 "fe/idl.tab.cpp"
+#line 4575 "fe/idl.tab.cpp"
     break;
 
   case 149:
-#line 1865 "fe/idl.ypp"
+#line 1867 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConstIDSeen);
         }
-#line 4581 "fe/idl.tab.cpp"
+#line 4583 "fe/idl.tab.cpp"
     break;
 
   case 150:
-#line 1869 "fe/idl.ypp"
+#line 1871 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConstAssignSeen);
         }
-#line 4589 "fe/idl.tab.cpp"
+#line 4591 "fe/idl.tab.cpp"
     break;
 
   case 151:
-#line 1873 "fe/idl.ypp"
+#line 1875 "fe/idl.ypp"
         {
           (yyval.dcval) = 0;
           UTL_ScopedName n ((yyvsp[-4].idval), 0);
@@ -4645,27 +4647,27 @@ yyreduce:
           delete (yyvsp[-4].idval);
           (yyvsp[-4].idval) = 0;
         }
-#line 4649 "fe/idl.tab.cpp"
+#line 4651 "fe/idl.tab.cpp"
     break;
 
   case 158:
-#line 1938 "fe/idl.ypp"
+#line 1940 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_string;
         }
-#line 4657 "fe/idl.tab.cpp"
+#line 4659 "fe/idl.tab.cpp"
     break;
 
   case 159:
-#line 1942 "fe/idl.ypp"
+#line 1944 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_wstring;
         }
-#line 4665 "fe/idl.tab.cpp"
+#line 4667 "fe/idl.tab.cpp"
     break;
 
   case 160:
-#line 1946 "fe/idl.ypp"
+#line 1948 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_PredefinedType *c = 0;
@@ -4731,11 +4733,11 @@ yyreduce:
           sn = 0;
           (yyvsp[0].idlist) = 0;
         }
-#line 4735 "fe/idl.tab.cpp"
+#line 4737 "fe/idl.tab.cpp"
     break;
 
   case 164:
-#line 2019 "fe/idl.ypp"
+#line 2021 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4744,11 +4746,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4748 "fe/idl.tab.cpp"
+#line 4750 "fe/idl.tab.cpp"
     break;
 
   case 166:
-#line 2032 "fe/idl.ypp"
+#line 2034 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4757,11 +4759,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4761 "fe/idl.tab.cpp"
+#line 4763 "fe/idl.tab.cpp"
     break;
 
   case 168:
-#line 2045 "fe/idl.ypp"
+#line 2047 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4770,11 +4772,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4774 "fe/idl.tab.cpp"
+#line 4776 "fe/idl.tab.cpp"
     break;
 
   case 170:
-#line 2058 "fe/idl.ypp"
+#line 2060 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4783,11 +4785,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4787 "fe/idl.tab.cpp"
+#line 4789 "fe/idl.tab.cpp"
     break;
 
   case 171:
-#line 2067 "fe/idl.ypp"
+#line 2069 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4796,11 +4798,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4800 "fe/idl.tab.cpp"
+#line 4802 "fe/idl.tab.cpp"
     break;
 
   case 173:
-#line 2080 "fe/idl.ypp"
+#line 2082 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4809,11 +4811,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4813 "fe/idl.tab.cpp"
+#line 4815 "fe/idl.tab.cpp"
     break;
 
   case 174:
-#line 2089 "fe/idl.ypp"
+#line 2091 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4822,11 +4824,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4826 "fe/idl.tab.cpp"
+#line 4828 "fe/idl.tab.cpp"
     break;
 
   case 176:
-#line 2102 "fe/idl.ypp"
+#line 2104 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4835,11 +4837,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4839 "fe/idl.tab.cpp"
+#line 4841 "fe/idl.tab.cpp"
     break;
 
   case 177:
-#line 2111 "fe/idl.ypp"
+#line 2113 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4848,11 +4850,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4852 "fe/idl.tab.cpp"
+#line 4854 "fe/idl.tab.cpp"
     break;
 
   case 178:
-#line 2120 "fe/idl.ypp"
+#line 2122 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4861,11 +4863,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4865 "fe/idl.tab.cpp"
+#line 4867 "fe/idl.tab.cpp"
     break;
 
   case 180:
-#line 2133 "fe/idl.ypp"
+#line 2135 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4874,11 +4876,11 @@ yyreduce:
                                     0
                                   );
         }
-#line 4878 "fe/idl.tab.cpp"
+#line 4880 "fe/idl.tab.cpp"
     break;
 
   case 181:
-#line 2142 "fe/idl.ypp"
+#line 2144 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4887,11 +4889,11 @@ yyreduce:
                                    0
                                  );
         }
-#line 4891 "fe/idl.tab.cpp"
+#line 4893 "fe/idl.tab.cpp"
     break;
 
   case 182:
-#line 2151 "fe/idl.ypp"
+#line 2153 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4900,11 +4902,11 @@ yyreduce:
                                    0
                                  );
         }
-#line 4904 "fe/idl.tab.cpp"
+#line 4906 "fe/idl.tab.cpp"
     break;
 
   case 183:
-#line 2163 "fe/idl.ypp"
+#line 2165 "fe/idl.ypp"
         {
           UTL_ScopedName *name = (yyvsp[0].idlist);
 
@@ -4961,107 +4963,107 @@ yyreduce:
           delete name;
           (yyvsp[0].idlist) = name = 0;
         }
-#line 4965 "fe/idl.tab.cpp"
+#line 4967 "fe/idl.tab.cpp"
     break;
 
   case 185:
-#line 2221 "fe/idl.ypp"
+#line 2223 "fe/idl.ypp"
         {
           (yyval.exval) = (yyvsp[-1].exval);
         }
-#line 4973 "fe/idl.tab.cpp"
+#line 4975 "fe/idl.tab.cpp"
     break;
 
   case 186:
-#line 2228 "fe/idl.ypp"
+#line 2230 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].ival));
         }
-#line 4981 "fe/idl.tab.cpp"
+#line 4983 "fe/idl.tab.cpp"
     break;
 
   case 187:
-#line 2232 "fe/idl.ypp"
+#line 2234 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr ((yyvsp[0].uival));
         }
-#line 4990 "fe/idl.tab.cpp"
+#line 4992 "fe/idl.tab.cpp"
     break;
 
   case 188:
-#line 2237 "fe/idl.ypp"
+#line 2239 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].sval));
           (yyvsp[0].sval)->destroy ();
           delete (yyvsp[0].sval);
           (yyvsp[0].sval) = 0;
         }
-#line 5001 "fe/idl.tab.cpp"
+#line 5003 "fe/idl.tab.cpp"
     break;
 
   case 189:
-#line 2244 "fe/idl.ypp"
+#line 2246 "fe/idl.ypp"
         {
           char *wide_string = (yyvsp[0].wsval);
           (yyval.exval) = idl_global->gen ()->create_expr (wide_string);
           ACE_OS::free (wide_string);
           (yyvsp[0].wsval) = 0;
         }
-#line 5012 "fe/idl.tab.cpp"
+#line 5014 "fe/idl.tab.cpp"
     break;
 
   case 190:
-#line 2251 "fe/idl.ypp"
+#line 2253 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].cval));
         }
-#line 5020 "fe/idl.tab.cpp"
+#line 5022 "fe/idl.tab.cpp"
     break;
 
   case 191:
-#line 2255 "fe/idl.ypp"
+#line 2257 "fe/idl.ypp"
         {
           ACE_OutputCDR::from_wchar wc ((yyvsp[0].wcval));
           (yyval.exval) = idl_global->gen ()->create_expr (wc);
         }
-#line 5029 "fe/idl.tab.cpp"
+#line 5031 "fe/idl.tab.cpp"
     break;
 
   case 192:
-#line 2260 "fe/idl.ypp"
+#line 2262 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].fixval));
         }
-#line 5037 "fe/idl.tab.cpp"
+#line 5039 "fe/idl.tab.cpp"
     break;
 
   case 193:
-#line 2264 "fe/idl.ypp"
+#line 2266 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].dval));
         }
-#line 5045 "fe/idl.tab.cpp"
+#line 5047 "fe/idl.tab.cpp"
     break;
 
   case 194:
-#line 2268 "fe/idl.ypp"
+#line 2270 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr (true);
         }
-#line 5053 "fe/idl.tab.cpp"
+#line 5055 "fe/idl.tab.cpp"
     break;
 
   case 195:
-#line 2272 "fe/idl.ypp"
+#line 2274 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr (false);
         }
-#line 5061 "fe/idl.tab.cpp"
+#line 5063 "fe/idl.tab.cpp"
     break;
 
   case 196:
-#line 2279 "fe/idl.ypp"
+#line 2281 "fe/idl.ypp"
         {
           int good_expression = 1;
           (yyvsp[0].exval)->evaluate (AST_Expression::EK_positive_int);
@@ -5126,11 +5128,11 @@ yyreduce:
               idl_global->err ()->syntax_error (idl_global->parse_state ());
             }
         }
-#line 5130 "fe/idl.tab.cpp"
+#line 5132 "fe/idl.tab.cpp"
     break;
 
   case 197:
-#line 2347 "fe/idl.ypp"
+#line 2349 "fe/idl.ypp"
         {
           if (idl_global->idl_version_ < IDL_VERSION_4)
             {
@@ -5147,11 +5149,11 @@ yyreduce:
             fe_add_annotation_decl (annotation_decl);
           idl_global->scopes ().push (annotation_decl);
         }
-#line 5151 "fe/idl.tab.cpp"
+#line 5153 "fe/idl.tab.cpp"
     break;
 
   case 198:
-#line 2364 "fe/idl.ypp"
+#line 2366 "fe/idl.ypp"
         {
           Identifier *id = (yyvsp[-4].idval);
           idl_global->scopes ().pop ();
@@ -5160,20 +5162,20 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 5164 "fe/idl.tab.cpp"
+#line 5166 "fe/idl.tab.cpp"
     break;
 
   case 204:
-#line 2384 "fe/idl.ypp"
+#line 2386 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypedefSeen);
           idl_global->in_typedef (true);
         }
-#line 5173 "fe/idl.tab.cpp"
+#line 5175 "fe/idl.tab.cpp"
     break;
 
   case 208:
-#line 2398 "fe/idl.ypp"
+#line 2400 "fe/idl.ypp"
         {
           UTL_Scope *scope = idl_global->scopes ().top_non_null ();
           UTL_Scope *root = idl_global->scopes ().bottom ();
@@ -5226,27 +5228,27 @@ yyreduce:
               delete result;
             }
         }
-#line 5230 "fe/idl.tab.cpp"
+#line 5232 "fe/idl.tab.cpp"
     break;
 
   case 209:
-#line 2454 "fe/idl.ypp"
+#line 2456 "fe/idl.ypp"
         {
           (yyval.exval) = (yyvsp[0].exval);
         }
-#line 5238 "fe/idl.tab.cpp"
+#line 5240 "fe/idl.tab.cpp"
     break;
 
   case 210:
-#line 2458 "fe/idl.ypp"
+#line 2460 "fe/idl.ypp"
         {
           (yyval.exval) = 0;
         }
-#line 5246 "fe/idl.tab.cpp"
+#line 5248 "fe/idl.tab.cpp"
     break;
 
   case 211:
-#line 2465 "fe/idl.ypp"
+#line 2467 "fe/idl.ypp"
         {
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
           AST_Annotation_Appl *annotation = (yyvsp[0].annotation_val);
@@ -5256,11 +5258,11 @@ yyreduce:
             }
           (yyval.annotations_val) = annotations;
         }
-#line 5260 "fe/idl.tab.cpp"
+#line 5262 "fe/idl.tab.cpp"
     break;
 
   case 212:
-#line 2478 "fe/idl.ypp"
+#line 2480 "fe/idl.ypp"
         {
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
           AST_Annotation_Appl *annotation = (yyvsp[0].annotation_val);
@@ -5270,19 +5272,19 @@ yyreduce:
             }
           (yyval.annotations_val) = annotations;
         }
-#line 5274 "fe/idl.tab.cpp"
+#line 5276 "fe/idl.tab.cpp"
     break;
 
   case 213:
-#line 2488 "fe/idl.ypp"
+#line 2490 "fe/idl.ypp"
         {
           (yyval.annotations_val) = new AST_Annotation_Appls ();
         }
-#line 5282 "fe/idl.tab.cpp"
+#line 5284 "fe/idl.tab.cpp"
     break;
 
   case 214:
-#line 2495 "fe/idl.ypp"
+#line 2497 "fe/idl.ypp"
         {
           if (idl_global->idl_version_ < IDL_VERSION_4)
             {
@@ -5339,11 +5341,11 @@ yyreduce:
 
           (yyval.annotation_decl_val) = decl;
         }
-#line 5343 "fe/idl.tab.cpp"
+#line 5345 "fe/idl.tab.cpp"
     break;
 
   case 215:
-#line 2552 "fe/idl.ypp"
+#line 2554 "fe/idl.ypp"
         {
           idl_global->ignore_lookup_errors_ = false;
           stack_based_lookup_for_primary_expr = false;
@@ -5371,27 +5373,27 @@ yyreduce:
 
           (yyval.annotation_val) = appl;
         }
-#line 5375 "fe/idl.tab.cpp"
+#line 5377 "fe/idl.tab.cpp"
     break;
 
   case 216:
-#line 2583 "fe/idl.ypp"
+#line 2585 "fe/idl.ypp"
         {
           (yyval.annotation_params_val) = (yyvsp[-1].annotation_params_val);
         }
-#line 5383 "fe/idl.tab.cpp"
+#line 5385 "fe/idl.tab.cpp"
     break;
 
   case 217:
-#line 2587 "fe/idl.ypp"
+#line 2589 "fe/idl.ypp"
         {
           (yyval.annotation_params_val) = 0;
         }
-#line 5391 "fe/idl.tab.cpp"
+#line 5393 "fe/idl.tab.cpp"
     break;
 
   case 218:
-#line 2594 "fe/idl.ypp"
+#line 2596 "fe/idl.ypp"
         {
           AST_Annotation_Appl::Params *params = new AST_Annotation_Appl::Params;
           AST_Annotation_Appl::Param *param = new AST_Annotation_Appl::Param;
@@ -5400,47 +5402,47 @@ yyreduce:
           params->push (param);
           (yyval.annotation_params_val) = params;
         }
-#line 5404 "fe/idl.tab.cpp"
+#line 5406 "fe/idl.tab.cpp"
     break;
 
   case 219:
-#line 2603 "fe/idl.ypp"
+#line 2605 "fe/idl.ypp"
         {
           (yyval.annotation_params_val) = (yyvsp[0].annotation_params_val);
         }
-#line 5412 "fe/idl.tab.cpp"
+#line 5414 "fe/idl.tab.cpp"
     break;
 
   case 220:
-#line 2610 "fe/idl.ypp"
+#line 2612 "fe/idl.ypp"
         {
           AST_Annotation_Appl::Params *params = (yyvsp[0].annotation_params_val);
           params->push ((yyvsp[-1].annotation_param_val));
           (yyval.annotation_params_val) = params;
         }
-#line 5422 "fe/idl.tab.cpp"
+#line 5424 "fe/idl.tab.cpp"
     break;
 
   case 221:
-#line 2618 "fe/idl.ypp"
+#line 2620 "fe/idl.ypp"
         {
           AST_Annotation_Appl::Params *params = (yyvsp[0].annotation_params_val);
           params->push ((yyvsp[-1].annotation_param_val));
           (yyval.annotation_params_val) = params;
         }
-#line 5432 "fe/idl.tab.cpp"
+#line 5434 "fe/idl.tab.cpp"
     break;
 
   case 222:
-#line 2624 "fe/idl.ypp"
+#line 2626 "fe/idl.ypp"
         {
           (yyval.annotation_params_val) = new AST_Annotation_Appl::Params;
         }
-#line 5440 "fe/idl.tab.cpp"
+#line 5442 "fe/idl.tab.cpp"
     break;
 
   case 223:
-#line 2631 "fe/idl.ypp"
+#line 2633 "fe/idl.ypp"
         {
           AST_Annotation_Appl::Param *param = new AST_Annotation_Appl::Param;
           param->id = (yyvsp[-2].idval);
@@ -5449,52 +5451,52 @@ yyreduce:
           param->expr = (yyvsp[0].exval);
           (yyval.annotation_param_val) = param;
         }
-#line 5453 "fe/idl.tab.cpp"
+#line 5455 "fe/idl.tab.cpp"
     break;
 
   case 224:
-#line 2643 "fe/idl.ypp"
+#line 2645 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypedefSeen);
           idl_global->in_typedef (true);
         }
-#line 5462 "fe/idl.tab.cpp"
+#line 5464 "fe/idl.tab.cpp"
     break;
 
   case 225:
-#line 2648 "fe/idl.ypp"
+#line 2650 "fe/idl.ypp"
         {
           (yyval.dcval) = (yyvsp[0].dcval);
         }
-#line 5470 "fe/idl.tab.cpp"
+#line 5472 "fe/idl.tab.cpp"
     break;
 
   case 226:
-#line 2652 "fe/idl.ypp"
+#line 2654 "fe/idl.ypp"
         {
           (yyval.dcval) = (yyvsp[0].dcval);
         }
-#line 5478 "fe/idl.tab.cpp"
+#line 5480 "fe/idl.tab.cpp"
     break;
 
   case 227:
-#line 2656 "fe/idl.ypp"
+#line 2658 "fe/idl.ypp"
         {
           (yyval.dcval) = (yyvsp[0].dcval);
         }
-#line 5486 "fe/idl.tab.cpp"
+#line 5488 "fe/idl.tab.cpp"
     break;
 
   case 228:
-#line 2660 "fe/idl.ypp"
+#line 2662 "fe/idl.ypp"
         {
           (yyval.dcval) = (yyvsp[0].dcval);
         }
-#line 5494 "fe/idl.tab.cpp"
+#line 5496 "fe/idl.tab.cpp"
     break;
 
   case 229:
-#line 2664 "fe/idl.ypp"
+#line 2666 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Native *node = 0;
@@ -5522,27 +5524,27 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 5526 "fe/idl.tab.cpp"
+#line 5528 "fe/idl.tab.cpp"
     break;
 
   case 230:
-#line 2692 "fe/idl.ypp"
+#line 2694 "fe/idl.ypp"
         {
           (yyval.dcval) = 0;
         }
-#line 5534 "fe/idl.tab.cpp"
+#line 5536 "fe/idl.tab.cpp"
     break;
 
   case 231:
-#line 2699 "fe/idl.ypp"
+#line 2701 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypeSpecSeen);
         }
-#line 5542 "fe/idl.tab.cpp"
+#line 5544 "fe/idl.tab.cpp"
     break;
 
   case 232:
-#line 2703 "fe/idl.ypp"
+#line 2705 "fe/idl.ypp"
         {
           AST_Decl *type_spec = (yyvsp[-2].dcval);
           UTL_DeclList *decls = (yyvsp[0].dlval);
@@ -5606,22 +5608,22 @@ yyreduce:
 
           (yyval.dcval) = t;
         }
-#line 5610 "fe/idl.tab.cpp"
+#line 5612 "fe/idl.tab.cpp"
     break;
 
   case 235:
-#line 2775 "fe/idl.ypp"
+#line 2777 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 5621 "fe/idl.tab.cpp"
+#line 5623 "fe/idl.tab.cpp"
     break;
 
   case 237:
-#line 2783 "fe/idl.ypp"
+#line 2785 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = 0;
@@ -5644,30 +5646,30 @@ yyreduce:
 
           (yyval.dcval) = d;
         }
-#line 5648 "fe/idl.tab.cpp"
+#line 5650 "fe/idl.tab.cpp"
     break;
 
   case 255:
-#line 2838 "fe/idl.ypp"
+#line 2840 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.dlval),
                           UTL_DeclList ((yyvsp[-1].deval),
                                         (yyvsp[0].dlval)),
                           1);
         }
-#line 5659 "fe/idl.tab.cpp"
+#line 5661 "fe/idl.tab.cpp"
     break;
 
   case 256:
-#line 2849 "fe/idl.ypp"
+#line 2851 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DeclsCommaSeen);
         }
-#line 5667 "fe/idl.tab.cpp"
+#line 5669 "fe/idl.tab.cpp"
     break;
 
   case 257:
-#line 2853 "fe/idl.ypp"
+#line 2855 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DeclsDeclSeen);
 
@@ -5687,38 +5689,38 @@ yyreduce:
               (yyval.dlval) = (yyvsp[-3].dlval);
             }
         }
-#line 5691 "fe/idl.tab.cpp"
+#line 5693 "fe/idl.tab.cpp"
     break;
 
   case 258:
-#line 2873 "fe/idl.ypp"
+#line 2875 "fe/idl.ypp"
         {
           (yyval.dlval) = 0;
         }
-#line 5699 "fe/idl.tab.cpp"
+#line 5701 "fe/idl.tab.cpp"
     break;
 
   case 261:
-#line 2885 "fe/idl.ypp"
+#line 2887 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.dlval),
                           UTL_DeclList ((yyvsp[-1].deval),
                                         (yyvsp[0].dlval)),
                           1);
         }
-#line 5710 "fe/idl.tab.cpp"
+#line 5712 "fe/idl.tab.cpp"
     break;
 
   case 262:
-#line 2896 "fe/idl.ypp"
+#line 2898 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DeclsCommaSeen);
         }
-#line 5718 "fe/idl.tab.cpp"
+#line 5720 "fe/idl.tab.cpp"
     break;
 
   case 263:
-#line 2900 "fe/idl.ypp"
+#line 2902 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DeclsDeclSeen);
 
@@ -5738,19 +5740,19 @@ yyreduce:
               (yyval.dlval) = (yyvsp[-3].dlval);
             }
         }
-#line 5742 "fe/idl.tab.cpp"
+#line 5744 "fe/idl.tab.cpp"
     break;
 
   case 264:
-#line 2920 "fe/idl.ypp"
+#line 2922 "fe/idl.ypp"
         {
           (yyval.dlval) = 0;
         }
-#line 5750 "fe/idl.tab.cpp"
+#line 5752 "fe/idl.tab.cpp"
     break;
 
   case 265:
-#line 2927 "fe/idl.ypp"
+#line 2929 "fe/idl.ypp"
         {
           UTL_ScopedName *sn = 0;
           ACE_NEW_RETURN (sn,
@@ -5763,11 +5765,11 @@ yyreduce:
                                          0),
                           1);
         }
-#line 5767 "fe/idl.tab.cpp"
+#line 5769 "fe/idl.tab.cpp"
     break;
 
   case 266:
-#line 2943 "fe/idl.ypp"
+#line 2945 "fe/idl.ypp"
         {
           UTL_ScopedName *sn = 0;
           ACE_NEW_RETURN (sn,
@@ -5782,156 +5784,156 @@ yyreduce:
                                          (yyvsp[0].dcval)),
                           1);
         }
-#line 5786 "fe/idl.tab.cpp"
+#line 5788 "fe/idl.tab.cpp"
     break;
 
   case 269:
-#line 2966 "fe/idl.ypp"
+#line 2968 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_long;
         }
-#line 5794 "fe/idl.tab.cpp"
+#line 5796 "fe/idl.tab.cpp"
     break;
 
   case 270:
-#line 2970 "fe/idl.ypp"
+#line 2972 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_longlong;
         }
-#line 5802 "fe/idl.tab.cpp"
+#line 5804 "fe/idl.tab.cpp"
     break;
 
   case 271:
-#line 2974 "fe/idl.ypp"
+#line 2976 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_short;
         }
-#line 5810 "fe/idl.tab.cpp"
+#line 5812 "fe/idl.tab.cpp"
     break;
 
   case 272:
-#line 2981 "fe/idl.ypp"
+#line 2983 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_ulong;
         }
-#line 5818 "fe/idl.tab.cpp"
+#line 5820 "fe/idl.tab.cpp"
     break;
 
   case 273:
-#line 2985 "fe/idl.ypp"
+#line 2987 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_ulonglong;
         }
-#line 5826 "fe/idl.tab.cpp"
+#line 5828 "fe/idl.tab.cpp"
     break;
 
   case 274:
-#line 2989 "fe/idl.ypp"
+#line 2991 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_ushort;
         }
-#line 5834 "fe/idl.tab.cpp"
+#line 5836 "fe/idl.tab.cpp"
     break;
 
   case 275:
-#line 2996 "fe/idl.ypp"
+#line 2998 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_double;
         }
-#line 5842 "fe/idl.tab.cpp"
+#line 5844 "fe/idl.tab.cpp"
     break;
 
   case 276:
-#line 3000 "fe/idl.ypp"
+#line 3002 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_float;
         }
-#line 5850 "fe/idl.tab.cpp"
+#line 5852 "fe/idl.tab.cpp"
     break;
 
   case 277:
-#line 3004 "fe/idl.ypp"
+#line 3006 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_longdouble;
         }
-#line 5858 "fe/idl.tab.cpp"
+#line 5860 "fe/idl.tab.cpp"
     break;
 
   case 278:
-#line 3011 "fe/idl.ypp"
+#line 3013 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_fixed;
         }
-#line 5866 "fe/idl.tab.cpp"
+#line 5868 "fe/idl.tab.cpp"
     break;
 
   case 279:
-#line 3018 "fe/idl.ypp"
+#line 3020 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_char;
         }
-#line 5874 "fe/idl.tab.cpp"
+#line 5876 "fe/idl.tab.cpp"
     break;
 
   case 280:
-#line 3022 "fe/idl.ypp"
+#line 3024 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_wchar;
         }
-#line 5882 "fe/idl.tab.cpp"
+#line 5884 "fe/idl.tab.cpp"
     break;
 
   case 281:
-#line 3029 "fe/idl.ypp"
+#line 3031 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_octet;
         }
-#line 5890 "fe/idl.tab.cpp"
+#line 5892 "fe/idl.tab.cpp"
     break;
 
   case 282:
-#line 3036 "fe/idl.ypp"
+#line 3038 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_bool;
         }
-#line 5898 "fe/idl.tab.cpp"
+#line 5900 "fe/idl.tab.cpp"
     break;
 
   case 283:
-#line 3043 "fe/idl.ypp"
+#line 3045 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_any;
         }
-#line 5906 "fe/idl.tab.cpp"
+#line 5908 "fe/idl.tab.cpp"
     break;
 
   case 284:
-#line 3050 "fe/idl.ypp"
+#line 3052 "fe/idl.ypp"
         {
           (yyval.etval) = AST_Expression::EV_object;
         }
-#line 5914 "fe/idl.tab.cpp"
+#line 5916 "fe/idl.tab.cpp"
     break;
 
   case 285:
-#line 3057 "fe/idl.ypp"
+#line 3059 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StructSeen);
         }
-#line 5922 "fe/idl.tab.cpp"
+#line 5924 "fe/idl.tab.cpp"
     break;
 
   case 286:
-#line 3061 "fe/idl.ypp"
+#line 3063 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StructIDSeen);
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 5931 "fe/idl.tab.cpp"
+#line 5933 "fe/idl.tab.cpp"
     break;
 
   case 287:
-#line 3070 "fe/idl.ypp"
+#line 3072 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval), 0);
@@ -5962,27 +5964,27 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 5966 "fe/idl.tab.cpp"
+#line 5968 "fe/idl.tab.cpp"
     break;
 
   case 288:
-#line 3101 "fe/idl.ypp"
+#line 3103 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StructSqSeen);
         }
-#line 5974 "fe/idl.tab.cpp"
+#line 5976 "fe/idl.tab.cpp"
     break;
 
   case 289:
-#line 3105 "fe/idl.ypp"
+#line 3107 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StructBodySeen);
         }
-#line 5982 "fe/idl.tab.cpp"
+#line 5984 "fe/idl.tab.cpp"
     break;
 
   case 290:
-#line 3109 "fe/idl.ypp"
+#line 3111 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StructQsSeen);
 
@@ -5994,11 +5996,11 @@ yyreduce:
                  );
           idl_global->scopes ().pop ();
         }
-#line 5998 "fe/idl.tab.cpp"
+#line 6000 "fe/idl.tab.cpp"
     break;
 
   case 294:
-#line 3131 "fe/idl.ypp"
+#line 3133 "fe/idl.ypp"
         {
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
           AST_Decls *members = (yyvsp[0].decls_val);
@@ -6012,27 +6014,27 @@ yyreduce:
           delete annotations;
           delete members;
         }
-#line 6016 "fe/idl.tab.cpp"
+#line 6018 "fe/idl.tab.cpp"
     break;
 
   case 295:
-#line 3148 "fe/idl.ypp"
+#line 3150 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_MemberTypeSeen);
         }
-#line 6024 "fe/idl.tab.cpp"
+#line 6026 "fe/idl.tab.cpp"
     break;
 
   case 296:
-#line 3152 "fe/idl.ypp"
+#line 3154 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_MemberDeclsSeen);
         }
-#line 6032 "fe/idl.tab.cpp"
+#line 6034 "fe/idl.tab.cpp"
     break;
 
   case 297:
-#line 3156 "fe/idl.ypp"
+#line 3158 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           FE_Declarator *d = 0;
@@ -6086,53 +6088,53 @@ yyreduce:
 
           (yyval.decls_val) = members;
         }
-#line 6090 "fe/idl.tab.cpp"
+#line 6092 "fe/idl.tab.cpp"
     break;
 
   case 298:
-#line 3210 "fe/idl.ypp"
+#line 3212 "fe/idl.ypp"
         {
           idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
-#line 6098 "fe/idl.tab.cpp"
+#line 6100 "fe/idl.tab.cpp"
     break;
 
   case 299:
-#line 3214 "fe/idl.ypp"
+#line 3216 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           yyerrok;
         }
-#line 6107 "fe/idl.tab.cpp"
+#line 6109 "fe/idl.tab.cpp"
     break;
 
   case 300:
-#line 3222 "fe/idl.ypp"
+#line 3224 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionSeen);
         }
-#line 6115 "fe/idl.tab.cpp"
+#line 6117 "fe/idl.tab.cpp"
     break;
 
   case 301:
-#line 3226 "fe/idl.ypp"
+#line 3228 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionIDSeen);
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 6124 "fe/idl.tab.cpp"
+#line 6126 "fe/idl.tab.cpp"
     break;
 
   case 302:
-#line 3234 "fe/idl.ypp"
+#line 3236 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SwitchSeen);
         }
-#line 6132 "fe/idl.tab.cpp"
+#line 6134 "fe/idl.tab.cpp"
     break;
 
   case 303:
-#line 3238 "fe/idl.ypp"
+#line 3240 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[-3].idval), 0);
@@ -6165,19 +6167,19 @@ yyreduce:
            * Don't delete $1 yet; we'll need it a bit later.
            */
         }
-#line 6169 "fe/idl.tab.cpp"
+#line 6171 "fe/idl.tab.cpp"
     break;
 
   case 304:
-#line 3271 "fe/idl.ypp"
+#line 3273 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SwitchTypeSeen);
         }
-#line 6177 "fe/idl.tab.cpp"
+#line 6179 "fe/idl.tab.cpp"
     break;
 
   case 305:
-#line 3275 "fe/idl.ypp"
+#line 3277 "fe/idl.ypp"
         {
           /*
            * The top of the scopes must be an empty union we added after we
@@ -6236,27 +6238,27 @@ yyreduce:
 
           delete disc_annotations;
         }
-#line 6240 "fe/idl.tab.cpp"
+#line 6242 "fe/idl.tab.cpp"
     break;
 
   case 306:
-#line 3334 "fe/idl.ypp"
+#line 3336 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionSqSeen);
         }
-#line 6248 "fe/idl.tab.cpp"
+#line 6250 "fe/idl.tab.cpp"
     break;
 
   case 307:
-#line 3338 "fe/idl.ypp"
+#line 3340 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionBodySeen);
         }
-#line 6256 "fe/idl.tab.cpp"
+#line 6258 "fe/idl.tab.cpp"
     break;
 
   case 308:
-#line 3342 "fe/idl.ypp"
+#line 3344 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionQsSeen);
 
@@ -6272,22 +6274,22 @@ yyreduce:
               idl_global->scopes ().pop ();
             }
         }
-#line 6276 "fe/idl.tab.cpp"
+#line 6278 "fe/idl.tab.cpp"
     break;
 
   case 309:
-#line 3361 "fe/idl.ypp"
+#line 3363 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6287 "fe/idl.tab.cpp"
+#line 6289 "fe/idl.tab.cpp"
     break;
 
   case 310:
-#line 3368 "fe/idl.ypp"
+#line 3370 "fe/idl.ypp"
         {
           /* wchars are not allowed. */
           if ((yyvsp[0].etval) == AST_Expression::EV_wchar)
@@ -6300,11 +6302,11 @@ yyreduce:
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6304 "fe/idl.tab.cpp"
+#line 6306 "fe/idl.tab.cpp"
     break;
 
   case 311:
-#line 3381 "fe/idl.ypp"
+#line 3383 "fe/idl.ypp"
         {
           /* octets are not allowed. */
           idl_global->err ()->error0 (UTL_Error::EIDL_DISC_TYPE);
@@ -6313,22 +6315,22 @@ yyreduce:
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6317 "fe/idl.tab.cpp"
+#line 6319 "fe/idl.tab.cpp"
     break;
 
   case 312:
-#line 3390 "fe/idl.ypp"
+#line 3392 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6328 "fe/idl.tab.cpp"
+#line 6330 "fe/idl.tab.cpp"
     break;
 
   case 314:
-#line 3398 "fe/idl.ypp"
+#line 3400 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = 0;
@@ -6435,27 +6437,27 @@ yyreduce:
           delete (yyvsp[0].idlist);
           (yyvsp[0].idlist) = 0;
         }
-#line 6439 "fe/idl.tab.cpp"
+#line 6441 "fe/idl.tab.cpp"
     break;
 
   case 318:
-#line 3515 "fe/idl.ypp"
+#line 3517 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionLabelSeen);
         }
-#line 6447 "fe/idl.tab.cpp"
+#line 6449 "fe/idl.tab.cpp"
     break;
 
   case 319:
-#line 3519 "fe/idl.ypp"
+#line 3521 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionElemSeen);
         }
-#line 6455 "fe/idl.tab.cpp"
+#line 6457 "fe/idl.tab.cpp"
     break;
 
   case 320:
-#line 3523 "fe/idl.ypp"
+#line 3525 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_UnionBranch *b = 0;
@@ -6487,39 +6489,39 @@ yyreduce:
 
           delete annotations;
         }
-#line 6491 "fe/idl.tab.cpp"
+#line 6493 "fe/idl.tab.cpp"
     break;
 
   case 321:
-#line 3555 "fe/idl.ypp"
+#line 3557 "fe/idl.ypp"
         {
           idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
-#line 6499 "fe/idl.tab.cpp"
+#line 6501 "fe/idl.tab.cpp"
     break;
 
   case 322:
-#line 3559 "fe/idl.ypp"
+#line 3561 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           yyerrok;
         }
-#line 6508 "fe/idl.tab.cpp"
+#line 6510 "fe/idl.tab.cpp"
     break;
 
   case 323:
-#line 3567 "fe/idl.ypp"
+#line 3569 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.llval),
                           UTL_LabelList ((yyvsp[-1].ulval),
                                          (yyvsp[0].llval)),
                           1);
         }
-#line 6519 "fe/idl.tab.cpp"
+#line 6521 "fe/idl.tab.cpp"
     break;
 
   case 324:
-#line 3577 "fe/idl.ypp"
+#line 3579 "fe/idl.ypp"
         {
           UTL_LabelList *ll = 0;
           ACE_NEW_RETURN (ll,
@@ -6537,27 +6539,27 @@ yyreduce:
               (yyval.llval) = (yyvsp[-1].llval);
             }
         }
-#line 6541 "fe/idl.tab.cpp"
+#line 6543 "fe/idl.tab.cpp"
     break;
 
   case 325:
-#line 3595 "fe/idl.ypp"
+#line 3597 "fe/idl.ypp"
         {
           (yyval.llval) = 0;
         }
-#line 6549 "fe/idl.tab.cpp"
+#line 6551 "fe/idl.tab.cpp"
     break;
 
   case 326:
-#line 3602 "fe/idl.ypp"
+#line 3604 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DefaultSeen);
         }
-#line 6557 "fe/idl.tab.cpp"
+#line 6559 "fe/idl.tab.cpp"
     break;
 
   case 327:
-#line 3606 "fe/idl.ypp"
+#line 3608 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_LabelColonSeen);
 
@@ -6566,27 +6568,27 @@ yyreduce:
                                        0
                                      );
         }
-#line 6570 "fe/idl.tab.cpp"
+#line 6572 "fe/idl.tab.cpp"
     break;
 
   case 328:
-#line 3615 "fe/idl.ypp"
+#line 3617 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_CaseSeen);
         }
-#line 6578 "fe/idl.tab.cpp"
+#line 6580 "fe/idl.tab.cpp"
     break;
 
   case 329:
-#line 3619 "fe/idl.ypp"
+#line 3621 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_LabelExprSeen);
         }
-#line 6586 "fe/idl.tab.cpp"
+#line 6588 "fe/idl.tab.cpp"
     break;
 
   case 330:
-#line 3623 "fe/idl.ypp"
+#line 3625 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_LabelColonSeen);
 
@@ -6595,19 +6597,19 @@ yyreduce:
                                       (yyvsp[-2].exval)
                                     );
         }
-#line 6599 "fe/idl.tab.cpp"
+#line 6601 "fe/idl.tab.cpp"
     break;
 
   case 331:
-#line 3635 "fe/idl.ypp"
+#line 3637 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionElemTypeSeen);
         }
-#line 6607 "fe/idl.tab.cpp"
+#line 6609 "fe/idl.tab.cpp"
     break;
 
   case 332:
-#line 3639 "fe/idl.ypp"
+#line 3641 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionElemDeclSeen);
 
@@ -6650,11 +6652,11 @@ yyreduce:
               (yyvsp[0].deval) = 0;
             }
         }
-#line 6654 "fe/idl.tab.cpp"
+#line 6656 "fe/idl.tab.cpp"
     break;
 
   case 333:
-#line 3685 "fe/idl.ypp"
+#line 3687 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -6676,11 +6678,11 @@ yyreduce:
 
           (yyval.dcval) = d;
         }
-#line 6680 "fe/idl.tab.cpp"
+#line 6682 "fe/idl.tab.cpp"
     break;
 
   case 334:
-#line 3710 "fe/idl.ypp"
+#line 3712 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -6700,19 +6702,19 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 6704 "fe/idl.tab.cpp"
+#line 6706 "fe/idl.tab.cpp"
     break;
 
   case 335:
-#line 3733 "fe/idl.ypp"
+#line 3735 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumSeen);
         }
-#line 6712 "fe/idl.tab.cpp"
+#line 6714 "fe/idl.tab.cpp"
     break;
 
   case 336:
-#line 3737 "fe/idl.ypp"
+#line 3739 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval), 0);
@@ -6743,27 +6745,27 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 6747 "fe/idl.tab.cpp"
+#line 6749 "fe/idl.tab.cpp"
     break;
 
   case 337:
-#line 3768 "fe/idl.ypp"
+#line 3770 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumSqSeen);
         }
-#line 6755 "fe/idl.tab.cpp"
+#line 6757 "fe/idl.tab.cpp"
     break;
 
   case 338:
-#line 3772 "fe/idl.ypp"
+#line 3774 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumBodySeen);
         }
-#line 6763 "fe/idl.tab.cpp"
+#line 6765 "fe/idl.tab.cpp"
     break;
 
   case 339:
-#line 3776 "fe/idl.ypp"
+#line 3778 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumQsSeen);
 
@@ -6782,19 +6784,19 @@ yyreduce:
               idl_global->scopes ().pop ();
             }
         }
-#line 6786 "fe/idl.tab.cpp"
+#line 6788 "fe/idl.tab.cpp"
     break;
 
   case 341:
-#line 3801 "fe/idl.ypp"
+#line 3803 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumCommaSeen);
         }
-#line 6794 "fe/idl.tab.cpp"
+#line 6796 "fe/idl.tab.cpp"
     break;
 
   case 344:
-#line 3810 "fe/idl.ypp"
+#line 3812 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
@@ -6829,27 +6831,27 @@ yyreduce:
 
           delete annotations;
         }
-#line 6833 "fe/idl.tab.cpp"
+#line 6835 "fe/idl.tab.cpp"
     break;
 
   case 345:
-#line 3849 "fe/idl.ypp"
+#line 3851 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceCommaSeen);
         }
-#line 6841 "fe/idl.tab.cpp"
+#line 6843 "fe/idl.tab.cpp"
     break;
 
   case 346:
-#line 3853 "fe/idl.ypp"
+#line 3855 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceExprSeen);
         }
-#line 6849 "fe/idl.tab.cpp"
+#line 6851 "fe/idl.tab.cpp"
     break;
 
   case 347:
-#line 3857 "fe/idl.ypp"
+#line 3859 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceQsSeen);
 
@@ -6934,11 +6936,11 @@ yyreduce:
           ev = 0;
           (yyval.dcval) = seq;
         }
-#line 6938 "fe/idl.tab.cpp"
+#line 6940 "fe/idl.tab.cpp"
     break;
 
   case 348:
-#line 3943 "fe/idl.ypp"
+#line 3945 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceQsSeen);
 
@@ -7004,11 +7006,11 @@ yyreduce:
           delete type_annotations;
           (yyval.dcval) = seq;
         }
-#line 7008 "fe/idl.tab.cpp"
+#line 7010 "fe/idl.tab.cpp"
     break;
 
   case 349:
-#line 4012 "fe/idl.ypp"
+#line 4014 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceSeen);
 
@@ -7017,19 +7019,19 @@ yyreduce:
            */
           idl_global->scopes ().push (0);
         }
-#line 7021 "fe/idl.tab.cpp"
+#line 7023 "fe/idl.tab.cpp"
     break;
 
   case 350:
-#line 4021 "fe/idl.ypp"
+#line 4023 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceSqSeen);
         }
-#line 7029 "fe/idl.tab.cpp"
+#line 7031 "fe/idl.tab.cpp"
     break;
 
   case 351:
-#line 4025 "fe/idl.ypp"
+#line 4027 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceTypeSeen);
           Decl_Annotations_Pair *seq_head = new Decl_Annotations_Pair;
@@ -7037,36 +7039,36 @@ yyreduce:
           seq_head->annotations = (yyvsp[-1].annotations_val);
           (yyval.decl_annotations_pair_val) = seq_head;
         }
-#line 7041 "fe/idl.tab.cpp"
+#line 7043 "fe/idl.tab.cpp"
     break;
 
   case 352:
-#line 4036 "fe/idl.ypp"
+#line 4038 "fe/idl.ypp"
         {
           (yyvsp[-1].exval)->evaluate (AST_Expression::EK_positive_int);
           (yyval.dcval) = idl_global->gen ()->create_fixed ((yyvsp[-3].exval), (yyvsp[-1].exval));
         }
-#line 7050 "fe/idl.tab.cpp"
+#line 7052 "fe/idl.tab.cpp"
     break;
 
   case 353:
-#line 4045 "fe/idl.ypp"
+#line 4047 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringSqSeen);
         }
-#line 7058 "fe/idl.tab.cpp"
+#line 7060 "fe/idl.tab.cpp"
     break;
 
   case 354:
-#line 4049 "fe/idl.ypp"
+#line 4051 "fe/idl.ypp"
         {
            idl_global->set_parse_state (IDL_GlobalData::PS_StringExprSeen);
         }
-#line 7066 "fe/idl.tab.cpp"
+#line 7068 "fe/idl.tab.cpp"
     break;
 
   case 355:
-#line 4053 "fe/idl.ypp"
+#line 4055 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringQsSeen);
 
@@ -7108,11 +7110,11 @@ yyreduce:
           delete ev;
           ev = 0;
         }
-#line 7112 "fe/idl.tab.cpp"
+#line 7114 "fe/idl.tab.cpp"
     break;
 
   case 356:
-#line 4095 "fe/idl.ypp"
+#line 4097 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringCompleted);
 
@@ -7135,35 +7137,35 @@ yyreduce:
 
           (yyval.dcval) = tao_string_decl;
         }
-#line 7139 "fe/idl.tab.cpp"
+#line 7141 "fe/idl.tab.cpp"
     break;
 
   case 357:
-#line 4121 "fe/idl.ypp"
+#line 4123 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringSeen);
         }
-#line 7147 "fe/idl.tab.cpp"
+#line 7149 "fe/idl.tab.cpp"
     break;
 
   case 358:
-#line 4129 "fe/idl.ypp"
+#line 4131 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringSqSeen);
         }
-#line 7155 "fe/idl.tab.cpp"
+#line 7157 "fe/idl.tab.cpp"
     break;
 
   case 359:
-#line 4133 "fe/idl.ypp"
+#line 4135 "fe/idl.ypp"
         {
            idl_global->set_parse_state (IDL_GlobalData::PS_StringExprSeen);
         }
-#line 7163 "fe/idl.tab.cpp"
+#line 7165 "fe/idl.tab.cpp"
     break;
 
   case 360:
-#line 4137 "fe/idl.ypp"
+#line 4139 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringQsSeen);
 
@@ -7196,11 +7198,11 @@ yyreduce:
               (yyval.dcval) = string;
             }
         }
-#line 7200 "fe/idl.tab.cpp"
+#line 7202 "fe/idl.tab.cpp"
     break;
 
   case 361:
-#line 4170 "fe/idl.ypp"
+#line 4172 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringCompleted);
 
@@ -7223,27 +7225,27 @@ yyreduce:
 
           (yyval.dcval) = string;
         }
-#line 7227 "fe/idl.tab.cpp"
+#line 7229 "fe/idl.tab.cpp"
     break;
 
   case 362:
-#line 4196 "fe/idl.ypp"
+#line 4198 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringSeen);
         }
-#line 7235 "fe/idl.tab.cpp"
+#line 7237 "fe/idl.tab.cpp"
     break;
 
   case 363:
-#line 4203 "fe/idl.ypp"
+#line 4205 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ArrayIDSeen);
         }
-#line 7243 "fe/idl.tab.cpp"
+#line 7245 "fe/idl.tab.cpp"
     break;
 
   case 364:
-#line 4207 "fe/idl.ypp"
+#line 4209 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ArrayCompleted);
 
@@ -7283,22 +7285,22 @@ yyreduce:
 
           (yyval.dcval) = array;
         }
-#line 7287 "fe/idl.tab.cpp"
+#line 7289 "fe/idl.tab.cpp"
     break;
 
   case 365:
-#line 4250 "fe/idl.ypp"
+#line 4252 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.elval),
                           UTL_ExprList ((yyvsp[-1].exval),
                                         (yyvsp[0].elval)),
                           1);
         }
-#line 7298 "fe/idl.tab.cpp"
+#line 7300 "fe/idl.tab.cpp"
     break;
 
   case 366:
-#line 4260 "fe/idl.ypp"
+#line 4262 "fe/idl.ypp"
         {
           UTL_ExprList *el = 0;
           ACE_NEW_RETURN (el,
@@ -7316,35 +7318,35 @@ yyreduce:
               (yyval.elval) = (yyvsp[-1].elval);
             }
         }
-#line 7320 "fe/idl.tab.cpp"
+#line 7322 "fe/idl.tab.cpp"
     break;
 
   case 367:
-#line 4278 "fe/idl.ypp"
+#line 4280 "fe/idl.ypp"
         {
           (yyval.elval) = 0;
         }
-#line 7328 "fe/idl.tab.cpp"
+#line 7330 "fe/idl.tab.cpp"
     break;
 
   case 368:
-#line 4285 "fe/idl.ypp"
+#line 4287 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DimSqSeen);
         }
-#line 7336 "fe/idl.tab.cpp"
+#line 7338 "fe/idl.tab.cpp"
     break;
 
   case 369:
-#line 4289 "fe/idl.ypp"
+#line 4291 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DimExprSeen);
         }
-#line 7344 "fe/idl.tab.cpp"
+#line 7346 "fe/idl.tab.cpp"
     break;
 
   case 370:
-#line 4293 "fe/idl.ypp"
+#line 4295 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DimQsSeen);
 
@@ -7398,43 +7400,43 @@ yyreduce:
           delete ev;
           ev = 0;
         }
-#line 7402 "fe/idl.tab.cpp"
+#line 7404 "fe/idl.tab.cpp"
     break;
 
   case 373:
-#line 4355 "fe/idl.ypp"
+#line 4357 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrROSeen);
         }
-#line 7410 "fe/idl.tab.cpp"
+#line 7412 "fe/idl.tab.cpp"
     break;
 
   case 374:
-#line 4359 "fe/idl.ypp"
+#line 4361 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrSeen);
         }
-#line 7418 "fe/idl.tab.cpp"
+#line 7420 "fe/idl.tab.cpp"
     break;
 
   case 375:
-#line 4363 "fe/idl.ypp"
+#line 4365 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrTypeSeen);
         }
-#line 7426 "fe/idl.tab.cpp"
+#line 7428 "fe/idl.tab.cpp"
     break;
 
   case 376:
-#line 4367 "fe/idl.ypp"
+#line 4369 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclsSeen);
         }
-#line 7434 "fe/idl.tab.cpp"
+#line 7436 "fe/idl.tab.cpp"
     break;
 
   case 377:
-#line 4371 "fe/idl.ypp"
+#line 4373 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Attribute *a = 0;
@@ -7486,43 +7488,43 @@ yyreduce:
 
           (yyval.dcval) = a;
         }
-#line 7490 "fe/idl.tab.cpp"
+#line 7492 "fe/idl.tab.cpp"
     break;
 
   case 378:
-#line 4426 "fe/idl.ypp"
+#line 4428 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrSeen);
         }
-#line 7498 "fe/idl.tab.cpp"
+#line 7500 "fe/idl.tab.cpp"
     break;
 
   case 379:
-#line 4430 "fe/idl.ypp"
+#line 4432 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrTypeSeen);
         }
-#line 7506 "fe/idl.tab.cpp"
+#line 7508 "fe/idl.tab.cpp"
     break;
 
   case 380:
-#line 4434 "fe/idl.ypp"
+#line 4436 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclsSeen);
         }
-#line 7514 "fe/idl.tab.cpp"
+#line 7516 "fe/idl.tab.cpp"
     break;
 
   case 381:
-#line 4438 "fe/idl.ypp"
+#line 4440 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseCompleted);
         }
-#line 7522 "fe/idl.tab.cpp"
+#line 7524 "fe/idl.tab.cpp"
     break;
 
   case 382:
-#line 4442 "fe/idl.ypp"
+#line 4444 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Attribute *a = 0;
@@ -7583,19 +7585,19 @@ yyreduce:
 
           (yyval.dcval) = a;
         }
-#line 7587 "fe/idl.tab.cpp"
+#line 7589 "fe/idl.tab.cpp"
     break;
 
   case 383:
-#line 4506 "fe/idl.ypp"
+#line 4508 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptSeen);
         }
-#line 7595 "fe/idl.tab.cpp"
+#line 7597 "fe/idl.tab.cpp"
     break;
 
   case 384:
-#line 4510 "fe/idl.ypp"
+#line 4512 "fe/idl.ypp"
         {
           Identifier *&id = (yyvsp[0].idval);
           UTL_Scope *scope = idl_global->scopes ().top_non_null ();
@@ -7627,27 +7629,27 @@ yyreduce:
 
           (yyval.dcval) = exception;
         }
-#line 7631 "fe/idl.tab.cpp"
+#line 7633 "fe/idl.tab.cpp"
     break;
 
   case 385:
-#line 4542 "fe/idl.ypp"
+#line 4544 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptSqSeen);
         }
-#line 7639 "fe/idl.tab.cpp"
+#line 7641 "fe/idl.tab.cpp"
     break;
 
   case 386:
-#line 4546 "fe/idl.ypp"
+#line 4548 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptBodySeen);
         }
-#line 7647 "fe/idl.tab.cpp"
+#line 7649 "fe/idl.tab.cpp"
     break;
 
   case 387:
-#line 4550 "fe/idl.ypp"
+#line 4552 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptQsSeen);
           /*
@@ -7657,19 +7659,19 @@ yyreduce:
 
           (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 7661 "fe/idl.tab.cpp"
+#line 7663 "fe/idl.tab.cpp"
     break;
 
   case 388:
-#line 4563 "fe/idl.ypp"
+#line 4565 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpTypeSeen);
         }
-#line 7669 "fe/idl.tab.cpp"
+#line 7671 "fe/idl.tab.cpp"
     break;
 
   case 389:
-#line 4567 "fe/idl.ypp"
+#line 4569 "fe/idl.ypp"
         {
           AST_Operation *op = 0;
           UTL_Scope *scope = idl_global->scopes ().top_non_null ();
@@ -7730,27 +7732,27 @@ yyreduce:
            */
           idl_global->scopes ().push (op);
         }
-#line 7734 "fe/idl.tab.cpp"
+#line 7736 "fe/idl.tab.cpp"
     break;
 
   case 390:
-#line 4628 "fe/idl.ypp"
+#line 4630 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
         }
-#line 7742 "fe/idl.tab.cpp"
+#line 7744 "fe/idl.tab.cpp"
     break;
 
   case 391:
-#line 4632 "fe/idl.ypp"
+#line 4634 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
         }
-#line 7750 "fe/idl.tab.cpp"
+#line 7752 "fe/idl.tab.cpp"
     break;
 
   case 392:
-#line 4636 "fe/idl.ypp"
+#line 4638 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Operation *o = 0;
@@ -7781,57 +7783,57 @@ yyreduce:
 
           (yyval.dcval) = o;
         }
-#line 7785 "fe/idl.tab.cpp"
+#line 7787 "fe/idl.tab.cpp"
     break;
 
   case 393:
-#line 4670 "fe/idl.ypp"
+#line 4672 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpAttrSeen);
           (yyval.ofval) = AST_Operation::OP_oneway;
         }
-#line 7794 "fe/idl.tab.cpp"
+#line 7796 "fe/idl.tab.cpp"
     break;
 
   case 394:
-#line 4675 "fe/idl.ypp"
+#line 4677 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpAttrSeen);
           (yyval.ofval) = AST_Operation::OP_idempotent;
         }
-#line 7803 "fe/idl.tab.cpp"
+#line 7805 "fe/idl.tab.cpp"
     break;
 
   case 395:
-#line 4680 "fe/idl.ypp"
+#line 4682 "fe/idl.ypp"
         {
           (yyval.ofval) = AST_Operation::OP_noflags;
         }
-#line 7811 "fe/idl.tab.cpp"
+#line 7813 "fe/idl.tab.cpp"
     break;
 
   case 397:
-#line 4688 "fe/idl.ypp"
+#line 4690 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                   AST_Expression::EV_void
                                                 );
         }
-#line 7822 "fe/idl.tab.cpp"
+#line 7824 "fe/idl.tab.cpp"
     break;
 
   case 398:
-#line 4698 "fe/idl.ypp"
+#line 4700 "fe/idl.ypp"
         {
           //@@ PS_FactorySeen?
           idl_global->set_parse_state (IDL_GlobalData::PS_OpTypeSeen);
         }
-#line 7831 "fe/idl.tab.cpp"
+#line 7833 "fe/idl.tab.cpp"
     break;
 
   case 399:
-#line 4703 "fe/idl.ypp"
+#line 4705 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
 
@@ -7874,19 +7876,19 @@ yyreduce:
 
           (yyval.dcval) = factory;
         }
-#line 7878 "fe/idl.tab.cpp"
+#line 7880 "fe/idl.tab.cpp"
     break;
 
   case 400:
-#line 4746 "fe/idl.ypp"
+#line 4748 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
         }
-#line 7886 "fe/idl.tab.cpp"
+#line 7888 "fe/idl.tab.cpp"
     break;
 
   case 401:
-#line 4750 "fe/idl.ypp"
+#line 4752 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
 
@@ -7901,67 +7903,67 @@ yyreduce:
 
           (yyval.dcval) = (yyvsp[-3].dcval);
         }
-#line 7905 "fe/idl.tab.cpp"
+#line 7907 "fe/idl.tab.cpp"
     break;
 
   case 402:
-#line 4768 "fe/idl.ypp"
+#line 4770 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
         }
-#line 7913 "fe/idl.tab.cpp"
+#line 7915 "fe/idl.tab.cpp"
     break;
 
   case 403:
-#line 4772 "fe/idl.ypp"
+#line 4774 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
         }
-#line 7921 "fe/idl.tab.cpp"
+#line 7923 "fe/idl.tab.cpp"
     break;
 
   case 404:
-#line 4776 "fe/idl.ypp"
+#line 4778 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
         }
-#line 7929 "fe/idl.tab.cpp"
+#line 7931 "fe/idl.tab.cpp"
     break;
 
   case 405:
-#line 4781 "fe/idl.ypp"
+#line 4783 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
         }
-#line 7937 "fe/idl.tab.cpp"
+#line 7939 "fe/idl.tab.cpp"
     break;
 
   case 407:
-#line 4791 "fe/idl.ypp"
+#line 4793 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParCommaSeen);
         }
-#line 7945 "fe/idl.tab.cpp"
+#line 7947 "fe/idl.tab.cpp"
     break;
 
   case 410:
-#line 4800 "fe/idl.ypp"
+#line 4802 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParDirSeen);
         }
-#line 7953 "fe/idl.tab.cpp"
+#line 7955 "fe/idl.tab.cpp"
     break;
 
   case 411:
-#line 4804 "fe/idl.ypp"
+#line 4806 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParTypeSeen);
         }
-#line 7961 "fe/idl.tab.cpp"
+#line 7963 "fe/idl.tab.cpp"
     break;
 
   case 412:
-#line 4808 "fe/idl.ypp"
+#line 4810 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Argument *a = 0;
@@ -7993,67 +7995,67 @@ yyreduce:
           delete (yyvsp[0].deval);
           (yyvsp[0].deval) = 0;
         }
-#line 7997 "fe/idl.tab.cpp"
+#line 7999 "fe/idl.tab.cpp"
     break;
 
   case 413:
-#line 4843 "fe/idl.ypp"
+#line 4845 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
         }
-#line 8005 "fe/idl.tab.cpp"
+#line 8007 "fe/idl.tab.cpp"
     break;
 
   case 414:
-#line 4847 "fe/idl.ypp"
+#line 4849 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
         }
-#line 8013 "fe/idl.tab.cpp"
+#line 8015 "fe/idl.tab.cpp"
     break;
 
   case 415:
-#line 4851 "fe/idl.ypp"
+#line 4853 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
         }
-#line 8021 "fe/idl.tab.cpp"
+#line 8023 "fe/idl.tab.cpp"
     break;
 
   case 416:
-#line 4856 "fe/idl.ypp"
+#line 4858 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
         }
-#line 8029 "fe/idl.tab.cpp"
+#line 8031 "fe/idl.tab.cpp"
     break;
 
   case 418:
-#line 4866 "fe/idl.ypp"
+#line 4868 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParCommaSeen);
         }
-#line 8037 "fe/idl.tab.cpp"
+#line 8039 "fe/idl.tab.cpp"
     break;
 
   case 421:
-#line 4875 "fe/idl.ypp"
+#line 4877 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParDirSeen);
         }
-#line 8045 "fe/idl.tab.cpp"
+#line 8047 "fe/idl.tab.cpp"
     break;
 
   case 422:
-#line 4879 "fe/idl.ypp"
+#line 4881 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParTypeSeen);
         }
-#line 8053 "fe/idl.tab.cpp"
+#line 8055 "fe/idl.tab.cpp"
     break;
 
   case 423:
-#line 4883 "fe/idl.ypp"
+#line 4885 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Argument *a = 0;
@@ -8092,22 +8094,22 @@ yyreduce:
           delete (yyvsp[0].deval);
           (yyvsp[0].deval) = 0;
         }
-#line 8096 "fe/idl.tab.cpp"
+#line 8098 "fe/idl.tab.cpp"
     break;
 
   case 424:
-#line 4925 "fe/idl.ypp"
+#line 4927 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 8107 "fe/idl.tab.cpp"
+#line 8109 "fe/idl.tab.cpp"
     break;
 
   case 427:
-#line 4934 "fe/idl.ypp"
+#line 4936 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = 0;
@@ -8211,186 +8213,186 @@ yyreduce:
 
           (yyval.dcval) = d;
         }
-#line 8215 "fe/idl.tab.cpp"
+#line 8217 "fe/idl.tab.cpp"
     break;
 
   case 428:
-#line 5041 "fe/idl.ypp"
+#line 5043 "fe/idl.ypp"
         {
           (yyval.dival) = AST_Argument::dir_IN;
         }
-#line 8223 "fe/idl.tab.cpp"
+#line 8225 "fe/idl.tab.cpp"
     break;
 
   case 429:
-#line 5045 "fe/idl.ypp"
+#line 5047 "fe/idl.ypp"
         {
           (yyval.dival) = AST_Argument::dir_OUT;
         }
-#line 8231 "fe/idl.tab.cpp"
+#line 8233 "fe/idl.tab.cpp"
     break;
 
   case 430:
-#line 5049 "fe/idl.ypp"
+#line 5051 "fe/idl.ypp"
         {
           (yyval.dival) = AST_Argument::dir_INOUT;
         }
-#line 8239 "fe/idl.tab.cpp"
+#line 8241 "fe/idl.tab.cpp"
     break;
 
   case 431:
-#line 5056 "fe/idl.ypp"
+#line 5058 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseSeen);
         }
-#line 8247 "fe/idl.tab.cpp"
+#line 8249 "fe/idl.tab.cpp"
     break;
 
   case 432:
-#line 5060 "fe/idl.ypp"
+#line 5062 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseSqSeen);
         }
-#line 8255 "fe/idl.tab.cpp"
+#line 8257 "fe/idl.tab.cpp"
     break;
 
   case 433:
-#line 5065 "fe/idl.ypp"
+#line 5067 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseQsSeen);
           (yyval.nlval) = (yyvsp[-1].nlval);
         }
-#line 8264 "fe/idl.tab.cpp"
+#line 8266 "fe/idl.tab.cpp"
     break;
 
   case 434:
-#line 5070 "fe/idl.ypp"
+#line 5072 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 8272 "fe/idl.tab.cpp"
+#line 8274 "fe/idl.tab.cpp"
     break;
 
   case 435:
-#line 5077 "fe/idl.ypp"
+#line 5079 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseSeen);
         }
-#line 8280 "fe/idl.tab.cpp"
+#line 8282 "fe/idl.tab.cpp"
     break;
 
   case 436:
-#line 5081 "fe/idl.ypp"
+#line 5083 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseSqSeen);
         }
-#line 8288 "fe/idl.tab.cpp"
+#line 8290 "fe/idl.tab.cpp"
     break;
 
   case 437:
-#line 5086 "fe/idl.ypp"
+#line 5088 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseQsSeen);
           (yyval.nlval) = (yyvsp[-1].nlval);
         }
-#line 8297 "fe/idl.tab.cpp"
+#line 8299 "fe/idl.tab.cpp"
     break;
 
   case 438:
-#line 5091 "fe/idl.ypp"
+#line 5093 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 8305 "fe/idl.tab.cpp"
+#line 8307 "fe/idl.tab.cpp"
     break;
 
   case 439:
-#line 5098 "fe/idl.ypp"
+#line 5100 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseSeen);
         }
-#line 8313 "fe/idl.tab.cpp"
+#line 8315 "fe/idl.tab.cpp"
     break;
 
   case 440:
-#line 5102 "fe/idl.ypp"
+#line 5104 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseSqSeen);
         }
-#line 8321 "fe/idl.tab.cpp"
+#line 8323 "fe/idl.tab.cpp"
     break;
 
   case 441:
-#line 5107 "fe/idl.ypp"
+#line 5109 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseQsSeen);
           (yyval.nlval) = (yyvsp[-1].nlval);
         }
-#line 8330 "fe/idl.tab.cpp"
+#line 8332 "fe/idl.tab.cpp"
     break;
 
   case 442:
-#line 5112 "fe/idl.ypp"
+#line 5114 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 8338 "fe/idl.tab.cpp"
+#line 8340 "fe/idl.tab.cpp"
     break;
 
   case 443:
-#line 5119 "fe/idl.ypp"
+#line 5121 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpContextSeen);
         }
-#line 8346 "fe/idl.tab.cpp"
+#line 8348 "fe/idl.tab.cpp"
     break;
 
   case 444:
-#line 5123 "fe/idl.ypp"
+#line 5125 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpContextSqSeen);
         }
-#line 8354 "fe/idl.tab.cpp"
+#line 8356 "fe/idl.tab.cpp"
     break;
 
   case 445:
-#line 5128 "fe/idl.ypp"
+#line 5130 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpContextQsSeen);
           (yyval.slval) = (yyvsp[-1].slval);
         }
-#line 8363 "fe/idl.tab.cpp"
+#line 8365 "fe/idl.tab.cpp"
     break;
 
   case 446:
-#line 5133 "fe/idl.ypp"
+#line 5135 "fe/idl.ypp"
         {
           (yyval.slval) = 0;
         }
-#line 8371 "fe/idl.tab.cpp"
+#line 8373 "fe/idl.tab.cpp"
     break;
 
   case 447:
-#line 5140 "fe/idl.ypp"
+#line 5142 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.slval),
                           UTL_StrList ((yyvsp[-1].sval),
                                        (yyvsp[0].slval)),
                           1);
         }
-#line 8382 "fe/idl.tab.cpp"
+#line 8384 "fe/idl.tab.cpp"
     break;
 
   case 448:
-#line 5151 "fe/idl.ypp"
+#line 5153 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpContextCommaSeen);
         }
-#line 8390 "fe/idl.tab.cpp"
+#line 8392 "fe/idl.tab.cpp"
     break;
 
   case 449:
-#line 5155 "fe/idl.ypp"
+#line 5157 "fe/idl.ypp"
         {
           UTL_StrList *sl = 0;
           ACE_NEW_RETURN (sl,
@@ -8408,19 +8410,19 @@ yyreduce:
               (yyval.slval) = (yyvsp[-3].slval);
             }
         }
-#line 8412 "fe/idl.tab.cpp"
+#line 8414 "fe/idl.tab.cpp"
     break;
 
   case 450:
-#line 5173 "fe/idl.ypp"
+#line 5175 "fe/idl.ypp"
         {
           (yyval.slval) = 0;
         }
-#line 8420 "fe/idl.tab.cpp"
+#line 8422 "fe/idl.tab.cpp"
     break;
 
   case 451:
-#line 5180 "fe/idl.ypp"
+#line 5182 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d =
@@ -8447,11 +8449,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 8451 "fe/idl.tab.cpp"
+#line 8453 "fe/idl.tab.cpp"
     break;
 
   case 452:
-#line 5210 "fe/idl.ypp"
+#line 5212 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = ScopeAsDecl (s);
@@ -8487,11 +8489,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 8491 "fe/idl.tab.cpp"
+#line 8493 "fe/idl.tab.cpp"
     break;
 
   case 455:
-#line 5255 "fe/idl.ypp"
+#line 5257 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -8517,11 +8519,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 8521 "fe/idl.tab.cpp"
+#line 8523 "fe/idl.tab.cpp"
     break;
 
   case 456:
-#line 5284 "fe/idl.ypp"
+#line 5286 "fe/idl.ypp"
         {
           FE_ComponentHeader *&component_header = (yyvsp[0].chval);
           UTL_Scope *scope = idl_global->scopes ().top_non_null ();
@@ -8562,27 +8564,27 @@ yyreduce:
 
           (yyval.dcval) = component;
         }
-#line 8566 "fe/idl.tab.cpp"
+#line 8568 "fe/idl.tab.cpp"
     break;
 
   case 457:
-#line 5325 "fe/idl.ypp"
+#line 5327 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ComponentSqSeen);
         }
-#line 8574 "fe/idl.tab.cpp"
+#line 8576 "fe/idl.tab.cpp"
     break;
 
   case 458:
-#line 5329 "fe/idl.ypp"
+#line 5331 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ComponentBodySeen);
         }
-#line 8582 "fe/idl.tab.cpp"
+#line 8584 "fe/idl.tab.cpp"
     break;
 
   case 459:
-#line 5333 "fe/idl.ypp"
+#line 5335 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ComponentQsSeen);
 
@@ -8593,27 +8595,27 @@ yyreduce:
 
           (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 8597 "fe/idl.tab.cpp"
+#line 8599 "fe/idl.tab.cpp"
     break;
 
   case 460:
-#line 5348 "fe/idl.ypp"
+#line 5350 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ComponentIDSeen);
         }
-#line 8605 "fe/idl.tab.cpp"
+#line 8607 "fe/idl.tab.cpp"
     break;
 
   case 461:
-#line 5352 "fe/idl.ypp"
+#line 5354 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
         }
-#line 8613 "fe/idl.tab.cpp"
+#line 8615 "fe/idl.tab.cpp"
     break;
 
   case 462:
-#line 5356 "fe/idl.ypp"
+#line 5358 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
 
@@ -8647,35 +8649,35 @@ yyreduce:
               (yyvsp[-2].idlist) = 0;
             }
         }
-#line 8651 "fe/idl.tab.cpp"
+#line 8653 "fe/idl.tab.cpp"
     break;
 
   case 463:
-#line 5393 "fe/idl.ypp"
+#line 5395 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
         }
-#line 8659 "fe/idl.tab.cpp"
+#line 8661 "fe/idl.tab.cpp"
     break;
 
   case 464:
-#line 5397 "fe/idl.ypp"
+#line 5399 "fe/idl.ypp"
         {
           (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 8667 "fe/idl.tab.cpp"
+#line 8669 "fe/idl.tab.cpp"
     break;
 
   case 465:
-#line 5401 "fe/idl.ypp"
+#line 5403 "fe/idl.ypp"
         {
           (yyval.idlist) = 0;
         }
-#line 8675 "fe/idl.tab.cpp"
+#line 8677 "fe/idl.tab.cpp"
     break;
 
   case 466:
-#line 5408 "fe/idl.ypp"
+#line 5410 "fe/idl.ypp"
         {
           AST_Annotation_Appls *&annotations = (yyvsp[-1].annotations_val);
           AST_Decl *&node = (yyvsp[0].dcval);
@@ -8690,130 +8692,130 @@ yyreduce:
             }
           delete annotations;
         }
-#line 8694 "fe/idl.tab.cpp"
+#line 8696 "fe/idl.tab.cpp"
     break;
 
   case 469:
-#line 5428 "fe/idl.ypp"
+#line 5430 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ProvidesDeclSeen);
         }
-#line 8702 "fe/idl.tab.cpp"
+#line 8704 "fe/idl.tab.cpp"
     break;
 
   case 470:
-#line 5432 "fe/idl.ypp"
+#line 5434 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8711 "fe/idl.tab.cpp"
+#line 8713 "fe/idl.tab.cpp"
     break;
 
   case 471:
-#line 5437 "fe/idl.ypp"
+#line 5439 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UsesDeclSeen);
         }
-#line 8719 "fe/idl.tab.cpp"
+#line 8721 "fe/idl.tab.cpp"
     break;
 
   case 472:
-#line 5441 "fe/idl.ypp"
+#line 5443 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8728 "fe/idl.tab.cpp"
+#line 8730 "fe/idl.tab.cpp"
     break;
 
   case 473:
-#line 5446 "fe/idl.ypp"
+#line 5448 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EmitsDeclSeen);
         }
-#line 8736 "fe/idl.tab.cpp"
+#line 8738 "fe/idl.tab.cpp"
     break;
 
   case 474:
-#line 5450 "fe/idl.ypp"
+#line 5452 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8745 "fe/idl.tab.cpp"
+#line 8747 "fe/idl.tab.cpp"
     break;
 
   case 475:
-#line 5455 "fe/idl.ypp"
+#line 5457 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PublishesDeclSeen);
         }
-#line 8753 "fe/idl.tab.cpp"
+#line 8755 "fe/idl.tab.cpp"
     break;
 
   case 476:
-#line 5459 "fe/idl.ypp"
+#line 5461 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8762 "fe/idl.tab.cpp"
+#line 8764 "fe/idl.tab.cpp"
     break;
 
   case 477:
-#line 5464 "fe/idl.ypp"
+#line 5466 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConsumesDeclSeen);
         }
-#line 8770 "fe/idl.tab.cpp"
+#line 8772 "fe/idl.tab.cpp"
     break;
 
   case 478:
-#line 5468 "fe/idl.ypp"
+#line 5470 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8779 "fe/idl.tab.cpp"
+#line 8781 "fe/idl.tab.cpp"
     break;
 
   case 479:
-#line 5473 "fe/idl.ypp"
+#line 5475 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
         }
-#line 8787 "fe/idl.tab.cpp"
+#line 8789 "fe/idl.tab.cpp"
     break;
 
   case 480:
-#line 5477 "fe/idl.ypp"
+#line 5479 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8796 "fe/idl.tab.cpp"
+#line 8798 "fe/idl.tab.cpp"
     break;
 
   case 481:
-#line 5482 "fe/idl.ypp"
+#line 5484 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
         }
-#line 8804 "fe/idl.tab.cpp"
+#line 8806 "fe/idl.tab.cpp"
     break;
 
   case 482:
-#line 5486 "fe/idl.ypp"
+#line 5488 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8813 "fe/idl.tab.cpp"
+#line 8815 "fe/idl.tab.cpp"
     break;
 
   case 483:
-#line 5493 "fe/idl.ypp"
+#line 5495 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -8903,21 +8905,21 @@ yyreduce:
 
           (yyval.dcval) = dynamic_cast<AST_Decl *> (provides);
         }
-#line 8907 "fe/idl.tab.cpp"
+#line 8909 "fe/idl.tab.cpp"
     break;
 
   case 484:
-#line 5586 "fe/idl.ypp"
+#line 5588 "fe/idl.ypp"
         {
           // Lookups and checking are done where the 'interface_type'
           // token is used, in 'provides_decl' and 'uses_decl'.
           (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 8917 "fe/idl.tab.cpp"
+#line 8919 "fe/idl.tab.cpp"
     break;
 
   case 485:
-#line 5592 "fe/idl.ypp"
+#line 5594 "fe/idl.ypp"
         {
           Identifier *corba_id = 0;
 
@@ -8940,11 +8942,11 @@ yyreduce:
                                       conc_name),
                           1);
         }
-#line 8944 "fe/idl.tab.cpp"
+#line 8946 "fe/idl.tab.cpp"
     break;
 
   case 486:
-#line 5617 "fe/idl.ypp"
+#line 5619 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -9048,37 +9050,37 @@ yyreduce:
 
           (yyval.dcval) = uses;
         }
-#line 9052 "fe/idl.tab.cpp"
+#line 9054 "fe/idl.tab.cpp"
     break;
 
   case 487:
-#line 5724 "fe/idl.ypp"
+#line 5726 "fe/idl.ypp"
         {
           // We use this extra rule here to use in both uses_decl and
           // extended_uses_decl, so the LALR(1) parser can avoid conflicts.
           (yyval.bval) = (yyvsp[0].bval);
         }
-#line 9062 "fe/idl.tab.cpp"
+#line 9064 "fe/idl.tab.cpp"
     break;
 
   case 488:
-#line 5733 "fe/idl.ypp"
+#line 5735 "fe/idl.ypp"
         {
           (yyval.bval) = true;
         }
-#line 9070 "fe/idl.tab.cpp"
+#line 9072 "fe/idl.tab.cpp"
     break;
 
   case 489:
-#line 5737 "fe/idl.ypp"
+#line 5739 "fe/idl.ypp"
         {
           (yyval.bval) = false;
         }
-#line 9078 "fe/idl.tab.cpp"
+#line 9080 "fe/idl.tab.cpp"
     break;
 
   case 490:
-#line 5744 "fe/idl.ypp"
+#line 5746 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -9150,11 +9152,11 @@ yyreduce:
 
           (yyval.dcval) = e;
         }
-#line 9154 "fe/idl.tab.cpp"
+#line 9156 "fe/idl.tab.cpp"
     break;
 
   case 491:
-#line 5819 "fe/idl.ypp"
+#line 5821 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -9223,11 +9225,11 @@ yyreduce:
 
           (yyval.dcval) = p;
         }
-#line 9227 "fe/idl.tab.cpp"
+#line 9229 "fe/idl.tab.cpp"
     break;
 
   case 492:
-#line 5891 "fe/idl.ypp"
+#line 5893 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -9299,11 +9301,11 @@ yyreduce:
 
           (yyval.dcval) = c;
        }
-#line 9303 "fe/idl.tab.cpp"
+#line 9305 "fe/idl.tab.cpp"
     break;
 
   case 493:
-#line 5966 "fe/idl.ypp"
+#line 5968 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Home *h = 0;
@@ -9340,11 +9342,11 @@ yyreduce:
            */
           idl_global->scopes ().push (h);
         }
-#line 9344 "fe/idl.tab.cpp"
+#line 9346 "fe/idl.tab.cpp"
     break;
 
   case 494:
-#line 6003 "fe/idl.ypp"
+#line 6005 "fe/idl.ypp"
         {
           /*
            * Done with this component - pop it off the scopes stack.
@@ -9353,59 +9355,59 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9357 "fe/idl.tab.cpp"
+#line 9359 "fe/idl.tab.cpp"
     break;
 
   case 495:
-#line 6015 "fe/idl.ypp"
+#line 6017 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeSeen);
         }
-#line 9365 "fe/idl.tab.cpp"
+#line 9367 "fe/idl.tab.cpp"
     break;
 
   case 496:
-#line 6019 "fe/idl.ypp"
+#line 6021 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeIDSeen);
         }
-#line 9373 "fe/idl.tab.cpp"
+#line 9375 "fe/idl.tab.cpp"
     break;
 
   case 497:
-#line 6023 "fe/idl.ypp"
+#line 6025 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
         }
-#line 9381 "fe/idl.tab.cpp"
+#line 9383 "fe/idl.tab.cpp"
     break;
 
   case 498:
-#line 6027 "fe/idl.ypp"
+#line 6029 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
         }
-#line 9389 "fe/idl.tab.cpp"
+#line 9391 "fe/idl.tab.cpp"
     break;
 
   case 499:
-#line 6031 "fe/idl.ypp"
+#line 6033 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ManagesSeen);
         }
-#line 9397 "fe/idl.tab.cpp"
+#line 9399 "fe/idl.tab.cpp"
     break;
 
   case 500:
-#line 6035 "fe/idl.ypp"
+#line 6037 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ManagesIDSeen);
         }
-#line 9405 "fe/idl.tab.cpp"
+#line 9407 "fe/idl.tab.cpp"
     break;
 
   case 501:
-#line 6039 "fe/idl.ypp"
+#line 6041 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PrimaryKeySpecSeen);
 
@@ -9451,107 +9453,107 @@ yyreduce:
               (yyvsp[-6].nlval) = 0;
             }
         }
-#line 9455 "fe/idl.tab.cpp"
+#line 9457 "fe/idl.tab.cpp"
     break;
 
   case 502:
-#line 6088 "fe/idl.ypp"
+#line 6090 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
         }
-#line 9463 "fe/idl.tab.cpp"
+#line 9465 "fe/idl.tab.cpp"
     break;
 
   case 503:
-#line 6092 "fe/idl.ypp"
+#line 6094 "fe/idl.ypp"
         {
           (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 9471 "fe/idl.tab.cpp"
+#line 9473 "fe/idl.tab.cpp"
     break;
 
   case 504:
-#line 6096 "fe/idl.ypp"
+#line 6098 "fe/idl.ypp"
         {
           (yyval.idlist) = 0;
         }
-#line 9479 "fe/idl.tab.cpp"
+#line 9481 "fe/idl.tab.cpp"
     break;
 
   case 505:
-#line 6104 "fe/idl.ypp"
+#line 6106 "fe/idl.ypp"
         {
           (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 9487 "fe/idl.tab.cpp"
+#line 9489 "fe/idl.tab.cpp"
     break;
 
   case 506:
-#line 6108 "fe/idl.ypp"
+#line 6110 "fe/idl.ypp"
         {
           (yyval.idlist) = 0;
         }
-#line 9495 "fe/idl.tab.cpp"
+#line 9497 "fe/idl.tab.cpp"
     break;
 
   case 507:
-#line 6115 "fe/idl.ypp"
+#line 6117 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeSqSeen);
         }
-#line 9503 "fe/idl.tab.cpp"
+#line 9505 "fe/idl.tab.cpp"
     break;
 
   case 508:
-#line 6119 "fe/idl.ypp"
+#line 6121 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeBodySeen);
         }
-#line 9511 "fe/idl.tab.cpp"
+#line 9513 "fe/idl.tab.cpp"
     break;
 
   case 509:
-#line 6123 "fe/idl.ypp"
+#line 6125 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeQsSeen);
         }
-#line 9519 "fe/idl.tab.cpp"
+#line 9521 "fe/idl.tab.cpp"
     break;
 
   case 513:
-#line 6136 "fe/idl.ypp"
+#line 6138 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_FactoryDeclSeen);
         }
-#line 9527 "fe/idl.tab.cpp"
+#line 9529 "fe/idl.tab.cpp"
     break;
 
   case 514:
-#line 6140 "fe/idl.ypp"
+#line 6142 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 9535 "fe/idl.tab.cpp"
+#line 9537 "fe/idl.tab.cpp"
     break;
 
   case 515:
-#line 6144 "fe/idl.ypp"
+#line 6146 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_FinderDeclSeen);
         }
-#line 9543 "fe/idl.tab.cpp"
+#line 9545 "fe/idl.tab.cpp"
     break;
 
   case 516:
-#line 6148 "fe/idl.ypp"
+#line 6150 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 9551 "fe/idl.tab.cpp"
+#line 9553 "fe/idl.tab.cpp"
     break;
 
   case 517:
-#line 6156 "fe/idl.ypp"
+#line 6158 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9574,19 +9576,19 @@ yyreduce:
            */
           idl_global->scopes ().push (f);
         }
-#line 9578 "fe/idl.tab.cpp"
+#line 9580 "fe/idl.tab.cpp"
     break;
 
   case 518:
-#line 6179 "fe/idl.ypp"
+#line 6181 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
         }
-#line 9586 "fe/idl.tab.cpp"
+#line 9588 "fe/idl.tab.cpp"
     break;
 
   case 519:
-#line 6183 "fe/idl.ypp"
+#line 6185 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
@@ -9604,11 +9606,11 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
         }
-#line 9608 "fe/idl.tab.cpp"
+#line 9610 "fe/idl.tab.cpp"
     break;
 
   case 520:
-#line 6205 "fe/idl.ypp"
+#line 6207 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9635,19 +9637,19 @@ yyreduce:
            */
           idl_global->scopes ().push (f);
         }
-#line 9639 "fe/idl.tab.cpp"
+#line 9641 "fe/idl.tab.cpp"
     break;
 
   case 521:
-#line 6232 "fe/idl.ypp"
+#line 6234 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
         }
-#line 9647 "fe/idl.tab.cpp"
+#line 9649 "fe/idl.tab.cpp"
     break;
 
   case 522:
-#line 6236 "fe/idl.ypp"
+#line 6238 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
@@ -9665,11 +9667,11 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
         }
-#line 9669 "fe/idl.tab.cpp"
+#line 9671 "fe/idl.tab.cpp"
     break;
 
   case 528:
-#line 6269 "fe/idl.ypp"
+#line 6271 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9694,11 +9696,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9698 "fe/idl.tab.cpp"
+#line 9700 "fe/idl.tab.cpp"
     break;
 
   case 529:
-#line 6299 "fe/idl.ypp"
+#line 6301 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9723,11 +9725,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9727 "fe/idl.tab.cpp"
+#line 9729 "fe/idl.tab.cpp"
     break;
 
   case 530:
-#line 6328 "fe/idl.ypp"
+#line 6330 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_EventType *e = 0;
@@ -9771,27 +9773,27 @@ yyreduce:
           delete (yyvsp[-1].idval);
           (yyvsp[-1].idval) = 0;
         }
-#line 9775 "fe/idl.tab.cpp"
+#line 9777 "fe/idl.tab.cpp"
     break;
 
   case 531:
-#line 6372 "fe/idl.ypp"
+#line 6374 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeSqSeen);
         }
-#line 9783 "fe/idl.tab.cpp"
+#line 9785 "fe/idl.tab.cpp"
     break;
 
   case 532:
-#line 6376 "fe/idl.ypp"
+#line 6378 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeBodySeen);
         }
-#line 9791 "fe/idl.tab.cpp"
+#line 9793 "fe/idl.tab.cpp"
     break;
 
   case 533:
-#line 6380 "fe/idl.ypp"
+#line 6382 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeQsSeen);
 
@@ -9802,19 +9804,19 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9806 "fe/idl.tab.cpp"
+#line 9808 "fe/idl.tab.cpp"
     break;
 
   case 534:
-#line 6396 "fe/idl.ypp"
+#line 6398 "fe/idl.ypp"
         {
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9814 "fe/idl.tab.cpp"
+#line 9816 "fe/idl.tab.cpp"
     break;
 
   case 535:
-#line 6405 "fe/idl.ypp"
+#line 6407 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeIDSeen);
 
@@ -9827,29 +9829,29 @@ yyreduce:
                       ACE_TEXT (" custom yet\n")));
           (yyval.idval) = 0;
         }
-#line 9831 "fe/idl.tab.cpp"
+#line 9833 "fe/idl.tab.cpp"
     break;
 
   case 536:
-#line 6422 "fe/idl.ypp"
+#line 6424 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeIDSeen);
 
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9841 "fe/idl.tab.cpp"
+#line 9843 "fe/idl.tab.cpp"
     break;
 
   case 537:
-#line 6431 "fe/idl.ypp"
+#line 6433 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
         }
-#line 9849 "fe/idl.tab.cpp"
+#line 9851 "fe/idl.tab.cpp"
     break;
 
   case 538:
-#line 6435 "fe/idl.ypp"
+#line 6437 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
 
@@ -9878,11 +9880,11 @@ yyreduce:
               (yyvsp[-2].nlval) = 0;
             }
         }
-#line 9882 "fe/idl.tab.cpp"
+#line 9884 "fe/idl.tab.cpp"
     break;
 
   case 539:
-#line 6468 "fe/idl.ypp"
+#line 6470 "fe/idl.ypp"
         {
           UTL_Scope *scope = idl_global->scopes ().top_non_null ();
           Identifier *&event_id = (yyvsp[-1].idval);
@@ -9932,27 +9934,27 @@ yyreduce:
 
           (yyval.dcval) = eventtype;
         }
-#line 9936 "fe/idl.tab.cpp"
+#line 9938 "fe/idl.tab.cpp"
     break;
 
   case 540:
-#line 6518 "fe/idl.ypp"
+#line 6520 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeSqSeen);
         }
-#line 9944 "fe/idl.tab.cpp"
+#line 9946 "fe/idl.tab.cpp"
     break;
 
   case 541:
-#line 6522 "fe/idl.ypp"
+#line 6524 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeBodySeen);
         }
-#line 9952 "fe/idl.tab.cpp"
+#line 9954 "fe/idl.tab.cpp"
     break;
 
   case 542:
-#line 6526 "fe/idl.ypp"
+#line 6528 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeQsSeen);
 
@@ -9963,108 +9965,108 @@ yyreduce:
 
           (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 9967 "fe/idl.tab.cpp"
+#line 9969 "fe/idl.tab.cpp"
     break;
 
   case 543:
-#line 6540 "fe/idl.ypp"
+#line 6542 "fe/idl.ypp"
         {
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9975 "fe/idl.tab.cpp"
+#line 9977 "fe/idl.tab.cpp"
     break;
 
   case 544:
-#line 6544 "fe/idl.ypp"
+#line 6546 "fe/idl.ypp"
         {
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9983 "fe/idl.tab.cpp"
+#line 9985 "fe/idl.tab.cpp"
     break;
 
   case 545:
-#line 6551 "fe/idl.ypp"
+#line 6553 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_type;
         }
-#line 9991 "fe/idl.tab.cpp"
+#line 9993 "fe/idl.tab.cpp"
     break;
 
   case 546:
-#line 6555 "fe/idl.ypp"
+#line 6557 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_struct;
         }
-#line 9999 "fe/idl.tab.cpp"
+#line 10001 "fe/idl.tab.cpp"
     break;
 
   case 547:
-#line 6559 "fe/idl.ypp"
+#line 6561 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_union;
         }
-#line 10007 "fe/idl.tab.cpp"
+#line 10009 "fe/idl.tab.cpp"
     break;
 
   case 548:
-#line 6563 "fe/idl.ypp"
+#line 6565 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_eventtype;
         }
-#line 10015 "fe/idl.tab.cpp"
+#line 10017 "fe/idl.tab.cpp"
     break;
 
   case 549:
-#line 6567 "fe/idl.ypp"
+#line 6569 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_sequence;
         }
-#line 10023 "fe/idl.tab.cpp"
+#line 10025 "fe/idl.tab.cpp"
     break;
 
   case 550:
-#line 6571 "fe/idl.ypp"
+#line 6573 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_interface;
         }
-#line 10031 "fe/idl.tab.cpp"
+#line 10033 "fe/idl.tab.cpp"
     break;
 
   case 551:
-#line 6575 "fe/idl.ypp"
+#line 6577 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_valuetype;
         }
-#line 10039 "fe/idl.tab.cpp"
+#line 10041 "fe/idl.tab.cpp"
     break;
 
   case 552:
-#line 6579 "fe/idl.ypp"
+#line 6581 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_enum;
         }
-#line 10047 "fe/idl.tab.cpp"
+#line 10049 "fe/idl.tab.cpp"
     break;
 
   case 553:
-#line 6583 "fe/idl.ypp"
+#line 6585 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_except;
         }
-#line 10055 "fe/idl.tab.cpp"
+#line 10057 "fe/idl.tab.cpp"
     break;
 
   case 554:
-#line 6587 "fe/idl.ypp"
+#line 6589 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_const;
           t_param_const_type = (yyvsp[0].etval);
         }
-#line 10064 "fe/idl.tab.cpp"
+#line 10066 "fe/idl.tab.cpp"
     break;
 
   case 555:
-#line 6595 "fe/idl.ypp"
+#line 6597 "fe/idl.ypp"
         {
           if ((yyvsp[0].plval) == 0)
             {
@@ -10092,11 +10094,11 @@ yyreduce:
 
           (yyval.plval) = (yyvsp[0].plval);
         }
-#line 10096 "fe/idl.tab.cpp"
+#line 10098 "fe/idl.tab.cpp"
     break;
 
   case 556:
-#line 6626 "fe/idl.ypp"
+#line 6628 "fe/idl.ypp"
         {
           if ((yyvsp[-2].plval) == 0)
             {
@@ -10109,19 +10111,19 @@ yyreduce:
           delete (yyvsp[0].pival);
           (yyvsp[0].pival) = 0;
         }
-#line 10113 "fe/idl.tab.cpp"
+#line 10115 "fe/idl.tab.cpp"
     break;
 
   case 557:
-#line 6639 "fe/idl.ypp"
+#line 6641 "fe/idl.ypp"
         {
           (yyval.plval) = 0;
         }
-#line 10121 "fe/idl.tab.cpp"
+#line 10123 "fe/idl.tab.cpp"
     break;
 
   case 558:
-#line 6646 "fe/idl.ypp"
+#line 6648 "fe/idl.ypp"
         {
 
           ACE_NEW_RETURN ((yyval.pival),
@@ -10146,11 +10148,11 @@ yyreduce:
               tao_enum_constant_decl = 0;
             }
         }
-#line 10150 "fe/idl.tab.cpp"
+#line 10152 "fe/idl.tab.cpp"
     break;
 
   case 559:
-#line 6671 "fe/idl.ypp"
+#line 6673 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.pival),
                           FE_Utils::T_Param_Info,
@@ -10165,19 +10167,19 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 10169 "fe/idl.tab.cpp"
+#line 10171 "fe/idl.tab.cpp"
     break;
 
   case 560:
-#line 6689 "fe/idl.ypp"
+#line 6691 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.slval), UTL_StrList ((yyvsp[-1].sval), (yyvsp[0].slval)), 1);
         }
-#line 10177 "fe/idl.tab.cpp"
+#line 10179 "fe/idl.tab.cpp"
     break;
 
   case 561:
-#line 6696 "fe/idl.ypp"
+#line 6698 "fe/idl.ypp"
         {
           UTL_StrList *sl = 0;
           ACE_NEW_RETURN (sl, UTL_StrList ((yyvsp[0].sval), 0), 1);
@@ -10192,37 +10194,37 @@ yyreduce:
               (yyval.slval) = (yyvsp[-2].slval);
             }
         }
-#line 10196 "fe/idl.tab.cpp"
+#line 10198 "fe/idl.tab.cpp"
     break;
 
   case 562:
-#line 6711 "fe/idl.ypp"
+#line 6713 "fe/idl.ypp"
         {
           (yyval.slval) = 0;
         }
-#line 10204 "fe/idl.tab.cpp"
+#line 10206 "fe/idl.tab.cpp"
     break;
 
   case 563:
-#line 6718 "fe/idl.ypp"
+#line 6720 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.sval),
                           UTL_String ((yyvsp[0].strval), true),
                           1);
         }
-#line 10214 "fe/idl.tab.cpp"
+#line 10216 "fe/idl.tab.cpp"
     break;
 
   case 564:
-#line 6727 "fe/idl.ypp"
+#line 6729 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSeen);
         }
-#line 10222 "fe/idl.tab.cpp"
+#line 10224 "fe/idl.tab.cpp"
     break;
 
   case 565:
-#line 6731 "fe/idl.ypp"
+#line 6733 "fe/idl.ypp"
         {
           char *&id_value = (yyvsp[0].strval);
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeIDSeen);
@@ -10241,27 +10243,27 @@ yyreduce:
           // Push it on the scopes stack.
           idl_global->scopes ().push (porttype);
         }
-#line 10245 "fe/idl.tab.cpp"
+#line 10247 "fe/idl.tab.cpp"
     break;
 
   case 566:
-#line 6750 "fe/idl.ypp"
+#line 6752 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSqSeen);
         }
-#line 10253 "fe/idl.tab.cpp"
+#line 10255 "fe/idl.tab.cpp"
     break;
 
   case 567:
-#line 6758 "fe/idl.ypp"
+#line 6760 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeBodySeen);
         }
-#line 10261 "fe/idl.tab.cpp"
+#line 10263 "fe/idl.tab.cpp"
     break;
 
   case 568:
-#line 6762 "fe/idl.ypp"
+#line 6764 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeQsSeen);
 
@@ -10270,11 +10272,11 @@ yyreduce:
 
           (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 10274 "fe/idl.tab.cpp"
+#line 10276 "fe/idl.tab.cpp"
     break;
 
   case 569:
-#line 6774 "fe/idl.ypp"
+#line 6776 "fe/idl.ypp"
         {
           AST_Annotation_Appls *&annotations = (yyvsp[-1].annotations_val);
           AST_Decl *&node = (yyvsp[0].dcval);
@@ -10289,27 +10291,27 @@ yyreduce:
             }
           delete annotations;
         }
-#line 10293 "fe/idl.tab.cpp"
+#line 10295 "fe/idl.tab.cpp"
     break;
 
   case 575:
-#line 6800 "fe/idl.ypp"
+#line 6802 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
         }
-#line 10301 "fe/idl.tab.cpp"
+#line 10303 "fe/idl.tab.cpp"
     break;
 
   case 576:
-#line 6804 "fe/idl.ypp"
+#line 6806 "fe/idl.ypp"
         {
           (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 10309 "fe/idl.tab.cpp"
+#line 10311 "fe/idl.tab.cpp"
     break;
 
   case 577:
-#line 6811 "fe/idl.ypp"
+#line 6813 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
@@ -10376,11 +10378,11 @@ yyreduce:
 
           (yyval.dcval) = ep;
         }
-#line 10380 "fe/idl.tab.cpp"
+#line 10382 "fe/idl.tab.cpp"
     break;
 
   case 578:
-#line 6878 "fe/idl.ypp"
+#line 6880 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_MirrorPortDeclSeen);
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
@@ -10425,11 +10427,11 @@ yyreduce:
 
           (yyval.dcval) = mp;
         }
-#line 10429 "fe/idl.tab.cpp"
+#line 10431 "fe/idl.tab.cpp"
     break;
 
   case 579:
-#line 6926 "fe/idl.ypp"
+#line 6928 "fe/idl.ypp"
         {
           if ((yyvsp[0].alval) == 0)
             {
@@ -10442,11 +10444,11 @@ yyreduce:
           (yyvsp[0].alval)->enqueue_head ((yyvsp[-1].dcval));
           (yyval.alval) = (yyvsp[0].alval);
         }
-#line 10446 "fe/idl.tab.cpp"
+#line 10448 "fe/idl.tab.cpp"
     break;
 
   case 580:
-#line 6942 "fe/idl.ypp"
+#line 6944 "fe/idl.ypp"
         {
           if ((yyvsp[-3].alval) == 0)
             {
@@ -10459,19 +10461,19 @@ yyreduce:
           (yyvsp[-3].alval)->enqueue_tail ((yyvsp[0].dcval));
           (yyval.alval) = (yyvsp[-3].alval);
         }
-#line 10463 "fe/idl.tab.cpp"
+#line 10465 "fe/idl.tab.cpp"
     break;
 
   case 581:
-#line 6955 "fe/idl.ypp"
+#line 6957 "fe/idl.ypp"
         {
           (yyval.alval) = 0;
         }
-#line 10471 "fe/idl.tab.cpp"
+#line 10473 "fe/idl.tab.cpp"
     break;
 
   case 582:
-#line 6962 "fe/idl.ypp"
+#line 6964 "fe/idl.ypp"
         {
           // To avoid grammar conflicts with this LALR(1) parser,
           // we take advantage of the fact that an expression can
@@ -10527,35 +10529,35 @@ yyreduce:
                   0);
             }
         }
-#line 10531 "fe/idl.tab.cpp"
+#line 10533 "fe/idl.tab.cpp"
     break;
 
   case 583:
-#line 7021 "fe/idl.ypp"
+#line 7023 "fe/idl.ypp"
         {
           (yyval.dcval) = 0;
         }
-#line 10539 "fe/idl.tab.cpp"
+#line 10541 "fe/idl.tab.cpp"
     break;
 
   case 584:
-#line 7028 "fe/idl.ypp"
+#line 7030 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorSeen);
         }
-#line 10547 "fe/idl.tab.cpp"
+#line 10549 "fe/idl.tab.cpp"
     break;
 
   case 585:
-#line 7032 "fe/idl.ypp"
+#line 7034 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorIDSeen);
         }
-#line 10555 "fe/idl.tab.cpp"
+#line 10557 "fe/idl.tab.cpp"
     break;
 
   case 586:
-#line 7036 "fe/idl.ypp"
+#line 7038 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Connector *parent = 0;
@@ -10609,102 +10611,102 @@ yyreduce:
 
           delete (yyvsp[-3].annotations_val);
         }
-#line 10613 "fe/idl.tab.cpp"
+#line 10615 "fe/idl.tab.cpp"
     break;
 
   case 587:
-#line 7093 "fe/idl.ypp"
+#line 7095 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorSqSeen);
         }
-#line 10621 "fe/idl.tab.cpp"
+#line 10623 "fe/idl.tab.cpp"
     break;
 
   case 588:
-#line 7097 "fe/idl.ypp"
+#line 7099 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorBodySeen);
         }
-#line 10629 "fe/idl.tab.cpp"
+#line 10631 "fe/idl.tab.cpp"
     break;
 
   case 589:
-#line 7101 "fe/idl.ypp"
+#line 7103 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorQsSeen);
 
           // Done with this connector - pop it off the scope stack.
           idl_global->scopes ().pop ();
         }
-#line 10640 "fe/idl.tab.cpp"
+#line 10642 "fe/idl.tab.cpp"
     break;
 
   case 592:
-#line 7116 "fe/idl.ypp"
+#line 7118 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ProvidesDeclSeen);
         }
-#line 10648 "fe/idl.tab.cpp"
+#line 10650 "fe/idl.tab.cpp"
     break;
 
   case 593:
-#line 7120 "fe/idl.ypp"
+#line 7122 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 10656 "fe/idl.tab.cpp"
+#line 10658 "fe/idl.tab.cpp"
     break;
 
   case 594:
-#line 7124 "fe/idl.ypp"
+#line 7126 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UsesDeclSeen);
         }
-#line 10664 "fe/idl.tab.cpp"
+#line 10666 "fe/idl.tab.cpp"
     break;
 
   case 595:
-#line 7128 "fe/idl.ypp"
+#line 7130 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 10672 "fe/idl.tab.cpp"
+#line 10674 "fe/idl.tab.cpp"
     break;
 
   case 596:
-#line 7132 "fe/idl.ypp"
+#line 7134 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
         }
-#line 10680 "fe/idl.tab.cpp"
+#line 10682 "fe/idl.tab.cpp"
     break;
 
   case 597:
-#line 7136 "fe/idl.ypp"
+#line 7138 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 10688 "fe/idl.tab.cpp"
+#line 10690 "fe/idl.tab.cpp"
     break;
 
   case 598:
-#line 7140 "fe/idl.ypp"
+#line 7142 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
         }
-#line 10696 "fe/idl.tab.cpp"
+#line 10698 "fe/idl.tab.cpp"
     break;
 
   case 599:
-#line 7144 "fe/idl.ypp"
+#line 7146 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 10704 "fe/idl.tab.cpp"
+#line 10706 "fe/idl.tab.cpp"
     break;
 
 
-#line 10708 "fe/idl.tab.cpp"
+#line 10710 "fe/idl.tab.cpp"
 
       default: break;
     }
@@ -10898,7 +10900,7 @@ yyreturn:
   return yyresult;
 }
 
-#line 7149 "fe/idl.ypp"
+#line 7151 "fe/idl.ypp"
 
 /* programs */
 

--- a/TAO/TAO_IDL/fe/idl.tab.cpp
+++ b/TAO/TAO_IDL/fe/idl.tab.cpp
@@ -76,73 +76,74 @@
 /* First part of user prologue.  */
 #line 72 "fe/idl.ypp"
 
-#include "utl_identifier.h"
-#include "utl_err.h"
-#include "utl_string.h"
-#include "utl_strlist.h"
-#include "utl_namelist.h"
-#include "utl_exprlist.h"
-#include "utl_labellist.h"
-#include "utl_decllist.h"
+#include <utl_identifier.h>
+#include <utl_err.h>
+#include <utl_string.h>
+#include <utl_strlist.h>
+#include <utl_namelist.h>
+#include <utl_exprlist.h>
+#include <utl_labellist.h>
+#include <utl_decllist.h>
 
-#include "global_extern.h"
-#include "nr_extern.h"
+#include <global_extern.h>
+#include <nr_extern.h>
 
-#include "ast_argument.h"
-#include "ast_array.h"
-#include "ast_attribute.h"
-#include "ast_field.h"
-#include "ast_fixed.h"
-#include "ast_expression.h"
-#include "ast_operation.h"
-#include "ast_generator.h"
-#include "ast_template_module.h"
-#include "ast_template_module_inst.h"
-#include "ast_template_module_ref.h"
-#include "ast_typedef.h"
-#include "ast_valuebox.h"
-#include "ast_valuetype.h"
-#include "ast_valuetype_fwd.h"
-#include "ast_eventtype.h"
-#include "ast_eventtype_fwd.h"
-#include "ast_component.h"
-#include "ast_component_fwd.h"
-#include "ast_home.h"
-#include "ast_porttype.h"
-#include "ast_connector.h"
-#include "ast_uses.h"
-#include "ast_constant.h"
-#include "ast_union.h"
-#include "ast_union_fwd.h"
-#include "ast_structure_fwd.h"
-#include "ast_extern.h"
-#include "ast_enum.h"
-#include "ast_root.h"
-#include "ast_sequence.h"
-#include "ast_string.h"
-#include "ast_factory.h"
-#include "ast_finder.h"
-#include "ast_exception.h"
-#include "ast_param_holder.h"
-#include "ast_visitor_tmpl_module_inst.h"
-#include "ast_visitor_tmpl_module_ref.h"
-#include "ast_visitor_context.h"
-#include "ast_annotation_appl.h"
-#include "ast_union_branch.h"
-#include "ast_enum_val.h"
-#include "ast_annotation_member.h"
+#include <ast_argument.h>
+#include <ast_array.h>
+#include <ast_attribute.h>
+#include <ast_field.h>
+#include <ast_fixed.h>
+#include <ast_expression.h>
+#include <ast_operation.h>
+#include <ast_generator.h>
+#include <ast_template_module.h>
+#include <ast_template_module_inst.h>
+#include <ast_template_module_ref.h>
+#include <ast_typedef.h>
+#include <ast_valuebox.h>
+#include <ast_valuetype.h>
+#include <ast_valuetype_fwd.h>
+#include <ast_eventtype.h>
+#include <ast_eventtype_fwd.h>
+#include <ast_component.h>
+#include <ast_component_fwd.h>
+#include <ast_home.h>
+#include <ast_porttype.h>
+#include <ast_connector.h>
+#include <ast_uses.h>
+#include <ast_constant.h>
+#include <ast_union.h>
+#include <ast_union_fwd.h>
+#include <ast_structure_fwd.h>
+#include <ast_extern.h>
+#include <ast_enum.h>
+#include <ast_root.h>
+#include <ast_sequence.h>
+#include <ast_string.h>
+#include <ast_factory.h>
+#include <ast_finder.h>
+#include <ast_exception.h>
+#include <ast_param_holder.h>
+#include <ast_visitor_tmpl_module_inst.h>
+#include <ast_visitor_tmpl_module_ref.h>
+#include <ast_visitor_context.h>
+#include <ast_annotation_appl.h>
+#include <ast_union_branch.h>
+#include <ast_enum_val.h>
+#include <ast_annotation_member.h>
+#include <ast_provides.h>
+#include <ast_emits.h>
+#include <ast_publishes.h>
+#include <ast_consumes.h>
+#include <ast_extended_port.h>
+#include <ast_mirror_port.h>
 
-#include "fe_declarator.h"
-#include "fe_interface_header.h"
-#include "fe_obv_header.h"
-#include "fe_component_header.h"
-#include "fe_home_header.h"
-#include "fe_utils.h"
-
-#if (defined(apollo) || defined(hpux)) && defined(__cplusplus)
-extern  "C" int tao_yywrap();
-#endif  // (defined(apollo) || defined(hpux)) && defined(__cplusplus)
-
+#include <fe_declarator.h>
+#include <fe_interface_header.h>
+#include <fe_obv_header.h>
+#include <fe_component_header.h>
+#include <fe_home_header.h>
+#include <fe_utils.h>
 
 void tao_yyerror (const char *);
 int tao_yylex (void);
@@ -160,7 +161,7 @@ bool stack_based_lookup_for_primary_expr = false;
 // Compile Optional Tracing Output for Parser, can be enabled with --bison-trace
 #define YYDEBUG 1
 
-#line 164 "fe/idl.tab.cpp"
+#line 165 "fe/idl.tab.cpp"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -297,7 +298,7 @@ extern int tao_yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 162 "fe/idl.ypp"
+#line 163 "fe/idl.ypp"
 
   AST_Decl                      *dcval;         /* Decl value           */
   UTL_StrList                   *slval;         /* String list          */
@@ -342,7 +343,7 @@ union YYSTYPE
   AST_Decls *decls_val;
   Decl_Annotations_Pair *decl_annotations_pair_val;
 
-#line 346 "fe/idl.tab.cpp"
+#line 347 "fe/idl.tab.cpp"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -525,7 +526,7 @@ enum yysymbol_kind_t
   YYSYMBOL_value_def = 162,                /* value_def  */
   YYSYMBOL_valuetype = 163,                /* valuetype  */
   YYSYMBOL_value_concrete_decl = 164,      /* value_concrete_decl  */
-  YYSYMBOL_165_34 = 165,                   /* $@34  */
+  YYSYMBOL_165_34 = 165,                   /* @34  */
   YYSYMBOL_166_35 = 166,                   /* $@35  */
   YYSYMBOL_167_36 = 167,                   /* $@36  */
   YYSYMBOL_value_abs_decl = 168,           /* value_abs_decl  */
@@ -542,12 +543,12 @@ enum yysymbol_kind_t
   YYSYMBOL_value_box_decl = 179,           /* value_box_decl  */
   YYSYMBOL_value_elements = 180,           /* value_elements  */
   YYSYMBOL_value_element = 181,            /* value_element  */
-  YYSYMBOL_visibility = 182,               /* visibility  */
-  YYSYMBOL_state_member = 183,             /* state_member  */
-  YYSYMBOL_exports = 184,                  /* exports  */
-  YYSYMBOL_at_least_one_export = 185,      /* at_least_one_export  */
-  YYSYMBOL_export = 186,                   /* export  */
-  YYSYMBOL_187_42 = 187,                   /* $@42  */
+  YYSYMBOL_182_42 = 182,                   /* @42  */
+  YYSYMBOL_visibility = 183,               /* visibility  */
+  YYSYMBOL_state_member = 184,             /* state_member  */
+  YYSYMBOL_exports = 185,                  /* exports  */
+  YYSYMBOL_at_least_one_export = 186,      /* at_least_one_export  */
+  YYSYMBOL_export = 187,                   /* export  */
   YYSYMBOL_188_43 = 188,                   /* $@43  */
   YYSYMBOL_189_44 = 189,                   /* $@44  */
   YYSYMBOL_190_45 = 190,                   /* $@45  */
@@ -555,319 +556,318 @@ enum yysymbol_kind_t
   YYSYMBOL_192_47 = 192,                   /* $@47  */
   YYSYMBOL_193_48 = 193,                   /* $@48  */
   YYSYMBOL_194_49 = 194,                   /* $@49  */
-  YYSYMBOL_at_least_one_scoped_name = 195, /* at_least_one_scoped_name  */
-  YYSYMBOL_scoped_names = 196,             /* scoped_names  */
-  YYSYMBOL_197_50 = 197,                   /* $@50  */
-  YYSYMBOL_scoped_name = 198,              /* scoped_name  */
-  YYSYMBOL_199_51 = 199,                   /* $@51  */
+  YYSYMBOL_195_50 = 195,                   /* $@50  */
+  YYSYMBOL_at_least_one_scoped_name = 196, /* at_least_one_scoped_name  */
+  YYSYMBOL_scoped_names = 197,             /* scoped_names  */
+  YYSYMBOL_198_51 = 198,                   /* $@51  */
+  YYSYMBOL_scoped_name = 199,              /* scoped_name  */
   YYSYMBOL_200_52 = 200,                   /* $@52  */
-  YYSYMBOL_id = 201,                       /* id  */
-  YYSYMBOL_defining_id = 202,              /* defining_id  */
-  YYSYMBOL_interface_forward = 203,        /* interface_forward  */
-  YYSYMBOL_const_dcl = 204,                /* const_dcl  */
-  YYSYMBOL_205_53 = 205,                   /* $@53  */
+  YYSYMBOL_201_53 = 201,                   /* $@53  */
+  YYSYMBOL_id = 202,                       /* id  */
+  YYSYMBOL_defining_id = 203,              /* defining_id  */
+  YYSYMBOL_interface_forward = 204,        /* interface_forward  */
+  YYSYMBOL_const_dcl = 205,                /* const_dcl  */
   YYSYMBOL_206_54 = 206,                   /* $@54  */
   YYSYMBOL_207_55 = 207,                   /* $@55  */
   YYSYMBOL_208_56 = 208,                   /* $@56  */
-  YYSYMBOL_const_type = 209,               /* const_type  */
-  YYSYMBOL_expression = 210,               /* expression  */
-  YYSYMBOL_const_expr = 211,               /* const_expr  */
-  YYSYMBOL_or_expr = 212,                  /* or_expr  */
-  YYSYMBOL_xor_expr = 213,                 /* xor_expr  */
-  YYSYMBOL_and_expr = 214,                 /* and_expr  */
-  YYSYMBOL_shift_expr = 215,               /* shift_expr  */
-  YYSYMBOL_add_expr = 216,                 /* add_expr  */
-  YYSYMBOL_mult_expr = 217,                /* mult_expr  */
-  YYSYMBOL_unary_expr = 218,               /* unary_expr  */
-  YYSYMBOL_primary_expr = 219,             /* primary_expr  */
-  YYSYMBOL_literal = 220,                  /* literal  */
-  YYSYMBOL_positive_int_expr = 221,        /* positive_int_expr  */
-  YYSYMBOL_annotation_dcl = 222,           /* annotation_dcl  */
-  YYSYMBOL_223_57 = 223,                   /* $@57  */
-  YYSYMBOL_annotation_body = 224,          /* annotation_body  */
-  YYSYMBOL_annotation_statement = 225,     /* annotation_statement  */
-  YYSYMBOL_226_58 = 226,                   /* $@58  */
-  YYSYMBOL_annotation_member_type = 227,   /* annotation_member_type  */
-  YYSYMBOL_annotation_member = 228,        /* annotation_member  */
-  YYSYMBOL_annotation_member_default = 229, /* annotation_member_default  */
-  YYSYMBOL_at_least_one_annotation = 230,  /* at_least_one_annotation  */
-  YYSYMBOL_annotations_maybe = 231,        /* annotations_maybe  */
-  YYSYMBOL_annotation_appl = 232,          /* annotation_appl  */
-  YYSYMBOL_233_59 = 233,                   /* @59  */
-  YYSYMBOL_annotation_appl_params_maybe = 234, /* annotation_appl_params_maybe  */
-  YYSYMBOL_annotation_appl_params = 235,   /* annotation_appl_params  */
-  YYSYMBOL_named_annotation_appl_params = 236, /* named_annotation_appl_params  */
-  YYSYMBOL_more_named_annotation_appl_params = 237, /* more_named_annotation_appl_params  */
-  YYSYMBOL_named_annotation_appl_param = 238, /* named_annotation_appl_param  */
-  YYSYMBOL_type_dcl = 239,                 /* type_dcl  */
-  YYSYMBOL_240_60 = 240,                   /* $@60  */
-  YYSYMBOL_type_declarator = 241,          /* type_declarator  */
-  YYSYMBOL_242_61 = 242,                   /* $@61  */
-  YYSYMBOL_type_spec = 243,                /* type_spec  */
-  YYSYMBOL_simple_type_spec = 244,         /* simple_type_spec  */
-  YYSYMBOL_base_type_spec = 245,           /* base_type_spec  */
-  YYSYMBOL_template_type_spec = 246,       /* template_type_spec  */
-  YYSYMBOL_constructed_type_spec = 247,    /* constructed_type_spec  */
-  YYSYMBOL_constructed_forward_type_spec = 248, /* constructed_forward_type_spec  */
-  YYSYMBOL_at_least_one_declarator = 249,  /* at_least_one_declarator  */
-  YYSYMBOL_declarators = 250,              /* declarators  */
-  YYSYMBOL_251_62 = 251,                   /* $@62  */
-  YYSYMBOL_declarator = 252,               /* declarator  */
-  YYSYMBOL_at_least_one_simple_declarator = 253, /* at_least_one_simple_declarator  */
-  YYSYMBOL_simple_declarators = 254,       /* simple_declarators  */
-  YYSYMBOL_255_63 = 255,                   /* $@63  */
-  YYSYMBOL_simple_declarator = 256,        /* simple_declarator  */
-  YYSYMBOL_complex_declarator = 257,       /* complex_declarator  */
-  YYSYMBOL_integer_type = 258,             /* integer_type  */
-  YYSYMBOL_signed_int = 259,               /* signed_int  */
-  YYSYMBOL_unsigned_int = 260,             /* unsigned_int  */
-  YYSYMBOL_floating_pt_type = 261,         /* floating_pt_type  */
-  YYSYMBOL_fixed_type = 262,               /* fixed_type  */
-  YYSYMBOL_char_type = 263,                /* char_type  */
-  YYSYMBOL_octet_type = 264,               /* octet_type  */
-  YYSYMBOL_boolean_type = 265,             /* boolean_type  */
-  YYSYMBOL_any_type = 266,                 /* any_type  */
-  YYSYMBOL_object_type = 267,              /* object_type  */
-  YYSYMBOL_struct_decl = 268,              /* struct_decl  */
-  YYSYMBOL_269_64 = 269,                   /* $@64  */
-  YYSYMBOL_struct_type = 270,              /* struct_type  */
-  YYSYMBOL_271_65 = 271,                   /* $@65  */
+  YYSYMBOL_209_57 = 209,                   /* $@57  */
+  YYSYMBOL_const_type = 210,               /* const_type  */
+  YYSYMBOL_expression = 211,               /* expression  */
+  YYSYMBOL_const_expr = 212,               /* const_expr  */
+  YYSYMBOL_or_expr = 213,                  /* or_expr  */
+  YYSYMBOL_xor_expr = 214,                 /* xor_expr  */
+  YYSYMBOL_and_expr = 215,                 /* and_expr  */
+  YYSYMBOL_shift_expr = 216,               /* shift_expr  */
+  YYSYMBOL_add_expr = 217,                 /* add_expr  */
+  YYSYMBOL_mult_expr = 218,                /* mult_expr  */
+  YYSYMBOL_unary_expr = 219,               /* unary_expr  */
+  YYSYMBOL_primary_expr = 220,             /* primary_expr  */
+  YYSYMBOL_literal = 221,                  /* literal  */
+  YYSYMBOL_positive_int_expr = 222,        /* positive_int_expr  */
+  YYSYMBOL_annotation_dcl = 223,           /* annotation_dcl  */
+  YYSYMBOL_224_58 = 224,                   /* $@58  */
+  YYSYMBOL_annotation_body = 225,          /* annotation_body  */
+  YYSYMBOL_annotation_statement = 226,     /* annotation_statement  */
+  YYSYMBOL_227_59 = 227,                   /* $@59  */
+  YYSYMBOL_annotation_member_type = 228,   /* annotation_member_type  */
+  YYSYMBOL_annotation_member = 229,        /* annotation_member  */
+  YYSYMBOL_annotation_member_default = 230, /* annotation_member_default  */
+  YYSYMBOL_at_least_one_annotation = 231,  /* at_least_one_annotation  */
+  YYSYMBOL_annotations_maybe = 232,        /* annotations_maybe  */
+  YYSYMBOL_annotation_appl = 233,          /* annotation_appl  */
+  YYSYMBOL_234_60 = 234,                   /* @60  */
+  YYSYMBOL_annotation_appl_params_maybe = 235, /* annotation_appl_params_maybe  */
+  YYSYMBOL_annotation_appl_params = 236,   /* annotation_appl_params  */
+  YYSYMBOL_named_annotation_appl_params = 237, /* named_annotation_appl_params  */
+  YYSYMBOL_more_named_annotation_appl_params = 238, /* more_named_annotation_appl_params  */
+  YYSYMBOL_named_annotation_appl_param = 239, /* named_annotation_appl_param  */
+  YYSYMBOL_type_dcl = 240,                 /* type_dcl  */
+  YYSYMBOL_241_61 = 241,                   /* $@61  */
+  YYSYMBOL_type_declarator = 242,          /* type_declarator  */
+  YYSYMBOL_243_62 = 243,                   /* $@62  */
+  YYSYMBOL_type_spec = 244,                /* type_spec  */
+  YYSYMBOL_simple_type_spec = 245,         /* simple_type_spec  */
+  YYSYMBOL_base_type_spec = 246,           /* base_type_spec  */
+  YYSYMBOL_template_type_spec = 247,       /* template_type_spec  */
+  YYSYMBOL_constructed_type_spec = 248,    /* constructed_type_spec  */
+  YYSYMBOL_constructed_forward_type_spec = 249, /* constructed_forward_type_spec  */
+  YYSYMBOL_at_least_one_declarator = 250,  /* at_least_one_declarator  */
+  YYSYMBOL_declarators = 251,              /* declarators  */
+  YYSYMBOL_252_63 = 252,                   /* $@63  */
+  YYSYMBOL_declarator = 253,               /* declarator  */
+  YYSYMBOL_at_least_one_simple_declarator = 254, /* at_least_one_simple_declarator  */
+  YYSYMBOL_simple_declarators = 255,       /* simple_declarators  */
+  YYSYMBOL_256_64 = 256,                   /* $@64  */
+  YYSYMBOL_simple_declarator = 257,        /* simple_declarator  */
+  YYSYMBOL_complex_declarator = 258,       /* complex_declarator  */
+  YYSYMBOL_integer_type = 259,             /* integer_type  */
+  YYSYMBOL_signed_int = 260,               /* signed_int  */
+  YYSYMBOL_unsigned_int = 261,             /* unsigned_int  */
+  YYSYMBOL_floating_pt_type = 262,         /* floating_pt_type  */
+  YYSYMBOL_fixed_type = 263,               /* fixed_type  */
+  YYSYMBOL_char_type = 264,                /* char_type  */
+  YYSYMBOL_octet_type = 265,               /* octet_type  */
+  YYSYMBOL_boolean_type = 266,             /* boolean_type  */
+  YYSYMBOL_any_type = 267,                 /* any_type  */
+  YYSYMBOL_object_type = 268,              /* object_type  */
+  YYSYMBOL_struct_decl = 269,              /* struct_decl  */
+  YYSYMBOL_270_65 = 270,                   /* $@65  */
+  YYSYMBOL_struct_type = 271,              /* struct_type  */
   YYSYMBOL_272_66 = 272,                   /* $@66  */
   YYSYMBOL_273_67 = 273,                   /* $@67  */
-  YYSYMBOL_at_least_one_member = 274,      /* at_least_one_member  */
-  YYSYMBOL_members = 275,                  /* members  */
-  YYSYMBOL_member = 276,                   /* member  */
-  YYSYMBOL_member_i = 277,                 /* member_i  */
-  YYSYMBOL_278_68 = 278,                   /* $@68  */
+  YYSYMBOL_274_68 = 274,                   /* $@68  */
+  YYSYMBOL_at_least_one_member = 275,      /* at_least_one_member  */
+  YYSYMBOL_members = 276,                  /* members  */
+  YYSYMBOL_member = 277,                   /* member  */
+  YYSYMBOL_member_i = 278,                 /* member_i  */
   YYSYMBOL_279_69 = 279,                   /* $@69  */
   YYSYMBOL_280_70 = 280,                   /* $@70  */
-  YYSYMBOL_union_decl = 281,               /* union_decl  */
-  YYSYMBOL_282_71 = 282,                   /* $@71  */
-  YYSYMBOL_union_type = 283,               /* union_type  */
-  YYSYMBOL_284_72 = 284,                   /* $@72  */
+  YYSYMBOL_281_71 = 281,                   /* $@71  */
+  YYSYMBOL_union_decl = 282,               /* union_decl  */
+  YYSYMBOL_283_72 = 283,                   /* $@72  */
+  YYSYMBOL_union_type = 284,               /* union_type  */
   YYSYMBOL_285_73 = 285,                   /* $@73  */
   YYSYMBOL_286_74 = 286,                   /* $@74  */
   YYSYMBOL_287_75 = 287,                   /* $@75  */
   YYSYMBOL_288_76 = 288,                   /* $@76  */
   YYSYMBOL_289_77 = 289,                   /* $@77  */
-  YYSYMBOL_switch_type_spec = 290,         /* switch_type_spec  */
-  YYSYMBOL_at_least_one_case_branch = 291, /* at_least_one_case_branch  */
-  YYSYMBOL_case_branches = 292,            /* case_branches  */
-  YYSYMBOL_case_branch = 293,              /* case_branch  */
-  YYSYMBOL_294_78 = 294,                   /* $@78  */
+  YYSYMBOL_290_78 = 290,                   /* $@78  */
+  YYSYMBOL_switch_type_spec = 291,         /* switch_type_spec  */
+  YYSYMBOL_at_least_one_case_branch = 292, /* at_least_one_case_branch  */
+  YYSYMBOL_case_branches = 293,            /* case_branches  */
+  YYSYMBOL_case_branch = 294,              /* case_branch  */
   YYSYMBOL_295_79 = 295,                   /* $@79  */
   YYSYMBOL_296_80 = 296,                   /* $@80  */
-  YYSYMBOL_at_least_one_case_label = 297,  /* at_least_one_case_label  */
-  YYSYMBOL_case_labels = 298,              /* case_labels  */
-  YYSYMBOL_case_label = 299,               /* case_label  */
-  YYSYMBOL_300_81 = 300,                   /* $@81  */
+  YYSYMBOL_297_81 = 297,                   /* $@81  */
+  YYSYMBOL_at_least_one_case_label = 298,  /* at_least_one_case_label  */
+  YYSYMBOL_case_labels = 299,              /* case_labels  */
+  YYSYMBOL_case_label = 300,               /* case_label  */
   YYSYMBOL_301_82 = 301,                   /* $@82  */
   YYSYMBOL_302_83 = 302,                   /* $@83  */
-  YYSYMBOL_element_spec = 303,             /* element_spec  */
-  YYSYMBOL_304_84 = 304,                   /* $@84  */
-  YYSYMBOL_struct_forward_type = 305,      /* struct_forward_type  */
-  YYSYMBOL_union_forward_type = 306,       /* union_forward_type  */
-  YYSYMBOL_enum_type = 307,                /* enum_type  */
-  YYSYMBOL_308_85 = 308,                   /* $@85  */
+  YYSYMBOL_303_84 = 303,                   /* $@84  */
+  YYSYMBOL_element_spec = 304,             /* element_spec  */
+  YYSYMBOL_305_85 = 305,                   /* $@85  */
+  YYSYMBOL_struct_forward_type = 306,      /* struct_forward_type  */
+  YYSYMBOL_union_forward_type = 307,       /* union_forward_type  */
+  YYSYMBOL_enum_type = 308,                /* enum_type  */
   YYSYMBOL_309_86 = 309,                   /* $@86  */
   YYSYMBOL_310_87 = 310,                   /* $@87  */
   YYSYMBOL_311_88 = 311,                   /* $@88  */
-  YYSYMBOL_at_least_one_enumerator = 312,  /* at_least_one_enumerator  */
-  YYSYMBOL_enumerators = 313,              /* enumerators  */
-  YYSYMBOL_314_89 = 314,                   /* $@89  */
-  YYSYMBOL_enumerator = 315,               /* enumerator  */
-  YYSYMBOL_sequence_type_spec = 316,       /* sequence_type_spec  */
-  YYSYMBOL_317_90 = 317,                   /* $@90  */
+  YYSYMBOL_312_89 = 312,                   /* $@89  */
+  YYSYMBOL_at_least_one_enumerator = 313,  /* at_least_one_enumerator  */
+  YYSYMBOL_enumerators = 314,              /* enumerators  */
+  YYSYMBOL_315_90 = 315,                   /* $@90  */
+  YYSYMBOL_enumerator = 316,               /* enumerator  */
+  YYSYMBOL_sequence_type_spec = 317,       /* sequence_type_spec  */
   YYSYMBOL_318_91 = 318,                   /* $@91  */
-  YYSYMBOL_seq_head = 319,                 /* seq_head  */
-  YYSYMBOL_320_92 = 320,                   /* $@92  */
+  YYSYMBOL_319_92 = 319,                   /* $@92  */
+  YYSYMBOL_seq_head = 320,                 /* seq_head  */
   YYSYMBOL_321_93 = 321,                   /* $@93  */
-  YYSYMBOL_fixed_type_spec = 322,          /* fixed_type_spec  */
-  YYSYMBOL_string_type_spec = 323,         /* string_type_spec  */
-  YYSYMBOL_324_94 = 324,                   /* $@94  */
+  YYSYMBOL_322_94 = 322,                   /* $@94  */
+  YYSYMBOL_fixed_type_spec = 323,          /* fixed_type_spec  */
+  YYSYMBOL_string_type_spec = 324,         /* string_type_spec  */
   YYSYMBOL_325_95 = 325,                   /* $@95  */
-  YYSYMBOL_string_head = 326,              /* string_head  */
-  YYSYMBOL_wstring_type_spec = 327,        /* wstring_type_spec  */
-  YYSYMBOL_328_96 = 328,                   /* $@96  */
+  YYSYMBOL_326_96 = 326,                   /* $@96  */
+  YYSYMBOL_string_head = 327,              /* string_head  */
+  YYSYMBOL_wstring_type_spec = 328,        /* wstring_type_spec  */
   YYSYMBOL_329_97 = 329,                   /* $@97  */
-  YYSYMBOL_wstring_head = 330,             /* wstring_head  */
-  YYSYMBOL_array_declarator = 331,         /* array_declarator  */
-  YYSYMBOL_332_98 = 332,                   /* $@98  */
-  YYSYMBOL_at_least_one_array_dim = 333,   /* at_least_one_array_dim  */
-  YYSYMBOL_array_dims = 334,               /* array_dims  */
-  YYSYMBOL_array_dim = 335,                /* array_dim  */
-  YYSYMBOL_336_99 = 336,                   /* $@99  */
+  YYSYMBOL_330_98 = 330,                   /* $@98  */
+  YYSYMBOL_wstring_head = 331,             /* wstring_head  */
+  YYSYMBOL_array_declarator = 332,         /* array_declarator  */
+  YYSYMBOL_333_99 = 333,                   /* $@99  */
+  YYSYMBOL_at_least_one_array_dim = 334,   /* at_least_one_array_dim  */
+  YYSYMBOL_array_dims = 335,               /* array_dims  */
+  YYSYMBOL_array_dim = 336,                /* array_dim  */
   YYSYMBOL_337_100 = 337,                  /* $@100  */
-  YYSYMBOL_attribute = 338,                /* attribute  */
-  YYSYMBOL_attribute_readonly = 339,       /* attribute_readonly  */
-  YYSYMBOL_340_101 = 340,                  /* $@101  */
+  YYSYMBOL_338_101 = 338,                  /* $@101  */
+  YYSYMBOL_attribute = 339,                /* attribute  */
+  YYSYMBOL_attribute_readonly = 340,       /* attribute_readonly  */
   YYSYMBOL_341_102 = 341,                  /* $@102  */
   YYSYMBOL_342_103 = 342,                  /* $@103  */
   YYSYMBOL_343_104 = 343,                  /* $@104  */
-  YYSYMBOL_attribute_readwrite = 344,      /* attribute_readwrite  */
-  YYSYMBOL_345_105 = 345,                  /* $@105  */
+  YYSYMBOL_344_105 = 344,                  /* $@105  */
+  YYSYMBOL_attribute_readwrite = 345,      /* attribute_readwrite  */
   YYSYMBOL_346_106 = 346,                  /* $@106  */
   YYSYMBOL_347_107 = 347,                  /* $@107  */
   YYSYMBOL_348_108 = 348,                  /* $@108  */
-  YYSYMBOL_exception = 349,                /* exception  */
-  YYSYMBOL_350_109 = 350,                  /* $@109  */
+  YYSYMBOL_349_109 = 349,                  /* $@109  */
+  YYSYMBOL_exception = 350,                /* exception  */
   YYSYMBOL_351_110 = 351,                  /* $@110  */
-  YYSYMBOL_352_111 = 352,                  /* $@111  */
+  YYSYMBOL_352_111 = 352,                  /* @111  */
   YYSYMBOL_353_112 = 353,                  /* $@112  */
-  YYSYMBOL_operation = 354,                /* operation  */
-  YYSYMBOL_355_113 = 355,                  /* $@113  */
+  YYSYMBOL_354_113 = 354,                  /* $@113  */
+  YYSYMBOL_operation = 355,                /* operation  */
   YYSYMBOL_356_114 = 356,                  /* $@114  */
   YYSYMBOL_357_115 = 357,                  /* $@115  */
   YYSYMBOL_358_116 = 358,                  /* $@116  */
-  YYSYMBOL_opt_op_attribute = 359,         /* opt_op_attribute  */
-  YYSYMBOL_op_type_spec = 360,             /* op_type_spec  */
-  YYSYMBOL_init_decl = 361,                /* init_decl  */
-  YYSYMBOL_362_117 = 362,                  /* $@117  */
+  YYSYMBOL_359_117 = 359,                  /* $@117  */
+  YYSYMBOL_opt_op_attribute = 360,         /* opt_op_attribute  */
+  YYSYMBOL_op_type_spec = 361,             /* op_type_spec  */
+  YYSYMBOL_init_decl = 362,                /* init_decl  */
   YYSYMBOL_363_118 = 363,                  /* $@118  */
-  YYSYMBOL_364_119 = 364,                  /* $@119  */
-  YYSYMBOL_init_parameter_list = 365,      /* init_parameter_list  */
-  YYSYMBOL_366_120 = 366,                  /* $@120  */
+  YYSYMBOL_364_119 = 364,                  /* @119  */
+  YYSYMBOL_365_120 = 365,                  /* $@120  */
+  YYSYMBOL_init_parameter_list = 366,      /* init_parameter_list  */
   YYSYMBOL_367_121 = 367,                  /* $@121  */
-  YYSYMBOL_at_least_one_in_parameter = 368, /* at_least_one_in_parameter  */
-  YYSYMBOL_in_parameters = 369,            /* in_parameters  */
-  YYSYMBOL_370_122 = 370,                  /* $@122  */
-  YYSYMBOL_in_parameter = 371,             /* in_parameter  */
-  YYSYMBOL_372_123 = 372,                  /* $@123  */
+  YYSYMBOL_368_122 = 368,                  /* $@122  */
+  YYSYMBOL_at_least_one_in_parameter = 369, /* at_least_one_in_parameter  */
+  YYSYMBOL_in_parameters = 370,            /* in_parameters  */
+  YYSYMBOL_371_123 = 371,                  /* $@123  */
+  YYSYMBOL_in_parameter = 372,             /* in_parameter  */
   YYSYMBOL_373_124 = 373,                  /* $@124  */
-  YYSYMBOL_parameter_list = 374,           /* parameter_list  */
-  YYSYMBOL_375_125 = 375,                  /* $@125  */
+  YYSYMBOL_374_125 = 374,                  /* $@125  */
+  YYSYMBOL_parameter_list = 375,           /* parameter_list  */
   YYSYMBOL_376_126 = 376,                  /* $@126  */
-  YYSYMBOL_at_least_one_parameter = 377,   /* at_least_one_parameter  */
-  YYSYMBOL_parameters = 378,               /* parameters  */
-  YYSYMBOL_379_127 = 379,                  /* $@127  */
-  YYSYMBOL_parameter = 380,                /* parameter  */
-  YYSYMBOL_381_128 = 381,                  /* $@128  */
+  YYSYMBOL_377_127 = 377,                  /* $@127  */
+  YYSYMBOL_at_least_one_parameter = 378,   /* at_least_one_parameter  */
+  YYSYMBOL_parameters = 379,               /* parameters  */
+  YYSYMBOL_380_128 = 380,                  /* $@128  */
+  YYSYMBOL_parameter = 381,                /* parameter  */
   YYSYMBOL_382_129 = 382,                  /* $@129  */
-  YYSYMBOL_param_type_spec = 383,          /* param_type_spec  */
-  YYSYMBOL_direction = 384,                /* direction  */
-  YYSYMBOL_opt_raises = 385,               /* opt_raises  */
-  YYSYMBOL_386_130 = 386,                  /* $@130  */
+  YYSYMBOL_383_130 = 383,                  /* $@130  */
+  YYSYMBOL_param_type_spec = 384,          /* param_type_spec  */
+  YYSYMBOL_direction = 385,                /* direction  */
+  YYSYMBOL_opt_raises = 386,               /* opt_raises  */
   YYSYMBOL_387_131 = 387,                  /* $@131  */
-  YYSYMBOL_opt_getraises = 388,            /* opt_getraises  */
-  YYSYMBOL_389_132 = 389,                  /* $@132  */
+  YYSYMBOL_388_132 = 388,                  /* $@132  */
+  YYSYMBOL_opt_getraises = 389,            /* opt_getraises  */
   YYSYMBOL_390_133 = 390,                  /* $@133  */
-  YYSYMBOL_opt_setraises = 391,            /* opt_setraises  */
-  YYSYMBOL_392_134 = 392,                  /* $@134  */
+  YYSYMBOL_391_134 = 391,                  /* $@134  */
+  YYSYMBOL_opt_setraises = 392,            /* opt_setraises  */
   YYSYMBOL_393_135 = 393,                  /* $@135  */
-  YYSYMBOL_opt_context = 394,              /* opt_context  */
-  YYSYMBOL_395_136 = 395,                  /* $@136  */
+  YYSYMBOL_394_136 = 394,                  /* $@136  */
+  YYSYMBOL_opt_context = 395,              /* opt_context  */
   YYSYMBOL_396_137 = 396,                  /* $@137  */
-  YYSYMBOL_at_least_one_string_literal = 397, /* at_least_one_string_literal  */
-  YYSYMBOL_string_literals = 398,          /* string_literals  */
-  YYSYMBOL_399_138 = 399,                  /* $@138  */
-  YYSYMBOL_typeid_dcl = 400,               /* typeid_dcl  */
-  YYSYMBOL_typeprefix_dcl = 401,           /* typeprefix_dcl  */
-  YYSYMBOL_component = 402,                /* component  */
-  YYSYMBOL_component_forward_decl = 403,   /* component_forward_decl  */
-  YYSYMBOL_component_decl = 404,           /* component_decl  */
-  YYSYMBOL_405_139 = 405,                  /* $@139  */
-  YYSYMBOL_406_140 = 406,                  /* $@140  */
+  YYSYMBOL_397_138 = 397,                  /* $@138  */
+  YYSYMBOL_at_least_one_string_literal = 398, /* at_least_one_string_literal  */
+  YYSYMBOL_string_literals = 399,          /* string_literals  */
+  YYSYMBOL_400_139 = 400,                  /* $@139  */
+  YYSYMBOL_typeid_dcl = 401,               /* typeid_dcl  */
+  YYSYMBOL_typeprefix_dcl = 402,           /* typeprefix_dcl  */
+  YYSYMBOL_component = 403,                /* component  */
+  YYSYMBOL_component_forward_decl = 404,   /* component_forward_decl  */
+  YYSYMBOL_component_decl = 405,           /* component_decl  */
+  YYSYMBOL_406_140 = 406,                  /* @140  */
   YYSYMBOL_407_141 = 407,                  /* $@141  */
-  YYSYMBOL_component_header = 408,         /* component_header  */
-  YYSYMBOL_409_142 = 409,                  /* $@142  */
+  YYSYMBOL_408_142 = 408,                  /* $@142  */
+  YYSYMBOL_component_header = 409,         /* component_header  */
   YYSYMBOL_410_143 = 410,                  /* $@143  */
-  YYSYMBOL_component_inheritance_spec = 411, /* component_inheritance_spec  */
-  YYSYMBOL_412_144 = 412,                  /* $@144  */
-  YYSYMBOL_component_exports = 413,        /* component_exports  */
-  YYSYMBOL_component_export = 414,         /* component_export  */
-  YYSYMBOL_415_145 = 415,                  /* $@145  */
+  YYSYMBOL_411_144 = 411,                  /* $@144  */
+  YYSYMBOL_component_inheritance_spec = 412, /* component_inheritance_spec  */
+  YYSYMBOL_413_145 = 413,                  /* $@145  */
+  YYSYMBOL_component_exports = 414,        /* component_exports  */
+  YYSYMBOL_component_export = 415,         /* component_export  */
   YYSYMBOL_416_146 = 416,                  /* $@146  */
   YYSYMBOL_417_147 = 417,                  /* $@147  */
   YYSYMBOL_418_148 = 418,                  /* $@148  */
   YYSYMBOL_419_149 = 419,                  /* $@149  */
   YYSYMBOL_420_150 = 420,                  /* $@150  */
   YYSYMBOL_421_151 = 421,                  /* $@151  */
-  YYSYMBOL_provides_decl = 422,            /* provides_decl  */
-  YYSYMBOL_interface_type = 423,           /* interface_type  */
-  YYSYMBOL_uses_decl = 424,                /* uses_decl  */
-  YYSYMBOL_uses_opt_multiple = 425,        /* uses_opt_multiple  */
-  YYSYMBOL_opt_multiple = 426,             /* opt_multiple  */
-  YYSYMBOL_emits_decl = 427,               /* emits_decl  */
-  YYSYMBOL_publishes_decl = 428,           /* publishes_decl  */
-  YYSYMBOL_consumes_decl = 429,            /* consumes_decl  */
-  YYSYMBOL_home_decl = 430,                /* home_decl  */
-  YYSYMBOL_431_152 = 431,                  /* $@152  */
-  YYSYMBOL_home_header = 432,              /* home_header  */
-  YYSYMBOL_433_153 = 433,                  /* $@153  */
+  YYSYMBOL_422_152 = 422,                  /* $@152  */
+  YYSYMBOL_provides_decl = 423,            /* provides_decl  */
+  YYSYMBOL_interface_type = 424,           /* interface_type  */
+  YYSYMBOL_uses_decl = 425,                /* uses_decl  */
+  YYSYMBOL_uses_opt_multiple = 426,        /* uses_opt_multiple  */
+  YYSYMBOL_opt_multiple = 427,             /* opt_multiple  */
+  YYSYMBOL_emits_decl = 428,               /* emits_decl  */
+  YYSYMBOL_publishes_decl = 429,           /* publishes_decl  */
+  YYSYMBOL_consumes_decl = 430,            /* consumes_decl  */
+  YYSYMBOL_home_decl = 431,                /* home_decl  */
+  YYSYMBOL_432_153 = 432,                  /* $@153  */
+  YYSYMBOL_home_header = 433,              /* home_header  */
   YYSYMBOL_434_154 = 434,                  /* $@154  */
   YYSYMBOL_435_155 = 435,                  /* $@155  */
   YYSYMBOL_436_156 = 436,                  /* $@156  */
   YYSYMBOL_437_157 = 437,                  /* $@157  */
   YYSYMBOL_438_158 = 438,                  /* $@158  */
-  YYSYMBOL_home_inheritance_spec = 439,    /* home_inheritance_spec  */
-  YYSYMBOL_440_159 = 440,                  /* $@159  */
-  YYSYMBOL_primary_key_spec = 441,         /* primary_key_spec  */
-  YYSYMBOL_home_body = 442,                /* home_body  */
-  YYSYMBOL_443_160 = 443,                  /* $@160  */
+  YYSYMBOL_439_159 = 439,                  /* $@159  */
+  YYSYMBOL_home_inheritance_spec = 440,    /* home_inheritance_spec  */
+  YYSYMBOL_441_160 = 441,                  /* $@160  */
+  YYSYMBOL_primary_key_spec = 442,         /* primary_key_spec  */
+  YYSYMBOL_home_body = 443,                /* home_body  */
   YYSYMBOL_444_161 = 444,                  /* $@161  */
-  YYSYMBOL_home_exports = 445,             /* home_exports  */
-  YYSYMBOL_home_export = 446,              /* home_export  */
-  YYSYMBOL_447_162 = 447,                  /* $@162  */
+  YYSYMBOL_445_162 = 445,                  /* $@162  */
+  YYSYMBOL_home_exports = 446,             /* home_exports  */
+  YYSYMBOL_home_export = 447,              /* home_export  */
   YYSYMBOL_448_163 = 448,                  /* $@163  */
-  YYSYMBOL_factory_decl = 449,             /* factory_decl  */
-  YYSYMBOL_450_164 = 450,                  /* $@164  */
+  YYSYMBOL_449_164 = 449,                  /* $@164  */
+  YYSYMBOL_factory_decl = 450,             /* factory_decl  */
   YYSYMBOL_451_165 = 451,                  /* $@165  */
-  YYSYMBOL_finder_decl = 452,              /* finder_decl  */
-  YYSYMBOL_453_166 = 453,                  /* $@166  */
+  YYSYMBOL_452_166 = 452,                  /* $@166  */
+  YYSYMBOL_finder_decl = 453,              /* finder_decl  */
   YYSYMBOL_454_167 = 454,                  /* $@167  */
-  YYSYMBOL_event = 455,                    /* event  */
-  YYSYMBOL_event_forward_decl = 456,       /* event_forward_decl  */
-  YYSYMBOL_event_concrete_forward_decl = 457, /* event_concrete_forward_decl  */
-  YYSYMBOL_event_abs_forward_decl = 458,   /* event_abs_forward_decl  */
-  YYSYMBOL_event_abs_decl = 459,           /* event_abs_decl  */
-  YYSYMBOL_460_168 = 460,                  /* $@168  */
+  YYSYMBOL_455_168 = 455,                  /* $@168  */
+  YYSYMBOL_event = 456,                    /* event  */
+  YYSYMBOL_event_forward_decl = 457,       /* event_forward_decl  */
+  YYSYMBOL_event_concrete_forward_decl = 458, /* event_concrete_forward_decl  */
+  YYSYMBOL_event_abs_forward_decl = 459,   /* event_abs_forward_decl  */
+  YYSYMBOL_event_abs_decl = 460,           /* event_abs_decl  */
   YYSYMBOL_461_169 = 461,                  /* $@169  */
   YYSYMBOL_462_170 = 462,                  /* $@170  */
-  YYSYMBOL_event_abs_header = 463,         /* event_abs_header  */
-  YYSYMBOL_event_custom_header = 464,      /* event_custom_header  */
-  YYSYMBOL_event_plain_header = 465,       /* event_plain_header  */
-  YYSYMBOL_event_rest_of_header = 466,     /* event_rest_of_header  */
-  YYSYMBOL_467_171 = 467,                  /* $@171  */
-  YYSYMBOL_event_decl = 468,               /* event_decl  */
-  YYSYMBOL_469_172 = 469,                  /* $@172  */
-  YYSYMBOL_470_173 = 470,                  /* $@173  */
+  YYSYMBOL_463_171 = 463,                  /* $@171  */
+  YYSYMBOL_event_abs_header = 464,         /* event_abs_header  */
+  YYSYMBOL_event_custom_header = 465,      /* event_custom_header  */
+  YYSYMBOL_event_plain_header = 466,       /* event_plain_header  */
+  YYSYMBOL_event_rest_of_header = 467,     /* event_rest_of_header  */
+  YYSYMBOL_468_172 = 468,                  /* $@172  */
+  YYSYMBOL_event_decl = 469,               /* event_decl  */
+  YYSYMBOL_470_173 = 470,                  /* @173  */
   YYSYMBOL_471_174 = 471,                  /* $@174  */
-  YYSYMBOL_event_header = 472,             /* event_header  */
-  YYSYMBOL_formal_parameter_type = 473,    /* formal_parameter_type  */
-  YYSYMBOL_at_least_one_formal_parameter = 474, /* at_least_one_formal_parameter  */
-  YYSYMBOL_formal_parameters = 475,        /* formal_parameters  */
-  YYSYMBOL_formal_parameter = 476,         /* formal_parameter  */
-  YYSYMBOL_at_least_one_formal_parameter_name = 477, /* at_least_one_formal_parameter_name  */
-  YYSYMBOL_formal_parameter_names = 478,   /* formal_parameter_names  */
-  YYSYMBOL_formal_parameter_name = 479,    /* formal_parameter_name  */
-  YYSYMBOL_porttype_decl = 480,            /* porttype_decl  */
-  YYSYMBOL_481_175 = 481,                  /* $@175  */
+  YYSYMBOL_472_175 = 472,                  /* $@175  */
+  YYSYMBOL_event_header = 473,             /* event_header  */
+  YYSYMBOL_formal_parameter_type = 474,    /* formal_parameter_type  */
+  YYSYMBOL_at_least_one_formal_parameter = 475, /* at_least_one_formal_parameter  */
+  YYSYMBOL_formal_parameters = 476,        /* formal_parameters  */
+  YYSYMBOL_formal_parameter = 477,         /* formal_parameter  */
+  YYSYMBOL_at_least_one_formal_parameter_name = 478, /* at_least_one_formal_parameter_name  */
+  YYSYMBOL_formal_parameter_names = 479,   /* formal_parameter_names  */
+  YYSYMBOL_formal_parameter_name = 480,    /* formal_parameter_name  */
+  YYSYMBOL_porttype_decl = 481,            /* porttype_decl  */
   YYSYMBOL_482_176 = 482,                  /* $@176  */
-  YYSYMBOL_483_177 = 483,                  /* $@177  */
+  YYSYMBOL_483_177 = 483,                  /* @177  */
   YYSYMBOL_484_178 = 484,                  /* $@178  */
-  YYSYMBOL_at_least_one_port_export = 485, /* at_least_one_port_export  */
-  YYSYMBOL_port_exports = 486,             /* port_exports  */
-  YYSYMBOL_port_export = 487,              /* port_export  */
-  YYSYMBOL_488_179 = 488,                  /* $@179  */
+  YYSYMBOL_485_179 = 485,                  /* $@179  */
+  YYSYMBOL_at_least_one_port_export = 486, /* at_least_one_port_export  */
+  YYSYMBOL_port_exports = 487,             /* port_exports  */
+  YYSYMBOL_port_export = 488,              /* port_export  */
   YYSYMBOL_489_180 = 489,                  /* $@180  */
-  YYSYMBOL_490_181 = 490,                  /* $@181  */
-  YYSYMBOL_extended_port_decl = 491,       /* extended_port_decl  */
-  YYSYMBOL_at_least_one_actual_parameter = 492, /* at_least_one_actual_parameter  */
-  YYSYMBOL_actual_parameters = 493,        /* actual_parameters  */
-  YYSYMBOL_actual_parameter = 494,         /* actual_parameter  */
-  YYSYMBOL_connector_decl = 495,           /* connector_decl  */
-  YYSYMBOL_connector_header = 496,         /* connector_header  */
+  YYSYMBOL_extended_port_decl = 490,       /* extended_port_decl  */
+  YYSYMBOL_at_least_one_actual_parameter = 491, /* at_least_one_actual_parameter  */
+  YYSYMBOL_actual_parameters = 492,        /* actual_parameters  */
+  YYSYMBOL_actual_parameter = 493,         /* actual_parameter  */
+  YYSYMBOL_connector_decl = 494,           /* connector_decl  */
+  YYSYMBOL_connector_header = 495,         /* connector_header  */
+  YYSYMBOL_496_181 = 496,                  /* $@181  */
   YYSYMBOL_497_182 = 497,                  /* $@182  */
-  YYSYMBOL_498_183 = 498,                  /* $@183  */
-  YYSYMBOL_connector_body = 499,           /* connector_body  */
+  YYSYMBOL_connector_body = 498,           /* connector_body  */
+  YYSYMBOL_499_183 = 499,                  /* $@183  */
   YYSYMBOL_500_184 = 500,                  /* $@184  */
-  YYSYMBOL_501_185 = 501,                  /* $@185  */
-  YYSYMBOL_connector_exports = 502,        /* connector_exports  */
-  YYSYMBOL_connector_export = 503,         /* connector_export  */
+  YYSYMBOL_connector_exports = 501,        /* connector_exports  */
+  YYSYMBOL_connector_export = 502,         /* connector_export  */
+  YYSYMBOL_503_185 = 503,                  /* $@185  */
   YYSYMBOL_504_186 = 504,                  /* $@186  */
   YYSYMBOL_505_187 = 505,                  /* $@187  */
-  YYSYMBOL_506_188 = 506,                  /* $@188  */
-  YYSYMBOL_507_189 = 507                   /* $@189  */
+  YYSYMBOL_506_188 = 506                   /* $@188  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -1177,16 +1177,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  4
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   1567
+#define YYLAST   1637
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  109
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  399
+#define YYNNTS  398
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  597
+#define YYNRULES  599
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  878
+#define YYNSTATES  880
 
 #define YYMAXUTOK   342
 
@@ -1243,66 +1243,66 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINEYYN -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   400,   400,   403,   404,   412,   427,   433,   434,   435,
-     440,   439,   448,   447,   456,   455,   464,   463,   472,   471,
-     480,   479,   488,   487,   496,   495,   504,   503,   512,   511,
-     520,   519,   528,   527,   536,   535,   544,   543,   552,   551,
-     565,   564,   576,   615,   619,   575,   635,   643,   657,   667,
-     697,   701,   642,   726,   730,   731,   735,   736,   741,   746,
-     740,   832,   837,   831,   908,   909,   914,   952,   956,   913,
-     973,   972,   984,  1021,  1051,  1084,  1083,  1092,  1099,  1100,
-    1101,  1102,  1106,  1111,  1116,  1159,  1163,  1115,  1192,  1235,
-    1239,  1190,  1258,  1256,  1296,  1295,  1307,  1311,  1318,  1323,
-    1330,  1355,  1383,  1449,  1450,  1454,  1455,  1456,  1461,  1465,
-    1472,  1491,  1492,  1496,  1511,  1518,  1517,  1526,  1525,  1534,
-    1533,  1542,  1541,  1550,  1549,  1558,  1557,  1566,  1565,  1574,
-    1573,  1586,  1598,  1596,  1621,  1628,  1638,  1637,  1663,  1661,
-    1686,  1696,  1707,  1751,  1778,  1810,  1814,  1818,  1822,  1809,
-    1884,  1885,  1886,  1887,  1888,  1889,  1890,  1894,  1898,  1966,
-    1968,  1970,  1971,  1983,  1984,  1996,  1997,  2009,  2010,  2019,
-    2031,  2032,  2041,  2053,  2054,  2063,  2072,  2084,  2085,  2094,
-    2103,  2115,  2172,  2173,  2180,  2184,  2189,  2196,  2203,  2207,
-    2212,  2216,  2220,  2224,  2231,  2300,  2299,  2328,  2329,  2333,
-    2334,  2335,  2337,  2336,  2345,  2346,  2350,  2406,  2410,  2417,
-    2430,  2440,  2448,  2447,  2535,  2539,  2546,  2555,  2562,  2570,
-    2576,  2583,  2596,  2595,  2604,  2608,  2612,  2616,  2644,  2652,
-    2651,  2722,  2723,  2727,  2734,  2735,  2761,  2762,  2763,  2764,
-    2765,  2766,  2767,  2768,  2772,  2773,  2774,  2775,  2779,  2780,
-    2781,  2785,  2786,  2790,  2802,  2800,  2825,  2832,  2833,  2837,
-    2849,  2847,  2872,  2879,  2895,  2913,  2914,  2918,  2922,  2926,
-    2933,  2937,  2941,  2948,  2952,  2956,  2963,  2970,  2974,  2981,
-    2988,  2995,  3002,  3010,  3009,  3023,  3054,  3058,  3022,  3075,
-    3078,  3079,  3083,  3101,  3105,  3100,  3163,  3162,  3175,  3174,
-    3187,  3191,  3224,  3228,  3287,  3291,  3186,  3313,  3320,  3333,
-    3342,  3349,  3350,  3459,  3462,  3463,  3468,  3472,  3467,  3508,
-    3507,  3519,  3529,  3547,  3555,  3554,  3568,  3572,  3567,  3588,
-    3587,  3638,  3663,  3687,  3691,  3722,  3726,  3686,  3750,  3755,
-    3753,  3759,  3763,  3803,  3807,  3801,  3895,  3966,  3975,  3965,
-    3989,  3999,  4003,  3997,  4048,  4074,  4083,  4087,  4081,  4123,
-    4149,  4157,  4156,  4203,  4213,  4231,  4239,  4243,  4238,  4303,
-    4304,  4309,  4313,  4317,  4321,  4308,  4380,  4384,  4388,  4392,
-    4379,  4460,  4464,  4493,  4497,  4459,  4514,  4518,  4579,  4583,
-    4513,  4620,  4625,  4630,  4637,  4638,  4649,  4654,  4697,  4648,
-    4717,  4716,  4725,  4724,  4735,  4740,  4738,  4744,  4749,  4753,
-    4748,  4792,  4791,  4800,  4799,  4810,  4815,  4813,  4819,  4824,
-    4828,  4823,  4873,  4880,  4881,  4882,  4989,  4993,  4997,  5005,
-    5009,  5004,  5018,  5026,  5030,  5025,  5039,  5047,  5051,  5046,
-    5060,  5068,  5072,  5067,  5081,  5088,  5100,  5098,  5121,  5128,
-    5158,  5197,  5198,  5202,  5233,  5272,  5276,  5232,  5295,  5299,
-    5293,  5340,  5339,  5347,  5354,  5355,  5360,  5359,  5368,  5367,
-    5376,  5375,  5384,  5383,  5392,  5391,  5400,  5399,  5408,  5407,
-    5417,  5507,  5513,  5538,  5644,  5653,  5657,  5663,  5735,  5807,
-    5881,  5880,  5930,  5934,  5938,  5942,  5946,  5950,  5929,  6003,
-    6002,  6010,  6017,  6022,  6030,  6034,  6029,  6044,  6045,  6049,
-    6051,  6050,  6059,  6058,  6071,  6094,  6069,  6120,  6147,  6118,
-    6171,  6172,  6173,  6177,  6178,  6182,  6211,  6243,  6287,  6291,
-    6241,  6308,  6317,  6335,  6346,  6345,  6383,  6432,  6436,  6381,
-    6453,  6457,  6464,  6468,  6472,  6476,  6480,  6484,  6488,  6492,
-    6496,  6500,  6508,  6539,  6552,  6559,  6584,  6602,  6609,  6624,
-    6631,  6641,  6645,  6665,  6669,  6640,  6684,  6690,  6693,  6700,
-    6699,  6706,  6705,  6712,  6711,  6721,  6790,  6840,  6856,  6869,
-    6876,  6935,  6943,  6947,  6942,  7008,  7012,  7007,  7025,  7026,
-    7031,  7030,  7039,  7038,  7047,  7046,  7055,  7054
+       0,   404,   404,   407,   408,   416,   431,   435,   436,   437,
+     442,   441,   450,   449,   458,   457,   466,   465,   474,   473,
+     482,   481,   490,   489,   498,   497,   506,   505,   514,   513,
+     522,   521,   530,   529,   538,   537,   546,   545,   554,   553,
+     567,   566,   578,   617,   621,   577,   637,   645,   659,   669,
+     699,   703,   644,   728,   732,   733,   737,   738,   743,   748,
+     742,   834,   839,   833,   910,   911,   916,   954,   958,   915,
+     975,   974,   986,  1023,  1053,  1086,  1085,  1094,  1101,  1102,
+    1103,  1104,  1108,  1113,  1118,  1163,  1167,  1117,  1196,  1239,
+    1243,  1194,  1262,  1260,  1300,  1299,  1311,  1315,  1322,  1327,
+    1334,  1359,  1387,  1453,  1472,  1476,  1480,  1481,  1493,  1492,
+    1510,  1514,  1521,  1540,  1541,  1545,  1560,  1565,  1564,  1573,
+    1572,  1581,  1580,  1589,  1588,  1597,  1596,  1605,  1604,  1613,
+    1612,  1621,  1620,  1633,  1645,  1643,  1668,  1675,  1685,  1684,
+    1710,  1708,  1733,  1743,  1754,  1798,  1825,  1857,  1861,  1865,
+    1869,  1856,  1931,  1932,  1933,  1934,  1935,  1936,  1937,  1941,
+    1945,  2013,  2015,  2017,  2018,  2030,  2031,  2043,  2044,  2056,
+    2057,  2066,  2078,  2079,  2088,  2100,  2101,  2110,  2119,  2131,
+    2132,  2141,  2150,  2162,  2219,  2220,  2227,  2231,  2236,  2243,
+    2250,  2254,  2259,  2263,  2267,  2271,  2278,  2347,  2346,  2375,
+    2376,  2380,  2381,  2382,  2384,  2383,  2392,  2393,  2397,  2453,
+    2457,  2464,  2477,  2487,  2495,  2494,  2582,  2586,  2593,  2602,
+    2609,  2617,  2623,  2630,  2643,  2642,  2651,  2655,  2659,  2663,
+    2691,  2699,  2698,  2769,  2770,  2774,  2781,  2782,  2808,  2809,
+    2810,  2811,  2812,  2813,  2814,  2815,  2819,  2820,  2821,  2822,
+    2826,  2827,  2828,  2832,  2833,  2837,  2849,  2847,  2872,  2879,
+    2880,  2884,  2896,  2894,  2919,  2926,  2942,  2960,  2961,  2965,
+    2969,  2973,  2980,  2984,  2988,  2995,  2999,  3003,  3010,  3017,
+    3021,  3028,  3035,  3042,  3049,  3057,  3056,  3070,  3101,  3105,
+    3069,  3122,  3125,  3126,  3130,  3148,  3152,  3147,  3210,  3209,
+    3222,  3221,  3234,  3238,  3271,  3275,  3334,  3338,  3233,  3360,
+    3367,  3380,  3389,  3396,  3397,  3506,  3509,  3510,  3515,  3519,
+    3514,  3555,  3554,  3566,  3576,  3594,  3602,  3601,  3615,  3619,
+    3614,  3635,  3634,  3684,  3709,  3733,  3737,  3768,  3772,  3732,
+    3796,  3801,  3799,  3805,  3809,  3849,  3853,  3847,  3941,  4012,
+    4021,  4011,  4035,  4045,  4049,  4043,  4094,  4120,  4129,  4133,
+    4127,  4169,  4195,  4203,  4202,  4249,  4259,  4277,  4285,  4289,
+    4284,  4349,  4350,  4355,  4359,  4363,  4367,  4354,  4426,  4430,
+    4434,  4438,  4425,  4506,  4510,  4542,  4546,  4505,  4563,  4567,
+    4628,  4632,  4562,  4669,  4674,  4679,  4686,  4687,  4698,  4703,
+    4746,  4697,  4768,  4767,  4776,  4775,  4786,  4791,  4789,  4795,
+    4800,  4804,  4799,  4843,  4842,  4851,  4850,  4861,  4866,  4864,
+    4870,  4875,  4879,  4874,  4924,  4931,  4932,  4933,  5040,  5044,
+    5048,  5056,  5060,  5055,  5069,  5077,  5081,  5076,  5090,  5098,
+    5102,  5097,  5111,  5119,  5123,  5118,  5132,  5139,  5151,  5149,
+    5172,  5179,  5209,  5248,  5249,  5253,  5284,  5325,  5329,  5283,
+    5348,  5352,  5346,  5393,  5392,  5400,  5407,  5422,  5423,  5428,
+    5427,  5437,  5436,  5446,  5445,  5455,  5454,  5464,  5463,  5473,
+    5472,  5482,  5481,  5492,  5585,  5591,  5616,  5723,  5732,  5736,
+    5743,  5818,  5890,  5966,  5965,  6015,  6019,  6023,  6027,  6031,
+    6035,  6014,  6088,  6087,  6095,  6102,  6107,  6115,  6119,  6114,
+    6129,  6130,  6134,  6136,  6135,  6144,  6143,  6156,  6179,  6154,
+    6205,  6232,  6203,  6256,  6257,  6258,  6262,  6263,  6267,  6296,
+    6328,  6372,  6376,  6326,  6393,  6402,  6420,  6431,  6430,  6468,
+    6518,  6522,  6466,  6539,  6543,  6550,  6554,  6558,  6562,  6566,
+    6570,  6574,  6578,  6582,  6586,  6594,  6625,  6638,  6645,  6670,
+    6688,  6695,  6710,  6717,  6727,  6731,  6750,  6758,  6726,  6773,
+    6788,  6792,  6793,  6797,  6798,  6800,  6799,  6810,  6877,  6925,
+    6941,  6954,  6961,  7020,  7028,  7032,  7027,  7093,  7097,  7092,
+    7110,  7111,  7116,  7115,  7124,  7123,  7132,  7131,  7140,  7139
 };
 #endif
 
@@ -1351,80 +1351,80 @@ static const char *const yytname[] =
   "template_module_inst", "$@27", "$@28", "interface_def", "interface",
   "$@29", "$@30", "$@31", "interface_decl", "$@32", "interface_header",
   "inheritance_spec", "$@33", "value_def", "valuetype",
-  "value_concrete_decl", "$@34", "$@35", "$@36", "value_abs_decl", "$@37",
+  "value_concrete_decl", "@34", "$@35", "$@36", "value_abs_decl", "$@37",
   "$@38", "$@39", "value_header", "$@40", "value_decl", "$@41",
   "opt_truncatable", "supports_spec", "value_forward_decl",
-  "value_box_decl", "value_elements", "value_element", "visibility",
-  "state_member", "exports", "at_least_one_export", "export", "$@42",
-  "$@43", "$@44", "$@45", "$@46", "$@47", "$@48", "$@49",
-  "at_least_one_scoped_name", "scoped_names", "$@50", "scoped_name",
-  "$@51", "$@52", "id", "defining_id", "interface_forward", "const_dcl",
-  "$@53", "$@54", "$@55", "$@56", "const_type", "expression", "const_expr",
+  "value_box_decl", "value_elements", "value_element", "@42", "visibility",
+  "state_member", "exports", "at_least_one_export", "export", "$@43",
+  "$@44", "$@45", "$@46", "$@47", "$@48", "$@49", "$@50",
+  "at_least_one_scoped_name", "scoped_names", "$@51", "scoped_name",
+  "$@52", "$@53", "id", "defining_id", "interface_forward", "const_dcl",
+  "$@54", "$@55", "$@56", "$@57", "const_type", "expression", "const_expr",
   "or_expr", "xor_expr", "and_expr", "shift_expr", "add_expr", "mult_expr",
   "unary_expr", "primary_expr", "literal", "positive_int_expr",
-  "annotation_dcl", "$@57", "annotation_body", "annotation_statement",
-  "$@58", "annotation_member_type", "annotation_member",
+  "annotation_dcl", "$@58", "annotation_body", "annotation_statement",
+  "$@59", "annotation_member_type", "annotation_member",
   "annotation_member_default", "at_least_one_annotation",
-  "annotations_maybe", "annotation_appl", "@59",
+  "annotations_maybe", "annotation_appl", "@60",
   "annotation_appl_params_maybe", "annotation_appl_params",
   "named_annotation_appl_params", "more_named_annotation_appl_params",
-  "named_annotation_appl_param", "type_dcl", "$@60", "type_declarator",
-  "$@61", "type_spec", "simple_type_spec", "base_type_spec",
+  "named_annotation_appl_param", "type_dcl", "$@61", "type_declarator",
+  "$@62", "type_spec", "simple_type_spec", "base_type_spec",
   "template_type_spec", "constructed_type_spec",
   "constructed_forward_type_spec", "at_least_one_declarator",
-  "declarators", "$@62", "declarator", "at_least_one_simple_declarator",
-  "simple_declarators", "$@63", "simple_declarator", "complex_declarator",
+  "declarators", "$@63", "declarator", "at_least_one_simple_declarator",
+  "simple_declarators", "$@64", "simple_declarator", "complex_declarator",
   "integer_type", "signed_int", "unsigned_int", "floating_pt_type",
   "fixed_type", "char_type", "octet_type", "boolean_type", "any_type",
-  "object_type", "struct_decl", "$@64", "struct_type", "$@65", "$@66",
-  "$@67", "at_least_one_member", "members", "member", "member_i", "$@68",
-  "$@69", "$@70", "union_decl", "$@71", "union_type", "$@72", "$@73",
-  "$@74", "$@75", "$@76", "$@77", "switch_type_spec",
-  "at_least_one_case_branch", "case_branches", "case_branch", "$@78",
-  "$@79", "$@80", "at_least_one_case_label", "case_labels", "case_label",
-  "$@81", "$@82", "$@83", "element_spec", "$@84", "struct_forward_type",
-  "union_forward_type", "enum_type", "$@85", "$@86", "$@87", "$@88",
-  "at_least_one_enumerator", "enumerators", "$@89", "enumerator",
-  "sequence_type_spec", "$@90", "$@91", "seq_head", "$@92", "$@93",
-  "fixed_type_spec", "string_type_spec", "$@94", "$@95", "string_head",
-  "wstring_type_spec", "$@96", "$@97", "wstring_head", "array_declarator",
-  "$@98", "at_least_one_array_dim", "array_dims", "array_dim", "$@99",
-  "$@100", "attribute", "attribute_readonly", "$@101", "$@102", "$@103",
-  "$@104", "attribute_readwrite", "$@105", "$@106", "$@107", "$@108",
-  "exception", "$@109", "$@110", "$@111", "$@112", "operation", "$@113",
-  "$@114", "$@115", "$@116", "opt_op_attribute", "op_type_spec",
-  "init_decl", "$@117", "$@118", "$@119", "init_parameter_list", "$@120",
-  "$@121", "at_least_one_in_parameter", "in_parameters", "$@122",
-  "in_parameter", "$@123", "$@124", "parameter_list", "$@125", "$@126",
-  "at_least_one_parameter", "parameters", "$@127", "parameter", "$@128",
-  "$@129", "param_type_spec", "direction", "opt_raises", "$@130", "$@131",
-  "opt_getraises", "$@132", "$@133", "opt_setraises", "$@134", "$@135",
-  "opt_context", "$@136", "$@137", "at_least_one_string_literal",
-  "string_literals", "$@138", "typeid_dcl", "typeprefix_dcl", "component",
-  "component_forward_decl", "component_decl", "$@139", "$@140", "$@141",
-  "component_header", "$@142", "$@143", "component_inheritance_spec",
-  "$@144", "component_exports", "component_export", "$@145", "$@146",
-  "$@147", "$@148", "$@149", "$@150", "$@151", "provides_decl",
+  "object_type", "struct_decl", "$@65", "struct_type", "$@66", "$@67",
+  "$@68", "at_least_one_member", "members", "member", "member_i", "$@69",
+  "$@70", "$@71", "union_decl", "$@72", "union_type", "$@73", "$@74",
+  "$@75", "$@76", "$@77", "$@78", "switch_type_spec",
+  "at_least_one_case_branch", "case_branches", "case_branch", "$@79",
+  "$@80", "$@81", "at_least_one_case_label", "case_labels", "case_label",
+  "$@82", "$@83", "$@84", "element_spec", "$@85", "struct_forward_type",
+  "union_forward_type", "enum_type", "$@86", "$@87", "$@88", "$@89",
+  "at_least_one_enumerator", "enumerators", "$@90", "enumerator",
+  "sequence_type_spec", "$@91", "$@92", "seq_head", "$@93", "$@94",
+  "fixed_type_spec", "string_type_spec", "$@95", "$@96", "string_head",
+  "wstring_type_spec", "$@97", "$@98", "wstring_head", "array_declarator",
+  "$@99", "at_least_one_array_dim", "array_dims", "array_dim", "$@100",
+  "$@101", "attribute", "attribute_readonly", "$@102", "$@103", "$@104",
+  "$@105", "attribute_readwrite", "$@106", "$@107", "$@108", "$@109",
+  "exception", "$@110", "@111", "$@112", "$@113", "operation", "$@114",
+  "$@115", "$@116", "$@117", "opt_op_attribute", "op_type_spec",
+  "init_decl", "$@118", "@119", "$@120", "init_parameter_list", "$@121",
+  "$@122", "at_least_one_in_parameter", "in_parameters", "$@123",
+  "in_parameter", "$@124", "$@125", "parameter_list", "$@126", "$@127",
+  "at_least_one_parameter", "parameters", "$@128", "parameter", "$@129",
+  "$@130", "param_type_spec", "direction", "opt_raises", "$@131", "$@132",
+  "opt_getraises", "$@133", "$@134", "opt_setraises", "$@135", "$@136",
+  "opt_context", "$@137", "$@138", "at_least_one_string_literal",
+  "string_literals", "$@139", "typeid_dcl", "typeprefix_dcl", "component",
+  "component_forward_decl", "component_decl", "@140", "$@141", "$@142",
+  "component_header", "$@143", "$@144", "component_inheritance_spec",
+  "$@145", "component_exports", "component_export", "$@146", "$@147",
+  "$@148", "$@149", "$@150", "$@151", "$@152", "provides_decl",
   "interface_type", "uses_decl", "uses_opt_multiple", "opt_multiple",
-  "emits_decl", "publishes_decl", "consumes_decl", "home_decl", "$@152",
-  "home_header", "$@153", "$@154", "$@155", "$@156", "$@157", "$@158",
-  "home_inheritance_spec", "$@159", "primary_key_spec", "home_body",
-  "$@160", "$@161", "home_exports", "home_export", "$@162", "$@163",
-  "factory_decl", "$@164", "$@165", "finder_decl", "$@166", "$@167",
+  "emits_decl", "publishes_decl", "consumes_decl", "home_decl", "$@153",
+  "home_header", "$@154", "$@155", "$@156", "$@157", "$@158", "$@159",
+  "home_inheritance_spec", "$@160", "primary_key_spec", "home_body",
+  "$@161", "$@162", "home_exports", "home_export", "$@163", "$@164",
+  "factory_decl", "$@165", "$@166", "finder_decl", "$@167", "$@168",
   "event", "event_forward_decl", "event_concrete_forward_decl",
-  "event_abs_forward_decl", "event_abs_decl", "$@168", "$@169", "$@170",
+  "event_abs_forward_decl", "event_abs_decl", "$@169", "$@170", "$@171",
   "event_abs_header", "event_custom_header", "event_plain_header",
-  "event_rest_of_header", "$@171", "event_decl", "$@172", "$@173", "$@174",
+  "event_rest_of_header", "$@172", "event_decl", "@173", "$@174", "$@175",
   "event_header", "formal_parameter_type", "at_least_one_formal_parameter",
   "formal_parameters", "formal_parameter",
   "at_least_one_formal_parameter_name", "formal_parameter_names",
-  "formal_parameter_name", "porttype_decl", "$@175", "$@176", "$@177",
-  "$@178", "at_least_one_port_export", "port_exports", "port_export",
-  "$@179", "$@180", "$@181", "extended_port_decl",
-  "at_least_one_actual_parameter", "actual_parameters", "actual_parameter",
-  "connector_decl", "connector_header", "$@182", "$@183", "connector_body",
-  "$@184", "$@185", "connector_exports", "connector_export", "$@186",
-  "$@187", "$@188", "$@189", YY_NULLPTR
+  "formal_parameter_name", "porttype_decl", "$@176", "@177", "$@178",
+  "$@179", "at_least_one_port_export", "port_exports", "port_export",
+  "$@180", "extended_port_decl", "at_least_one_actual_parameter",
+  "actual_parameters", "actual_parameter", "connector_decl",
+  "connector_header", "$@181", "$@182", "connector_body", "$@183", "$@184",
+  "connector_exports", "connector_export", "$@185", "$@186", "$@187",
+  "$@188", YY_NULLPTR
 };
 
 static const char *
@@ -1453,12 +1453,12 @@ static const yytype_int16 yytoknum[] =
 };
 #endif
 
-#define YYPACT_NINF (-656)
+#define YYPACT_NINF (-613)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-539)
+#define YYTABLE_NINF (-568)
 
 #define yytable_value_is_error(Yyn) \
   0
@@ -1467,94 +1467,94 @@ static const yytype_int16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-    -656,   127,  1208,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,    83,   105,   115,   155,  -656,    83,
-      83,  -656,    44,    44,  -656,  -656,    83,  -656,  -656,    98,
-    -656,   285,    57,   110,  -656,  -656,    26,  -656,  -656,  -656,
-    -656,  -656,  -656,   527,  -656,  -656,  -656,  -656,  -656,  1339,
-     130,  -656,  -656,   131,  -656,   199,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,   147,  -656,  -656,  -656,   147,  -656,
-    -656,   134,   157,  1486,    44,    83,  1462,    83,    83,    83,
-      83,  -656,  -656,  -656,    53,    83,    86,  -656,   100,    83,
-    -656,   147,    83,   167,   169,    83,  -656,  -656,   109,  -656,
-     111,  -656,  -656,   181,  -656,   186,   189,   692,  -656,  -656,
-    -656,   194,   242,  -656,   203,   206,   215,   161,  -656,    42,
-    -656,  -656,  -656,  -656,  -656,  -656,   216,  -656,  -656,  -656,
-    -656,  -656,  -656,   230,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,   199,  -656,  -656,  -656,   103,  -656,  -656,   229,  -656,
-     238,   243,   244,  -656,    44,   249,   251,   248,  -656,   252,
-     254,   255,   257,   258,   261,   262,   265,  -656,  -656,  -656,
-     266,   267,  -656,  -656,  -656,  -656,   230,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,   230,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,   269,  -656,   270,  -656,  -656,
-     263,  -656,   357,  -656,  -656,  -656,    50,    56,  -656,  -656,
-    -656,  1486,  -656,  -656,  -656,  -656,   271,  -656,  -656,  -656,
-    -656,   360,  -656,  -656,    55,   274,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,   361,  -656,   154,   279,   324,  -656,
-    -656,  -656,  -656,  -656,  -656,   230,  -656,  -656,   275,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,   324,   286,
-     287,  -656,  -656,  -656,    83,    83,   293,   295,  -656,  -656,
-    -656,   292,  -656,   357,  -656,  -656,  -656,  -656,  -656,  -656,
-     387,  -656,   305,   304,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,   188,   188,   188,   154,   230,  -656,
-    -656,   303,   307,   302,   143,   137,   113,  -656,  -656,  -656,
-    -656,  -656,    44,  -656,  -656,  -656,  -656,   312,  -656,    44,
-    -656,   154,   154,   154,   296,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,   211,  -656,   -11,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,    44,   324,  -656,  -656,  -656,   318,   263,
-      90,  1261,   320,   319,  -656,   692,  -656,  -656,  -656,   306,
-     154,   154,   154,   154,   154,   154,   154,   154,   154,   154,
-     321,    83,  -656,   230,   983,  -656,   554,   154,  -656,  -656,
-    -656,  -656,  -656,   154,  -656,   637,  -656,  -656,  -656,   410,
-     899,  -656,  -656,  -656,  -656,    41,   355,    44,    44,  -656,
-    -656,  -656,  -656,  -656,    41,  -656,   326,  -656,   322,  -656,
-     327,  -656,  -656,  1018,   230,  -656,    44,   324,  -656,  -656,
-    -656,  -656,   330,  -656,  -656,    83,  -656,  -656,   332,   336,
-     424,   339,  -656,  -656,   307,   302,   143,   137,   137,   113,
-     113,  -656,  -656,  -656,  -656,  -656,   335,  -656,  -656,  -656,
-     340,  -656,  -656,  1429,  -656,  -656,  -656,  -656,   676,  -656,
-    -656,  -656,  -656,  -656,   341,  -656,   773,  -656,  -656,   344,
-     342,   873,   346,   347,   350,   338,  -656,   337,  -656,   353,
-    -656,  -656,  -656,   354,   362,   197,    44,    44,    44,  -656,
-     370,  -656,  -656,  -656,  -656,  -656,  -656,  -656,    83,    83,
-    -656,   376,  -656,  -656,  -656,  1103,   815,   405,  1075,  -656,
-     230,   357,  -656,  -656,    68,    70,   379,   380,   384,   357,
-     385,  -656,  -656,    71,  -656,    60,  -656,  -656,   386,   390,
-     230,  -656,   136,  1462,  -656,   421,  -656,  -656,  -656,  -656,
-      55,  -656,   389,  -656,   393,  -656,   394,   399,   400,   401,
-    -656,   230,  -656,  -656,  -656,  -656,  -656,   402,   403,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,   154,  -656,
-     357,  -656,   404,    83,  -656,  -656,   466,   230,  -656,  -656,
-    -656,  -656,  -656,  -656,    81,    81,    81,   407,  -656,   408,
-     409,   411,   412,   413,   414,  -656,  -656,  -656,   417,   419,
-     420,   427,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,   154,  -656,  -656,  -656,    83,  -656,   428,   425,
-     430,  -656,   432,  -656,  -656,  -656,  -656,  -656,   423,   154,
-     426,  1286,  -656,    44,  -656,  -656,  -656,  -656,  -656,  -656,
-     490,  -656,  -656,    66,  -656,   338,   353,  -656,  -656,   416,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-     418,   418,  -656,  -656,  -656,  -656,  1075,    83,  -656,   154,
-     422,  -656,  -656,  -656,  -656,  -656,   436,   437,   438,   442,
-     136,  -656,  -656,  -656,    44,  -656,  -656,  -656,  -656,   439,
-     230,  -656,  -656,  -656,   440,  -656,   498,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,    44,  -656,  -656,  -656,  -656,
-    -656,   230,   459,  1154,  -656,   449,   418,  -656,   467,   453,
-     525,   538,   538,    83,   523,   488,   475,  -656,   230,   499,
-    -656,  -656,   483,  -656,  -656,  -656,  -656,  -656,   485,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,   533,   592,
-     491,   212,   538,   538,   174,  1075,  -656,   502,   496,   538,
-     497,   541,    83,    44,  -656,  -656,   512,  -656,  -656,  -656,
-    -656,  -656,   500,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,   230,  -656,   511,  -656,   513,  1075,   570,   522,
-     154,   519,   524,    54,  -656,   268,    83,   525,    44,    44,
-     508,    83,   592,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  1403,  -656,  -656,  -656,   515,   516,  -656,  -656,
-    -656,   212,    83,   514,   530,  -656,  -656,  -656,  -656,    44,
-    -656,  -656,  -656,  -656,    83,   536,   520,   550,  -656,  -656,
-    -656,  -656,   521,   534,  -656,  -656,   555,  -656
+    -613,    52,  1211,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,    57,    78,    45,   157,  -613,    57,
+      57,  -613,    85,    85,  -613,  -613,    57,  -613,  -613,    12,
+    -613,   237,   -17,     9,  -613,  -613,   -20,  -613,  -613,  -613,
+    -613,  -613,  -613,   537,  -613,  -613,  -613,  -613,  -613,  1342,
+      32,  -613,  -613,    44,  -613,   119,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,   111,  -613,  -613,  -613,   111,  -613,
+    -613,    75,   132,   857,    85,    57,  1556,    57,    57,    57,
+      57,  -613,  -613,  -613,   -19,    57,    77,  -613,   107,    57,
+    -613,   111,    57,   134,   144,    57,  -613,  -613,   -25,  -613,
+       1,   256,  -613,   151,  -613,   173,   184,   331,  -613,  -613,
+    -613,   199,   251,  -613,   218,   220,   229,   207,  -613,   190,
+    -613,  -613,  -613,  -613,  -613,  -613,   234,  -613,  -613,  -613,
+    -613,  -613,  -613,   239,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,   119,  -613,  -613,  -613,    65,  -613,  -613,   236,  -613,
+     241,   245,   246,  -613,    85,   249,   252,   250,  -613,   255,
+     257,   265,   268,   270,   269,   271,   273,  -613,  -613,  -613,
+     274,   275,  -613,  -613,  -613,  -613,   239,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,   239,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,   278,  -613,   280,  -613,  -613,
+     235,  -613,   341,  -613,  -613,  -613,  -613,    55,  -613,  -613,
+    -613,   857,  -613,  -613,  -613,  -613,   281,  -613,  -613,  -613,
+    -613,   367,  -613,  -613,    50,   293,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,   363,  -613,   171,   287,   343,  -613,
+    -613,  -613,  -613,  -613,  -613,   239,  -613,  -613,   292,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,   343,   302,
+     310,  -613,  -613,  -613,    57,    57,   311,   312,  -613,  -613,
+    -613,   313,  -613,   341,   315,  -613,  -613,  -613,  -613,  -613,
+     402,  -613,   318,   319,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,   204,   204,   204,   171,   239,  -613,
+    -613,   316,   324,   309,   131,   135,   136,  -613,  -613,  -613,
+    -613,  -613,    85,  -613,  -613,  -613,  -613,   321,  -613,    85,
+    -613,   171,   171,   171,   317,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,   159,  -613,    71,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,    85,   343,  -613,  -613,  -613,  -613,   235,
+     689,  1264,   326,   333,  -613,   331,  -613,  -613,  -613,   320,
+     171,   171,   171,   171,   171,   171,   171,   171,   171,   171,
+     334,    57,  -613,   239,   986,  -613,   564,   171,  -613,  -613,
+    -613,  -613,  -613,   171,  -613,   876,  -613,  -613,  -613,   601,
+     902,  -613,  -613,  -613,  -613,    98,   369,    85,    85,  -613,
+    -613,  -613,  -613,  -613,    98,  -613,   339,  -613,   335,  -613,
+     337,  -613,  -613,  1021,   239,  -613,    85,   343,  -613,  -613,
+    -613,  -613,   344,  -613,  -613,    57,  -613,  -613,   345,   346,
+     431,   348,  -613,  -613,   324,   309,   131,   135,   135,   136,
+     136,  -613,  -613,  -613,  -613,  -613,   347,  -613,  -613,  -613,
+     349,  -613,  -613,  1497,  -613,  -613,  -613,  -613,   463,  -613,
+    -613,  -613,  -613,  -613,   350,  -613,  1531,  -613,  -613,  1422,
+    -613,   351,  1079,   352,   358,   360,   364,  -613,   336,  -613,
+     359,  -613,  -613,  -613,   372,   373,   130,    85,    85,    85,
+     461,  -613,   377,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+      57,    57,  -613,   379,  -613,  -613,  -613,  1106,   817,   452,
+      96,  -613,   239,   341,  -613,  -613,    88,    90,   405,   406,
+     407,   341,   408,  -613,  -613,    86,  -613,    60,  -613,  -613,
+     400,   409,   239,  -613,   410,   137,  1556,  -613,   469,  -613,
+    -613,  -613,  -613,    50,  -613,   413,  -613,   414,  -613,   415,
+     416,   417,   421,  -613,   239,  -613,  -613,  -613,  -613,  -613,
+     426,   429,   517,  -613,  -613,  -613,   435,  -613,  -613,  -613,
+    -613,  -613,   171,  -613,   341,  -613,   437,    57,  -613,  -613,
+     519,   239,  -613,  -613,  -613,  -613,  -613,  -613,   113,   113,
+     113,  -613,   440,  -613,   443,   444,   445,   447,   448,   450,
+    -613,  -613,  -613,   451,   453,   474,   476,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,   171,  -613,  -613,
+    -613,    57,  -613,   479,   465,   496,  -613,   522,   502,   137,
+    -613,   454,   505,  -613,   511,   171,   512,  1289,  -613,    85,
+    -613,  -613,  -613,  -613,  -613,  -613,   598,  -613,  -613,  -613,
+    -613,  -613,   364,   359,  -613,  -613,   497,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,   501,   501,  -613,
+    -613,  -613,  -613,    96,    57,  -613,   171,   495,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,   523,  -613,  -613,  -613,  -613,
+    -613,    85,  -613,  -613,  -613,  -613,   524,   239,  -613,   501,
+    -613,   525,  -613,   572,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,    85,  -613,   239,   526,  1157,  -613,   509,  -613,
+    -613,   528,   513,   580,   582,   582,    57,   566,   532,   514,
+    -613,   239,   538,  -613,  -613,   527,  -613,   582,  -613,  -613,
+    -613,   529,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,   575,   633,   533,   230,   582,  -613,   202,    96,  -613,
+     544,   535,   582,   536,   581,    57,    85,  -613,  -613,   550,
+    -613,  -613,  -613,  -613,  -613,   540,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,   239,  -613,   553,  -613,   554,    96,
+     605,   562,   171,   563,   565,    58,  -613,   240,    57,   580,
+      85,    85,   552,    57,   633,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,   708,  -613,  -613,  -613,   558,   559,
+    -613,  -613,  -613,   230,    57,   555,   574,  -613,  -613,  -613,
+    -613,    85,  -613,  -613,  -613,  -613,    57,   570,   571,   584,
+    -613,  -613,  -613,  -613,   573,   578,  -613,  -613,   593,  -613
 };
 
   /* YYDEFACTSTATE-NUM -- Default reduction number in state STATE-NUM.
@@ -1562,139 +1562,139 @@ static const yytype_int16 yypact[] =
      means the default is an error.  */
 static const yytype_int16 yydefact[] =
 {
-       4,     0,     0,     3,     1,    38,   145,    40,    70,   222,
-     283,   298,   333,   381,     0,     0,     0,     0,    94,     0,
-       0,   492,     0,     0,   561,   582,     0,     6,     7,    42,
+       4,     0,     0,     3,     1,    38,   147,    40,    70,   224,
+     285,   300,   335,   383,     0,     0,     0,     0,    94,     0,
+       0,   495,     0,     0,   564,   584,     0,     6,     7,    42,
       24,    61,     0,     0,    22,    64,    77,    66,    26,    78,
       83,    79,    84,    77,    80,    81,    65,    18,    10,     0,
-       0,    12,   228,   285,   224,   332,   225,   251,   252,   226,
-      20,    14,    16,    28,   452,   451,   454,    30,   490,    32,
-     522,   524,   523,   521,    77,   540,   541,   520,    77,    34,
+       0,    12,   230,   287,   226,   334,   227,   253,   254,   228,
+      20,    14,    16,    28,   454,   453,   456,    30,   493,    32,
+     525,   527,   526,   524,    77,   543,   544,   523,    77,    34,
       36,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   141,   263,   227,    77,     0,    77,    88,    77,     0,
-      82,    77,     0,   458,   533,     0,   140,   136,     0,   135,
-       0,   211,   211,     0,    46,     0,     0,     0,   211,     8,
-       9,     0,    97,    72,     0,     0,     0,   267,   269,     0,
-     273,   274,   277,   278,   279,   280,   276,   281,   282,   347,
-     355,   360,    92,   235,   102,   231,   233,   234,   232,   236,
-     265,   266,   237,   241,   238,   240,   239,   242,   243,   285,
-     248,     0,   249,   250,   244,     0,   247,   245,   354,   246,
-     359,     0,     0,     5,     0,   209,     0,     0,   300,     0,
-       0,     0,     0,     0,     0,     0,     0,   534,   527,   536,
-       0,     0,   585,   581,    39,   276,   158,   146,   150,   154,
-     155,   151,   152,   153,   156,   157,    41,    71,   223,   229,
-     284,   299,   334,   382,    73,   531,    74,     0,   532,    95,
-     463,   493,     0,   449,   138,   450,     0,     0,   195,    43,
-      25,     0,   547,   543,   544,   549,   546,   550,   548,   545,
-     542,     0,    48,   554,     0,     0,    23,    96,    75,    67,
-      27,    85,   268,   275,   270,   272,     0,     0,    99,   346,
-     343,   351,   356,    19,    11,   212,    13,   286,     0,    21,
-      15,    17,    29,   455,    31,   504,   491,    33,    99,     0,
-       0,    35,    37,   589,     0,     0,     0,     0,    89,   461,
-     459,   501,   137,     0,   562,   210,   583,   198,     4,   551,
-       0,   555,     0,   552,   184,   185,   186,   188,   191,   190,
-     192,   193,   189,   187,     0,     0,     0,     0,   181,   580,
-     159,   160,   161,   163,   165,   167,   170,   173,   177,   182,
-     579,    62,     0,   112,   104,   271,   194,     0,   348,     0,
-      93,     0,     0,     0,   215,   211,   301,   465,   508,   535,
-     528,   537,   586,   147,   263,   230,   256,   257,   258,   264,
-     335,   383,   112,     0,    99,   499,   494,   139,     0,   463,
-       0,     0,     3,     0,    49,     0,   178,   179,   180,     0,
+       0,   143,   265,   229,    77,     0,    77,    88,    77,     0,
+      82,    77,     0,   460,   536,     0,   142,   138,     0,   137,
+       0,     0,   213,     0,    46,     0,     0,     0,   213,     8,
+       9,     0,    97,    72,     0,     0,     0,   269,   271,     0,
+     275,   276,   279,   280,   281,   282,   278,   283,   284,   349,
+     357,   362,    92,   237,   102,   233,   235,   236,   234,   238,
+     267,   268,   239,   243,   240,   242,   241,   244,   245,   287,
+     250,     0,   251,   252,   246,     0,   249,   247,   356,   248,
+     361,     0,     0,     5,     0,   211,     0,     0,   302,     0,
+       0,     0,     0,     0,     0,     0,     0,   537,   530,   539,
+       0,     0,   587,   583,    39,   278,   160,   148,   152,   156,
+     157,   153,   154,   155,   158,   159,    41,    71,   225,   231,
+     286,   301,   336,   384,    73,   534,    74,     0,   535,    95,
+     465,   496,     0,   451,   140,   452,   565,     0,   197,    43,
+      25,     0,   550,   546,   547,   552,   549,   553,   551,   548,
+     545,     0,    48,   557,     0,     0,    23,    96,    75,    67,
+      27,    85,   270,   277,   272,   274,     0,     0,    99,   348,
+     345,   353,   358,    19,    11,   214,    13,   288,     0,    21,
+      15,    17,    29,   457,    31,   507,   494,    33,    99,     0,
+       0,    35,    37,   591,     0,     0,     0,     0,    89,   463,
+     461,   504,   139,     0,     0,   585,   212,   200,     4,   554,
+       0,   558,     0,   555,   186,   187,   188,   190,   193,   192,
+     194,   195,   191,   189,     0,     0,     0,     0,   183,   582,
+     161,   162,   163,   165,   167,   169,   172,   175,   179,   184,
+     581,    62,     0,   114,   105,   273,   196,     0,   350,     0,
+      93,     0,     0,     0,   217,   213,   303,   468,   511,   538,
+     531,   540,   588,   149,   265,   232,   258,   259,   260,   266,
+     337,   385,   114,     0,    99,   502,   497,   141,   566,   465,
+       0,     0,     3,     0,    49,     0,   180,   181,   182,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     577,     0,    76,   134,     0,   111,     0,     0,   211,    98,
-     344,   352,   357,     0,   213,     0,   287,   291,   211,   456,
-       0,   112,   104,   371,   376,     0,   486,     0,     0,   594,
-     369,   370,   590,   592,     0,   596,     0,   588,     0,   211,
-     253,   211,   291,     0,   462,   460,     0,    99,   563,   584,
-     202,   196,     0,   204,   197,     0,   199,   205,     0,     0,
-       0,     0,   553,   183,   162,   164,   166,   168,   169,   171,
-     172,   174,   175,   176,   211,    63,   131,   129,   391,   392,
-       0,   114,   121,     0,   115,   125,   123,   127,     0,   117,
-     119,   396,   109,   108,     0,   103,     0,   105,   106,     0,
-       0,     0,     0,     0,     0,   135,   216,     0,   217,   220,
-     296,   293,   292,     0,   211,     0,     0,     0,     0,   476,
-       0,   464,   466,   468,   470,   472,   474,   478,     0,     0,
-     509,     0,   507,   510,   512,     0,     0,     0,     0,   482,
-     481,     0,   485,   484,     0,     0,     0,     0,     0,     0,
-       0,   587,   148,     0,   254,     0,   336,   341,   211,     0,
-     500,   495,     0,     0,   200,   208,   201,    45,   556,    50,
-       0,   132,     0,    69,     0,   113,     0,     0,     0,     0,
-     395,   425,   422,   423,   424,   386,   394,     0,     0,   211,
-      87,   110,   107,   350,   349,   345,   353,   358,     0,   214,
-       0,   218,     0,     0,   288,   290,   267,   312,   307,   308,
-     309,   310,   302,   311,     0,     0,     0,     0,   457,     0,
-       0,     0,     0,     0,     0,   514,   517,   506,     0,     0,
-       0,     0,   372,   377,   480,   575,   576,   595,   591,   593,
-     483,   597,     0,   366,   362,   365,     0,   342,     0,   338,
-       0,    91,     0,   573,   569,   571,   564,   568,     0,     0,
-       0,     0,   578,     0,   130,   122,   116,   126,   124,   128,
-       0,   118,   120,     0,   221,     0,   220,   297,   294,     0,
-     489,   487,   488,   477,   467,   469,   471,   473,   475,   479,
-       0,     0,   511,   513,   530,   539,     0,     0,   149,     0,
-     363,   255,   337,   339,   385,   496,     0,     0,     0,     0,
-     566,   203,   207,   206,     0,    56,    42,    51,    55,     0,
-     133,   387,   397,   219,     0,   303,   400,   515,   518,   373,
-     378,   262,   367,   364,   211,     0,   574,   570,   572,   565,
-     567,    58,     0,     0,    57,     0,     0,   295,     0,     0,
-       0,   432,   432,     0,   436,   259,     0,   340,   497,     0,
-      52,    54,   413,   388,   398,   304,   401,   408,     0,   407,
-     429,   516,   519,   374,   433,   379,   260,   368,   503,     0,
-       0,     0,   432,   432,     0,     0,   403,   404,     0,   432,
-       0,   440,     0,     0,   498,   560,     0,   559,   412,   426,
-     427,   428,     0,   418,   419,   389,   399,   319,   326,   324,
-     305,   315,   316,   323,   409,   405,   430,   375,   434,   437,
-     380,   261,   502,    59,   557,   414,   415,     0,   444,     0,
-       0,     0,     0,     0,   211,   321,     0,     0,     0,     0,
-       0,     0,     0,   416,   420,   441,   390,   320,   327,   325,
-     306,   314,     0,   322,   410,   406,     0,     0,   438,    60,
-     558,     0,     0,     0,     0,   329,   317,   431,   435,     0,
-     417,   421,   442,   328,     0,     0,     0,     0,   330,   318,
-     439,   448,     0,   445,   443,   446,     0,   447
+     579,     0,    76,   136,     0,   113,     0,     0,   213,    98,
+     346,   354,   359,     0,   215,     0,   289,   293,   213,   213,
+       0,   114,   105,   373,   378,     0,   489,     0,     0,   596,
+     371,   372,   592,   594,     0,   598,     0,   590,     0,   213,
+     255,   213,   293,     0,   464,   462,     0,    99,   572,   586,
+     204,   198,     0,   206,   199,     0,   201,   207,     0,     0,
+       0,     0,   556,   185,   164,   166,   168,   170,   171,   173,
+     174,   176,   177,   178,   213,    63,   133,   131,   393,   394,
+       0,   116,   123,     0,   117,   127,   125,   129,     0,   119,
+     121,   398,   111,   110,     0,   104,     0,   106,   107,     0,
+     108,     0,     0,     0,     0,     0,   137,   218,     0,   219,
+     222,   298,   295,   294,     0,   213,     0,     0,     0,     0,
+       0,   479,     0,   467,   469,   471,   473,   475,   477,   481,
+       0,     0,   512,     0,   510,   513,   515,     0,     0,     0,
+       0,   485,   484,     0,   488,   487,     0,     0,     0,     0,
+       0,     0,     0,   589,   150,     0,   256,     0,   338,   343,
+     213,     0,   503,   498,   571,   213,     0,   202,   210,   203,
+      45,   559,    50,     0,   134,     0,    69,     0,   115,     0,
+       0,     0,     0,   397,   427,   424,   425,   426,   388,   396,
+       0,     0,     0,    87,   112,   103,     0,   352,   351,   347,
+     355,   360,     0,   216,     0,   220,     0,     0,   290,   292,
+     269,   314,   309,   310,   311,   312,   304,   313,     0,     0,
+       0,   466,     0,   459,     0,     0,     0,     0,     0,     0,
+     517,   520,   509,     0,     0,     0,     0,   374,   379,   483,
+     577,   578,   597,   593,   595,   486,   599,     0,   368,   364,
+     367,     0,   344,     0,   340,     0,    91,     0,     0,     0,
+     575,     0,     0,   570,     0,     0,     0,     0,   580,     0,
+     132,   124,   118,   128,   126,   130,     0,   120,   122,   399,
+     109,   223,     0,   222,   299,   296,     0,   492,   490,   491,
+     480,   470,   472,   474,   476,   478,   482,     0,     0,   514,
+     516,   533,   542,     0,     0,   151,     0,   365,   257,   339,
+     341,   387,   499,   568,   569,     0,   573,   574,   205,   209,
+     208,     0,    56,    42,    51,    55,     0,   135,   389,     0,
+     221,     0,   305,   402,   518,   521,   375,   380,   264,   369,
+     366,   213,     0,   576,    58,     0,     0,    57,     0,   400,
+     297,     0,     0,     0,   434,   434,     0,   438,   261,     0,
+     342,   500,     0,    52,    54,   415,   390,   434,   306,   403,
+     410,     0,   409,   431,   519,   522,   376,   435,   381,   262,
+     370,   506,     0,     0,     0,   434,   401,     0,     0,   405,
+     406,     0,   434,     0,   442,     0,     0,   501,   563,     0,
+     562,   414,   428,   429,   430,     0,   420,   421,   391,   321,
+     328,   326,   307,   317,   318,   325,   411,   407,   432,   377,
+     436,   439,   382,   263,   505,    59,   560,   416,   417,     0,
+     446,     0,     0,     0,     0,     0,   213,   323,     0,     0,
+       0,     0,     0,     0,     0,   418,   422,   443,   392,   322,
+     329,   327,   308,   316,     0,   324,   412,   408,     0,     0,
+     440,    60,   561,     0,     0,     0,     0,   331,   319,   433,
+     437,     0,   419,   423,   444,   330,     0,     0,     0,     0,
+     332,   320,   441,   450,     0,   447,   445,   448,     0,   449
 };
 
   /* YYPGOTONTERM-NUM.  */
 static const yytype_int16 yypgoto[] =
 {
-    -656,  -656,   331,   334,   584,  -595,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -583,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,   -99,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,   283,  -656,
-    -656,   207,  -656,  -656,  -656,   619,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,   621,  -656,   298,  -656,  -656,  -238,  -656,
-    -656,   231,  -656,  -656,  -656,  -288,  -656,  -353,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -325,  -656,  -656,   -22,
-    -656,  -656,  -181,   -10,  -656,    16,  -656,  -656,  -656,  -656,
-    -189,     9,  -227,  -656,   290,   278,   260,   -65,   -58,  -137,
-     -28,  -656,  -311,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,    20,   -85,   615,  -656,  -656,  -656,  -656,     0,    85,
-      17,  -656,   118,  -656,   -31,   182,  -440,  -656,  -656,  -656,
-      88,  -656,  -656,  -608,   -67,  -656,  -656,    -7,  -656,   -68,
-    -656,  -656,   -49,   -44,   -54,   -48,   -46,   308,  -656,   -41,
-    -656,   -38,  -656,  -656,  -656,  -656,   272,   352,   213,  -656,
-    -656,  -656,   -37,  -656,   -32,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -140,  -656,  -656,  -656,  -656,  -656,
-    -119,  -656,  -656,  -656,  -656,  -656,  -656,  -656,   -40,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,   -17,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,   -75,  -656,  -656,  -656,   -70,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,    19,  -656,  -656,  -328,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-      18,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -571,  -656,  -656,  -656,
-    -656,  -656,  -116,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -143,  -656,  -656,  -492,  -656,  -655,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,    21,    23,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,   345,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -300,   297,  -261,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,   639,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,   348,  -656,  -656,
-    -112,  -656,  -656,  -656,  -656,  -656,  -656,  -656,    22,  -656,
-    -656,  -656,   316,  -656,  -656,   166,  -656,  -656,  -656,  -656,
-    -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656,  -656
+    -613,  -613,   378,   382,   632,  -585,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -576,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,   -54,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,   279,  -613,
+    -613,   127,  -613,  -613,  -613,   666,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,   669,  -613,   286,  -613,  -613,  -246,  -613,
+    -613,   276,   197,  -613,  -613,  -613,  -315,  -613,  -353,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -324,  -613,  -613,
+     -22,  -613,  -613,  -191,   -10,  -613,     6,  -613,  -613,  -613,
+    -613,  -189,    53,  -217,  -613,   314,   332,   353,   -78,   -73,
+     -96,   -18,  -613,  -302,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,    15,   -82,   645,  -613,  -613,  -613,  -613,    64,
+     146,    16,  -613,   174,  -613,   -31,   253,  -440,  -613,  -613,
+    -613,   141,  -613,  -613,  -612,    -5,  -613,  -613,    -7,  -613,
+     -59,  -613,  -613,   -46,   -39,   -55,   -49,   -48,   376,  -613,
+     -40,  -613,   -38,  -613,  -613,  -613,  -613,   323,   398,   261,
+    -613,  -613,  -613,   -37,  -613,   -32,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,   -77,  -613,  -613,  -613,  -613,
+    -613,   -76,  -613,  -613,  -613,  -613,  -613,  -613,  -613,   -41,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,    27,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,   -70,  -613,  -613,  -613,   -69,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,    62,  -613,  -613,
+    -326,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,    17,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -532,  -613,  -613,
+    -613,  -613,  -613,   -68,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,   -93,  -613,  -613,  -505,  -613,  -549,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,    18,    21,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,   393,  -613,  -613,   258,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -330,   342,  -319,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,   685,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613,   390,  -613,
+    -613,   -67,  -613,  -613,  -613,  -613,  -613,  -613,  -613,   120,
+    -613,   419,  -613,  -613,   209,  -613,  -613,  -613,  -613,  -613,
+    -613,  -613,  -613,  -613,  -613,  -613,  -613,  -613
 };
 
   /* YYDEFGOTONTERM-NUM.  */
@@ -1703,43 +1703,43 @@ static const yytype_int16 yydefgoto[] =
       -1,     1,     2,     3,    27,    28,   172,   176,   180,   181,
      171,   179,   121,   116,   125,   182,   184,   186,   190,   191,
       82,    29,    84,    30,   115,   298,   449,    31,    32,   117,
-     302,   451,   651,   732,   707,   733,   708,   709,   749,   831,
+     302,   451,   657,   735,   714,   736,   715,   716,   752,   833,
       33,   118,   391,    34,    35,   124,   333,   470,    36,    85,
       37,   142,   332,    38,    39,    40,   126,   334,   484,    41,
-     217,   362,   549,    42,   258,    43,   102,   248,   340,    44,
-      45,   396,   485,   486,   487,   394,   395,   471,   566,   577,
-     578,   564,   568,   567,   569,   562,   392,   466,   653,   318,
-     222,   293,   109,   354,    46,   472,    83,   284,   428,   632,
-     197,   319,   336,   321,   322,   323,   324,   325,   326,   327,
-     328,   329,   337,    48,   297,   370,   444,   553,   445,   446,
-     650,   473,    50,   295,   344,   404,   497,   498,   591,   499,
-     474,    86,   208,   285,   209,   145,   146,   147,   148,    52,
-     355,   430,   636,   356,   720,   745,   782,   357,   358,   149,
-     150,   151,   152,   153,   154,   155,   156,   157,   158,    53,
-      87,    54,   177,   345,   503,   406,   504,   595,   502,   593,
-     714,   592,    55,    88,    56,   268,   408,   669,   738,   774,
-     822,   602,   800,   823,   801,   824,   865,   819,   802,   825,
-     803,   821,   820,   854,   856,   864,    57,    58,    59,    89,
-     286,   431,   638,   546,   639,   724,   547,   164,   341,   492,
-     165,   257,   398,   166,   167,   342,   493,   168,   169,   343,
-     494,   170,   359,   429,   634,   690,   635,   689,   746,   475,
-     420,   527,   686,   743,   779,   421,   528,   687,   744,   781,
-     476,    90,   287,   432,   640,   477,   660,   735,   772,   818,
-     478,   575,   489,   579,   736,   773,   717,   739,   740,   758,
-     777,   827,   759,   775,   826,   753,   770,   771,   792,   816,
-     851,   793,   817,   852,   576,   794,   761,   778,   828,   765,
-     780,   829,   810,   830,   859,   836,   853,   867,   872,   873,
-     876,   479,   480,    63,    64,    65,   183,   347,   510,    66,
-     220,   364,   290,   363,   409,   511,   609,   610,   611,   612,
-     613,   607,   614,   644,   531,   645,   424,   533,   514,   515,
-     516,    67,   185,    68,   105,   291,   437,   642,   725,   768,
-     366,   436,   784,   276,   348,   521,   410,   522,   618,   619,
-     523,   680,   741,   524,   681,   742,    69,    70,    71,    72,
-      73,   279,   411,   620,    74,    75,    76,   188,   278,    77,
-     280,   412,   621,    78,   241,   242,   303,   243,   786,   814,
-     787,    79,   111,   368,   552,   699,   646,   700,   647,   697,
-     698,   696,   425,   245,   390,   330,    80,    81,   112,   369,
-     193,   283,   426,   352,   427,   537,   538,   536,   540
+     217,   362,   551,    42,   258,    43,   102,   248,   340,    44,
+      45,   396,   485,   586,   486,   487,   394,   395,   471,   569,
+     580,   581,   567,   571,   570,   572,   565,   392,   466,   659,
+     318,   222,   293,   109,   354,    46,   472,    83,   284,   428,
+     637,   197,   319,   336,   321,   322,   323,   324,   325,   326,
+     327,   328,   329,   337,    48,   297,   370,   444,   556,   445,
+     446,   656,   473,    50,   296,   344,   404,   498,   499,   595,
+     500,   474,    86,   208,   285,   209,   145,   146,   147,   148,
+      52,   355,   430,   641,   356,   727,   748,   785,   357,   358,
+     149,   150,   151,   152,   153,   154,   155,   156,   157,   158,
+      53,    87,    54,   177,   345,   504,   406,   505,   599,   503,
+     597,   721,   596,    55,    88,    56,   268,   408,   676,   741,
+     777,   824,   606,   802,   825,   803,   826,   867,   821,   804,
+     827,   805,   823,   822,   856,   858,   866,    57,    58,    59,
+      89,   286,   431,   643,   548,   644,   731,   549,   164,   341,
+     493,   165,   257,   398,   166,   167,   342,   494,   168,   169,
+     343,   495,   170,   359,   429,   639,   697,   640,   696,   749,
+     475,   420,   529,   693,   746,   782,   421,   530,   694,   747,
+     784,   476,    90,   287,   432,   645,   477,   666,   738,   775,
+     820,   478,   578,   490,   582,   719,   757,   724,   742,   743,
+     761,   780,   829,   762,   778,   828,   756,   773,   774,   795,
+     818,   853,   796,   819,   854,   579,   797,   764,   781,   830,
+     768,   783,   831,   812,   832,   861,   838,   855,   869,   874,
+     875,   878,   479,   480,    63,    64,    65,   183,   347,   512,
+      66,   220,   364,   290,   363,   409,   513,   614,   615,   616,
+     617,   618,   612,   619,   514,   533,   515,   424,   535,   516,
+     517,   518,    67,   185,    68,   105,   291,   437,   647,   732,
+     771,   366,   436,   787,   276,   348,   523,   410,   524,   623,
+     624,   525,   687,   744,   526,   688,   745,    69,    70,    71,
+      72,    73,   279,   411,   625,    74,    75,    76,   188,   278,
+      77,   280,   412,   626,    78,   241,   242,   303,   243,   789,
+     816,   790,    79,   111,   294,   438,   648,   554,   555,   653,
+     705,   519,   245,   390,   330,    80,    81,   112,   369,   193,
+     283,   426,   352,   427,   539,   540,   538,   542
 };
 
   /* YYTABLEYYPACT[STATE-NUM] -- What to do in state STATE-NUM.  If
@@ -1747,322 +1747,336 @@ static const yytype_int16 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-     108,   110,   159,   163,    92,   160,   161,    93,   204,   103,
-     104,   162,   144,   205,   399,   198,   113,   320,    47,    51,
-      60,   143,    49,    61,   419,    62,   226,   227,   691,   201,
-     400,   401,   402,   244,   199,   202,   623,   203,   572,   200,
-     349,   292,   299,   488,   106,   159,   163,   106,   160,   161,
-     254,   255,   422,   294,   162,   797,   705,   520,   106,   296,
-     529,   196,   206,   637,   143,    47,    51,    60,   706,   712,
-      61,   625,    62,   626,   433,   207,  -361,   210,   211,   212,
-     213,   509,   798,   799,   106,   215,    91,   762,   572,   218,
-     379,   423,   219,   106,     6,   221,  -361,   440,   127,   128,
-     129,   130,   131,   132,   133,   134,   135,   195,   137,   512,
-     718,     8,   367,    12,  -142,   140,   141,   795,   796,   122,
-     565,     8,   107,   525,   807,   107,   435,     4,   304,   305,
-     306,   307,   308,   309,   310,   311,   107,   174,   705,   312,
-     313,  -143,   174,   174,  -313,   119,   122,   174,   513,   224,
-     706,   224,   265,   174,   314,   315,   204,   106,   174,   316,
-     317,   205,   224,   198,    18,   754,   413,   414,    95,   252,
-     490,   107,   253,   488,  -144,   797,   496,   201,   633,   122,
-     441,   443,   199,   202,   223,   203,   225,   200,  -100,   114,
-     224,   106,   224,   122,   719,   259,   415,   260,   120,   551,
-     106,   416,   798,   799,    18,   596,   128,   129,    99,   196,
-     132,   133,   134,   135,   387,   388,   389,   174,   844,  -331,
-      12,   178,   495,   192,   643,   383,   384,   304,   305,   306,
-     307,   308,   309,   310,   311,   107,   385,   386,   312,   313,
-     122,   413,   414,   123,   861,   194,   572,   789,   790,   791,
-     461,   462,   463,   314,   315,  -453,   868,  -525,   316,   317,
-     405,   304,   305,   306,   307,   308,   309,   310,   311,   107,
-     228,   415,   312,   313,   353,   229,   416,   230,   107,   417,
-     418,   187,   246,   804,   174,   187,   376,   377,   378,   -47,
-     247,   -47,   249,   317,   250,   204,   798,   799,    94,    96,
-     205,   214,   198,   216,   251,   -47,   -47,   256,   -47,   -47,
-     393,   224,   -47,   491,    98,   101,   201,   393,   457,   458,
-     261,   199,   202,   505,   203,   834,   200,   459,   460,   262,
-     448,   263,   264,   320,   -47,   572,  -210,   267,   -47,   266,
-     269,   434,   270,   271,   543,   272,   545,   273,   196,   274,
-     624,   275,   -47,   277,   281,   282,   289,  -526,   630,   288,
-     106,   664,   300,   301,   159,   163,   331,   160,   161,   335,
-     338,   339,   643,   162,   501,   350,   351,   572,   722,   560,
-     346,   465,   360,   143,   361,   365,   442,    47,    51,    60,
-     373,    49,    61,   530,    62,   534,   535,   374,   375,   380,
-     382,   403,   530,   573,   381,   320,   397,   438,   574,   665,
-     -44,   450,   453,   532,   550,   464,   541,   542,   554,   405,
-     556,   544,   702,   670,   671,   672,   557,   558,   559,   561,
-     563,   580,   582,   588,   583,   555,   622,   598,   585,   586,
-     413,   414,   587,   589,   594,   159,   163,   590,   160,   161,
-     649,   599,  -289,   573,   162,   501,   571,   600,   574,   601,
-     608,   506,   507,   405,   143,   603,   617,   627,   628,   143,
-     415,   508,   629,   631,   252,   416,  -384,   654,   417,   418,
-     641,   655,   656,   597,   604,   605,   606,   657,   658,   659,
-     661,   662,   667,   711,   663,   673,   674,   675,   695,   676,
-     677,   678,   679,   846,   847,   682,   571,   683,   615,   616,
-     684,   701,   159,   163,   703,   160,   161,   685,   692,   693,
-     694,   162,   715,   716,   726,   727,   728,   734,   737,   633,
-     106,   143,   729,  -402,   866,   127,   128,   129,   130,   131,
-     132,   133,   134,   135,   136,   137,   138,    10,    11,   750,
-      12,   139,   140,   141,   752,   467,   755,  -393,     6,   756,
-     757,     9,  -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,
-    -393,  -393,  -393,  -393,    10,    11,   760,    12,   764,  -393,
-    -393,    13,   766,   767,   413,   414,   468,   469,  -393,  -411,
-     769,   776,   783,   838,    14,   785,   805,   788,   481,   482,
-     483,   806,   808,   809,   813,   832,   815,   833,   107,   835,
-     837,   573,   839,   848,   840,  -101,   574,    22,    23,   862,
-     122,   857,   858,   863,   869,   871,   870,   874,   875,   371,
-     877,   710,   372,   173,   751,  -393,   100,    97,   500,   545,
-     106,   688,   456,   526,   -86,   127,   128,   129,   130,   131,
-     132,   133,   134,   135,   136,   137,   138,    10,    11,   455,
-      12,   139,   140,   141,   571,   175,   713,    47,    51,    60,
-     454,   648,    61,   584,    62,   666,   763,    92,   447,   106,
-     721,   668,   731,   841,   127,   128,   129,   130,   131,   132,
-     133,   134,   135,   195,   137,   138,   231,   407,   232,   581,
-     573,   140,   141,   748,   548,   574,   843,   747,   860,   723,
-     570,   845,   233,   234,   439,   235,   236,   189,   107,   237,
-     850,   539,   730,   452,   174,   517,   652,     0,     0,     0,
-       0,     0,     0,    92,     0,     0,   721,     0,     0,   842,
-       0,   238,   573,     0,     0,   239,     0,   574,     0,    47,
-      51,    60,     0,   571,    61,     0,    62,   107,     0,   240,
-       0,   812,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    92,     0,   500,   811,   106,     0,     0,     0,
-       0,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,    10,    11,   571,    12,   139,   140,   141,
-       0,   159,   163,     0,   160,   161,   393,   393,     0,     0,
-     162,   855,     0,     0,     0,     0,   467,     0,  -393,     6,
-     143,   849,     9,  -393,  -393,  -393,  -393,  -393,  -393,  -393,
-    -393,  -393,  -393,  -393,  -393,    10,    11,   393,    12,     0,
-    -393,  -393,    13,     0,     0,   413,   414,   468,   469,  -393,
-       0,     0,     0,     0,   107,    14,     0,     0,     0,   481,
-     482,   483,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   106,     0,    22,    23,
-       0,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,     0,     0,     0,  -393,   139,   140,   141,
-     467,     0,  -393,     6,     0,  -538,     9,  -393,  -393,  -393,
-    -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,    10,
-      11,     0,    12,     0,  -393,  -393,    13,     0,     0,   413,
-     414,   468,   469,  -393,     0,     0,     0,     0,     0,    14,
-       0,     0,     0,   518,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   519,   107,     0,     0,     0,     0,     0,
-     174,     0,    22,    23,     0,     0,     0,     0,     0,     0,
+     108,   110,   163,   159,    92,   160,   161,    93,    47,   103,
+     104,   162,   144,   204,   205,   399,   113,    49,    51,    60,
+      61,   143,   422,    62,   198,   628,   419,   320,   201,   698,
+     227,   292,   349,   423,   202,   203,   244,   199,   575,   400,
+     401,   402,   299,   488,   200,   163,   159,   433,   160,   161,
+     223,     8,     4,   106,   162,    47,   224,   522,   295,   799,
+      91,   196,   206,   642,   143,    51,    60,    61,  -144,  -145,
+      62,   119,   712,   122,   122,   207,   225,   210,   211,   212,
+     213,   713,   224,   511,     8,   215,   800,   801,   106,   218,
+     575,   630,   219,   631,    18,   221,   527,   120,    95,   106,
+     379,   106,   367,   114,   127,   128,   129,   130,   131,   132,
+     133,   134,   135,   195,   137,   138,   106,   531,   435,   174,
+     568,   140,   141,   304,   305,   306,   307,   308,   309,   310,
+     311,   107,  -333,   106,   312,   313,   488,   174,   600,   128,
+     129,   178,   174,   132,   133,   134,   135,   174,  -315,   314,
+     315,   712,   265,    12,   316,   317,   725,   259,  -363,   260,
+     713,   204,   205,   123,   192,  -146,   107,   413,   414,   224,
+     122,   224,   198,   174,   106,   488,   201,   107,  -363,   107,
+     491,   443,   202,   203,   511,   199,   497,   739,   726,   413,
+     414,   553,   200,   638,   224,  -100,   765,   415,   254,   255,
+     122,   187,   416,   799,   122,   187,    18,   106,   776,   196,
+      99,   107,   496,   383,   384,   252,   846,   174,   253,   415,
+     194,   214,  -455,   216,   416,   651,   798,   417,   418,   650,
+     800,   801,  -528,   809,   385,   386,   652,   387,   388,   389,
+     228,   -47,   863,   -47,   304,   305,   306,   307,   308,   309,
+     310,   311,   107,   575,   870,   312,   313,   -47,   -47,   226,
+     -47,   -47,   229,   405,   -47,   792,   793,   794,   800,   801,
+     314,   315,   230,   806,   353,   316,   317,   304,   305,   306,
+     307,   308,   309,   310,   311,   107,   -47,   246,   312,   313,
+     -47,   461,   462,   463,    94,    96,   376,   377,   378,   247,
+     204,   205,    98,   101,   -47,   457,   458,   249,   250,   317,
+     393,   198,   459,   460,   836,   201,   492,   393,   251,   651,
+     224,   202,   203,   650,   199,   256,   506,   261,   289,   448,
+     652,   200,   262,   263,   264,   231,  -212,   232,   575,   267,
+     266,   434,   629,   269,   106,   270,   320,   545,   196,   547,
+     635,   233,   234,   271,   235,   236,   272,   274,   237,   273,
+     275,   277,   281,   282,   163,   159,  -529,   160,   161,   288,
+     301,   335,   300,   162,   502,   671,   442,    47,   338,   575,
+     238,   465,   563,   143,   239,   331,    49,    51,    60,    61,
+     339,   350,    62,   532,   729,   536,   537,   346,   240,   351,
+     360,   361,   532,   672,   368,   373,   365,   382,   576,   577,
+     374,   489,   380,   375,   552,   397,   -44,   677,   678,   679,
+     320,   381,   403,   405,   510,   450,   453,   534,   464,   543,
+     544,   546,   557,   559,   561,   558,   560,   562,   709,   566,
+     583,   564,   593,   587,   589,   163,   159,   602,   160,   161,
+     590,   603,   591,   594,   162,   502,   574,   604,   605,   592,
+     576,   577,   598,  -291,   143,   607,   106,   613,   405,   622,
+     143,   127,   128,   129,   130,   131,   132,   133,   134,   135,
+     195,   137,   138,   627,   601,   608,   609,   610,   140,   141,
+    -386,   413,   414,   632,   633,   634,   636,   573,   655,   646,
+    -567,   660,   661,   662,   663,   664,   848,   849,   574,   665,
+     620,   621,   507,   508,   667,   163,   159,   668,   160,   161,
+     669,   415,   509,   670,   162,   674,   416,   252,   680,   417,
+     418,   681,   682,   683,   143,   684,   685,   868,   686,   689,
+     106,   690,   706,   489,   107,   127,   128,   129,   130,   131,
+     132,   133,   134,   135,   136,   137,   138,    10,    11,   700,
+      12,   139,   140,   141,   691,   467,   692,  -395,     6,   699,
+     649,     9,  -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,
+    -395,  -395,  -395,  -395,    10,    11,   701,    12,   702,  -395,
+    -395,    13,   703,   707,   413,   414,   468,   469,  -395,   708,
+     710,   718,   638,   722,    14,   840,   723,  -404,   481,   482,
+     483,   733,   737,   740,   755,   760,   753,   758,   107,   759,
+     763,   767,   770,   576,   577,  -101,   769,    22,    23,   772,
+     122,   413,   414,  -413,   786,   779,   788,   717,   807,   791,
+     808,   810,   815,   811,   837,  -395,   817,   834,   835,   547,
+     839,  -213,   507,   508,   -86,   842,   841,   850,   871,   873,
+     864,   415,   509,    47,   859,   860,   416,   865,   879,   417,
+     418,   574,   877,    51,    60,    61,   371,   872,    62,   876,
+     372,   173,   754,   100,    92,    97,   585,   728,   528,   734,
+     695,  -458,   106,     6,   454,   175,   440,   127,   128,   129,
+     130,   131,   132,   133,   134,   135,   195,   137,   576,   577,
+     751,   106,    12,   455,   140,   141,   127,   128,   129,   130,
+     131,   132,   133,   134,   135,   136,   137,   138,    10,    11,
+     654,    12,   139,   140,   141,   456,    92,   720,   675,   728,
+     673,   766,    47,   407,   844,   588,   447,   584,   843,   576,
+     577,   845,    51,    60,    61,   550,   574,    62,   750,   730,
+     862,   847,   439,   189,   814,   452,   541,   852,   611,   704,
+     107,   425,   658,     0,     0,    92,     0,     0,   813,   441,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   107,
+       0,     0,     0,     0,     0,   174,     0,   574,     0,     0,
+       0,     0,     0,   163,   159,     0,   160,   161,   393,   393,
+       0,     0,   162,   857,     0,     0,     0,     0,   467,     0,
+    -395,     6,   143,   851,     9,  -395,  -395,  -395,  -395,  -395,
+    -395,  -395,  -395,  -395,  -395,  -395,  -395,    10,    11,   393,
+      12,     0,  -395,  -395,    13,     0,     0,   413,   414,   468,
+     469,  -395,     0,     0,     0,     0,     0,    14,     0,     0,
+     106,   481,   482,   483,     0,   127,   128,   129,   130,   131,
+     132,   133,   134,   135,   195,     0,     0,   501,     0,   106,
+      22,    23,   140,   141,   127,   128,   129,   130,   131,   132,
+     133,   134,   135,   136,   137,   138,    10,    11,  -395,    12,
+     139,   140,   141,   467,  -213,  -395,     6,  -541,     0,     9,
+    -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,
+    -395,  -395,    10,    11,     0,    12,     0,  -395,  -395,    13,
+       0,     0,   413,   414,   468,   469,  -395,     0,   107,     0,
+       0,     0,    14,     0,     0,     0,   520,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   521,   107,     0,     0,
+       0,     0,     0,   174,     0,    22,    23,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-    -393,     0,     0,     0,   467,     0,  -393,     6,     0,  -505,
-       9,  -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,
-    -393,  -393,  -393,    10,    11,     0,    12,     0,  -393,  -393,
-      13,     0,     0,   413,   414,   468,   469,  -393,     0,   467,
-       0,  -393,     6,    14,     0,     9,  -393,  -393,  -393,  -393,
-    -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,    10,    11,
-       0,    12,     0,  -393,  -393,    13,    22,    23,   413,   414,
-     468,   469,  -393,     0,     0,     0,     0,     0,    14,     0,
-       0,     0,     0,     0,  -393,     0,     0,     0,     0,     0,
-    -211,     0,     0,   -68,     0,     0,     0,     0,   106,     0,
-       0,    22,    23,   127,   128,   129,   130,   131,   132,   133,
-     134,   135,   195,   137,   138,     0,     0,     0,     0,  -393,
-     140,   141,     0,     0,   467,  -211,  -393,     6,   -90,     0,
-       9,  -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,
-    -393,  -393,  -393,    10,    11,     0,    12,     0,  -393,  -393,
-      13,     0,     0,   413,   414,   468,   469,  -393,     0,     0,
-       0,     0,     0,    14,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     5,   107,     0,     6,     7,
-       8,     9,     0,     0,     0,     0,    22,    23,     0,     0,
-       0,     0,     0,     0,    10,    11,     0,    12,     0,     0,
-       0,    13,     0,     0,  -393,     0,     0,     0,     0,     0,
-    -211,     0,     0,  -529,    14,    15,    16,    17,     0,     0,
-       0,     0,     0,    18,    19,     0,     0,    20,    -2,     5,
-      21,     0,     6,     7,     8,     9,     0,    22,    23,     0,
-       0,     0,     0,     0,    24,    25,   704,     0,    10,    11,
-       0,    12,     0,     0,     0,    13,     0,     0,     0,     0,
-      26,     0,     0,     0,   -53,     0,     0,     0,    14,    15,
-      16,    17,     0,     0,     0,     0,     0,    18,    19,     0,
-       0,    20,     5,     0,    21,     6,     7,     8,     9,     0,
-       0,    22,    23,     0,     0,     0,     0,     0,    24,    25,
-       0,    10,    11,     0,    12,     0,     0,     5,    13,     0,
-       6,     7,     8,     9,    26,  -211,     0,     0,     0,     0,
-       0,    14,    15,    16,    17,     0,    10,    11,     0,    12,
-      18,    19,     0,    13,    20,     0,     0,    21,     0,     0,
-       0,     0,     0,     0,    22,    23,    14,    15,    16,    17,
-       0,    24,    25,     0,     0,    18,    19,     0,     0,    20,
-       5,     0,    21,     6,     7,     8,     9,    26,  -211,    22,
-      23,     0,     0,     0,     0,     0,    24,    25,   704,    10,
-      11,     0,    12,     0,     0,     0,    13,     0,     0,     0,
-       0,     0,    26,     0,     0,     0,     0,     0,     0,    14,
-      15,    16,    17,     0,     0,     0,     0,     0,    18,    19,
-       0,     0,    20,     0,     0,    21,     0,     0,     0,     0,
-       0,     0,    22,    23,     0,     0,   106,     0,     0,    24,
-      25,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,    10,    11,    26,    12,   139,   140,   141,
-     467,     0,  -393,     6,     0,     0,     9,  -393,  -393,  -393,
-    -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,  -393,    10,
-      11,     0,    12,     0,  -393,  -393,    13,     0,     0,   413,
-     414,   468,   469,  -393,     0,   106,     0,     0,     0,    14,
-     127,   128,   129,   130,   131,   132,   133,   134,   135,   136,
-     137,   138,    10,    11,   107,    12,   139,   140,   141,   106,
-     174,     0,    22,    23,   127,   128,   129,   130,   131,   132,
-     133,   134,   135,   195,     0,     0,     0,     0,     0,     0,
-    -393,   140,   141,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,  -395,     0,     0,     0,   467,     0,  -395,
+       6,     0,  -508,     9,  -395,  -395,  -395,  -395,  -395,  -395,
+    -395,  -395,  -395,  -395,  -395,  -395,    10,    11,     0,    12,
+       0,  -395,  -395,    13,     0,     0,   413,   414,   468,   469,
+    -395,     0,   467,     0,  -395,     6,    14,     0,     9,  -395,
+    -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,
+    -395,    10,    11,     0,    12,     0,  -395,  -395,    13,    22,
+      23,   413,   414,   468,   469,  -395,     0,     0,     0,     0,
+       0,    14,     0,     0,     0,     0,     0,  -395,     0,     0,
+       0,     0,     0,  -213,     0,     0,   -68,     0,     0,     0,
+       0,     0,   106,     0,    22,    23,     0,   127,   128,   129,
+     130,   131,   132,   133,   134,   135,   136,   137,   138,     0,
+       0,     0,  -395,   139,   140,   141,     0,   467,  -213,  -395,
+       6,   -90,     0,     9,  -395,  -395,  -395,  -395,  -395,  -395,
+    -395,  -395,  -395,  -395,  -395,  -395,    10,    11,     0,    12,
+       0,  -395,  -395,    13,     0,     0,   413,   414,   468,   469,
+    -395,     0,     0,     0,     0,     0,    14,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     5,     0,
+     107,     6,     7,     8,     9,     0,   174,     0,     0,    22,
+      23,     0,     0,     0,     0,     0,     0,    10,    11,     0,
+      12,     0,     0,     0,    13,     0,     0,  -395,     0,     0,
+       0,     0,     0,  -213,     0,     0,  -532,    14,    15,    16,
+      17,     0,     0,     0,     0,     0,    18,    19,     0,     0,
+      20,    -2,     5,    21,     0,     6,     7,     8,     9,     0,
+      22,    23,     0,     0,     0,     0,     0,    24,    25,   711,
+       0,    10,    11,     0,    12,     0,     0,     0,    13,     0,
+       0,     0,     0,    26,     0,     0,     0,   -53,     0,     0,
+       0,    14,    15,    16,    17,     0,     0,     0,     0,     0,
+      18,    19,     0,     0,    20,     5,     0,    21,     6,     7,
+       8,     9,     0,     0,    22,    23,     0,     0,     0,     0,
+       0,    24,    25,     0,    10,    11,     0,    12,     0,     0,
+       5,    13,     0,     6,     7,     8,     9,    26,  -213,     0,
+       0,     0,     0,     0,    14,    15,    16,    17,     0,    10,
+      11,     0,    12,    18,    19,     0,    13,    20,     0,     0,
+      21,     0,     0,     0,     0,     0,     0,    22,    23,    14,
+      15,    16,    17,     0,    24,    25,     0,     0,    18,    19,
+       0,     0,    20,     5,     0,    21,     6,     7,     8,     9,
+      26,  -213,    22,    23,     0,     0,     0,     0,     0,    24,
+      25,   711,    10,    11,     0,    12,     0,     0,     0,    13,
+       0,     0,     0,     0,     0,    26,     0,     0,     0,     0,
+       0,     0,    14,    15,    16,    17,     0,     0,     0,     0,
+       0,    18,    19,     0,     0,    20,     0,     0,    21,     0,
+       0,     0,     0,     0,     0,    22,    23,     0,     0,     0,
+       0,     0,    24,    25,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   467,     0,  -395,     6,     0,    26,     9,
+    -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,  -395,
+    -395,  -395,    10,    11,     0,    12,     0,  -395,  -395,    13,
+       0,     0,   413,   414,   468,   469,  -395,     0,     0,     0,
+       0,     0,    14,     0,     0,     0,   481,   482,   483,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    22,    23,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   467,     0,
+    -395,     6,     0,  -395,     9,  -395,  -395,  -395,  -395,  -395,
+    -395,  -395,  -395,  -395,  -395,  -395,  -395,    10,    11,     0,
+      12,     0,  -395,  -395,    13,     0,     0,   413,   414,   468,
+     469,  -395,   501,     0,   106,     0,     0,    14,     0,   127,
+     128,   129,   130,   131,   132,   133,   134,   135,   136,   137,
+     138,    10,    11,     0,    12,   139,   140,   141,     0,   106,
+      22,    23,     0,     0,   127,   128,   129,   130,   131,   132,
+     133,   134,   135,   136,   137,   138,    10,    11,  -395,    12,
+     139,   140,   141,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   107,     0,     0,     0,     0,     0,     0,
+       0,     0,   107,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,   107
 };
 
 static const yytype_int16 yycheck[] =
 {
-      22,    23,    43,    43,    14,    43,    43,    14,    83,    19,
-      20,    43,    43,    83,   339,    83,    26,   244,     2,     2,
-       2,    43,     2,     2,   352,     2,   111,   112,   636,    83,
-     341,   342,   343,   118,    83,    83,   528,    83,   478,    83,
-     278,   222,   231,   396,     3,    86,    86,     3,    86,    86,
-       8,     9,   352,     3,    86,     1,   651,   410,     3,     3,
-      19,    83,    84,     3,    86,    49,    49,    49,   651,     3,
-      49,     3,    49,     3,   362,    85,    87,    87,    88,    89,
-      90,   409,    28,    29,     3,    95,     3,   742,   528,    99,
-     317,   352,   102,     3,     4,   105,   107,     7,     8,     9,
-      10,    11,    12,    13,    14,    15,    16,    17,    18,   409,
-     681,     6,   293,    23,    88,    25,    26,   772,   773,    93,
-     473,     6,    81,   411,   779,    81,   364,     0,    73,    74,
-      75,    76,    77,    78,    79,    80,    81,    87,   733,    84,
-      85,    88,    87,    87,    90,    88,    93,    87,   409,    81,
-     733,    81,   174,    87,    99,   100,   231,     3,    87,   104,
-     105,   231,    81,   231,    49,   736,    30,    31,    53,     8,
-     397,    81,    11,   526,    88,     1,   403,   231,   107,    93,
-      90,   370,   231,   231,    75,   231,    75,   231,    88,    91,
-      81,     3,    81,    93,   686,    92,    60,    94,    88,   437,
-       3,    65,    28,    29,    49,     8,     9,    10,    53,   231,
-      13,    14,    15,    16,   101,   102,   103,    87,   826,    88,
-      23,    22,   403,    89,   552,    82,    83,    73,    74,    75,
-      76,    77,    78,    79,    80,    81,    99,   100,    84,    85,
-      93,    30,    31,    36,   852,    88,   686,    35,    36,    37,
-     387,   388,   389,    99,   100,    88,   864,    88,   104,   105,
-     345,    73,    74,    75,    76,    77,    78,    79,    80,    81,
-      89,    60,    84,    85,   284,    89,    65,    88,    81,    68,
-      69,    74,    88,   775,    87,    78,   314,   315,   316,     4,
-      48,     6,    89,   105,    88,   370,    28,    29,    15,    16,
-     370,    94,   370,    96,    89,    20,    21,    91,    23,    24,
-     332,    81,    27,   398,    16,    17,   370,   339,   383,   384,
-      91,   370,   370,   408,   370,   817,   370,   385,   386,    91,
-     370,    88,    88,   560,    49,   775,    87,    89,    53,    88,
-      88,   363,    88,    88,   429,    88,   431,    89,   370,    88,
-     531,    89,    67,    88,    88,    88,    93,    88,   539,    89,
-       3,   588,    91,     3,   405,   405,    92,   405,   405,     8,
-      91,    47,   700,   405,   405,    89,    89,   817,   689,   464,
-     105,   391,    89,   405,    89,    93,   370,   371,   371,   371,
-       3,   371,   371,   415,   371,   417,   418,    92,    94,    96,
-      98,   105,   424,   478,    97,   632,    94,    89,   478,   590,
-      90,    92,   106,    58,   436,    94,    90,    95,    88,   504,
-      88,    94,   649,   604,   605,   606,    90,     3,    89,    94,
-      90,    90,    88,    95,    92,   445,    31,   505,    92,    92,
-      30,    31,    92,   106,    90,   486,   486,    94,   486,   486,
-      29,   505,    90,   528,   486,   486,   478,   505,   528,   505,
-      90,    51,    52,   548,   486,   505,    90,    88,    88,   491,
-      60,    61,    88,    88,     8,    65,    90,    88,    68,    69,
-      90,    88,    88,   505,   506,   507,   508,    88,    88,    88,
-      88,    88,    88,     3,   579,    88,    88,    88,    66,    88,
-      88,    88,    88,   828,   829,    88,   528,    88,   518,   519,
-      90,    88,   553,   553,    88,   553,   553,    90,    90,    94,
-      90,   553,   106,   105,    88,    88,    88,    88,    88,   107,
-       3,   553,    90,    35,   859,     8,     9,    10,    11,    12,
-      13,    14,    15,    16,    17,    18,    19,    20,    21,    90,
-      23,    24,    25,    26,   105,     1,    89,     3,     4,   106,
-      35,     7,     8,     9,    10,    11,    12,    13,    14,    15,
-      16,    17,    18,    19,    20,    21,    38,    23,    55,    25,
-      26,    27,    94,   108,    30,    31,    32,    33,    34,   106,
-      91,   106,    59,   820,    40,     3,    94,   106,    44,    45,
-      46,   105,   105,    62,    92,    94,   106,    94,    81,    39,
-      88,   686,    93,   105,    90,    88,   686,    63,    64,   105,
-      93,   106,   106,    93,    88,    75,   106,   106,    94,   298,
-      75,   653,   298,    49,   733,    81,    17,    16,     1,   724,
-       3,   632,   382,   412,    90,     8,     9,    10,    11,    12,
-      13,    14,    15,    16,    17,    18,    19,    20,    21,   381,
-      23,    24,    25,    26,   686,    50,   666,   651,   651,   651,
-     380,   553,   651,   491,   651,   590,   743,   687,   370,     3,
-     687,   593,   704,   823,     8,     9,    10,    11,    12,    13,
-      14,    15,    16,    17,    18,    19,     4,   345,     6,   486,
-     775,    25,    26,   725,   432,   775,   825,   724,   851,   690,
-      34,   827,    20,    21,   369,    23,    24,    78,    81,    27,
-     832,   424,   700,   375,    87,   409,   560,    -1,    -1,    -1,
-      -1,    -1,    -1,   743,    -1,    -1,   743,    -1,    -1,   824,
-      -1,    49,   817,    -1,    -1,    53,    -1,   817,    -1,   733,
-     733,   733,    -1,   775,   733,    -1,   733,    81,    -1,    67,
-      -1,   783,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   782,    -1,     1,   782,     3,    -1,    -1,    -1,
-      -1,     8,     9,    10,    11,    12,    13,    14,    15,    16,
-      17,    18,    19,    20,    21,   817,    23,    24,    25,    26,
-      -1,   842,   842,    -1,   842,   842,   828,   829,    -1,    -1,
-     842,   842,    -1,    -1,    -1,    -1,     1,    -1,     3,     4,
-     842,   831,     7,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19,    20,    21,   859,    23,    -1,
-      25,    26,    27,    -1,    -1,    30,    31,    32,    33,    34,
-      -1,    -1,    -1,    -1,    81,    40,    -1,    -1,    -1,    44,
-      45,    46,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,     3,    -1,    63,    64,
-      -1,     8,     9,    10,    11,    12,    13,    14,    15,    16,
-      17,    18,    19,    -1,    -1,    -1,    81,    24,    25,    26,
-       1,    -1,     3,     4,    -1,    90,     7,     8,     9,    10,
-      11,    12,    13,    14,    15,    16,    17,    18,    19,    20,
-      21,    -1,    23,    -1,    25,    26,    27,    -1,    -1,    30,
-      31,    32,    33,    34,    -1,    -1,    -1,    -1,    -1,    40,
-      -1,    -1,    -1,    44,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    54,    81,    -1,    -1,    -1,    -1,    -1,
-      87,    -1,    63,    64,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      81,    -1,    -1,    -1,     1,    -1,     3,     4,    -1,    90,
-       7,     8,     9,    10,    11,    12,    13,    14,    15,    16,
-      17,    18,    19,    20,    21,    -1,    23,    -1,    25,    26,
-      27,    -1,    -1,    30,    31,    32,    33,    34,    -1,     1,
-      -1,     3,     4,    40,    -1,     7,     8,     9,    10,    11,
+      22,    23,    43,    43,    14,    43,    43,    14,     2,    19,
+      20,    43,    43,    83,    83,   339,    26,     2,     2,     2,
+       2,    43,   352,     2,    83,   530,   352,   244,    83,   641,
+     112,   222,   278,   352,    83,    83,   118,    83,   478,   341,
+     342,   343,   231,   396,    83,    86,    86,   362,    86,    86,
+      75,     6,     0,     3,    86,    49,    81,   410,     3,     1,
+       3,    83,    84,     3,    86,    49,    49,    49,    88,    88,
+      49,    88,   657,    93,    93,    85,    75,    87,    88,    89,
+      90,   657,    81,   409,     6,    95,    28,    29,     3,    99,
+     530,     3,   102,     3,    49,   105,   411,    88,    53,     3,
+     317,     3,   293,    91,     8,     9,    10,    11,    12,    13,
+      14,    15,    16,    17,    18,    19,     3,    19,   364,    87,
+     473,    25,    26,    73,    74,    75,    76,    77,    78,    79,
+      80,    81,    88,     3,    84,    85,   489,    87,     8,     9,
+      10,    22,    87,    13,    14,    15,    16,    87,    90,    99,
+     100,   736,   174,    23,   104,   105,   688,    92,    87,    94,
+     736,   231,   231,    36,    89,    88,    81,    30,    31,    81,
+      93,    81,   231,    87,     3,   528,   231,    81,   107,    81,
+     397,   370,   231,   231,   510,   231,   403,   719,   693,    30,
+      31,   437,   231,   107,    81,    88,   745,    60,     8,     9,
+      93,    74,    65,     1,    93,    78,    49,     3,   757,   231,
+      53,    81,   403,    82,    83,     8,   828,    87,    11,    60,
+      88,    94,    88,    96,    65,   555,   775,    68,    69,   555,
+      28,    29,    88,   782,    99,   100,   555,   101,   102,   103,
+      89,     4,   854,     6,    73,    74,    75,    76,    77,    78,
+      79,    80,    81,   693,   866,    84,    85,    20,    21,     3,
+      23,    24,    89,   345,    27,    35,    36,    37,    28,    29,
+      99,   100,    88,   778,   284,   104,   105,    73,    74,    75,
+      76,    77,    78,    79,    80,    81,    49,    88,    84,    85,
+      53,   387,   388,   389,    15,    16,   314,   315,   316,    48,
+     370,   370,    16,    17,    67,   383,   384,    89,    88,   105,
+     332,   370,   385,   386,   819,   370,   398,   339,    89,   649,
+      81,   370,   370,   649,   370,    91,   408,    91,    93,   370,
+     649,   370,    91,    88,    88,     4,    87,     6,   778,    89,
+      88,   363,   533,    88,     3,    88,   563,   429,   370,   431,
+     541,    20,    21,    88,    23,    24,    88,    88,    27,    89,
+      89,    88,    88,    88,   405,   405,    88,   405,   405,    89,
+       3,     8,    91,   405,   405,   592,   370,   371,    91,   819,
+      49,   391,   464,   405,    53,    92,   371,   371,   371,   371,
+      47,    89,   371,   415,   696,   417,   418,   105,    67,    89,
+      89,    89,   424,   594,    89,     3,    93,    98,   478,   478,
+      92,   396,    96,    94,   436,    94,    90,   608,   609,   610,
+     637,    97,   105,   505,   409,    92,   106,    58,    94,    90,
+      95,    94,    88,    88,     3,   445,    90,    89,   655,    90,
+      90,    94,   106,    92,    92,   486,   486,   506,   486,   486,
+      92,   506,    92,    94,   486,   486,   478,   506,   506,    95,
+     530,   530,    90,    90,   486,   506,     3,    90,   550,    90,
+     492,     8,     9,    10,    11,    12,    13,    14,    15,    16,
+      17,    18,    19,    31,   506,   507,   508,   509,    25,    26,
+      90,    30,    31,    88,    88,    88,    88,    34,    29,    90,
+      90,    88,    88,    88,    88,    88,   830,   831,   530,    88,
+     520,   521,    51,    52,    88,   556,   556,    88,   556,   556,
+       3,    60,    61,    88,   556,    88,    65,     8,    88,    68,
+      69,    88,    88,    88,   556,    88,    88,   861,    88,    88,
+       3,    88,    88,   528,    81,     8,     9,    10,    11,    12,
+      13,    14,    15,    16,    17,    18,    19,    20,    21,    94,
+      23,    24,    25,    26,    90,     1,    90,     3,     4,    90,
+     555,     7,     8,     9,    10,    11,    12,    13,    14,    15,
+      16,    17,    18,    19,    20,    21,    90,    23,    66,    25,
+      26,    27,    90,    88,    30,    31,    32,    33,    34,    88,
+      88,     3,   107,   106,    40,   822,   105,    35,    44,    45,
+      46,    88,    88,    88,   105,    35,    90,    89,    81,   106,
+      38,    55,   108,   693,   693,    88,    94,    63,    64,    91,
+      93,    30,    31,   106,    59,   106,     3,   659,    94,   106,
+     105,   105,    92,    62,    39,    81,   106,    94,    94,   731,
+      88,    87,    51,    52,    90,    90,    93,   105,    88,    75,
+     105,    60,    61,   657,   106,   106,    65,    93,    75,    68,
+      69,   693,    94,   657,   657,   657,   298,   106,   657,   106,
+     298,    49,   736,    17,   694,    16,   489,   694,   412,   711,
+     637,    90,     3,     4,   380,    50,     7,     8,     9,    10,
+      11,    12,    13,    14,    15,    16,    17,    18,   778,   778,
+     732,     3,    23,   381,    25,    26,     8,     9,    10,    11,
       12,    13,    14,    15,    16,    17,    18,    19,    20,    21,
-      -1,    23,    -1,    25,    26,    27,    63,    64,    30,    31,
-      32,    33,    34,    -1,    -1,    -1,    -1,    -1,    40,    -1,
-      -1,    -1,    -1,    -1,    81,    -1,    -1,    -1,    -1,    -1,
-      87,    -1,    -1,    90,    -1,    -1,    -1,    -1,     3,    -1,
-      -1,    63,    64,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    81,
-      25,    26,    -1,    -1,     1,    87,     3,     4,    90,    -1,
-       7,     8,     9,    10,    11,    12,    13,    14,    15,    16,
-      17,    18,    19,    20,    21,    -1,    23,    -1,    25,    26,
-      27,    -1,    -1,    30,    31,    32,    33,    34,    -1,    -1,
-      -1,    -1,    -1,    40,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,     1,    81,    -1,     4,     5,
-       6,     7,    -1,    -1,    -1,    -1,    63,    64,    -1,    -1,
-      -1,    -1,    -1,    -1,    20,    21,    -1,    23,    -1,    -1,
-      -1,    27,    -1,    -1,    81,    -1,    -1,    -1,    -1,    -1,
-      87,    -1,    -1,    90,    40,    41,    42,    43,    -1,    -1,
-      -1,    -1,    -1,    49,    50,    -1,    -1,    53,     0,     1,
-      56,    -1,     4,     5,     6,     7,    -1,    63,    64,    -1,
-      -1,    -1,    -1,    -1,    70,    71,    72,    -1,    20,    21,
-      -1,    23,    -1,    -1,    -1,    27,    -1,    -1,    -1,    -1,
-      86,    -1,    -1,    -1,    90,    -1,    -1,    -1,    40,    41,
-      42,    43,    -1,    -1,    -1,    -1,    -1,    49,    50,    -1,
-      -1,    53,     1,    -1,    56,     4,     5,     6,     7,    -1,
-      -1,    63,    64,    -1,    -1,    -1,    -1,    -1,    70,    71,
-      -1,    20,    21,    -1,    23,    -1,    -1,     1,    27,    -1,
-       4,     5,     6,     7,    86,    87,    -1,    -1,    -1,    -1,
-      -1,    40,    41,    42,    43,    -1,    20,    21,    -1,    23,
-      49,    50,    -1,    27,    53,    -1,    -1,    56,    -1,    -1,
-      -1,    -1,    -1,    -1,    63,    64,    40,    41,    42,    43,
-      -1,    70,    71,    -1,    -1,    49,    50,    -1,    -1,    53,
-       1,    -1,    56,     4,     5,     6,     7,    86,    87,    63,
-      64,    -1,    -1,    -1,    -1,    -1,    70,    71,    72,    20,
-      21,    -1,    23,    -1,    -1,    -1,    27,    -1,    -1,    -1,
-      -1,    -1,    86,    -1,    -1,    -1,    -1,    -1,    -1,    40,
-      41,    42,    43,    -1,    -1,    -1,    -1,    -1,    49,    50,
-      -1,    -1,    53,    -1,    -1,    56,    -1,    -1,    -1,    -1,
-      -1,    -1,    63,    64,    -1,    -1,     3,    -1,    -1,    70,
-      71,     8,     9,    10,    11,    12,    13,    14,    15,    16,
-      17,    18,    19,    20,    21,    86,    23,    24,    25,    26,
-       1,    -1,     3,     4,    -1,    -1,     7,     8,     9,    10,
-      11,    12,    13,    14,    15,    16,    17,    18,    19,    20,
-      21,    -1,    23,    -1,    25,    26,    27,    -1,    -1,    30,
-      31,    32,    33,    34,    -1,     3,    -1,    -1,    -1,    40,
+     556,    23,    24,    25,    26,   382,   746,   673,   597,   746,
+     594,   746,   736,   345,   826,   492,   370,   486,   825,   819,
+     819,   827,   736,   736,   736,   432,   778,   736,   731,   697,
+     853,   829,   369,    78,   786,   375,   424,   834,   510,   649,
+      81,   352,   563,    -1,    -1,   785,    -1,    -1,   785,    90,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    81,
+      -1,    -1,    -1,    -1,    -1,    87,    -1,   819,    -1,    -1,
+      -1,    -1,    -1,   844,   844,    -1,   844,   844,   830,   831,
+      -1,    -1,   844,   844,    -1,    -1,    -1,    -1,     1,    -1,
+       3,     4,   844,   833,     7,     8,     9,    10,    11,    12,
+      13,    14,    15,    16,    17,    18,    19,    20,    21,   861,
+      23,    -1,    25,    26,    27,    -1,    -1,    30,    31,    32,
+      33,    34,    -1,    -1,    -1,    -1,    -1,    40,    -1,    -1,
+       3,    44,    45,    46,    -1,     8,     9,    10,    11,    12,
+      13,    14,    15,    16,    17,    -1,    -1,     1,    -1,     3,
+      63,    64,    25,    26,     8,     9,    10,    11,    12,    13,
+      14,    15,    16,    17,    18,    19,    20,    21,    81,    23,
+      24,    25,    26,     1,    87,     3,     4,    90,    -1,     7,
        8,     9,    10,    11,    12,    13,    14,    15,    16,    17,
-      18,    19,    20,    21,    81,    23,    24,    25,    26,     3,
-      87,    -1,    63,    64,     8,     9,    10,    11,    12,    13,
-      14,    15,    16,    17,    -1,    -1,    -1,    -1,    -1,    -1,
-      81,    25,    26,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      18,    19,    20,    21,    -1,    23,    -1,    25,    26,    27,
+      -1,    -1,    30,    31,    32,    33,    34,    -1,    81,    -1,
+      -1,    -1,    40,    -1,    -1,    -1,    44,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    54,    81,    -1,    -1,
+      -1,    -1,    -1,    87,    -1,    63,    64,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    81,    -1,    -1,    -1,     1,    -1,     3,
+       4,    -1,    90,     7,     8,     9,    10,    11,    12,    13,
+      14,    15,    16,    17,    18,    19,    20,    21,    -1,    23,
+      -1,    25,    26,    27,    -1,    -1,    30,    31,    32,    33,
+      34,    -1,     1,    -1,     3,     4,    40,    -1,     7,     8,
+       9,    10,    11,    12,    13,    14,    15,    16,    17,    18,
+      19,    20,    21,    -1,    23,    -1,    25,    26,    27,    63,
+      64,    30,    31,    32,    33,    34,    -1,    -1,    -1,    -1,
+      -1,    40,    -1,    -1,    -1,    -1,    -1,    81,    -1,    -1,
+      -1,    -1,    -1,    87,    -1,    -1,    90,    -1,    -1,    -1,
+      -1,    -1,     3,    -1,    63,    64,    -1,     8,     9,    10,
+      11,    12,    13,    14,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    81,    24,    25,    26,    -1,     1,    87,     3,
+       4,    90,    -1,     7,     8,     9,    10,    11,    12,    13,
+      14,    15,    16,    17,    18,    19,    20,    21,    -1,    23,
+      -1,    25,    26,    27,    -1,    -1,    30,    31,    32,    33,
+      34,    -1,    -1,    -1,    -1,    -1,    40,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,    -1,
+      81,     4,     5,     6,     7,    -1,    87,    -1,    -1,    63,
+      64,    -1,    -1,    -1,    -1,    -1,    -1,    20,    21,    -1,
+      23,    -1,    -1,    -1,    27,    -1,    -1,    81,    -1,    -1,
+      -1,    -1,    -1,    87,    -1,    -1,    90,    40,    41,    42,
+      43,    -1,    -1,    -1,    -1,    -1,    49,    50,    -1,    -1,
+      53,     0,     1,    56,    -1,     4,     5,     6,     7,    -1,
+      63,    64,    -1,    -1,    -1,    -1,    -1,    70,    71,    72,
+      -1,    20,    21,    -1,    23,    -1,    -1,    -1,    27,    -1,
+      -1,    -1,    -1,    86,    -1,    -1,    -1,    90,    -1,    -1,
+      -1,    40,    41,    42,    43,    -1,    -1,    -1,    -1,    -1,
+      49,    50,    -1,    -1,    53,     1,    -1,    56,     4,     5,
+       6,     7,    -1,    -1,    63,    64,    -1,    -1,    -1,    -1,
+      -1,    70,    71,    -1,    20,    21,    -1,    23,    -1,    -1,
+       1,    27,    -1,     4,     5,     6,     7,    86,    87,    -1,
+      -1,    -1,    -1,    -1,    40,    41,    42,    43,    -1,    20,
+      21,    -1,    23,    49,    50,    -1,    27,    53,    -1,    -1,
+      56,    -1,    -1,    -1,    -1,    -1,    -1,    63,    64,    40,
+      41,    42,    43,    -1,    70,    71,    -1,    -1,    49,    50,
+      -1,    -1,    53,     1,    -1,    56,     4,     5,     6,     7,
+      86,    87,    63,    64,    -1,    -1,    -1,    -1,    -1,    70,
+      71,    72,    20,    21,    -1,    23,    -1,    -1,    -1,    27,
+      -1,    -1,    -1,    -1,    -1,    86,    -1,    -1,    -1,    -1,
+      -1,    -1,    40,    41,    42,    43,    -1,    -1,    -1,    -1,
+      -1,    49,    50,    -1,    -1,    53,    -1,    -1,    56,    -1,
+      -1,    -1,    -1,    -1,    -1,    63,    64,    -1,    -1,    -1,
+      -1,    -1,    70,    71,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,     1,    -1,     3,     4,    -1,    86,     7,
+       8,     9,    10,    11,    12,    13,    14,    15,    16,    17,
+      18,    19,    20,    21,    -1,    23,    -1,    25,    26,    27,
+      -1,    -1,    30,    31,    32,    33,    34,    -1,    -1,    -1,
+      -1,    -1,    40,    -1,    -1,    -1,    44,    45,    46,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    63,    64,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,    -1,
+       3,     4,    -1,    81,     7,     8,     9,    10,    11,    12,
+      13,    14,    15,    16,    17,    18,    19,    20,    21,    -1,
+      23,    -1,    25,    26,    27,    -1,    -1,    30,    31,    32,
+      33,    34,     1,    -1,     3,    -1,    -1,    40,    -1,     8,
+       9,    10,    11,    12,    13,    14,    15,    16,    17,    18,
+      19,    20,    21,    -1,    23,    24,    25,    26,    -1,     3,
+      63,    64,    -1,    -1,     8,     9,    10,    11,    12,    13,
+      14,    15,    16,    17,    18,    19,    20,    21,    81,    23,
+      24,    25,    26,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    81,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    81,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    81
 };
@@ -2075,90 +2089,90 @@ static const yytype_int16 yystos[] =
       20,    21,    23,    27,    40,    41,    42,    43,    49,    50,
       53,    56,    63,    64,    70,    71,    86,   113,   114,   130,
      132,   136,   137,   149,   152,   153,   157,   159,   162,   163,
-     164,   168,   172,   174,   178,   179,   203,   204,   222,   230,
-     231,   239,   248,   268,   270,   281,   283,   305,   306,   307,
-     349,   400,   401,   402,   403,   404,   408,   430,   432,   455,
-     456,   457,   458,   459,   463,   464,   465,   468,   472,   480,
-     495,   496,   129,   205,   131,   158,   240,   269,   282,   308,
-     350,     3,   202,   256,   157,    53,   157,   172,   174,    53,
-     164,   174,   175,   202,   202,   433,     3,    81,   198,   201,
-     198,   481,   497,   202,    91,   133,   122,   138,   150,    88,
+     164,   168,   172,   174,   178,   179,   204,   205,   223,   231,
+     232,   240,   249,   269,   271,   282,   284,   306,   307,   308,
+     350,   401,   402,   403,   404,   405,   409,   431,   433,   456,
+     457,   458,   459,   460,   464,   465,   466,   469,   473,   481,
+     494,   495,   129,   206,   131,   158,   241,   270,   283,   309,
+     351,     3,   203,   257,   157,    53,   157,   172,   174,    53,
+     164,   174,   175,   203,   203,   434,     3,    81,   199,   202,
+     199,   482,   496,   203,    91,   133,   122,   138,   150,    88,
       88,   121,    93,   160,   154,   123,   165,     8,     9,    10,
       11,    12,    13,    14,    15,    16,    17,    18,    19,    24,
-      25,    26,   160,   198,   243,   244,   245,   246,   247,   258,
-     259,   260,   261,   262,   263,   264,   265,   266,   267,   268,
-     270,   281,   283,   307,   316,   319,   322,   323,   326,   327,
-     330,   119,   115,   113,    87,   232,   116,   271,    22,   120,
-     117,   118,   124,   405,   125,   431,   126,   160,   466,   466,
-     127,   128,    89,   499,    88,    17,   198,   209,   258,   261,
-     262,   263,   264,   265,   323,   327,   198,   202,   241,   243,
-     202,   202,   202,   202,   160,   202,   160,   169,   202,   202,
-     409,   202,   199,    75,    81,    75,   231,   231,    89,    89,
+      25,    26,   160,   199,   244,   245,   246,   247,   248,   259,
+     260,   261,   262,   263,   264,   265,   266,   267,   268,   269,
+     271,   282,   284,   308,   317,   320,   323,   324,   327,   328,
+     331,   119,   115,   113,    87,   233,   116,   272,    22,   120,
+     117,   118,   124,   406,   125,   432,   126,   160,   467,   467,
+     127,   128,    89,   498,    88,    17,   199,   210,   259,   262,
+     263,   264,   265,   266,   324,   328,   199,   203,   242,   244,
+     203,   203,   203,   203,   160,   203,   160,   169,   203,   203,
+     410,   203,   200,    75,    81,    75,     3,   232,    89,    89,
       88,     4,     6,    20,    21,    23,    24,    27,    49,    53,
-      67,   473,   474,   476,   231,   492,    88,    48,   176,    89,
-      88,    89,     8,    11,     8,     9,    91,   320,   173,    92,
-      94,    91,    91,    88,    88,   198,    88,    89,   284,    88,
-      88,    88,    88,    89,    88,    89,   442,    88,   467,   460,
-     469,    88,    88,   500,   206,   242,   309,   351,    89,    93,
-     411,   434,   201,   200,     3,   232,     3,   223,   134,   209,
-      91,     3,   139,   475,    73,    74,    75,    76,    77,    78,
-      79,    80,    84,    85,    99,   100,   104,   105,   198,   210,
-     211,   212,   213,   214,   215,   216,   217,   218,   219,   220,
-     494,    92,   161,   155,   166,     8,   211,   221,    91,    47,
-     177,   317,   324,   328,   233,   272,   105,   406,   443,   177,
-      89,    89,   502,   202,   202,   249,   252,   256,   257,   331,
-      89,    89,   170,   412,   410,    93,   439,   201,   482,   498,
-     224,   111,   112,     3,    92,    94,   219,   219,   219,   211,
+      67,   474,   475,   477,   232,   491,    88,    48,   176,    89,
+      88,    89,     8,    11,     8,     9,    91,   321,   173,    92,
+      94,    91,    91,    88,    88,   199,    88,    89,   285,    88,
+      88,    88,    88,    89,    88,    89,   443,    88,   468,   461,
+     470,    88,    88,   499,   207,   243,   310,   352,    89,    93,
+     412,   435,   202,   201,   483,     3,   233,   224,   134,   210,
+      91,     3,   139,   476,    73,    74,    75,    76,    77,    78,
+      79,    80,    84,    85,    99,   100,   104,   105,   199,   211,
+     212,   213,   214,   215,   216,   217,   218,   219,   220,   221,
+     493,    92,   161,   155,   166,     8,   212,   222,    91,    47,
+     177,   318,   325,   329,   234,   273,   105,   407,   444,   177,
+      89,    89,   501,   203,   203,   250,   253,   257,   258,   332,
+      89,    89,   170,   413,   411,    93,   440,   202,    89,   497,
+     225,   111,   112,     3,    92,    94,   220,   220,   220,   212,
       96,    97,    98,    82,    83,    99,   100,   101,   102,   103,
-     493,   151,   195,   198,   184,   185,   180,    94,   321,   195,
-     221,   221,   221,   105,   234,   231,   274,   276,   285,   413,
-     445,   461,   470,    30,    31,    60,    65,    68,    69,   338,
-     339,   344,   422,   424,   425,   491,   501,   503,   207,   332,
-     250,   310,   352,   184,   198,   177,   440,   435,    89,   411,
-       7,    90,   204,   209,   225,   227,   228,   266,   307,   135,
-      92,   140,   476,   106,   213,   214,   215,   216,   216,   217,
-     217,   218,   218,   218,    94,   202,   196,     1,    32,    33,
-     156,   186,   204,   230,   239,   338,   349,   354,   359,   400,
-     401,    44,    45,    46,   167,   181,   182,   183,   186,   361,
-     211,   231,   318,   325,   329,   201,   211,   235,   236,   238,
-       1,   243,   277,   273,   275,   231,    51,    52,    61,   338,
-     407,   414,   422,   424,   427,   428,   429,   491,    44,    54,
-     186,   444,   446,   449,   452,   184,   180,   340,   345,    19,
-     198,   423,    58,   426,   198,   198,   506,   504,   505,   423,
-     507,    90,    95,   231,    94,   231,   312,   315,   275,   171,
-     198,   177,   483,   226,    88,   202,    88,    90,     3,    89,
-     231,    94,   194,    90,   190,   186,   187,   192,   191,   193,
-      34,   198,   245,   323,   327,   360,   383,   188,   189,   362,
-      90,   277,    88,    92,   244,    92,    92,    92,    95,   106,
-      94,   237,   280,   278,    90,   276,     8,   198,   258,   263,
-     264,   265,   290,   307,   198,   198,   198,   420,    90,   415,
-     416,   417,   418,   419,   421,   202,   202,    90,   447,   448,
-     462,   471,    31,   383,   201,     3,     3,    88,    88,    88,
-     201,    88,   208,   107,   333,   335,   251,     3,   311,   313,
-     353,    90,   436,   338,   422,   424,   485,   487,   241,    29,
-     229,   141,   494,   197,    88,    88,    88,    88,    88,    88,
-     355,    88,    88,   231,   211,   201,   238,    88,   249,   286,
-     201,   201,   201,    88,    88,    88,    88,    88,    88,    88,
-     450,   453,    88,    88,    90,    90,   341,   346,   210,   336,
-     334,   252,    90,    94,    90,    66,   490,   488,   489,   484,
-     486,    88,   211,    88,    72,   114,   130,   143,   145,   146,
-     198,     3,     3,   237,   279,   106,   105,   365,   365,   383,
-     253,   256,   221,   335,   314,   437,    88,    88,    88,    90,
-     487,   198,   142,   144,    88,   356,   363,    88,   287,   366,
-     367,   451,   454,   342,   347,   254,   337,   315,   198,   147,
-      90,   145,   105,   374,   365,    89,   106,    35,   368,   371,
-      38,   385,   385,   253,    55,   388,    94,   108,   438,    91,
-     375,   376,   357,   364,   288,   372,   106,   369,   386,   343,
-     389,   348,   255,    59,   441,     3,   477,   479,   106,    35,
-      36,    37,   377,   380,   384,   385,   385,     1,    28,    29,
-     291,   293,   297,   299,   383,    94,   105,   385,   105,    62,
-     391,   256,   198,    92,   478,   106,   378,   381,   358,   296,
-     301,   300,   289,   292,   294,   298,   373,   370,   387,   390,
-     392,   148,    94,    94,   383,    39,   394,    88,   211,    93,
-      90,   293,   231,   299,   252,   371,   195,   195,   105,   202,
-     479,   379,   382,   395,   302,   243,   303,   106,   106,   393,
-     380,   252,   105,    93,   304,   295,   195,   396,   252,    88,
-     106,    75,   397,   398,   106,    94,   399,    75
+     492,   151,   196,   199,   185,   186,   180,    94,   322,   196,
+     222,   222,   222,   105,   235,   232,   275,   277,   286,   414,
+     446,   462,   471,    30,    31,    60,    65,    68,    69,   339,
+     340,   345,   423,   425,   426,   490,   500,   502,   208,   333,
+     251,   311,   353,   185,   199,   177,   441,   436,   484,   412,
+       7,    90,   205,   210,   226,   228,   229,   267,   308,   135,
+      92,   140,   477,   106,   214,   215,   216,   217,   217,   218,
+     218,   219,   219,   219,    94,   203,   197,     1,    32,    33,
+     156,   187,   205,   231,   240,   339,   350,   355,   360,   401,
+     402,    44,    45,    46,   167,   181,   183,   184,   187,   231,
+     362,   212,   232,   319,   326,   330,   202,   212,   236,   237,
+     239,     1,   244,   278,   274,   276,   232,    51,    52,    61,
+     231,   339,   408,   415,   423,   425,   428,   429,   430,   490,
+      44,    54,   187,   445,   447,   450,   453,   185,   180,   341,
+     346,    19,   199,   424,    58,   427,   199,   199,   505,   503,
+     504,   424,   506,    90,    95,   232,    94,   232,   313,   316,
+     276,   171,   199,   177,   486,   487,   227,    88,   203,    88,
+      90,     3,    89,   232,    94,   195,    90,   191,   187,   188,
+     193,   192,   194,    34,   199,   246,   324,   328,   361,   384,
+     189,   190,   363,    90,   278,   181,   182,    92,   245,    92,
+      92,    92,    95,   106,    94,   238,   281,   279,    90,   277,
+       8,   199,   259,   264,   265,   266,   291,   308,   199,   199,
+     199,   415,   421,    90,   416,   417,   418,   419,   420,   422,
+     203,   203,    90,   448,   449,   463,   472,    31,   384,   202,
+       3,     3,    88,    88,    88,   202,    88,   209,   107,   334,
+     336,   252,     3,   312,   314,   354,    90,   437,   485,   231,
+     339,   423,   425,   488,   242,    29,   230,   141,   493,   198,
+      88,    88,    88,    88,    88,    88,   356,    88,    88,     3,
+      88,   212,   202,   239,    88,   250,   287,   202,   202,   202,
+      88,    88,    88,    88,    88,    88,    88,   451,   454,    88,
+      88,    90,    90,   342,   347,   211,   337,   335,   253,    90,
+      94,    90,    66,    90,   488,   489,    88,    88,    88,   212,
+      88,    72,   114,   130,   143,   145,   146,   199,     3,   364,
+     238,   280,   106,   105,   366,   366,   384,   254,   257,   222,
+     336,   315,   438,    88,   199,   142,   144,    88,   357,   366,
+      88,   288,   367,   368,   452,   455,   343,   348,   255,   338,
+     316,   199,   147,    90,   145,   105,   375,   365,    89,   106,
+      35,   369,   372,    38,   386,   386,   254,    55,   389,    94,
+     108,   439,    91,   376,   377,   358,   386,   289,   373,   106,
+     370,   387,   344,   390,   349,   256,    59,   442,     3,   478,
+     480,   106,    35,    36,    37,   378,   381,   385,   386,     1,
+      28,    29,   292,   294,   298,   300,   384,    94,   105,   386,
+     105,    62,   392,   257,   199,    92,   479,   106,   379,   382,
+     359,   297,   302,   301,   290,   293,   295,   299,   374,   371,
+     388,   391,   393,   148,    94,    94,   384,    39,   395,    88,
+     212,    93,    90,   294,   232,   300,   253,   372,   196,   196,
+     105,   203,   480,   380,   383,   396,   303,   244,   304,   106,
+     106,   394,   381,   253,   105,    93,   305,   296,   196,   397,
+     253,    88,   106,    75,   398,   399,   106,    94,   400,    75
 };
 
   /* YYR1YYN -- Symbol number of symbol that rule YYN derives.  */
@@ -2174,56 +2188,56 @@ static const yytype_int16 yyr1[] =
      158,   157,   159,   159,   159,   161,   160,   160,   162,   162,
      162,   162,   163,   163,   165,   166,   167,   164,   169,   170,
      171,   168,   173,   172,   175,   174,   176,   176,   177,   177,
-     178,   178,   179,   180,   180,   181,   181,   181,   182,   182,
-     183,   184,   184,   185,   185,   187,   186,   188,   186,   189,
-     186,   190,   186,   191,   186,   192,   186,   193,   186,   194,
-     186,   195,   197,   196,   196,   198,   199,   198,   200,   198,
-     201,   202,   203,   203,   203,   205,   206,   207,   208,   204,
-     209,   209,   209,   209,   209,   209,   209,   209,   209,   210,
-     211,   212,   212,   213,   213,   214,   214,   215,   215,   215,
-     216,   216,   216,   217,   217,   217,   217,   218,   218,   218,
-     218,   219,   219,   219,   220,   220,   220,   220,   220,   220,
-     220,   220,   220,   220,   221,   223,   222,   224,   224,   225,
-     225,   225,   226,   225,   227,   227,   228,   229,   229,   230,
-     231,   231,   233,   232,   234,   234,   235,   235,   236,   237,
-     237,   238,   240,   239,   239,   239,   239,   239,   239,   242,
-     241,   243,   243,   244,   244,   244,   245,   245,   245,   245,
-     245,   245,   245,   245,   246,   246,   246,   246,   247,   247,
-     247,   248,   248,   249,   251,   250,   250,   252,   252,   253,
-     255,   254,   254,   256,   257,   258,   258,   259,   259,   259,
-     260,   260,   260,   261,   261,   261,   262,   263,   263,   264,
-     265,   266,   267,   269,   268,   271,   272,   273,   270,   274,
-     275,   275,   276,   278,   279,   277,   280,   277,   282,   281,
-     284,   285,   286,   287,   288,   289,   283,   290,   290,   290,
-     290,   290,   290,   291,   292,   292,   294,   295,   293,   296,
-     293,   297,   298,   298,   300,   299,   301,   302,   299,   304,
-     303,   305,   306,   308,   309,   310,   311,   307,   312,   314,
-     313,   313,   315,   317,   318,   316,   316,   320,   321,   319,
-     322,   324,   325,   323,   323,   326,   328,   329,   327,   327,
-     330,   332,   331,   333,   334,   334,   336,   337,   335,   338,
-     338,   340,   341,   342,   343,   339,   345,   346,   347,   348,
-     344,   350,   351,   352,   353,   349,   355,   356,   357,   358,
-     354,   359,   359,   359,   360,   360,   362,   363,   364,   361,
-     366,   365,   367,   365,   368,   370,   369,   369,   372,   373,
-     371,   375,   374,   376,   374,   377,   379,   378,   378,   381,
-     382,   380,   383,   383,   383,   383,   384,   384,   384,   386,
-     387,   385,   385,   389,   390,   388,   388,   392,   393,   391,
-     391,   395,   396,   394,   394,   397,   399,   398,   398,   400,
-     401,   402,   402,   403,   405,   406,   407,   404,   409,   410,
-     408,   412,   411,   411,   413,   413,   415,   414,   416,   414,
-     417,   414,   418,   414,   419,   414,   420,   414,   421,   414,
-     422,   423,   423,   424,   425,   426,   426,   427,   428,   429,
-     431,   430,   433,   434,   435,   436,   437,   438,   432,   440,
-     439,   439,   441,   441,   443,   444,   442,   445,   445,   446,
-     447,   446,   448,   446,   450,   451,   449,   453,   454,   452,
-     455,   455,   455,   456,   456,   457,   458,   460,   461,   462,
-     459,   463,   464,   465,   467,   466,   469,   470,   471,   468,
-     472,   472,   473,   473,   473,   473,   473,   473,   473,   473,
-     473,   473,   474,   475,   475,   476,   476,   477,   478,   478,
-     479,   481,   482,   483,   484,   480,   485,   486,   486,   488,
-     487,   489,   487,   490,   487,   491,   491,   492,   493,   493,
-     494,   495,   497,   498,   496,   500,   501,   499,   502,   502,
-     504,   503,   505,   503,   506,   503,   507,   503
+     178,   178,   179,   180,   180,   180,   181,   181,   182,   181,
+     183,   183,   184,   185,   185,   186,   186,   188,   187,   189,
+     187,   190,   187,   191,   187,   192,   187,   193,   187,   194,
+     187,   195,   187,   196,   198,   197,   197,   199,   200,   199,
+     201,   199,   202,   203,   204,   204,   204,   206,   207,   208,
+     209,   205,   210,   210,   210,   210,   210,   210,   210,   210,
+     210,   211,   212,   213,   213,   214,   214,   215,   215,   216,
+     216,   216,   217,   217,   217,   218,   218,   218,   218,   219,
+     219,   219,   219,   220,   220,   220,   221,   221,   221,   221,
+     221,   221,   221,   221,   221,   221,   222,   224,   223,   225,
+     225,   226,   226,   226,   227,   226,   228,   228,   229,   230,
+     230,   231,   232,   232,   234,   233,   235,   235,   236,   236,
+     237,   238,   238,   239,   241,   240,   240,   240,   240,   240,
+     240,   243,   242,   244,   244,   245,   245,   245,   246,   246,
+     246,   246,   246,   246,   246,   246,   247,   247,   247,   247,
+     248,   248,   248,   249,   249,   250,   252,   251,   251,   253,
+     253,   254,   256,   255,   255,   257,   258,   259,   259,   260,
+     260,   260,   261,   261,   261,   262,   262,   262,   263,   264,
+     264,   265,   266,   267,   268,   270,   269,   272,   273,   274,
+     271,   275,   276,   276,   277,   279,   280,   278,   281,   278,
+     283,   282,   285,   286,   287,   288,   289,   290,   284,   291,
+     291,   291,   291,   291,   291,   292,   293,   293,   295,   296,
+     294,   297,   294,   298,   299,   299,   301,   300,   302,   303,
+     300,   305,   304,   306,   307,   309,   310,   311,   312,   308,
+     313,   315,   314,   314,   316,   318,   319,   317,   317,   321,
+     322,   320,   323,   325,   326,   324,   324,   327,   329,   330,
+     328,   328,   331,   333,   332,   334,   335,   335,   337,   338,
+     336,   339,   339,   341,   342,   343,   344,   340,   346,   347,
+     348,   349,   345,   351,   352,   353,   354,   350,   356,   357,
+     358,   359,   355,   360,   360,   360,   361,   361,   363,   364,
+     365,   362,   367,   366,   368,   366,   369,   371,   370,   370,
+     373,   374,   372,   376,   375,   377,   375,   378,   380,   379,
+     379,   382,   383,   381,   384,   384,   384,   384,   385,   385,
+     385,   387,   388,   386,   386,   390,   391,   389,   389,   393,
+     394,   392,   392,   396,   397,   395,   395,   398,   400,   399,
+     399,   401,   402,   403,   403,   404,   406,   407,   408,   405,
+     410,   411,   409,   413,   412,   412,   414,   414,   414,   416,
+     415,   417,   415,   418,   415,   419,   415,   420,   415,   421,
+     415,   422,   415,   423,   424,   424,   425,   426,   427,   427,
+     428,   429,   430,   432,   431,   434,   435,   436,   437,   438,
+     439,   433,   441,   440,   440,   442,   442,   444,   445,   443,
+     446,   446,   447,   448,   447,   449,   447,   451,   452,   450,
+     454,   455,   453,   456,   456,   456,   457,   457,   458,   459,
+     461,   462,   463,   460,   464,   465,   466,   468,   467,   470,
+     471,   472,   469,   473,   473,   474,   474,   474,   474,   474,
+     474,   474,   474,   474,   474,   475,   476,   476,   477,   477,
+     478,   479,   479,   480,   482,   483,   484,   485,   481,   486,
+     486,   487,   487,   488,   488,   489,   488,   490,   490,   491,
+     492,   492,   493,   494,   496,   497,   495,   499,   500,   498,
+     501,   501,   503,   502,   504,   502,   505,   502,   506,   502
 };
 
   /* YYR2YYN -- Number of symbols on the right hand side of rule YYN.  */
@@ -2239,56 +2253,56 @@ static const yytype_int8 yyr2[] =
        0,     3,     2,     3,     3,     0,     4,     0,     1,     1,
        1,     1,     2,     1,     0,     0,     0,     7,     0,     0,
        0,     8,     0,     4,     0,     3,     1,     0,     2,     0,
-       2,     1,     2,     2,     0,     1,     1,     2,     1,     1,
-       2,     1,     0,     3,     2,     0,     3,     0,     3,     0,
+       2,     1,     2,     3,     2,     0,     1,     1,     0,     3,
+       1,     1,     2,     1,     0,     3,     2,     0,     3,     0,
        3,     0,     3,     0,     3,     0,     3,     0,     3,     0,
-       3,     2,     0,     4,     0,     1,     0,     3,     0,     4,
-       1,     1,     1,     2,     2,     0,     0,     0,     0,     9,
+       3,     0,     3,     2,     0,     4,     0,     1,     0,     3,
+       0,     4,     1,     1,     1,     2,     2,     0,     0,     0,
+       0,     9,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     3,     1,     3,     1,     3,     1,
+       3,     3,     1,     3,     3,     1,     3,     3,     3,     1,
+       2,     2,     2,     1,     1,     3,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     0,     6,     2,
+       0,     1,     2,     2,     0,     4,     1,     1,     4,     2,
+       0,     2,     2,     0,     0,     4,     3,     0,     1,     1,
+       2,     3,     0,     3,     0,     3,     1,     1,     1,     2,
+       1,     0,     3,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     3,     1,     3,     1,     3,     1,     3,     3,
-       1,     3,     3,     1,     3,     3,     3,     1,     2,     2,
-       2,     1,     1,     3,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     0,     6,     2,     0,     1,
-       2,     2,     0,     4,     1,     1,     4,     2,     0,     2,
-       2,     0,     0,     4,     3,     0,     1,     1,     2,     3,
-       0,     3,     0,     3,     1,     1,     1,     2,     1,     0,
-       3,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     2,     0,     4,     0,     1,     1,     2,
-       0,     4,     0,     1,     1,     1,     1,     1,     2,     1,
-       2,     3,     2,     1,     1,     2,     1,     1,     1,     1,
-       1,     1,     1,     0,     3,     0,     0,     0,     7,     2,
-       2,     0,     2,     0,     0,     5,     0,     3,     0,     3,
-       0,     0,     0,     0,     0,     0,    15,     1,     1,     1,
-       1,     1,     1,     2,     2,     0,     0,     0,     6,     0,
-       3,     2,     2,     0,     0,     3,     0,     0,     5,     0,
-       3,     1,     1,     0,     0,     0,     0,     9,     2,     0,
-       4,     0,     2,     0,     0,     6,     2,     0,     0,     6,
-       6,     0,     0,     6,     1,     1,     0,     0,     6,     1,
-       1,     0,     4,     2,     2,     0,     0,     0,     5,     1,
-       1,     0,     0,     0,     0,     9,     0,     0,     0,     0,
-       9,     0,     0,     0,     0,     9,     0,     0,     0,     0,
-      10,     1,     1,     0,     1,     1,     0,     0,     0,     8,
-       0,     3,     0,     4,     2,     0,     4,     0,     0,     0,
-       5,     0,     3,     0,     4,     2,     0,     4,     0,     0,
-       0,     5,     1,     1,     1,     1,     1,     1,     1,     0,
-       0,     6,     0,     0,     0,     6,     0,     0,     0,     6,
-       0,     0,     0,     6,     0,     2,     0,     4,     0,     3,
-       3,     1,     1,     2,     0,     0,     0,     7,     0,     0,
-       6,     0,     3,     0,     2,     0,     0,     3,     0,     3,
-       0,     3,     0,     3,     0,     3,     0,     3,     0,     3,
-       3,     1,     1,     3,     2,     1,     0,     3,     3,     3,
-       0,     3,     0,     0,     0,     0,     0,     0,    13,     0,
-       3,     0,     2,     0,     0,     0,     5,     2,     0,     1,
-       0,     3,     0,     3,     0,     0,     6,     0,     0,     6,
-       1,     1,     1,     1,     1,     2,     3,     0,     0,     0,
-       8,     3,     3,     2,     0,     3,     0,     0,     0,     8,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     2,     2,     3,     0,     2,     5,     2,     3,     0,
-       1,     0,     0,     0,     0,    10,     2,     2,     0,     0,
-       3,     0,     3,     0,     3,     3,     3,     3,     4,     0,
-       1,     2,     0,     0,     6,     0,     0,     5,     2,     0,
-       0,     3,     0,     3,     0,     3,     0,     3
+       1,     1,     1,     1,     1,     2,     0,     4,     0,     1,
+       1,     2,     0,     4,     0,     1,     1,     1,     1,     1,
+       2,     1,     2,     3,     2,     1,     1,     2,     1,     1,
+       1,     1,     1,     1,     1,     0,     3,     0,     0,     0,
+       7,     2,     2,     0,     2,     0,     0,     5,     0,     3,
+       0,     3,     0,     0,     0,     0,     0,     0,    15,     1,
+       1,     1,     1,     1,     1,     2,     2,     0,     0,     0,
+       6,     0,     3,     2,     2,     0,     0,     3,     0,     0,
+       5,     0,     3,     1,     1,     0,     0,     0,     0,     9,
+       2,     0,     4,     0,     2,     0,     0,     6,     2,     0,
+       0,     6,     6,     0,     0,     6,     1,     1,     0,     0,
+       6,     1,     1,     0,     4,     2,     2,     0,     0,     0,
+       5,     1,     1,     0,     0,     0,     0,     9,     0,     0,
+       0,     0,     9,     0,     0,     0,     0,     9,     0,     0,
+       0,     0,    10,     1,     1,     0,     1,     1,     0,     0,
+       0,     7,     0,     3,     0,     4,     2,     0,     4,     0,
+       0,     0,     5,     0,     3,     0,     4,     2,     0,     4,
+       0,     0,     0,     5,     1,     1,     1,     1,     1,     1,
+       1,     0,     0,     6,     0,     0,     0,     6,     0,     0,
+       0,     6,     0,     0,     0,     6,     0,     2,     0,     4,
+       0,     3,     3,     1,     1,     2,     0,     0,     0,     7,
+       0,     0,     6,     0,     3,     0,     3,     2,     0,     0,
+       3,     0,     3,     0,     3,     0,     3,     0,     3,     0,
+       3,     0,     3,     3,     1,     1,     3,     2,     1,     0,
+       3,     3,     3,     0,     3,     0,     0,     0,     0,     0,
+       0,    13,     0,     3,     0,     2,     0,     0,     0,     5,
+       2,     0,     1,     0,     3,     0,     3,     0,     0,     6,
+       0,     0,     6,     1,     1,     1,     1,     1,     2,     3,
+       0,     0,     0,     8,     3,     3,     2,     0,     3,     0,
+       0,     0,     8,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     2,     2,     3,     0,     2,     5,
+       2,     3,     0,     1,     0,     0,     0,     0,     9,     3,
+       2,     1,     0,     2,     2,     0,     3,     3,     3,     3,
+       4,     0,     1,     2,     0,     0,     6,     0,     0,     5,
+       2,     0,     0,     3,     0,     3,     0,     3,     0,     3
 };
 
 
@@ -2769,291 +2783,284 @@ yyreduce:
   switch (yyn)
     {
   case 5:
-#line 413 "fe/idl.ypp"
+#line 417 "fe/idl.ypp"
         {
-          AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
-          AST_Decl *d = (yyvsp[0].dcval);
-          if (d)
+          AST_Annotation_Appls *&annotations = (yyvsp[-1].annotations_val);
+          AST_Decl *&node = (yyvsp[0].dcval);
+          if (node)
             {
-              d->annotation_appls (*annotations);
+              node->annotation_appls (*annotations);
             }
           else
             {
-              idl_global->err ()-> unsupported_warning(
+              idl_global->err ()-> unsupported_warning (
                 "Annotating this is not supported");
             }
           delete annotations;
         }
-#line 2788 "fe/idl.tab.cpp"
-    break;
-
-  case 6:
-#line 428 "fe/idl.ypp"
-        {
-        }
-#line 2795 "fe/idl.tab.cpp"
+#line 2802 "fe/idl.tab.cpp"
     break;
 
   case 10:
-#line 440 "fe/idl.ypp"
+#line 442 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AnnotationDeclSeen);
         }
-#line 2803 "fe/idl.tab.cpp"
+#line 2810 "fe/idl.tab.cpp"
     break;
 
   case 11:
-#line 444 "fe/idl.ypp"
+#line 446 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2811 "fe/idl.tab.cpp"
+#line 2818 "fe/idl.tab.cpp"
     break;
 
   case 12:
-#line 448 "fe/idl.ypp"
+#line 450 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypeDeclSeen);
         }
-#line 2819 "fe/idl.tab.cpp"
+#line 2826 "fe/idl.tab.cpp"
     break;
 
   case 13:
-#line 452 "fe/idl.ypp"
+#line 454 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2827 "fe/idl.tab.cpp"
+#line 2834 "fe/idl.tab.cpp"
     break;
 
   case 14:
-#line 456 "fe/idl.ypp"
+#line 458 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypeIdDeclSeen);
         }
-#line 2835 "fe/idl.tab.cpp"
+#line 2842 "fe/idl.tab.cpp"
     break;
 
   case 15:
-#line 460 "fe/idl.ypp"
+#line 462 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2843 "fe/idl.tab.cpp"
+#line 2850 "fe/idl.tab.cpp"
     break;
 
   case 16:
-#line 464 "fe/idl.ypp"
+#line 466 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypePrefixDeclSeen);
         }
-#line 2851 "fe/idl.tab.cpp"
+#line 2858 "fe/idl.tab.cpp"
     break;
 
   case 17:
-#line 468 "fe/idl.ypp"
+#line 470 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2859 "fe/idl.tab.cpp"
+#line 2866 "fe/idl.tab.cpp"
     break;
 
   case 18:
-#line 472 "fe/idl.ypp"
+#line 474 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConstDeclSeen);
         }
-#line 2867 "fe/idl.tab.cpp"
+#line 2874 "fe/idl.tab.cpp"
     break;
 
   case 19:
-#line 476 "fe/idl.ypp"
+#line 478 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2875 "fe/idl.tab.cpp"
+#line 2882 "fe/idl.tab.cpp"
     break;
 
   case 20:
-#line 480 "fe/idl.ypp"
+#line 482 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptDeclSeen);
         }
-#line 2883 "fe/idl.tab.cpp"
+#line 2890 "fe/idl.tab.cpp"
     break;
 
   case 21:
-#line 484 "fe/idl.ypp"
+#line 486 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2891 "fe/idl.tab.cpp"
+#line 2898 "fe/idl.tab.cpp"
     break;
 
   case 22:
-#line 488 "fe/idl.ypp"
+#line 490 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InterfaceDeclSeen);
         }
-#line 2899 "fe/idl.tab.cpp"
+#line 2906 "fe/idl.tab.cpp"
     break;
 
   case 23:
-#line 492 "fe/idl.ypp"
+#line 494 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2907 "fe/idl.tab.cpp"
+#line 2914 "fe/idl.tab.cpp"
     break;
 
   case 24:
-#line 496 "fe/idl.ypp"
+#line 498 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ModuleDeclSeen);
         }
-#line 2915 "fe/idl.tab.cpp"
+#line 2922 "fe/idl.tab.cpp"
     break;
 
   case 25:
-#line 500 "fe/idl.ypp"
+#line 502 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2923 "fe/idl.tab.cpp"
+#line 2930 "fe/idl.tab.cpp"
     break;
 
   case 26:
-#line 504 "fe/idl.ypp"
+#line 506 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeDeclSeen);
         }
-#line 2931 "fe/idl.tab.cpp"
+#line 2938 "fe/idl.tab.cpp"
     break;
 
   case 27:
-#line 508 "fe/idl.ypp"
+#line 510 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2939 "fe/idl.tab.cpp"
+#line 2946 "fe/idl.tab.cpp"
     break;
 
   case 28:
-#line 512 "fe/idl.ypp"
+#line 514 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ComponentDeclSeen);
         }
-#line 2947 "fe/idl.tab.cpp"
+#line 2954 "fe/idl.tab.cpp"
     break;
 
   case 29:
-#line 516 "fe/idl.ypp"
+#line 518 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2955 "fe/idl.tab.cpp"
+#line 2962 "fe/idl.tab.cpp"
     break;
 
   case 30:
-#line 520 "fe/idl.ypp"
+#line 522 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeDeclSeen);
         }
-#line 2963 "fe/idl.tab.cpp"
+#line 2970 "fe/idl.tab.cpp"
     break;
 
   case 31:
-#line 524 "fe/idl.ypp"
+#line 526 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2971 "fe/idl.tab.cpp"
+#line 2978 "fe/idl.tab.cpp"
     break;
 
   case 32:
-#line 528 "fe/idl.ypp"
+#line 530 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventDeclSeen);
         }
-#line 2979 "fe/idl.tab.cpp"
+#line 2986 "fe/idl.tab.cpp"
     break;
 
   case 33:
-#line 532 "fe/idl.ypp"
+#line 534 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 2987 "fe/idl.tab.cpp"
+#line 2994 "fe/idl.tab.cpp"
     break;
 
   case 34:
-#line 536 "fe/idl.ypp"
+#line 538 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeDeclSeen);
         }
-#line 2995 "fe/idl.tab.cpp"
+#line 3002 "fe/idl.tab.cpp"
     break;
 
   case 35:
-#line 540 "fe/idl.ypp"
+#line 542 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 3003 "fe/idl.tab.cpp"
+#line 3010 "fe/idl.tab.cpp"
     break;
 
   case 36:
-#line 544 "fe/idl.ypp"
+#line 546 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorDeclSeen);
         }
-#line 3011 "fe/idl.tab.cpp"
+#line 3018 "fe/idl.tab.cpp"
     break;
 
   case 37:
-#line 548 "fe/idl.ypp"
+#line 550 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 3019 "fe/idl.tab.cpp"
+#line 3026 "fe/idl.tab.cpp"
     break;
 
   case 38:
-#line 552 "fe/idl.ypp"
+#line 554 "fe/idl.ypp"
         {
-          idl_global->err()->syntax_error (idl_global->parse_state());
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
-#line 3027 "fe/idl.tab.cpp"
+#line 3034 "fe/idl.tab.cpp"
     break;
 
   case 39:
-#line 556 "fe/idl.ypp"
+#line 558 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           yyerrok;
           (yyval.dcval) = 0;
         }
-#line 3037 "fe/idl.tab.cpp"
+#line 3044 "fe/idl.tab.cpp"
     break;
 
   case 40:
-#line 565 "fe/idl.ypp"
+#line 567 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ModuleSeen);
         }
-#line 3045 "fe/idl.tab.cpp"
+#line 3052 "fe/idl.tab.cpp"
     break;
 
   case 41:
-#line 569 "fe/idl.ypp"
+#line 571 "fe/idl.ypp"
         {
           (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 3053 "fe/idl.tab.cpp"
+#line 3060 "fe/idl.tab.cpp"
     break;
 
   case 42:
-#line 576 "fe/idl.ypp"
+#line 578 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ModuleIDSeen);
 
@@ -3092,27 +3099,27 @@ yyreduce:
 
           (yyval.dcval) = m;
         }
-#line 3096 "fe/idl.tab.cpp"
+#line 3103 "fe/idl.tab.cpp"
     break;
 
   case 43:
-#line 615 "fe/idl.ypp"
+#line 617 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ModuleSqSeen);
         }
-#line 3104 "fe/idl.tab.cpp"
+#line 3111 "fe/idl.tab.cpp"
     break;
 
   case 44:
-#line 619 "fe/idl.ypp"
+#line 621 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ModuleBodySeen);
         }
-#line 3112 "fe/idl.tab.cpp"
+#line 3119 "fe/idl.tab.cpp"
     break;
 
   case 45:
-#line 623 "fe/idl.ypp"
+#line 625 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ModuleQsSeen);
           /*
@@ -3122,19 +3129,19 @@ yyreduce:
           idl_global->scopes ().pop ();
           (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 3126 "fe/idl.tab.cpp"
+#line 3133 "fe/idl.tab.cpp"
     break;
 
   case 46:
-#line 636 "fe/idl.ypp"
+#line 638 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TmplModuleIDSeen);
         }
-#line 3134 "fe/idl.tab.cpp"
+#line 3141 "fe/idl.tab.cpp"
     break;
 
   case 47:
-#line 643 "fe/idl.ypp"
+#line 645 "fe/idl.ypp"
         {
           // The module_header rule is common to template module, fixed
           // module and instantiated template module. In the last
@@ -3148,11 +3155,11 @@ yyreduce:
                 IDL_GlobalData::PS_ModuleIDSeen);
             }
         }
-#line 3152 "fe/idl.tab.cpp"
+#line 3159 "fe/idl.tab.cpp"
     break;
 
   case 48:
-#line 657 "fe/idl.ypp"
+#line 659 "fe/idl.ypp"
         {
           if (FE_Utils::duplicate_param_id ((yyvsp[0].plval)))
             {
@@ -3162,11 +3169,11 @@ yyreduce:
               return 1;
             }
         }
-#line 3166 "fe/idl.tab.cpp"
+#line 3173 "fe/idl.tab.cpp"
     break;
 
   case 49:
-#line 667 "fe/idl.ypp"
+#line 669 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TmplModuleParamsSeen);
 
@@ -3196,27 +3203,27 @@ yyreduce:
           // of the template module.
           idl_global->current_params ((yyvsp[-2].plval));
         }
-#line 3200 "fe/idl.tab.cpp"
+#line 3207 "fe/idl.tab.cpp"
     break;
 
   case 50:
-#line 697 "fe/idl.ypp"
+#line 699 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TmplModuleSqSeen);
         }
-#line 3208 "fe/idl.tab.cpp"
+#line 3215 "fe/idl.tab.cpp"
     break;
 
   case 51:
-#line 701 "fe/idl.ypp"
+#line 703 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TmplModuleBodySeen);
         }
-#line 3216 "fe/idl.tab.cpp"
+#line 3223 "fe/idl.tab.cpp"
     break;
 
   case 52:
-#line 705 "fe/idl.ypp"
+#line 707 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TmplModuleQsSeen);
 
@@ -3235,29 +3242,29 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 3239 "fe/idl.tab.cpp"
+#line 3246 "fe/idl.tab.cpp"
     break;
 
   case 58:
-#line 741 "fe/idl.ypp"
+#line 743 "fe/idl.ypp"
         {
           idl_global->set_parse_state (
             IDL_GlobalData::PS_ModuleRefSeen);
         }
-#line 3248 "fe/idl.tab.cpp"
+#line 3255 "fe/idl.tab.cpp"
     break;
 
   case 59:
-#line 746 "fe/idl.ypp"
+#line 748 "fe/idl.ypp"
         {
           idl_global->set_parse_state (
             IDL_GlobalData::PS_ModuleRefParamsSeen);
         }
-#line 3257 "fe/idl.tab.cpp"
+#line 3264 "fe/idl.tab.cpp"
     break;
 
   case 60:
-#line 751 "fe/idl.ypp"
+#line 753 "fe/idl.ypp"
         {
           idl_global->set_parse_state (
             IDL_GlobalData::PS_ModuleRefIDSeen);
@@ -3335,29 +3342,29 @@ yyreduce:
           idl_global->in_tmpl_mod_no_alias (itmna_flag);
           idl_global->in_tmpl_mod_alias (false);
         }
-#line 3339 "fe/idl.tab.cpp"
+#line 3346 "fe/idl.tab.cpp"
     break;
 
   case 61:
-#line 832 "fe/idl.ypp"
+#line 834 "fe/idl.ypp"
         {
           idl_global->set_parse_state (
             IDL_GlobalData::PS_InstModuleSeen);
         }
-#line 3348 "fe/idl.tab.cpp"
+#line 3355 "fe/idl.tab.cpp"
     break;
 
   case 62:
-#line 837 "fe/idl.ypp"
+#line 839 "fe/idl.ypp"
         {
           idl_global->set_parse_state (
             IDL_GlobalData::PS_InstModuleArgsSeen);
         }
-#line 3357 "fe/idl.tab.cpp"
+#line 3364 "fe/idl.tab.cpp"
     break;
 
   case 63:
-#line 842 "fe/idl.ypp"
+#line 844 "fe/idl.ypp"
         {
           idl_global->set_parse_state (
             IDL_GlobalData::PS_InstModuleIDSeen);
@@ -3421,11 +3428,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 3425 "fe/idl.tab.cpp"
+#line 3432 "fe/idl.tab.cpp"
     break;
 
   case 66:
-#line 914 "fe/idl.ypp"
+#line 916 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Interface *i = 0;
@@ -3463,27 +3470,27 @@ yyreduce:
            */
           idl_global->scopes ().push (i);
         }
-#line 3467 "fe/idl.tab.cpp"
+#line 3474 "fe/idl.tab.cpp"
     break;
 
   case 67:
-#line 952 "fe/idl.ypp"
+#line 954 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InterfaceSqSeen);
         }
-#line 3475 "fe/idl.tab.cpp"
+#line 3482 "fe/idl.tab.cpp"
     break;
 
   case 68:
-#line 956 "fe/idl.ypp"
+#line 958 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InterfaceBodySeen);
         }
-#line 3483 "fe/idl.tab.cpp"
+#line 3490 "fe/idl.tab.cpp"
     break;
 
   case 69:
-#line 960 "fe/idl.ypp"
+#line 962 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InterfaceQsSeen);
 
@@ -3493,28 +3500,28 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
         }
-#line 3497 "fe/idl.tab.cpp"
+#line 3504 "fe/idl.tab.cpp"
     break;
 
   case 70:
-#line 973 "fe/idl.ypp"
+#line 975 "fe/idl.ypp"
          {
            idl_global->set_parse_state (IDL_GlobalData::PS_InterfaceSeen);
          }
-#line 3505 "fe/idl.tab.cpp"
+#line 3512 "fe/idl.tab.cpp"
     break;
 
   case 71:
-#line 977 "fe/idl.ypp"
+#line 979 "fe/idl.ypp"
          {
            idl_global->set_parse_state (IDL_GlobalData::PS_InterfaceIDSeen);
            (yyval.idval) = (yyvsp[0].idval);
          }
-#line 3514 "fe/idl.tab.cpp"
+#line 3521 "fe/idl.tab.cpp"
     break;
 
   case 72:
-#line 985 "fe/idl.ypp"
+#line 987 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
 
@@ -3550,11 +3557,11 @@ yyreduce:
               (yyvsp[0].nlval) = 0;
             }
         }
-#line 3554 "fe/idl.tab.cpp"
+#line 3561 "fe/idl.tab.cpp"
     break;
 
   case 73:
-#line 1022 "fe/idl.ypp"
+#line 1024 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
 
@@ -3583,11 +3590,11 @@ yyreduce:
               (yyvsp[0].nlval) = 0;
             }
         }
-#line 3587 "fe/idl.tab.cpp"
+#line 3594 "fe/idl.tab.cpp"
     break;
 
   case 74:
-#line 1052 "fe/idl.ypp"
+#line 1054 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
 
@@ -3616,108 +3623,110 @@ yyreduce:
               (yyvsp[0].nlval) = 0;
             }
         }
-#line 3620 "fe/idl.tab.cpp"
+#line 3627 "fe/idl.tab.cpp"
     break;
 
   case 75:
-#line 1084 "fe/idl.ypp"
+#line 1086 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
         }
-#line 3628 "fe/idl.tab.cpp"
+#line 3635 "fe/idl.tab.cpp"
     break;
 
   case 76:
-#line 1088 "fe/idl.ypp"
+#line 1090 "fe/idl.ypp"
         {
           (yyvsp[0].nlval)->truncatable ((yyvsp[-2].bval));
           (yyval.nlval) = (yyvsp[0].nlval);
         }
-#line 3637 "fe/idl.tab.cpp"
+#line 3644 "fe/idl.tab.cpp"
     break;
 
   case 77:
-#line 1093 "fe/idl.ypp"
+#line 1095 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 3645 "fe/idl.tab.cpp"
+#line 3652 "fe/idl.tab.cpp"
     break;
 
   case 82:
-#line 1107 "fe/idl.ypp"
+#line 1109 "fe/idl.ypp"
         {
           idl_global->err ()->unsupported_error ("custom is not supported");
-          (yyval.dcval) = 0;
+          (yyval.dcval) = (yyvsp[0].dcval);
         }
-#line 3654 "fe/idl.tab.cpp"
+#line 3661 "fe/idl.tab.cpp"
     break;
 
   case 84:
-#line 1116 "fe/idl.ypp"
+#line 1118 "fe/idl.ypp"
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          AST_ValueType *v = 0;
-          AST_Interface *i = 0;
+          FE_OBVHeader *valuetype_header = (yyvsp[0].vhval);
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          AST_ValueType *valuetype = 0;
 
-          if (s != 0 && (yyvsp[0].vhval) != 0)
+          if (scope && valuetype_header)
             {
-              v =
-                idl_global->gen ()->create_valuetype (
-                  (yyvsp[0].vhval)->name (),
-                  (yyvsp[0].vhval)->inherits (),
-                  (yyvsp[0].vhval)->n_inherits (),
-                  (yyvsp[0].vhval)->inherits_concrete (),
-                  (yyvsp[0].vhval)->inherits_flat (),
-                  (yyvsp[0].vhval)->n_inherits_flat (),
-                  (yyvsp[0].vhval)->supports (),
-                  (yyvsp[0].vhval)->n_supports (),
-                  (yyvsp[0].vhval)->supports_concrete (),
-                  false,
-                  (yyvsp[0].vhval)->truncatable (),
-                  false);
+              valuetype = idl_global->gen ()->create_valuetype (
+                valuetype_header->name (),
+                valuetype_header->inherits (),
+                valuetype_header->n_inherits (),
+                valuetype_header->inherits_concrete (),
+                valuetype_header->inherits_flat (),
+                valuetype_header->n_inherits_flat (),
+                valuetype_header->supports (),
+                valuetype_header->n_supports (),
+                valuetype_header->supports_concrete (),
+                false,
+                valuetype_header->truncatable (),
+                false);
 
-              i = AST_Interface::narrow_from_decl (v);
-              AST_Interface::fwd_redefinition_helper (i,
-                                                      s);
+              AST_Interface* valuetype_as_interface =
+                dynamic_cast<AST_Interface*> (valuetype);
+              AST_Interface::fwd_redefinition_helper (
+                valuetype_as_interface, scope);
+
               /*
                * Add the valuetype to its definition scope
                */
-              v = AST_ValueType::narrow_from_decl (i);
-              (void) s->fe_add_valuetype (v);
+              scope->fe_add_valuetype (valuetype);
 
               // FE_OBVHeader is not automatically destroyed in the AST
-              (yyvsp[0].vhval)->destroy ();
-              delete (yyvsp[0].vhval);
-              (yyvsp[0].vhval) = 0;
+              valuetype_header->destroy ();
+              delete valuetype_header;
+              valuetype_header = ((yyvsp[0].vhval) = 0);
             }
 
           /*
            * Push it on the scope stack
            */
-          idl_global->scopes ().push (v);
+          idl_global->scopes ().push (valuetype);
+
+          (yyval.dcval) = valuetype;
         }
-#line 3701 "fe/idl.tab.cpp"
+#line 3710 "fe/idl.tab.cpp"
     break;
 
   case 85:
-#line 1159 "fe/idl.ypp"
+#line 1163 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeSqSeen);
         }
-#line 3709 "fe/idl.tab.cpp"
+#line 3718 "fe/idl.tab.cpp"
     break;
 
   case 86:
-#line 1163 "fe/idl.ypp"
+#line 1167 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeBodySeen);
         }
-#line 3717 "fe/idl.tab.cpp"
+#line 3726 "fe/idl.tab.cpp"
     break;
 
   case 87:
-#line 1167 "fe/idl.ypp"
+#line 1171 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeQsSeen);
 
@@ -3736,13 +3745,13 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
 
-          (yyval.dcval) = 0;
+          (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 3742 "fe/idl.tab.cpp"
+#line 3751 "fe/idl.tab.cpp"
     break;
 
   case 88:
-#line 1192 "fe/idl.ypp"
+#line 1196 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_ValueType *v = 0;
@@ -3785,27 +3794,27 @@ yyreduce:
            */
           idl_global->scopes ().push (v);
         }
-#line 3789 "fe/idl.tab.cpp"
+#line 3798 "fe/idl.tab.cpp"
     break;
 
   case 89:
-#line 1235 "fe/idl.ypp"
+#line 1239 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeSqSeen);
         }
-#line 3797 "fe/idl.tab.cpp"
+#line 3806 "fe/idl.tab.cpp"
     break;
 
   case 90:
-#line 1239 "fe/idl.ypp"
+#line 1243 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeBodySeen);
         }
-#line 3805 "fe/idl.tab.cpp"
+#line 3814 "fe/idl.tab.cpp"
     break;
 
   case 91:
-#line 1243 "fe/idl.ypp"
+#line 1247 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeQsSeen);
 
@@ -3816,19 +3825,19 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 3820 "fe/idl.tab.cpp"
+#line 3829 "fe/idl.tab.cpp"
     break;
 
   case 92:
-#line 1258 "fe/idl.ypp"
+#line 1262 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
         }
-#line 3828 "fe/idl.tab.cpp"
+#line 3837 "fe/idl.tab.cpp"
     break;
 
   case 93:
-#line 1262 "fe/idl.ypp"
+#line 1266 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
 
@@ -3859,60 +3868,60 @@ yyreduce:
               (yyvsp[-2].nlval) = 0;
             }
         }
-#line 3863 "fe/idl.tab.cpp"
+#line 3872 "fe/idl.tab.cpp"
     break;
 
   case 94:
-#line 1296 "fe/idl.ypp"
-        {
-           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeSeen);
-        }
-#line 3871 "fe/idl.tab.cpp"
-    break;
-
-  case 95:
 #line 1300 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeIDSeen);
-          (yyval.idval) = (yyvsp[0].idval);
+           idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeSeen);
         }
 #line 3880 "fe/idl.tab.cpp"
     break;
 
+  case 95:
+#line 1304 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ValueTypeIDSeen);
+          (yyval.idval) = (yyvsp[0].idval);
+        }
+#line 3889 "fe/idl.tab.cpp"
+    break;
+
   case 96:
-#line 1308 "fe/idl.ypp"
+#line 1312 "fe/idl.ypp"
         {
           (yyval.bval) = true;
         }
-#line 3888 "fe/idl.tab.cpp"
+#line 3897 "fe/idl.tab.cpp"
     break;
 
   case 97:
-#line 1312 "fe/idl.ypp"
+#line 1316 "fe/idl.ypp"
         {
           (yyval.bval) = false;
         }
-#line 3896 "fe/idl.tab.cpp"
+#line 3905 "fe/idl.tab.cpp"
     break;
 
   case 98:
-#line 1320 "fe/idl.ypp"
+#line 1324 "fe/idl.ypp"
         {
           (yyval.nlval) = (yyvsp[0].nlval);
         }
-#line 3904 "fe/idl.tab.cpp"
+#line 3913 "fe/idl.tab.cpp"
     break;
 
   case 99:
-#line 1324 "fe/idl.ypp"
+#line 1328 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 3912 "fe/idl.tab.cpp"
+#line 3921 "fe/idl.tab.cpp"
     break;
 
   case 100:
-#line 1332 "fe/idl.ypp"
+#line 1336 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -3935,11 +3944,11 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 3939 "fe/idl.tab.cpp"
+#line 3948 "fe/idl.tab.cpp"
     break;
 
   case 101:
-#line 1356 "fe/idl.ypp"
+#line 1360 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -3964,11 +3973,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 3968 "fe/idl.tab.cpp"
+#line 3977 "fe/idl.tab.cpp"
     break;
 
   case 102:
-#line 1384 "fe/idl.ypp"
+#line 1388 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ValueBoxDeclSeen);
 
@@ -4031,47 +4040,116 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 4035 "fe/idl.tab.cpp"
+#line 4044 "fe/idl.tab.cpp"
+    break;
+
+  case 103:
+#line 1454 "fe/idl.ypp"
+        {
+          AST_Annotation_Appls *&annotations = (yyvsp[-1].annotations_val);
+          AST_Decls *&decls = (yyvsp[0].decls_val);
+          if (decls)
+            {
+              for (size_t i = 0; i < decls->size (); i++)
+                {
+                  (*decls)[i]->annotation_appls (*annotations);
+                }
+            }
+          else
+            {
+              idl_global->err ()-> unsupported_warning (
+                "Annotating this is not supported");
+            }
+          delete annotations;
+          delete decls;
+        }
+#line 4067 "fe/idl.tab.cpp"
+    break;
+
+  case 104:
+#line 1473 "fe/idl.ypp"
+        {
+          delete (yyvsp[0].decls_val);
+        }
+#line 4075 "fe/idl.tab.cpp"
+    break;
+
+  case 107:
+#line 1482 "fe/idl.ypp"
+        {
+          AST_Decl *&node = (yyvsp[0].dcval);
+          AST_Decls *value = 0;
+          if (node)
+            {
+              value = new AST_Decls;
+              value->push_back (node);
+            }
+          (yyval.decls_val) = value;
+        }
+#line 4090 "fe/idl.tab.cpp"
     break;
 
   case 108:
-#line 1462 "fe/idl.ypp"
+#line 1493 "fe/idl.ypp"
         {
-          (yyval.vival) = AST_Field::vis_PUBLIC;
+          AST_Decl *&node = (yyvsp[0].dcval);
+          AST_Decls *value = 0;
+          if (node)
+            {
+              value = new AST_Decls;
+              value->push_back (node);
+            }
+          (yyval.decls_val) = value;
         }
-#line 4043 "fe/idl.tab.cpp"
+#line 4105 "fe/idl.tab.cpp"
     break;
 
   case 109:
-#line 1466 "fe/idl.ypp"
+#line 1504 "fe/idl.ypp"
         {
-          (yyval.vival) = AST_Field::vis_PRIVATE;
+          (yyval.decls_val) = (yyvsp[-1].decls_val);
         }
-#line 4051 "fe/idl.tab.cpp"
+#line 4113 "fe/idl.tab.cpp"
     break;
 
   case 110:
-#line 1473 "fe/idl.ypp"
+#line 1511 "fe/idl.ypp"
+        {
+          (yyval.vival) = AST_Field::vis_PUBLIC;
+        }
+#line 4121 "fe/idl.tab.cpp"
+    break;
+
+  case 111:
+#line 1515 "fe/idl.ypp"
+        {
+          (yyval.vival) = AST_Field::vis_PRIVATE;
+        }
+#line 4129 "fe/idl.tab.cpp"
+    break;
+
+  case 112:
+#line 1522 "fe/idl.ypp"
         {
           if ((yyvsp[0].decls_val))
             {
               AST_Decls &decls = *(yyvsp[0].decls_val);
               for (size_t i = 0; i < decls.size (); i++)
                 {
-                  AST_Field * field = dynamic_cast<AST_Field*>(decls[i]);
+                  AST_Field * field = dynamic_cast<AST_Field*> (decls[i]);
                   if (field)
                     {
                       field->visibility ((yyvsp[-1].vival));
                     }
                 }
             }
-          delete (yyvsp[0].decls_val);
+          (yyval.decls_val) = (yyvsp[0].decls_val);
         }
-#line 4071 "fe/idl.tab.cpp"
+#line 4149 "fe/idl.tab.cpp"
     break;
 
-  case 113:
-#line 1497 "fe/idl.ypp"
+  case 115:
+#line 1546 "fe/idl.ypp"
         {
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
           AST_Decl *d = (yyvsp[0].dcval);
@@ -4081,172 +4159,165 @@ yyreduce:
             }
           else
             {
-              idl_global->err ()-> unsupported_warning(
+              idl_global->err ()-> unsupported_warning (
                 "Annotating this is not supported");
             }
           delete annotations;
         }
-#line 4090 "fe/idl.tab.cpp"
-    break;
-
-  case 114:
-#line 1512 "fe/idl.ypp"
-        {
-        }
-#line 4097 "fe/idl.tab.cpp"
-    break;
-
-  case 115:
-#line 1518 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_TypeDeclSeen);
-        }
-#line 4105 "fe/idl.tab.cpp"
-    break;
-
-  case 116:
-#line 1522 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 4113 "fe/idl.tab.cpp"
+#line 4168 "fe/idl.tab.cpp"
     break;
 
   case 117:
-#line 1526 "fe/idl.ypp"
+#line 1565 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_TypeIdDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_TypeDeclSeen);
         }
-#line 4121 "fe/idl.tab.cpp"
+#line 4176 "fe/idl.tab.cpp"
     break;
 
   case 118:
-#line 1530 "fe/idl.ypp"
+#line 1569 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4129 "fe/idl.tab.cpp"
+#line 4184 "fe/idl.tab.cpp"
     break;
 
   case 119:
-#line 1534 "fe/idl.ypp"
+#line 1573 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_TypePrefixDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_TypeIdDeclSeen);
         }
-#line 4137 "fe/idl.tab.cpp"
+#line 4192 "fe/idl.tab.cpp"
     break;
 
   case 120:
-#line 1538 "fe/idl.ypp"
+#line 1577 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4145 "fe/idl.tab.cpp"
+#line 4200 "fe/idl.tab.cpp"
     break;
 
   case 121:
-#line 1542 "fe/idl.ypp"
+#line 1581 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConstDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_TypePrefixDeclSeen);
         }
-#line 4153 "fe/idl.tab.cpp"
+#line 4208 "fe/idl.tab.cpp"
     break;
 
   case 122:
-#line 1546 "fe/idl.ypp"
+#line 1585 "fe/idl.ypp"
         {
-          idl_global->set_parse_state(IDL_GlobalData::PS_NoState);
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4161 "fe/idl.tab.cpp"
+#line 4216 "fe/idl.tab.cpp"
     break;
 
   case 123:
-#line 1550 "fe/idl.ypp"
+#line 1589 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ExceptDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConstDeclSeen);
         }
-#line 4169 "fe/idl.tab.cpp"
+#line 4224 "fe/idl.tab.cpp"
     break;
 
   case 124:
-#line 1554 "fe/idl.ypp"
+#line 1593 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4177 "fe/idl.tab.cpp"
+#line 4232 "fe/idl.tab.cpp"
     break;
 
   case 125:
-#line 1558 "fe/idl.ypp"
+#line 1597 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_ExceptDeclSeen);
         }
-#line 4185 "fe/idl.tab.cpp"
+#line 4240 "fe/idl.tab.cpp"
     break;
 
   case 126:
-#line 1562 "fe/idl.ypp"
+#line 1601 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4193 "fe/idl.tab.cpp"
+#line 4248 "fe/idl.tab.cpp"
     break;
 
   case 127:
-#line 1566 "fe/idl.ypp"
+#line 1605 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
         }
-#line 4201 "fe/idl.tab.cpp"
+#line 4256 "fe/idl.tab.cpp"
     break;
 
   case 128:
-#line 1570 "fe/idl.ypp"
+#line 1609 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 4209 "fe/idl.tab.cpp"
+#line 4264 "fe/idl.tab.cpp"
     break;
 
   case 129:
-#line 1574 "fe/idl.ypp"
+#line 1613 "fe/idl.ypp"
         {
-          idl_global->err()->syntax_error (idl_global->parse_state());
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpDeclSeen);
         }
-#line 4217 "fe/idl.tab.cpp"
+#line 4272 "fe/idl.tab.cpp"
     break;
 
   case 130:
-#line 1578 "fe/idl.ypp"
+#line 1617 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+        }
+#line 4280 "fe/idl.tab.cpp"
+    break;
+
+  case 131:
+#line 1621 "fe/idl.ypp"
+        {
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
+        }
+#line 4288 "fe/idl.tab.cpp"
+    break;
+
+  case 132:
+#line 1625 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           yyerrok;
           (yyval.dcval) = 0;
         }
-#line 4227 "fe/idl.tab.cpp"
+#line 4298 "fe/idl.tab.cpp"
     break;
 
-  case 131:
-#line 1587 "fe/idl.ypp"
+  case 133:
+#line 1634 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.nlval),
                           UTL_NameList ((yyvsp[-1].idlist),
                                         (yyvsp[0].nlval)),
                           1);
         }
-#line 4238 "fe/idl.tab.cpp"
+#line 4309 "fe/idl.tab.cpp"
     break;
 
-  case 132:
-#line 1598 "fe/idl.ypp"
+  case 134:
+#line 1645 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SNListCommaSeen);
         }
-#line 4246 "fe/idl.tab.cpp"
+#line 4317 "fe/idl.tab.cpp"
     break;
 
-  case 133:
-#line 1602 "fe/idl.ypp"
+  case 135:
+#line 1649 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ScopedNameSeen);
 
@@ -4266,19 +4337,19 @@ yyreduce:
               (yyval.nlval) = (yyvsp[-3].nlval);
             }
         }
-#line 4270 "fe/idl.tab.cpp"
+#line 4341 "fe/idl.tab.cpp"
     break;
 
-  case 134:
-#line 1622 "fe/idl.ypp"
+  case 136:
+#line 1669 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 4278 "fe/idl.tab.cpp"
+#line 4349 "fe/idl.tab.cpp"
     break;
 
-  case 135:
-#line 1629 "fe/idl.ypp"
+  case 137:
+#line 1676 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SN_IDSeen);
 
@@ -4287,19 +4358,19 @@ yyreduce:
                                       0),
                           1);
         }
-#line 4291 "fe/idl.tab.cpp"
+#line 4362 "fe/idl.tab.cpp"
     break;
 
-  case 136:
-#line 1638 "fe/idl.ypp"
+  case 138:
+#line 1685 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ScopeDelimSeen);
         }
-#line 4299 "fe/idl.tab.cpp"
+#line 4370 "fe/idl.tab.cpp"
     break;
 
-  case 137:
-#line 1642 "fe/idl.ypp"
+  case 139:
+#line 1689 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SN_IDSeen);
 
@@ -4319,11 +4390,11 @@ yyreduce:
                                       sn),
                           1);
         }
-#line 4323 "fe/idl.tab.cpp"
+#line 4394 "fe/idl.tab.cpp"
     break;
 
-  case 138:
-#line 1663 "fe/idl.ypp"
+  case 140:
+#line 1710 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ScopeDelimSeen);
 
@@ -4333,11 +4404,11 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 4337 "fe/idl.tab.cpp"
+#line 4408 "fe/idl.tab.cpp"
     break;
 
-  case 139:
-#line 1673 "fe/idl.ypp"
+  case 141:
+#line 1720 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SN_IDSeen);
 
@@ -4349,11 +4420,11 @@ yyreduce:
           (yyvsp[-3].idlist)->nconc (sn);
           (yyval.idlist) = (yyvsp[-3].idlist);
         }
-#line 4353 "fe/idl.tab.cpp"
+#line 4424 "fe/idl.tab.cpp"
     break;
 
-  case 140:
-#line 1687 "fe/idl.ypp"
+  case 142:
+#line 1734 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.idval),
                           Identifier ((yyvsp[0].strval)),
@@ -4361,11 +4432,11 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 4365 "fe/idl.tab.cpp"
+#line 4436 "fe/idl.tab.cpp"
     break;
 
-  case 141:
-#line 1697 "fe/idl.ypp"
+  case 143:
+#line 1744 "fe/idl.ypp"
         {
           /* defining_id is a defining identifier
              whereas id is usually a reference to a defining identifier */
@@ -4373,11 +4444,11 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 4377 "fe/idl.tab.cpp"
+#line 4448 "fe/idl.tab.cpp"
     break;
 
-  case 142:
-#line 1708 "fe/idl.ypp"
+  case 144:
+#line 1755 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval), 0);
@@ -4420,11 +4491,11 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 4424 "fe/idl.tab.cpp"
+#line 4495 "fe/idl.tab.cpp"
     break;
 
-  case 143:
-#line 1752 "fe/idl.ypp"
+  case 145:
+#line 1799 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -4450,11 +4521,11 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 4454 "fe/idl.tab.cpp"
+#line 4525 "fe/idl.tab.cpp"
     break;
 
-  case 144:
-#line 1779 "fe/idl.ypp"
+  case 146:
+#line 1826 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -4480,45 +4551,45 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
 
-          (yyval.dcval) = dynamic_cast<AST_Decl*>(f);
+          (yyval.dcval) = dynamic_cast<AST_Decl*> (f);
         }
-#line 4486 "fe/idl.tab.cpp"
-    break;
-
-  case 145:
-#line 1810 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConstSeen);
-        }
-#line 4494 "fe/idl.tab.cpp"
-    break;
-
-  case 146:
-#line 1814 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConstTypeSeen);
-        }
-#line 4502 "fe/idl.tab.cpp"
+#line 4557 "fe/idl.tab.cpp"
     break;
 
   case 147:
-#line 1818 "fe/idl.ypp"
+#line 1857 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConstIDSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConstSeen);
         }
-#line 4510 "fe/idl.tab.cpp"
+#line 4565 "fe/idl.tab.cpp"
     break;
 
   case 148:
-#line 1822 "fe/idl.ypp"
+#line 1861 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConstAssignSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConstTypeSeen);
         }
-#line 4518 "fe/idl.tab.cpp"
+#line 4573 "fe/idl.tab.cpp"
     break;
 
   case 149:
-#line 1826 "fe/idl.ypp"
+#line 1865 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConstIDSeen);
+        }
+#line 4581 "fe/idl.tab.cpp"
+    break;
+
+  case 150:
+#line 1869 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConstAssignSeen);
+        }
+#line 4589 "fe/idl.tab.cpp"
+    break;
+
+  case 151:
+#line 1873 "fe/idl.ypp"
         {
           (yyval.dcval) = 0;
           UTL_ScopedName n ((yyvsp[-4].idval), 0);
@@ -4574,27 +4645,27 @@ yyreduce:
           delete (yyvsp[-4].idval);
           (yyvsp[-4].idval) = 0;
         }
-#line 4578 "fe/idl.tab.cpp"
-    break;
-
-  case 156:
-#line 1891 "fe/idl.ypp"
-        {
-          (yyval.etval) = AST_Expression::EV_string;
-        }
-#line 4586 "fe/idl.tab.cpp"
-    break;
-
-  case 157:
-#line 1895 "fe/idl.ypp"
-        {
-          (yyval.etval) = AST_Expression::EV_wstring;
-        }
-#line 4594 "fe/idl.tab.cpp"
+#line 4649 "fe/idl.tab.cpp"
     break;
 
   case 158:
-#line 1899 "fe/idl.ypp"
+#line 1938 "fe/idl.ypp"
+        {
+          (yyval.etval) = AST_Expression::EV_string;
+        }
+#line 4657 "fe/idl.tab.cpp"
+    break;
+
+  case 159:
+#line 1942 "fe/idl.ypp"
+        {
+          (yyval.etval) = AST_Expression::EV_wstring;
+        }
+#line 4665 "fe/idl.tab.cpp"
+    break;
+
+  case 160:
+#line 1946 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_PredefinedType *c = 0;
@@ -4660,11 +4731,11 @@ yyreduce:
           sn = 0;
           (yyvsp[0].idlist) = 0;
         }
-#line 4664 "fe/idl.tab.cpp"
+#line 4735 "fe/idl.tab.cpp"
     break;
 
-  case 162:
-#line 1972 "fe/idl.ypp"
+  case 164:
+#line 2019 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4673,11 +4744,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4677 "fe/idl.tab.cpp"
+#line 4748 "fe/idl.tab.cpp"
     break;
 
-  case 164:
-#line 1985 "fe/idl.ypp"
+  case 166:
+#line 2032 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4686,11 +4757,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4690 "fe/idl.tab.cpp"
+#line 4761 "fe/idl.tab.cpp"
     break;
 
-  case 166:
-#line 1998 "fe/idl.ypp"
+  case 168:
+#line 2045 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4699,11 +4770,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4703 "fe/idl.tab.cpp"
+#line 4774 "fe/idl.tab.cpp"
     break;
 
-  case 168:
-#line 2011 "fe/idl.ypp"
+  case 170:
+#line 2058 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4712,11 +4783,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4716 "fe/idl.tab.cpp"
+#line 4787 "fe/idl.tab.cpp"
     break;
 
-  case 169:
-#line 2020 "fe/idl.ypp"
+  case 171:
+#line 2067 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4725,11 +4796,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4729 "fe/idl.tab.cpp"
+#line 4800 "fe/idl.tab.cpp"
     break;
 
-  case 171:
-#line 2033 "fe/idl.ypp"
+  case 173:
+#line 2080 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4738,11 +4809,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4742 "fe/idl.tab.cpp"
+#line 4813 "fe/idl.tab.cpp"
     break;
 
-  case 172:
-#line 2042 "fe/idl.ypp"
+  case 174:
+#line 2089 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4751,11 +4822,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4755 "fe/idl.tab.cpp"
+#line 4826 "fe/idl.tab.cpp"
     break;
 
-  case 174:
-#line 2055 "fe/idl.ypp"
+  case 176:
+#line 2102 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4764,11 +4835,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4768 "fe/idl.tab.cpp"
+#line 4839 "fe/idl.tab.cpp"
     break;
 
-  case 175:
-#line 2064 "fe/idl.ypp"
+  case 177:
+#line 2111 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4777,11 +4848,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4781 "fe/idl.tab.cpp"
+#line 4852 "fe/idl.tab.cpp"
     break;
 
-  case 176:
-#line 2073 "fe/idl.ypp"
+  case 178:
+#line 2120 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4790,11 +4861,11 @@ yyreduce:
                                     (yyvsp[0].exval)
                                   );
         }
-#line 4794 "fe/idl.tab.cpp"
+#line 4865 "fe/idl.tab.cpp"
     break;
 
-  case 178:
-#line 2086 "fe/idl.ypp"
+  case 180:
+#line 2133 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr (
@@ -4803,37 +4874,37 @@ yyreduce:
                                     0
                                   );
         }
-#line 4807 "fe/idl.tab.cpp"
+#line 4878 "fe/idl.tab.cpp"
     break;
 
-  case 179:
-#line 2095 "fe/idl.ypp"
+  case 181:
+#line 2142 "fe/idl.ypp"
         {
           (yyval.exval) =
-            idl_global->gen()->create_expr (
+            idl_global->gen ()->create_expr (
                                    AST_Expression::EC_u_minus,
                                    (yyvsp[0].exval),
                                    0
                                  );
         }
-#line 4820 "fe/idl.tab.cpp"
+#line 4891 "fe/idl.tab.cpp"
     break;
 
-  case 180:
-#line 2104 "fe/idl.ypp"
+  case 182:
+#line 2151 "fe/idl.ypp"
         {
           (yyval.exval) =
-            idl_global->gen()->create_expr (
+            idl_global->gen ()->create_expr (
                                    AST_Expression::EC_bit_neg,
                                    (yyvsp[0].exval),
                                    0
                                  );
         }
-#line 4833 "fe/idl.tab.cpp"
+#line 4904 "fe/idl.tab.cpp"
     break;
 
-  case 181:
-#line 2116 "fe/idl.ypp"
+  case 183:
+#line 2163 "fe/idl.ypp"
         {
           UTL_ScopedName *name = (yyvsp[0].idlist);
 
@@ -4890,107 +4961,107 @@ yyreduce:
           delete name;
           (yyvsp[0].idlist) = name = 0;
         }
-#line 4894 "fe/idl.tab.cpp"
-    break;
-
-  case 183:
-#line 2174 "fe/idl.ypp"
-        {
-          (yyval.exval) = (yyvsp[-1].exval);
-        }
-#line 4902 "fe/idl.tab.cpp"
-    break;
-
-  case 184:
-#line 2181 "fe/idl.ypp"
-        {
-          (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].ival));
-        }
-#line 4910 "fe/idl.tab.cpp"
+#line 4965 "fe/idl.tab.cpp"
     break;
 
   case 185:
-#line 2185 "fe/idl.ypp"
+#line 2221 "fe/idl.ypp"
+        {
+          (yyval.exval) = (yyvsp[-1].exval);
+        }
+#line 4973 "fe/idl.tab.cpp"
+    break;
+
+  case 186:
+#line 2228 "fe/idl.ypp"
+        {
+          (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].ival));
+        }
+#line 4981 "fe/idl.tab.cpp"
+    break;
+
+  case 187:
+#line 2232 "fe/idl.ypp"
         {
           (yyval.exval) =
             idl_global->gen ()->create_expr ((yyvsp[0].uival));
         }
-#line 4919 "fe/idl.tab.cpp"
+#line 4990 "fe/idl.tab.cpp"
     break;
 
-  case 186:
-#line 2190 "fe/idl.ypp"
+  case 188:
+#line 2237 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].sval));
           (yyvsp[0].sval)->destroy ();
           delete (yyvsp[0].sval);
           (yyvsp[0].sval) = 0;
         }
-#line 4930 "fe/idl.tab.cpp"
+#line 5001 "fe/idl.tab.cpp"
     break;
 
-  case 187:
-#line 2197 "fe/idl.ypp"
+  case 189:
+#line 2244 "fe/idl.ypp"
         {
           char *wide_string = (yyvsp[0].wsval);
           (yyval.exval) = idl_global->gen ()->create_expr (wide_string);
           ACE_OS::free (wide_string);
           (yyvsp[0].wsval) = 0;
         }
-#line 4941 "fe/idl.tab.cpp"
+#line 5012 "fe/idl.tab.cpp"
     break;
 
-  case 188:
-#line 2204 "fe/idl.ypp"
+  case 190:
+#line 2251 "fe/idl.ypp"
         {
           (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].cval));
         }
-#line 4949 "fe/idl.tab.cpp"
+#line 5020 "fe/idl.tab.cpp"
     break;
 
-  case 189:
-#line 2208 "fe/idl.ypp"
+  case 191:
+#line 2255 "fe/idl.ypp"
         {
           ACE_OutputCDR::from_wchar wc ((yyvsp[0].wcval));
           (yyval.exval) = idl_global->gen ()->create_expr (wc);
         }
-#line 4958 "fe/idl.tab.cpp"
-    break;
-
-  case 190:
-#line 2213 "fe/idl.ypp"
-        {
-          (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].fixval));
-        }
-#line 4966 "fe/idl.tab.cpp"
-    break;
-
-  case 191:
-#line 2217 "fe/idl.ypp"
-        {
-          (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].dval));
-        }
-#line 4974 "fe/idl.tab.cpp"
+#line 5029 "fe/idl.tab.cpp"
     break;
 
   case 192:
-#line 2221 "fe/idl.ypp"
+#line 2260 "fe/idl.ypp"
         {
-          (yyval.exval) = idl_global->gen ()->create_expr (true);
+          (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].fixval));
         }
-#line 4982 "fe/idl.tab.cpp"
+#line 5037 "fe/idl.tab.cpp"
     break;
 
   case 193:
-#line 2225 "fe/idl.ypp"
+#line 2264 "fe/idl.ypp"
         {
-          (yyval.exval) = idl_global->gen ()->create_expr (false);
+          (yyval.exval) = idl_global->gen ()->create_expr ((yyvsp[0].dval));
         }
-#line 4990 "fe/idl.tab.cpp"
+#line 5045 "fe/idl.tab.cpp"
     break;
 
   case 194:
-#line 2232 "fe/idl.ypp"
+#line 2268 "fe/idl.ypp"
+        {
+          (yyval.exval) = idl_global->gen ()->create_expr (true);
+        }
+#line 5053 "fe/idl.tab.cpp"
+    break;
+
+  case 195:
+#line 2272 "fe/idl.ypp"
+        {
+          (yyval.exval) = idl_global->gen ()->create_expr (false);
+        }
+#line 5061 "fe/idl.tab.cpp"
+    break;
+
+  case 196:
+#line 2279 "fe/idl.ypp"
         {
           int good_expression = 1;
           (yyvsp[0].exval)->evaluate (AST_Expression::EK_positive_int);
@@ -5055,11 +5126,11 @@ yyreduce:
               idl_global->err ()->syntax_error (idl_global->parse_state ());
             }
         }
-#line 5059 "fe/idl.tab.cpp"
+#line 5130 "fe/idl.tab.cpp"
     break;
 
-  case 195:
-#line 2300 "fe/idl.ypp"
+  case 197:
+#line 2347 "fe/idl.ypp"
         {
           if (idl_global->idl_version_ < IDL_VERSION_4)
             {
@@ -5076,11 +5147,11 @@ yyreduce:
             fe_add_annotation_decl (annotation_decl);
           idl_global->scopes ().push (annotation_decl);
         }
-#line 5080 "fe/idl.tab.cpp"
+#line 5151 "fe/idl.tab.cpp"
     break;
 
-  case 196:
-#line 2317 "fe/idl.ypp"
+  case 198:
+#line 2364 "fe/idl.ypp"
         {
           Identifier *id = (yyvsp[-4].idval);
           idl_global->scopes ().pop ();
@@ -5089,20 +5160,20 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 5093 "fe/idl.tab.cpp"
+#line 5164 "fe/idl.tab.cpp"
     break;
 
-  case 202:
-#line 2337 "fe/idl.ypp"
+  case 204:
+#line 2384 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypedefSeen);
           idl_global->in_typedef (true);
         }
-#line 5102 "fe/idl.tab.cpp"
+#line 5173 "fe/idl.tab.cpp"
     break;
 
-  case 206:
-#line 2351 "fe/idl.ypp"
+  case 208:
+#line 2398 "fe/idl.ypp"
         {
           UTL_Scope *scope = idl_global->scopes ().top_non_null ();
           UTL_Scope *root = idl_global->scopes ().bottom ();
@@ -5155,41 +5226,27 @@ yyreduce:
               delete result;
             }
         }
-#line 5159 "fe/idl.tab.cpp"
-    break;
-
-  case 207:
-#line 2407 "fe/idl.ypp"
-        {
-          (yyval.exval) = (yyvsp[0].exval);
-        }
-#line 5167 "fe/idl.tab.cpp"
-    break;
-
-  case 208:
-#line 2411 "fe/idl.ypp"
-        {
-          (yyval.exval) = 0;
-        }
-#line 5175 "fe/idl.tab.cpp"
+#line 5230 "fe/idl.tab.cpp"
     break;
 
   case 209:
-#line 2418 "fe/idl.ypp"
+#line 2454 "fe/idl.ypp"
         {
-          AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
-          AST_Annotation_Appl *annotation = (yyvsp[0].annotation_val);
-          if (annotation)
-            {
-              annotations->add (annotation);
-            }
-          (yyval.annotations_val) = annotations;
+          (yyval.exval) = (yyvsp[0].exval);
         }
-#line 5189 "fe/idl.tab.cpp"
+#line 5238 "fe/idl.tab.cpp"
     break;
 
   case 210:
-#line 2431 "fe/idl.ypp"
+#line 2458 "fe/idl.ypp"
+        {
+          (yyval.exval) = 0;
+        }
+#line 5246 "fe/idl.tab.cpp"
+    break;
+
+  case 211:
+#line 2465 "fe/idl.ypp"
         {
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
           AST_Annotation_Appl *annotation = (yyvsp[0].annotation_val);
@@ -5199,19 +5256,33 @@ yyreduce:
             }
           (yyval.annotations_val) = annotations;
         }
-#line 5203 "fe/idl.tab.cpp"
-    break;
-
-  case 211:
-#line 2441 "fe/idl.ypp"
-        {
-          (yyval.annotations_val) = new AST_Annotation_Appls ();
-        }
-#line 5211 "fe/idl.tab.cpp"
+#line 5260 "fe/idl.tab.cpp"
     break;
 
   case 212:
-#line 2448 "fe/idl.ypp"
+#line 2478 "fe/idl.ypp"
+        {
+          AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
+          AST_Annotation_Appl *annotation = (yyvsp[0].annotation_val);
+          if (annotation)
+            {
+              annotations->add (annotation);
+            }
+          (yyval.annotations_val) = annotations;
+        }
+#line 5274 "fe/idl.tab.cpp"
+    break;
+
+  case 213:
+#line 2488 "fe/idl.ypp"
+        {
+          (yyval.annotations_val) = new AST_Annotation_Appls ();
+        }
+#line 5282 "fe/idl.tab.cpp"
+    break;
+
+  case 214:
+#line 2495 "fe/idl.ypp"
         {
           if (idl_global->idl_version_ < IDL_VERSION_4)
             {
@@ -5268,11 +5339,11 @@ yyreduce:
 
           (yyval.annotation_decl_val) = decl;
         }
-#line 5272 "fe/idl.tab.cpp"
+#line 5343 "fe/idl.tab.cpp"
     break;
 
-  case 213:
-#line 2505 "fe/idl.ypp"
+  case 215:
+#line 2552 "fe/idl.ypp"
         {
           idl_global->ignore_lookup_errors_ = false;
           stack_based_lookup_for_primary_expr = false;
@@ -5300,27 +5371,27 @@ yyreduce:
 
           (yyval.annotation_val) = appl;
         }
-#line 5304 "fe/idl.tab.cpp"
-    break;
-
-  case 214:
-#line 2536 "fe/idl.ypp"
-        {
-          (yyval.annotation_params_val) = (yyvsp[-1].annotation_params_val);
-        }
-#line 5312 "fe/idl.tab.cpp"
-    break;
-
-  case 215:
-#line 2540 "fe/idl.ypp"
-        {
-          (yyval.annotation_params_val) = 0;
-        }
-#line 5320 "fe/idl.tab.cpp"
+#line 5375 "fe/idl.tab.cpp"
     break;
 
   case 216:
-#line 2547 "fe/idl.ypp"
+#line 2583 "fe/idl.ypp"
+        {
+          (yyval.annotation_params_val) = (yyvsp[-1].annotation_params_val);
+        }
+#line 5383 "fe/idl.tab.cpp"
+    break;
+
+  case 217:
+#line 2587 "fe/idl.ypp"
+        {
+          (yyval.annotation_params_val) = 0;
+        }
+#line 5391 "fe/idl.tab.cpp"
+    break;
+
+  case 218:
+#line 2594 "fe/idl.ypp"
         {
           AST_Annotation_Appl::Params *params = new AST_Annotation_Appl::Params;
           AST_Annotation_Appl::Param *param = new AST_Annotation_Appl::Param;
@@ -5329,47 +5400,47 @@ yyreduce:
           params->push (param);
           (yyval.annotation_params_val) = params;
         }
-#line 5333 "fe/idl.tab.cpp"
-    break;
-
-  case 217:
-#line 2556 "fe/idl.ypp"
-        {
-          (yyval.annotation_params_val) = (yyvsp[0].annotation_params_val);
-        }
-#line 5341 "fe/idl.tab.cpp"
-    break;
-
-  case 218:
-#line 2563 "fe/idl.ypp"
-        {
-          AST_Annotation_Appl::Params *params = (yyvsp[0].annotation_params_val);
-          params->push ((yyvsp[-1].annotation_param_val));
-          (yyval.annotation_params_val) = params;
-        }
-#line 5351 "fe/idl.tab.cpp"
+#line 5404 "fe/idl.tab.cpp"
     break;
 
   case 219:
-#line 2571 "fe/idl.ypp"
+#line 2603 "fe/idl.ypp"
+        {
+          (yyval.annotation_params_val) = (yyvsp[0].annotation_params_val);
+        }
+#line 5412 "fe/idl.tab.cpp"
+    break;
+
+  case 220:
+#line 2610 "fe/idl.ypp"
         {
           AST_Annotation_Appl::Params *params = (yyvsp[0].annotation_params_val);
           params->push ((yyvsp[-1].annotation_param_val));
           (yyval.annotation_params_val) = params;
         }
-#line 5361 "fe/idl.tab.cpp"
-    break;
-
-  case 220:
-#line 2577 "fe/idl.ypp"
-        {
-          (yyval.annotation_params_val) = new AST_Annotation_Appl::Params;
-        }
-#line 5369 "fe/idl.tab.cpp"
+#line 5422 "fe/idl.tab.cpp"
     break;
 
   case 221:
-#line 2584 "fe/idl.ypp"
+#line 2618 "fe/idl.ypp"
+        {
+          AST_Annotation_Appl::Params *params = (yyvsp[0].annotation_params_val);
+          params->push ((yyvsp[-1].annotation_param_val));
+          (yyval.annotation_params_val) = params;
+        }
+#line 5432 "fe/idl.tab.cpp"
+    break;
+
+  case 222:
+#line 2624 "fe/idl.ypp"
+        {
+          (yyval.annotation_params_val) = new AST_Annotation_Appl::Params;
+        }
+#line 5440 "fe/idl.tab.cpp"
+    break;
+
+  case 223:
+#line 2631 "fe/idl.ypp"
         {
           AST_Annotation_Appl::Param *param = new AST_Annotation_Appl::Param;
           param->id = (yyvsp[-2].idval);
@@ -5378,52 +5449,52 @@ yyreduce:
           param->expr = (yyvsp[0].exval);
           (yyval.annotation_param_val) = param;
         }
-#line 5382 "fe/idl.tab.cpp"
+#line 5453 "fe/idl.tab.cpp"
     break;
 
-  case 222:
-#line 2596 "fe/idl.ypp"
+  case 224:
+#line 2643 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_TypedefSeen);
           idl_global->in_typedef (true);
         }
-#line 5391 "fe/idl.tab.cpp"
-    break;
-
-  case 223:
-#line 2601 "fe/idl.ypp"
-        {
-          (yyval.dcval) = (yyvsp[0].dcval);
-        }
-#line 5399 "fe/idl.tab.cpp"
-    break;
-
-  case 224:
-#line 2605 "fe/idl.ypp"
-        {
-          (yyval.dcval) = (yyvsp[0].dcval);
-        }
-#line 5407 "fe/idl.tab.cpp"
+#line 5462 "fe/idl.tab.cpp"
     break;
 
   case 225:
-#line 2609 "fe/idl.ypp"
+#line 2648 "fe/idl.ypp"
         {
           (yyval.dcval) = (yyvsp[0].dcval);
         }
-#line 5415 "fe/idl.tab.cpp"
+#line 5470 "fe/idl.tab.cpp"
     break;
 
   case 226:
-#line 2613 "fe/idl.ypp"
+#line 2652 "fe/idl.ypp"
         {
           (yyval.dcval) = (yyvsp[0].dcval);
         }
-#line 5423 "fe/idl.tab.cpp"
+#line 5478 "fe/idl.tab.cpp"
     break;
 
   case 227:
-#line 2617 "fe/idl.ypp"
+#line 2656 "fe/idl.ypp"
+        {
+          (yyval.dcval) = (yyvsp[0].dcval);
+        }
+#line 5486 "fe/idl.tab.cpp"
+    break;
+
+  case 228:
+#line 2660 "fe/idl.ypp"
+        {
+          (yyval.dcval) = (yyvsp[0].dcval);
+        }
+#line 5494 "fe/idl.tab.cpp"
+    break;
+
+  case 229:
+#line 2664 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Native *node = 0;
@@ -5451,27 +5522,27 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 5455 "fe/idl.tab.cpp"
-    break;
-
-  case 228:
-#line 2645 "fe/idl.ypp"
-        {
-          (yyval.dcval) = 0;
-        }
-#line 5463 "fe/idl.tab.cpp"
-    break;
-
-  case 229:
-#line 2652 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_TypeSpecSeen);
-        }
-#line 5471 "fe/idl.tab.cpp"
+#line 5526 "fe/idl.tab.cpp"
     break;
 
   case 230:
-#line 2656 "fe/idl.ypp"
+#line 2692 "fe/idl.ypp"
+        {
+          (yyval.dcval) = 0;
+        }
+#line 5534 "fe/idl.tab.cpp"
+    break;
+
+  case 231:
+#line 2699 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_TypeSpecSeen);
+        }
+#line 5542 "fe/idl.tab.cpp"
+    break;
+
+  case 232:
+#line 2703 "fe/idl.ypp"
         {
           AST_Decl *type_spec = (yyvsp[-2].dcval);
           UTL_DeclList *decls = (yyvsp[0].dlval);
@@ -5535,22 +5606,22 @@ yyreduce:
 
           (yyval.dcval) = t;
         }
-#line 5539 "fe/idl.tab.cpp"
+#line 5610 "fe/idl.tab.cpp"
     break;
 
-  case 233:
-#line 2728 "fe/idl.ypp"
+  case 235:
+#line 2775 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 5550 "fe/idl.tab.cpp"
+#line 5621 "fe/idl.tab.cpp"
     break;
 
-  case 235:
-#line 2736 "fe/idl.ypp"
+  case 237:
+#line 2783 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = 0;
@@ -5573,61 +5644,10 @@ yyreduce:
 
           (yyval.dcval) = d;
         }
-#line 5577 "fe/idl.tab.cpp"
-    break;
-
-  case 253:
-#line 2791 "fe/idl.ypp"
-        {
-          ACE_NEW_RETURN ((yyval.dlval),
-                          UTL_DeclList ((yyvsp[-1].deval),
-                                        (yyvsp[0].dlval)),
-                          1);
-        }
-#line 5588 "fe/idl.tab.cpp"
-    break;
-
-  case 254:
-#line 2802 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_DeclsCommaSeen);
-        }
-#line 5596 "fe/idl.tab.cpp"
+#line 5648 "fe/idl.tab.cpp"
     break;
 
   case 255:
-#line 2806 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_DeclsDeclSeen);
-
-          UTL_DeclList *dl = 0;
-          ACE_NEW_RETURN (dl,
-                          UTL_DeclList ((yyvsp[0].deval),
-                                        0),
-                          1);
-
-          if ((yyvsp[-3].dlval) == 0)
-            {
-              (yyval.dlval) = dl;
-            }
-          else
-            {
-              (yyvsp[-3].dlval)->nconc (dl);
-              (yyval.dlval) = (yyvsp[-3].dlval);
-            }
-        }
-#line 5620 "fe/idl.tab.cpp"
-    break;
-
-  case 256:
-#line 2826 "fe/idl.ypp"
-        {
-          (yyval.dlval) = 0;
-        }
-#line 5628 "fe/idl.tab.cpp"
-    break;
-
-  case 259:
 #line 2838 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.dlval),
@@ -5635,18 +5655,18 @@ yyreduce:
                                         (yyvsp[0].dlval)),
                           1);
         }
-#line 5639 "fe/idl.tab.cpp"
+#line 5659 "fe/idl.tab.cpp"
     break;
 
-  case 260:
+  case 256:
 #line 2849 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DeclsCommaSeen);
         }
-#line 5647 "fe/idl.tab.cpp"
+#line 5667 "fe/idl.tab.cpp"
     break;
 
-  case 261:
+  case 257:
 #line 2853 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DeclsDeclSeen);
@@ -5667,19 +5687,70 @@ yyreduce:
               (yyval.dlval) = (yyvsp[-3].dlval);
             }
         }
-#line 5671 "fe/idl.tab.cpp"
+#line 5691 "fe/idl.tab.cpp"
     break;
 
-  case 262:
+  case 258:
 #line 2873 "fe/idl.ypp"
         {
           (yyval.dlval) = 0;
         }
-#line 5679 "fe/idl.tab.cpp"
+#line 5699 "fe/idl.tab.cpp"
+    break;
+
+  case 261:
+#line 2885 "fe/idl.ypp"
+        {
+          ACE_NEW_RETURN ((yyval.dlval),
+                          UTL_DeclList ((yyvsp[-1].deval),
+                                        (yyvsp[0].dlval)),
+                          1);
+        }
+#line 5710 "fe/idl.tab.cpp"
+    break;
+
+  case 262:
+#line 2896 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_DeclsCommaSeen);
+        }
+#line 5718 "fe/idl.tab.cpp"
     break;
 
   case 263:
-#line 2880 "fe/idl.ypp"
+#line 2900 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_DeclsDeclSeen);
+
+          UTL_DeclList *dl = 0;
+          ACE_NEW_RETURN (dl,
+                          UTL_DeclList ((yyvsp[0].deval),
+                                        0),
+                          1);
+
+          if ((yyvsp[-3].dlval) == 0)
+            {
+              (yyval.dlval) = dl;
+            }
+          else
+            {
+              (yyvsp[-3].dlval)->nconc (dl);
+              (yyval.dlval) = (yyvsp[-3].dlval);
+            }
+        }
+#line 5742 "fe/idl.tab.cpp"
+    break;
+
+  case 264:
+#line 2920 "fe/idl.ypp"
+        {
+          (yyval.dlval) = 0;
+        }
+#line 5750 "fe/idl.tab.cpp"
+    break;
+
+  case 265:
+#line 2927 "fe/idl.ypp"
         {
           UTL_ScopedName *sn = 0;
           ACE_NEW_RETURN (sn,
@@ -5692,11 +5763,11 @@ yyreduce:
                                          0),
                           1);
         }
-#line 5696 "fe/idl.tab.cpp"
+#line 5767 "fe/idl.tab.cpp"
     break;
 
-  case 264:
-#line 2896 "fe/idl.ypp"
+  case 266:
+#line 2943 "fe/idl.ypp"
         {
           UTL_ScopedName *sn = 0;
           ACE_NEW_RETURN (sn,
@@ -5711,156 +5782,156 @@ yyreduce:
                                          (yyvsp[0].dcval)),
                           1);
         }
-#line 5715 "fe/idl.tab.cpp"
-    break;
-
-  case 267:
-#line 2919 "fe/idl.ypp"
-        {
-          (yyval.etval) = AST_Expression::EV_long;
-        }
-#line 5723 "fe/idl.tab.cpp"
-    break;
-
-  case 268:
-#line 2923 "fe/idl.ypp"
-        {
-          (yyval.etval) = AST_Expression::EV_longlong;
-        }
-#line 5731 "fe/idl.tab.cpp"
+#line 5786 "fe/idl.tab.cpp"
     break;
 
   case 269:
-#line 2927 "fe/idl.ypp"
+#line 2966 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_short;
+          (yyval.etval) = AST_Expression::EV_long;
         }
-#line 5739 "fe/idl.tab.cpp"
+#line 5794 "fe/idl.tab.cpp"
     break;
 
   case 270:
-#line 2934 "fe/idl.ypp"
+#line 2970 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_ulong;
+          (yyval.etval) = AST_Expression::EV_longlong;
         }
-#line 5747 "fe/idl.tab.cpp"
+#line 5802 "fe/idl.tab.cpp"
     break;
 
   case 271:
-#line 2938 "fe/idl.ypp"
+#line 2974 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_ulonglong;
+          (yyval.etval) = AST_Expression::EV_short;
         }
-#line 5755 "fe/idl.tab.cpp"
+#line 5810 "fe/idl.tab.cpp"
     break;
 
   case 272:
-#line 2942 "fe/idl.ypp"
+#line 2981 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_ushort;
+          (yyval.etval) = AST_Expression::EV_ulong;
         }
-#line 5763 "fe/idl.tab.cpp"
+#line 5818 "fe/idl.tab.cpp"
     break;
 
   case 273:
-#line 2949 "fe/idl.ypp"
+#line 2985 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_double;
+          (yyval.etval) = AST_Expression::EV_ulonglong;
         }
-#line 5771 "fe/idl.tab.cpp"
+#line 5826 "fe/idl.tab.cpp"
     break;
 
   case 274:
-#line 2953 "fe/idl.ypp"
+#line 2989 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_float;
+          (yyval.etval) = AST_Expression::EV_ushort;
         }
-#line 5779 "fe/idl.tab.cpp"
+#line 5834 "fe/idl.tab.cpp"
     break;
 
   case 275:
-#line 2957 "fe/idl.ypp"
+#line 2996 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_longdouble;
+          (yyval.etval) = AST_Expression::EV_double;
         }
-#line 5787 "fe/idl.tab.cpp"
+#line 5842 "fe/idl.tab.cpp"
     break;
 
   case 276:
-#line 2964 "fe/idl.ypp"
+#line 3000 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_fixed;
+          (yyval.etval) = AST_Expression::EV_float;
         }
-#line 5795 "fe/idl.tab.cpp"
+#line 5850 "fe/idl.tab.cpp"
     break;
 
   case 277:
-#line 2971 "fe/idl.ypp"
+#line 3004 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_char;
+          (yyval.etval) = AST_Expression::EV_longdouble;
         }
-#line 5803 "fe/idl.tab.cpp"
+#line 5858 "fe/idl.tab.cpp"
     break;
 
   case 278:
-#line 2975 "fe/idl.ypp"
+#line 3011 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_wchar;
+          (yyval.etval) = AST_Expression::EV_fixed;
         }
-#line 5811 "fe/idl.tab.cpp"
+#line 5866 "fe/idl.tab.cpp"
     break;
 
   case 279:
-#line 2982 "fe/idl.ypp"
+#line 3018 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_octet;
+          (yyval.etval) = AST_Expression::EV_char;
         }
-#line 5819 "fe/idl.tab.cpp"
+#line 5874 "fe/idl.tab.cpp"
     break;
 
   case 280:
-#line 2989 "fe/idl.ypp"
+#line 3022 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_bool;
+          (yyval.etval) = AST_Expression::EV_wchar;
         }
-#line 5827 "fe/idl.tab.cpp"
+#line 5882 "fe/idl.tab.cpp"
     break;
 
   case 281:
-#line 2996 "fe/idl.ypp"
+#line 3029 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_any;
+          (yyval.etval) = AST_Expression::EV_octet;
         }
-#line 5835 "fe/idl.tab.cpp"
+#line 5890 "fe/idl.tab.cpp"
     break;
 
   case 282:
-#line 3003 "fe/idl.ypp"
+#line 3036 "fe/idl.ypp"
         {
-          (yyval.etval) = AST_Expression::EV_object;
+          (yyval.etval) = AST_Expression::EV_bool;
         }
-#line 5843 "fe/idl.tab.cpp"
+#line 5898 "fe/idl.tab.cpp"
     break;
 
   case 283:
-#line 3010 "fe/idl.ypp"
+#line 3043 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_StructSeen);
+          (yyval.etval) = AST_Expression::EV_any;
         }
-#line 5851 "fe/idl.tab.cpp"
+#line 5906 "fe/idl.tab.cpp"
     break;
 
   case 284:
-#line 3014 "fe/idl.ypp"
+#line 3050 "fe/idl.ypp"
+        {
+          (yyval.etval) = AST_Expression::EV_object;
+        }
+#line 5914 "fe/idl.tab.cpp"
+    break;
+
+  case 285:
+#line 3057 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_StructSeen);
+        }
+#line 5922 "fe/idl.tab.cpp"
+    break;
+
+  case 286:
+#line 3061 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StructIDSeen);
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 5860 "fe/idl.tab.cpp"
+#line 5931 "fe/idl.tab.cpp"
     break;
 
-  case 285:
-#line 3023 "fe/idl.ypp"
+  case 287:
+#line 3070 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval), 0);
@@ -5891,27 +5962,27 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 5895 "fe/idl.tab.cpp"
-    break;
-
-  case 286:
-#line 3054 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_StructSqSeen);
-        }
-#line 5903 "fe/idl.tab.cpp"
-    break;
-
-  case 287:
-#line 3058 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_StructBodySeen);
-        }
-#line 5911 "fe/idl.tab.cpp"
+#line 5966 "fe/idl.tab.cpp"
     break;
 
   case 288:
-#line 3062 "fe/idl.ypp"
+#line 3101 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_StructSqSeen);
+        }
+#line 5974 "fe/idl.tab.cpp"
+    break;
+
+  case 289:
+#line 3105 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_StructBodySeen);
+        }
+#line 5982 "fe/idl.tab.cpp"
+    break;
+
+  case 290:
+#line 3109 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StructQsSeen);
 
@@ -5923,11 +5994,11 @@ yyreduce:
                  );
           idl_global->scopes ().pop ();
         }
-#line 5927 "fe/idl.tab.cpp"
+#line 5998 "fe/idl.tab.cpp"
     break;
 
-  case 292:
-#line 3084 "fe/idl.ypp"
+  case 294:
+#line 3131 "fe/idl.ypp"
         {
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
           AST_Decls *members = (yyvsp[0].decls_val);
@@ -5941,27 +6012,27 @@ yyreduce:
           delete annotations;
           delete members;
         }
-#line 5945 "fe/idl.tab.cpp"
-    break;
-
-  case 293:
-#line 3101 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_MemberTypeSeen);
-        }
-#line 5953 "fe/idl.tab.cpp"
-    break;
-
-  case 294:
-#line 3105 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_MemberDeclsSeen);
-        }
-#line 5961 "fe/idl.tab.cpp"
+#line 6016 "fe/idl.tab.cpp"
     break;
 
   case 295:
-#line 3109 "fe/idl.ypp"
+#line 3148 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_MemberTypeSeen);
+        }
+#line 6024 "fe/idl.tab.cpp"
+    break;
+
+  case 296:
+#line 3152 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_MemberDeclsSeen);
+        }
+#line 6032 "fe/idl.tab.cpp"
+    break;
+
+  case 297:
+#line 3156 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           FE_Declarator *d = 0;
@@ -6015,53 +6086,53 @@ yyreduce:
 
           (yyval.decls_val) = members;
         }
-#line 6019 "fe/idl.tab.cpp"
+#line 6090 "fe/idl.tab.cpp"
     break;
 
-  case 296:
-#line 3163 "fe/idl.ypp"
+  case 298:
+#line 3210 "fe/idl.ypp"
         {
-          idl_global->err()->syntax_error (idl_global->parse_state ());
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
-#line 6027 "fe/idl.tab.cpp"
+#line 6098 "fe/idl.tab.cpp"
     break;
 
-  case 297:
-#line 3167 "fe/idl.ypp"
+  case 299:
+#line 3214 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           yyerrok;
         }
-#line 6036 "fe/idl.tab.cpp"
+#line 6107 "fe/idl.tab.cpp"
     break;
 
-  case 298:
-#line 3175 "fe/idl.ypp"
+  case 300:
+#line 3222 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionSeen);
         }
-#line 6044 "fe/idl.tab.cpp"
+#line 6115 "fe/idl.tab.cpp"
     break;
 
-  case 299:
-#line 3179 "fe/idl.ypp"
+  case 301:
+#line 3226 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionIDSeen);
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 6053 "fe/idl.tab.cpp"
+#line 6124 "fe/idl.tab.cpp"
     break;
 
-  case 300:
-#line 3187 "fe/idl.ypp"
+  case 302:
+#line 3234 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SwitchSeen);
         }
-#line 6061 "fe/idl.tab.cpp"
+#line 6132 "fe/idl.tab.cpp"
     break;
 
-  case 301:
-#line 3191 "fe/idl.ypp"
+  case 303:
+#line 3238 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[-3].idval), 0);
@@ -6094,19 +6165,19 @@ yyreduce:
            * Don't delete $1 yet; we'll need it a bit later.
            */
         }
-#line 6098 "fe/idl.tab.cpp"
+#line 6169 "fe/idl.tab.cpp"
     break;
 
-  case 302:
-#line 3224 "fe/idl.ypp"
+  case 304:
+#line 3271 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SwitchTypeSeen);
         }
-#line 6106 "fe/idl.tab.cpp"
+#line 6177 "fe/idl.tab.cpp"
     break;
 
-  case 303:
-#line 3228 "fe/idl.ypp"
+  case 305:
+#line 3275 "fe/idl.ypp"
         {
           /*
            * The top of the scopes must be an empty union we added after we
@@ -6165,27 +6236,27 @@ yyreduce:
 
           delete disc_annotations;
         }
-#line 6169 "fe/idl.tab.cpp"
-    break;
-
-  case 304:
-#line 3287 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_UnionSqSeen);
-        }
-#line 6177 "fe/idl.tab.cpp"
-    break;
-
-  case 305:
-#line 3291 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_UnionBodySeen);
-        }
-#line 6185 "fe/idl.tab.cpp"
+#line 6240 "fe/idl.tab.cpp"
     break;
 
   case 306:
-#line 3295 "fe/idl.ypp"
+#line 3334 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_UnionSqSeen);
+        }
+#line 6248 "fe/idl.tab.cpp"
+    break;
+
+  case 307:
+#line 3338 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_UnionBodySeen);
+        }
+#line 6256 "fe/idl.tab.cpp"
+    break;
+
+  case 308:
+#line 3342 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionQsSeen);
 
@@ -6201,22 +6272,22 @@ yyreduce:
               idl_global->scopes ().pop ();
             }
         }
-#line 6205 "fe/idl.tab.cpp"
+#line 6276 "fe/idl.tab.cpp"
     break;
 
-  case 307:
-#line 3314 "fe/idl.ypp"
+  case 309:
+#line 3361 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6216 "fe/idl.tab.cpp"
+#line 6287 "fe/idl.tab.cpp"
     break;
 
-  case 308:
-#line 3321 "fe/idl.ypp"
+  case 310:
+#line 3368 "fe/idl.ypp"
         {
           /* wchars are not allowed. */
           if ((yyvsp[0].etval) == AST_Expression::EV_wchar)
@@ -6229,11 +6300,11 @@ yyreduce:
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6233 "fe/idl.tab.cpp"
+#line 6304 "fe/idl.tab.cpp"
     break;
 
-  case 309:
-#line 3334 "fe/idl.ypp"
+  case 311:
+#line 3381 "fe/idl.ypp"
         {
           /* octets are not allowed. */
           idl_global->err ()->error0 (UTL_Error::EIDL_DISC_TYPE);
@@ -6242,22 +6313,22 @@ yyreduce:
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6246 "fe/idl.tab.cpp"
+#line 6317 "fe/idl.tab.cpp"
     break;
 
-  case 310:
-#line 3343 "fe/idl.ypp"
+  case 312:
+#line 3390 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 6257 "fe/idl.tab.cpp"
+#line 6328 "fe/idl.tab.cpp"
     break;
 
-  case 312:
-#line 3351 "fe/idl.ypp"
+  case 314:
+#line 3398 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = 0;
@@ -6364,27 +6435,27 @@ yyreduce:
           delete (yyvsp[0].idlist);
           (yyvsp[0].idlist) = 0;
         }
-#line 6368 "fe/idl.tab.cpp"
-    break;
-
-  case 316:
-#line 3468 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_UnionLabelSeen);
-        }
-#line 6376 "fe/idl.tab.cpp"
-    break;
-
-  case 317:
-#line 3472 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_UnionElemSeen);
-        }
-#line 6384 "fe/idl.tab.cpp"
+#line 6439 "fe/idl.tab.cpp"
     break;
 
   case 318:
-#line 3476 "fe/idl.ypp"
+#line 3515 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_UnionLabelSeen);
+        }
+#line 6447 "fe/idl.tab.cpp"
+    break;
+
+  case 319:
+#line 3519 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_UnionElemSeen);
+        }
+#line 6455 "fe/idl.tab.cpp"
+    break;
+
+  case 320:
+#line 3523 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_UnionBranch *b = 0;
@@ -6416,39 +6487,39 @@ yyreduce:
 
           delete annotations;
         }
-#line 6420 "fe/idl.tab.cpp"
+#line 6491 "fe/idl.tab.cpp"
     break;
 
-  case 319:
-#line 3508 "fe/idl.ypp"
+  case 321:
+#line 3555 "fe/idl.ypp"
         {
-          idl_global->err()->syntax_error (idl_global->parse_state());
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
-#line 6428 "fe/idl.tab.cpp"
+#line 6499 "fe/idl.tab.cpp"
     break;
 
-  case 320:
-#line 3512 "fe/idl.ypp"
+  case 322:
+#line 3559 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
           yyerrok;
         }
-#line 6437 "fe/idl.tab.cpp"
+#line 6508 "fe/idl.tab.cpp"
     break;
 
-  case 321:
-#line 3520 "fe/idl.ypp"
+  case 323:
+#line 3567 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.llval),
                           UTL_LabelList ((yyvsp[-1].ulval),
                                          (yyvsp[0].llval)),
                           1);
         }
-#line 6448 "fe/idl.tab.cpp"
+#line 6519 "fe/idl.tab.cpp"
     break;
 
-  case 322:
-#line 3530 "fe/idl.ypp"
+  case 324:
+#line 3577 "fe/idl.ypp"
         {
           UTL_LabelList *ll = 0;
           ACE_NEW_RETURN (ll,
@@ -6466,27 +6537,27 @@ yyreduce:
               (yyval.llval) = (yyvsp[-1].llval);
             }
         }
-#line 6470 "fe/idl.tab.cpp"
-    break;
-
-  case 323:
-#line 3548 "fe/idl.ypp"
-        {
-          (yyval.llval) = 0;
-        }
-#line 6478 "fe/idl.tab.cpp"
-    break;
-
-  case 324:
-#line 3555 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_DefaultSeen);
-        }
-#line 6486 "fe/idl.tab.cpp"
+#line 6541 "fe/idl.tab.cpp"
     break;
 
   case 325:
-#line 3559 "fe/idl.ypp"
+#line 3595 "fe/idl.ypp"
+        {
+          (yyval.llval) = 0;
+        }
+#line 6549 "fe/idl.tab.cpp"
+    break;
+
+  case 326:
+#line 3602 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_DefaultSeen);
+        }
+#line 6557 "fe/idl.tab.cpp"
+    break;
+
+  case 327:
+#line 3606 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_LabelColonSeen);
 
@@ -6495,48 +6566,48 @@ yyreduce:
                                        0
                                      );
         }
-#line 6499 "fe/idl.tab.cpp"
-    break;
-
-  case 326:
-#line 3568 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_CaseSeen);
-        }
-#line 6507 "fe/idl.tab.cpp"
-    break;
-
-  case 327:
-#line 3572 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_LabelExprSeen);
-        }
-#line 6515 "fe/idl.tab.cpp"
+#line 6570 "fe/idl.tab.cpp"
     break;
 
   case 328:
-#line 3576 "fe/idl.ypp"
+#line 3615 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_CaseSeen);
+        }
+#line 6578 "fe/idl.tab.cpp"
+    break;
+
+  case 329:
+#line 3619 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_LabelExprSeen);
+        }
+#line 6586 "fe/idl.tab.cpp"
+    break;
+
+  case 330:
+#line 3623 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_LabelColonSeen);
 
-          (yyval.ulval) = idl_global->gen()->create_union_label (
+          (yyval.ulval) = idl_global->gen ()->create_union_label (
                                       AST_UnionLabel::UL_label,
                                       (yyvsp[-2].exval)
                                     );
         }
-#line 6528 "fe/idl.tab.cpp"
+#line 6599 "fe/idl.tab.cpp"
     break;
 
-  case 329:
-#line 3588 "fe/idl.ypp"
+  case 331:
+#line 3635 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionElemTypeSeen);
         }
-#line 6536 "fe/idl.tab.cpp"
+#line 6607 "fe/idl.tab.cpp"
     break;
 
-  case 330:
-#line 3592 "fe/idl.ypp"
+  case 332:
+#line 3639 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_UnionElemDeclSeen);
 
@@ -6546,8 +6617,7 @@ yyreduce:
           if ((yyvsp[-2].dcval) != 0
               && AST_illegal_recursive_type ((yyvsp[-2].dcval)))
             {
-              idl_global->err()->error1 (UTL_Error::EIDL_RECURSIVE_TYPE,
-                                         (yyvsp[-2].dcval));
+              idl_global->err ()->error1 (UTL_Error::EIDL_RECURSIVE_TYPE, (yyvsp[-2].dcval));
 
               (yyval.ffval) = 0;
             }
@@ -6580,11 +6650,11 @@ yyreduce:
               (yyvsp[0].deval) = 0;
             }
         }
-#line 6584 "fe/idl.tab.cpp"
+#line 6654 "fe/idl.tab.cpp"
     break;
 
-  case 331:
-#line 3639 "fe/idl.ypp"
+  case 333:
+#line 3685 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -6606,11 +6676,11 @@ yyreduce:
 
           (yyval.dcval) = d;
         }
-#line 6610 "fe/idl.tab.cpp"
+#line 6680 "fe/idl.tab.cpp"
     break;
 
-  case 332:
-#line 3664 "fe/idl.ypp"
+  case 334:
+#line 3710 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -6630,19 +6700,19 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 6634 "fe/idl.tab.cpp"
+#line 6704 "fe/idl.tab.cpp"
     break;
 
-  case 333:
-#line 3687 "fe/idl.ypp"
+  case 335:
+#line 3733 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumSeen);
         }
-#line 6642 "fe/idl.tab.cpp"
+#line 6712 "fe/idl.tab.cpp"
     break;
 
-  case 334:
-#line 3691 "fe/idl.ypp"
+  case 336:
+#line 3737 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval), 0);
@@ -6673,27 +6743,27 @@ yyreduce:
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
         }
-#line 6677 "fe/idl.tab.cpp"
-    break;
-
-  case 335:
-#line 3722 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_EnumSqSeen);
-        }
-#line 6685 "fe/idl.tab.cpp"
-    break;
-
-  case 336:
-#line 3726 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_EnumBodySeen);
-        }
-#line 6693 "fe/idl.tab.cpp"
+#line 6747 "fe/idl.tab.cpp"
     break;
 
   case 337:
-#line 3730 "fe/idl.ypp"
+#line 3768 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_EnumSqSeen);
+        }
+#line 6755 "fe/idl.tab.cpp"
+    break;
+
+  case 338:
+#line 3772 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_EnumBodySeen);
+        }
+#line 6763 "fe/idl.tab.cpp"
+    break;
+
+  case 339:
+#line 3776 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumQsSeen);
 
@@ -6712,19 +6782,19 @@ yyreduce:
               idl_global->scopes ().pop ();
             }
         }
-#line 6716 "fe/idl.tab.cpp"
+#line 6786 "fe/idl.tab.cpp"
     break;
 
-  case 339:
-#line 3755 "fe/idl.ypp"
+  case 341:
+#line 3801 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EnumCommaSeen);
         }
-#line 6724 "fe/idl.tab.cpp"
+#line 6794 "fe/idl.tab.cpp"
     break;
 
-  case 342:
-#line 3764 "fe/idl.ypp"
+  case 344:
+#line 3810 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Annotation_Appls *annotations = (yyvsp[-1].annotations_val);
@@ -6759,27 +6829,27 @@ yyreduce:
 
           delete annotations;
         }
-#line 6763 "fe/idl.tab.cpp"
-    break;
-
-  case 343:
-#line 3803 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_SequenceCommaSeen);
-        }
-#line 6771 "fe/idl.tab.cpp"
-    break;
-
-  case 344:
-#line 3807 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_SequenceExprSeen);
-        }
-#line 6779 "fe/idl.tab.cpp"
+#line 6833 "fe/idl.tab.cpp"
     break;
 
   case 345:
-#line 3811 "fe/idl.ypp"
+#line 3849 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_SequenceCommaSeen);
+        }
+#line 6841 "fe/idl.tab.cpp"
+    break;
+
+  case 346:
+#line 3853 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_SequenceExprSeen);
+        }
+#line 6849 "fe/idl.tab.cpp"
+    break;
+
+  case 347:
+#line 3857 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceQsSeen);
 
@@ -6797,7 +6867,7 @@ yyreduce:
           /*
            * Remove sequence marker from scopes stack.
            */
-          if (idl_global->scopes ().top() == 0)
+          if (idl_global->scopes ().top () == 0)
             {
               idl_global->scopes ().pop ();
             }
@@ -6864,11 +6934,11 @@ yyreduce:
           ev = 0;
           (yyval.dcval) = seq;
         }
-#line 6868 "fe/idl.tab.cpp"
+#line 6938 "fe/idl.tab.cpp"
     break;
 
-  case 346:
-#line 3897 "fe/idl.ypp"
+  case 348:
+#line 3943 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceQsSeen);
 
@@ -6934,11 +7004,11 @@ yyreduce:
           delete type_annotations;
           (yyval.dcval) = seq;
         }
-#line 6938 "fe/idl.tab.cpp"
+#line 7008 "fe/idl.tab.cpp"
     break;
 
-  case 347:
-#line 3966 "fe/idl.ypp"
+  case 349:
+#line 4012 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceSeen);
 
@@ -6947,19 +7017,19 @@ yyreduce:
            */
           idl_global->scopes ().push (0);
         }
-#line 6951 "fe/idl.tab.cpp"
+#line 7021 "fe/idl.tab.cpp"
     break;
 
-  case 348:
-#line 3975 "fe/idl.ypp"
+  case 350:
+#line 4021 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceSqSeen);
         }
-#line 6959 "fe/idl.tab.cpp"
+#line 7029 "fe/idl.tab.cpp"
     break;
 
-  case 349:
-#line 3979 "fe/idl.ypp"
+  case 351:
+#line 4025 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SequenceTypeSeen);
           Decl_Annotations_Pair *seq_head = new Decl_Annotations_Pair;
@@ -6967,36 +7037,36 @@ yyreduce:
           seq_head->annotations = (yyvsp[-1].annotations_val);
           (yyval.decl_annotations_pair_val) = seq_head;
         }
-#line 6971 "fe/idl.tab.cpp"
+#line 7041 "fe/idl.tab.cpp"
     break;
 
-  case 350:
-#line 3990 "fe/idl.ypp"
+  case 352:
+#line 4036 "fe/idl.ypp"
         {
           (yyvsp[-1].exval)->evaluate (AST_Expression::EK_positive_int);
           (yyval.dcval) = idl_global->gen ()->create_fixed ((yyvsp[-3].exval), (yyvsp[-1].exval));
         }
-#line 6980 "fe/idl.tab.cpp"
-    break;
-
-  case 351:
-#line 3999 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_StringSqSeen);
-        }
-#line 6988 "fe/idl.tab.cpp"
-    break;
-
-  case 352:
-#line 4003 "fe/idl.ypp"
-        {
-           idl_global->set_parse_state (IDL_GlobalData::PS_StringExprSeen);
-        }
-#line 6996 "fe/idl.tab.cpp"
+#line 7050 "fe/idl.tab.cpp"
     break;
 
   case 353:
-#line 4007 "fe/idl.ypp"
+#line 4045 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_StringSqSeen);
+        }
+#line 7058 "fe/idl.tab.cpp"
+    break;
+
+  case 354:
+#line 4049 "fe/idl.ypp"
+        {
+           idl_global->set_parse_state (IDL_GlobalData::PS_StringExprSeen);
+        }
+#line 7066 "fe/idl.tab.cpp"
+    break;
+
+  case 355:
+#line 4053 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringQsSeen);
 
@@ -7038,11 +7108,11 @@ yyreduce:
           delete ev;
           ev = 0;
         }
-#line 7042 "fe/idl.tab.cpp"
+#line 7112 "fe/idl.tab.cpp"
     break;
 
-  case 354:
-#line 4049 "fe/idl.ypp"
+  case 356:
+#line 4095 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringCompleted);
 
@@ -7065,35 +7135,35 @@ yyreduce:
 
           (yyval.dcval) = tao_string_decl;
         }
-#line 7069 "fe/idl.tab.cpp"
-    break;
-
-  case 355:
-#line 4075 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_StringSeen);
-        }
-#line 7077 "fe/idl.tab.cpp"
-    break;
-
-  case 356:
-#line 4083 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_StringSqSeen);
-        }
-#line 7085 "fe/idl.tab.cpp"
+#line 7139 "fe/idl.tab.cpp"
     break;
 
   case 357:
-#line 4087 "fe/idl.ypp"
+#line 4121 "fe/idl.ypp"
         {
-           idl_global->set_parse_state (IDL_GlobalData::PS_StringExprSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_StringSeen);
         }
-#line 7093 "fe/idl.tab.cpp"
+#line 7147 "fe/idl.tab.cpp"
     break;
 
   case 358:
-#line 4091 "fe/idl.ypp"
+#line 4129 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_StringSqSeen);
+        }
+#line 7155 "fe/idl.tab.cpp"
+    break;
+
+  case 359:
+#line 4133 "fe/idl.ypp"
+        {
+           idl_global->set_parse_state (IDL_GlobalData::PS_StringExprSeen);
+        }
+#line 7163 "fe/idl.tab.cpp"
+    break;
+
+  case 360:
+#line 4137 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringQsSeen);
 
@@ -7126,11 +7196,11 @@ yyreduce:
               (yyval.dcval) = string;
             }
         }
-#line 7130 "fe/idl.tab.cpp"
+#line 7200 "fe/idl.tab.cpp"
     break;
 
-  case 359:
-#line 4124 "fe/idl.ypp"
+  case 361:
+#line 4170 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_StringCompleted);
 
@@ -7153,27 +7223,27 @@ yyreduce:
 
           (yyval.dcval) = string;
         }
-#line 7157 "fe/idl.tab.cpp"
-    break;
-
-  case 360:
-#line 4150 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_StringSeen);
-        }
-#line 7165 "fe/idl.tab.cpp"
-    break;
-
-  case 361:
-#line 4157 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ArrayIDSeen);
-        }
-#line 7173 "fe/idl.tab.cpp"
+#line 7227 "fe/idl.tab.cpp"
     break;
 
   case 362:
-#line 4161 "fe/idl.ypp"
+#line 4196 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_StringSeen);
+        }
+#line 7235 "fe/idl.tab.cpp"
+    break;
+
+  case 363:
+#line 4203 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ArrayIDSeen);
+        }
+#line 7243 "fe/idl.tab.cpp"
+    break;
+
+  case 364:
+#line 4207 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ArrayCompleted);
 
@@ -7213,22 +7283,22 @@ yyreduce:
 
           (yyval.dcval) = array;
         }
-#line 7217 "fe/idl.tab.cpp"
+#line 7287 "fe/idl.tab.cpp"
     break;
 
-  case 363:
-#line 4204 "fe/idl.ypp"
+  case 365:
+#line 4250 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.elval),
                           UTL_ExprList ((yyvsp[-1].exval),
                                         (yyvsp[0].elval)),
                           1);
         }
-#line 7228 "fe/idl.tab.cpp"
+#line 7298 "fe/idl.tab.cpp"
     break;
 
-  case 364:
-#line 4214 "fe/idl.ypp"
+  case 366:
+#line 4260 "fe/idl.ypp"
         {
           UTL_ExprList *el = 0;
           ACE_NEW_RETURN (el,
@@ -7246,35 +7316,35 @@ yyreduce:
               (yyval.elval) = (yyvsp[-1].elval);
             }
         }
-#line 7250 "fe/idl.tab.cpp"
-    break;
-
-  case 365:
-#line 4232 "fe/idl.ypp"
-        {
-          (yyval.elval) = 0;
-        }
-#line 7258 "fe/idl.tab.cpp"
-    break;
-
-  case 366:
-#line 4239 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_DimSqSeen);
-        }
-#line 7266 "fe/idl.tab.cpp"
+#line 7320 "fe/idl.tab.cpp"
     break;
 
   case 367:
-#line 4243 "fe/idl.ypp"
+#line 4278 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_DimExprSeen);
+          (yyval.elval) = 0;
         }
-#line 7274 "fe/idl.tab.cpp"
+#line 7328 "fe/idl.tab.cpp"
     break;
 
   case 368:
-#line 4247 "fe/idl.ypp"
+#line 4285 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_DimSqSeen);
+        }
+#line 7336 "fe/idl.tab.cpp"
+    break;
+
+  case 369:
+#line 4289 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_DimExprSeen);
+        }
+#line 7344 "fe/idl.tab.cpp"
+    break;
+
+  case 370:
+#line 4293 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_DimQsSeen);
 
@@ -7328,43 +7398,43 @@ yyreduce:
           delete ev;
           ev = 0;
         }
-#line 7332 "fe/idl.tab.cpp"
-    break;
-
-  case 371:
-#line 4309 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrROSeen);
-        }
-#line 7340 "fe/idl.tab.cpp"
-    break;
-
-  case 372:
-#line 4313 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrSeen);
-        }
-#line 7348 "fe/idl.tab.cpp"
+#line 7402 "fe/idl.tab.cpp"
     break;
 
   case 373:
-#line 4317 "fe/idl.ypp"
+#line 4355 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrTypeSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrROSeen);
         }
-#line 7356 "fe/idl.tab.cpp"
+#line 7410 "fe/idl.tab.cpp"
     break;
 
   case 374:
-#line 4321 "fe/idl.ypp"
+#line 4359 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclsSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrSeen);
         }
-#line 7364 "fe/idl.tab.cpp"
+#line 7418 "fe/idl.tab.cpp"
     break;
 
   case 375:
-#line 4325 "fe/idl.ypp"
+#line 4363 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrTypeSeen);
+        }
+#line 7426 "fe/idl.tab.cpp"
+    break;
+
+  case 376:
+#line 4367 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclsSeen);
+        }
+#line 7434 "fe/idl.tab.cpp"
+    break;
+
+  case 377:
+#line 4371 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Attribute *a = 0;
@@ -7416,43 +7486,43 @@ yyreduce:
 
           (yyval.dcval) = a;
         }
-#line 7420 "fe/idl.tab.cpp"
-    break;
-
-  case 376:
-#line 4380 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrSeen);
-        }
-#line 7428 "fe/idl.tab.cpp"
-    break;
-
-  case 377:
-#line 4384 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrTypeSeen);
-        }
-#line 7436 "fe/idl.tab.cpp"
+#line 7490 "fe/idl.tab.cpp"
     break;
 
   case 378:
-#line 4388 "fe/idl.ypp"
+#line 4426 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclsSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrSeen);
         }
-#line 7444 "fe/idl.tab.cpp"
+#line 7498 "fe/idl.tab.cpp"
     break;
 
   case 379:
-#line 4392 "fe/idl.ypp"
+#line 4430 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseCompleted);
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrTypeSeen);
         }
-#line 7452 "fe/idl.tab.cpp"
+#line 7506 "fe/idl.tab.cpp"
     break;
 
   case 380:
-#line 4396 "fe/idl.ypp"
+#line 4434 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclsSeen);
+        }
+#line 7514 "fe/idl.tab.cpp"
+    break;
+
+  case 381:
+#line 4438 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseCompleted);
+        }
+#line 7522 "fe/idl.tab.cpp"
+    break;
+
+  case 382:
+#line 4442 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Attribute *a = 0;
@@ -7513,68 +7583,71 @@ yyreduce:
 
           (yyval.dcval) = a;
         }
-#line 7517 "fe/idl.tab.cpp"
+#line 7587 "fe/idl.tab.cpp"
     break;
 
-  case 381:
-#line 4460 "fe/idl.ypp"
+  case 383:
+#line 4506 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptSeen);
         }
-#line 7525 "fe/idl.tab.cpp"
+#line 7595 "fe/idl.tab.cpp"
     break;
 
-  case 382:
-#line 4464 "fe/idl.ypp"
+  case 384:
+#line 4510 "fe/idl.ypp"
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          UTL_ScopedName n ((yyvsp[0].idval),
-                            0);
-          AST_Exception *e = 0;
+          Identifier *&id = (yyvsp[0].idval);
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          UTL_ScopedName scoped_name (id, 0);
+          AST_Exception *exception = 0;
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptIDSeen);
 
           /*
            * Create a node representing an exception and add it to
            * the enclosing scope.
            */
-          if (s != 0)
+          if (scope)
             {
-              e = idl_global->gen ()->create_exception (&n,
-                                                        s->is_local (),
-                                                        s->is_abstract ());
-              (void) s->fe_add_exception (e);
+              exception = idl_global->gen ()->create_exception (
+                &scoped_name,
+                scope->is_local (),
+                scope->is_abstract ());
+              scope->fe_add_exception (exception);
             }
 
           /*
            * Push the exception scope on the scope stack.
            */
-          idl_global->scopes ().push (e);
+          idl_global->scopes ().push (exception);
 
-          (yyvsp[0].idval)->destroy ();
-          delete (yyvsp[0].idval);
-          (yyvsp[0].idval) = 0;
-        }
-#line 7558 "fe/idl.tab.cpp"
-    break;
+          id->destroy ();
+          delete id;
+          id = 0;
 
-  case 383:
-#line 4493 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ExceptSqSeen);
+          (yyval.dcval) = exception;
         }
-#line 7566 "fe/idl.tab.cpp"
-    break;
-
-  case 384:
-#line 4497 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ExceptBodySeen);
-        }
-#line 7574 "fe/idl.tab.cpp"
+#line 7631 "fe/idl.tab.cpp"
     break;
 
   case 385:
-#line 4501 "fe/idl.ypp"
+#line 4542 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ExceptSqSeen);
+        }
+#line 7639 "fe/idl.tab.cpp"
+    break;
+
+  case 386:
+#line 4546 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ExceptBodySeen);
+        }
+#line 7647 "fe/idl.tab.cpp"
+    break;
+
+  case 387:
+#line 4550 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptQsSeen);
           /*
@@ -7582,21 +7655,21 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
 
-          (yyval.dcval) = 0;
+          (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 7588 "fe/idl.tab.cpp"
+#line 7661 "fe/idl.tab.cpp"
     break;
 
-  case 386:
-#line 4514 "fe/idl.ypp"
+  case 388:
+#line 4563 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpTypeSeen);
         }
-#line 7596 "fe/idl.tab.cpp"
+#line 7669 "fe/idl.tab.cpp"
     break;
 
-  case 387:
-#line 4518 "fe/idl.ypp"
+  case 389:
+#line 4567 "fe/idl.ypp"
         {
           AST_Operation *op = 0;
           UTL_Scope *scope = idl_global->scopes ().top_non_null ();
@@ -7657,27 +7730,27 @@ yyreduce:
            */
           idl_global->scopes ().push (op);
         }
-#line 7661 "fe/idl.tab.cpp"
-    break;
-
-  case 388:
-#line 4579 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
-        }
-#line 7669 "fe/idl.tab.cpp"
-    break;
-
-  case 389:
-#line 4583 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
-        }
-#line 7677 "fe/idl.tab.cpp"
+#line 7734 "fe/idl.tab.cpp"
     break;
 
   case 390:
-#line 4587 "fe/idl.ypp"
+#line 4628 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
+        }
+#line 7742 "fe/idl.tab.cpp"
+    break;
+
+  case 391:
+#line 4632 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
+        }
+#line 7750 "fe/idl.tab.cpp"
+    break;
+
+  case 392:
+#line 4636 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Operation *o = 0;
@@ -7708,57 +7781,57 @@ yyreduce:
 
           (yyval.dcval) = o;
         }
-#line 7712 "fe/idl.tab.cpp"
+#line 7785 "fe/idl.tab.cpp"
     break;
 
-  case 391:
-#line 4621 "fe/idl.ypp"
+  case 393:
+#line 4670 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpAttrSeen);
           (yyval.ofval) = AST_Operation::OP_oneway;
         }
-#line 7721 "fe/idl.tab.cpp"
+#line 7794 "fe/idl.tab.cpp"
     break;
 
-  case 392:
-#line 4626 "fe/idl.ypp"
+  case 394:
+#line 4675 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpAttrSeen);
           (yyval.ofval) = AST_Operation::OP_idempotent;
         }
-#line 7730 "fe/idl.tab.cpp"
-    break;
-
-  case 393:
-#line 4631 "fe/idl.ypp"
-        {
-          (yyval.ofval) = AST_Operation::OP_noflags;
-        }
-#line 7738 "fe/idl.tab.cpp"
+#line 7803 "fe/idl.tab.cpp"
     break;
 
   case 395:
-#line 4639 "fe/idl.ypp"
+#line 4680 "fe/idl.ypp"
+        {
+          (yyval.ofval) = AST_Operation::OP_noflags;
+        }
+#line 7811 "fe/idl.tab.cpp"
+    break;
+
+  case 397:
+#line 4688 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                   AST_Expression::EV_void
                                                 );
         }
-#line 7749 "fe/idl.tab.cpp"
+#line 7822 "fe/idl.tab.cpp"
     break;
 
-  case 396:
-#line 4649 "fe/idl.ypp"
+  case 398:
+#line 4698 "fe/idl.ypp"
         {
           //@@ PS_FactorySeen?
           idl_global->set_parse_state (IDL_GlobalData::PS_OpTypeSeen);
         }
-#line 7758 "fe/idl.tab.cpp"
+#line 7831 "fe/idl.tab.cpp"
     break;
 
-  case 397:
-#line 4654 "fe/idl.ypp"
+  case 399:
+#line 4703 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
 
@@ -7799,25 +7872,25 @@ yyreduce:
            */
           idl_global->scopes ().push (factory);
 
-          delete (yyvsp[-1].annotations_val);
+          (yyval.dcval) = factory;
         }
-#line 7805 "fe/idl.tab.cpp"
+#line 7878 "fe/idl.tab.cpp"
     break;
 
-  case 398:
-#line 4697 "fe/idl.ypp"
+  case 400:
+#line 4746 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
         }
-#line 7813 "fe/idl.tab.cpp"
+#line 7886 "fe/idl.tab.cpp"
     break;
 
-  case 399:
-#line 4701 "fe/idl.ypp"
+  case 401:
+#line 4750 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
 
-          if ((yyvsp[0].nlval) != 0)
+          if ((yyvsp[0].nlval))
             {
               UTL_Scope *s = idl_global->scopes ().top_non_null ();
               AST_Factory *f = AST_Factory::narrow_from_scope (s);
@@ -7825,68 +7898,70 @@ yyreduce:
             }
 
           idl_global->scopes ().pop ();
-        }
-#line 7830 "fe/idl.tab.cpp"
-    break;
 
-  case 400:
-#line 4717 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
+          (yyval.dcval) = (yyvsp[-3].dcval);
         }
-#line 7838 "fe/idl.tab.cpp"
-    break;
-
-  case 401:
-#line 4721 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
-        }
-#line 7846 "fe/idl.tab.cpp"
+#line 7905 "fe/idl.tab.cpp"
     break;
 
   case 402:
-#line 4725 "fe/idl.ypp"
+#line 4768 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
         }
-#line 7854 "fe/idl.tab.cpp"
+#line 7913 "fe/idl.tab.cpp"
     break;
 
   case 403:
-#line 4730 "fe/idl.ypp"
+#line 4772 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
         }
-#line 7862 "fe/idl.tab.cpp"
+#line 7921 "fe/idl.tab.cpp"
+    break;
+
+  case 404:
+#line 4776 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
+        }
+#line 7929 "fe/idl.tab.cpp"
     break;
 
   case 405:
-#line 4740 "fe/idl.ypp"
+#line 4781 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
+        }
+#line 7937 "fe/idl.tab.cpp"
+    break;
+
+  case 407:
+#line 4791 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParCommaSeen);
         }
-#line 7870 "fe/idl.tab.cpp"
-    break;
-
-  case 408:
-#line 4749 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpParDirSeen);
-        }
-#line 7878 "fe/idl.tab.cpp"
-    break;
-
-  case 409:
-#line 4753 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpParTypeSeen);
-        }
-#line 7886 "fe/idl.tab.cpp"
+#line 7945 "fe/idl.tab.cpp"
     break;
 
   case 410:
-#line 4757 "fe/idl.ypp"
+#line 4800 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpParDirSeen);
+        }
+#line 7953 "fe/idl.tab.cpp"
+    break;
+
+  case 411:
+#line 4804 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpParTypeSeen);
+        }
+#line 7961 "fe/idl.tab.cpp"
+    break;
+
+  case 412:
+#line 4808 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Argument *a = 0;
@@ -7918,67 +7993,67 @@ yyreduce:
           delete (yyvsp[0].deval);
           (yyvsp[0].deval) = 0;
         }
-#line 7922 "fe/idl.tab.cpp"
-    break;
-
-  case 411:
-#line 4792 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
-        }
-#line 7930 "fe/idl.tab.cpp"
-    break;
-
-  case 412:
-#line 4796 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
-        }
-#line 7938 "fe/idl.tab.cpp"
+#line 7997 "fe/idl.tab.cpp"
     break;
 
   case 413:
-#line 4800 "fe/idl.ypp"
+#line 4843 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
         }
-#line 7946 "fe/idl.tab.cpp"
+#line 8005 "fe/idl.tab.cpp"
     break;
 
   case 414:
-#line 4805 "fe/idl.ypp"
+#line 4847 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
         }
-#line 7954 "fe/idl.tab.cpp"
+#line 8013 "fe/idl.tab.cpp"
+    break;
+
+  case 415:
+#line 4851 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpSqSeen);
+        }
+#line 8021 "fe/idl.tab.cpp"
     break;
 
   case 416:
-#line 4815 "fe/idl.ypp"
+#line 4856 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpQsSeen);
+        }
+#line 8029 "fe/idl.tab.cpp"
+    break;
+
+  case 418:
+#line 4866 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParCommaSeen);
         }
-#line 7962 "fe/idl.tab.cpp"
-    break;
-
-  case 419:
-#line 4824 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpParDirSeen);
-        }
-#line 7970 "fe/idl.tab.cpp"
-    break;
-
-  case 420:
-#line 4828 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpParTypeSeen);
-        }
-#line 7978 "fe/idl.tab.cpp"
+#line 8037 "fe/idl.tab.cpp"
     break;
 
   case 421:
-#line 4832 "fe/idl.ypp"
+#line 4875 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpParDirSeen);
+        }
+#line 8045 "fe/idl.tab.cpp"
+    break;
+
+  case 422:
+#line 4879 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpParTypeSeen);
+        }
+#line 8053 "fe/idl.tab.cpp"
+    break;
+
+  case 423:
+#line 4883 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Argument *a = 0;
@@ -8017,22 +8092,22 @@ yyreduce:
           delete (yyvsp[0].deval);
           (yyvsp[0].deval) = 0;
         }
-#line 8021 "fe/idl.tab.cpp"
+#line 8096 "fe/idl.tab.cpp"
     break;
 
-  case 422:
-#line 4874 "fe/idl.ypp"
+  case 424:
+#line 4925 "fe/idl.ypp"
         {
           (yyval.dcval) =
             idl_global->scopes ().bottom ()->lookup_primitive_type (
                                                  (yyvsp[0].etval)
                                                );
         }
-#line 8032 "fe/idl.tab.cpp"
+#line 8107 "fe/idl.tab.cpp"
     break;
 
-  case 425:
-#line 4883 "fe/idl.ypp"
+  case 427:
+#line 4934 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = 0;
@@ -8136,186 +8211,186 @@ yyreduce:
 
           (yyval.dcval) = d;
         }
-#line 8140 "fe/idl.tab.cpp"
-    break;
-
-  case 426:
-#line 4990 "fe/idl.ypp"
-        {
-          (yyval.dival) = AST_Argument::dir_IN;
-        }
-#line 8148 "fe/idl.tab.cpp"
-    break;
-
-  case 427:
-#line 4994 "fe/idl.ypp"
-        {
-          (yyval.dival) = AST_Argument::dir_OUT;
-        }
-#line 8156 "fe/idl.tab.cpp"
+#line 8215 "fe/idl.tab.cpp"
     break;
 
   case 428:
-#line 4998 "fe/idl.ypp"
+#line 5041 "fe/idl.ypp"
         {
-          (yyval.dival) = AST_Argument::dir_INOUT;
+          (yyval.dival) = AST_Argument::dir_IN;
         }
-#line 8164 "fe/idl.tab.cpp"
+#line 8223 "fe/idl.tab.cpp"
     break;
 
   case 429:
-#line 5005 "fe/idl.ypp"
+#line 5045 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseSeen);
+          (yyval.dival) = AST_Argument::dir_OUT;
         }
-#line 8172 "fe/idl.tab.cpp"
+#line 8231 "fe/idl.tab.cpp"
     break;
 
   case 430:
-#line 5009 "fe/idl.ypp"
+#line 5049 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseSqSeen);
+          (yyval.dival) = AST_Argument::dir_INOUT;
         }
-#line 8180 "fe/idl.tab.cpp"
+#line 8239 "fe/idl.tab.cpp"
     break;
 
   case 431:
-#line 5014 "fe/idl.ypp"
+#line 5056 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseQsSeen);
-          (yyval.nlval) = (yyvsp[-1].nlval);
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseSeen);
         }
-#line 8189 "fe/idl.tab.cpp"
+#line 8247 "fe/idl.tab.cpp"
     break;
 
   case 432:
-#line 5019 "fe/idl.ypp"
+#line 5060 "fe/idl.ypp"
         {
-          (yyval.nlval) = 0;
-        }
-#line 8197 "fe/idl.tab.cpp"
-    break;
-
-  case 433:
-#line 5026 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseSeen);
-        }
-#line 8205 "fe/idl.tab.cpp"
-    break;
-
-  case 434:
-#line 5030 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseSqSeen);
-        }
-#line 8213 "fe/idl.tab.cpp"
-    break;
-
-  case 435:
-#line 5035 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseQsSeen);
-          (yyval.nlval) = (yyvsp[-1].nlval);
-        }
-#line 8222 "fe/idl.tab.cpp"
-    break;
-
-  case 436:
-#line 5040 "fe/idl.ypp"
-        {
-          (yyval.nlval) = 0;
-        }
-#line 8230 "fe/idl.tab.cpp"
-    break;
-
-  case 437:
-#line 5047 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseSeen);
-        }
-#line 8238 "fe/idl.tab.cpp"
-    break;
-
-  case 438:
-#line 5051 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseSqSeen);
-        }
-#line 8246 "fe/idl.tab.cpp"
-    break;
-
-  case 439:
-#line 5056 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseQsSeen);
-          (yyval.nlval) = (yyvsp[-1].nlval);
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseSqSeen);
         }
 #line 8255 "fe/idl.tab.cpp"
     break;
 
-  case 440:
-#line 5061 "fe/idl.ypp"
+  case 433:
+#line 5065 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseQsSeen);
+          (yyval.nlval) = (yyvsp[-1].nlval);
+        }
+#line 8264 "fe/idl.tab.cpp"
+    break;
+
+  case 434:
+#line 5070 "fe/idl.ypp"
         {
           (yyval.nlval) = 0;
         }
-#line 8263 "fe/idl.tab.cpp"
+#line 8272 "fe/idl.tab.cpp"
     break;
 
-  case 441:
-#line 5068 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpContextSeen);
-        }
-#line 8271 "fe/idl.tab.cpp"
-    break;
-
-  case 442:
-#line 5072 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpContextSqSeen);
-        }
-#line 8279 "fe/idl.tab.cpp"
-    break;
-
-  case 443:
+  case 435:
 #line 5077 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_OpContextQsSeen);
-          (yyval.slval) = (yyvsp[-1].slval);
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseSeen);
+        }
+#line 8280 "fe/idl.tab.cpp"
+    break;
+
+  case 436:
+#line 5081 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseSqSeen);
         }
 #line 8288 "fe/idl.tab.cpp"
     break;
 
-  case 444:
-#line 5082 "fe/idl.ypp"
+  case 437:
+#line 5086 "fe/idl.ypp"
         {
-          (yyval.slval) = 0;
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpGetRaiseQsSeen);
+          (yyval.nlval) = (yyvsp[-1].nlval);
         }
-#line 8296 "fe/idl.tab.cpp"
+#line 8297 "fe/idl.tab.cpp"
+    break;
+
+  case 438:
+#line 5091 "fe/idl.ypp"
+        {
+          (yyval.nlval) = 0;
+        }
+#line 8305 "fe/idl.tab.cpp"
+    break;
+
+  case 439:
+#line 5098 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseSeen);
+        }
+#line 8313 "fe/idl.tab.cpp"
+    break;
+
+  case 440:
+#line 5102 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseSqSeen);
+        }
+#line 8321 "fe/idl.tab.cpp"
+    break;
+
+  case 441:
+#line 5107 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpSetRaiseQsSeen);
+          (yyval.nlval) = (yyvsp[-1].nlval);
+        }
+#line 8330 "fe/idl.tab.cpp"
+    break;
+
+  case 442:
+#line 5112 "fe/idl.ypp"
+        {
+          (yyval.nlval) = 0;
+        }
+#line 8338 "fe/idl.tab.cpp"
+    break;
+
+  case 443:
+#line 5119 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpContextSeen);
+        }
+#line 8346 "fe/idl.tab.cpp"
+    break;
+
+  case 444:
+#line 5123 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpContextSqSeen);
+        }
+#line 8354 "fe/idl.tab.cpp"
     break;
 
   case 445:
-#line 5089 "fe/idl.ypp"
+#line 5128 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_OpContextQsSeen);
+          (yyval.slval) = (yyvsp[-1].slval);
+        }
+#line 8363 "fe/idl.tab.cpp"
+    break;
+
+  case 446:
+#line 5133 "fe/idl.ypp"
+        {
+          (yyval.slval) = 0;
+        }
+#line 8371 "fe/idl.tab.cpp"
+    break;
+
+  case 447:
+#line 5140 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.slval),
                           UTL_StrList ((yyvsp[-1].sval),
                                        (yyvsp[0].slval)),
                           1);
         }
-#line 8307 "fe/idl.tab.cpp"
+#line 8382 "fe/idl.tab.cpp"
     break;
 
-  case 446:
-#line 5100 "fe/idl.ypp"
+  case 448:
+#line 5151 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpContextCommaSeen);
         }
-#line 8315 "fe/idl.tab.cpp"
+#line 8390 "fe/idl.tab.cpp"
     break;
 
-  case 447:
-#line 5104 "fe/idl.ypp"
+  case 449:
+#line 5155 "fe/idl.ypp"
         {
           UTL_StrList *sl = 0;
           ACE_NEW_RETURN (sl,
@@ -8333,19 +8408,19 @@ yyreduce:
               (yyval.slval) = (yyvsp[-3].slval);
             }
         }
-#line 8337 "fe/idl.tab.cpp"
+#line 8412 "fe/idl.tab.cpp"
     break;
 
-  case 448:
-#line 5122 "fe/idl.ypp"
+  case 450:
+#line 5173 "fe/idl.ypp"
         {
           (yyval.slval) = 0;
         }
-#line 8345 "fe/idl.tab.cpp"
+#line 8420 "fe/idl.tab.cpp"
     break;
 
-  case 449:
-#line 5129 "fe/idl.ypp"
+  case 451:
+#line 5180 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d =
@@ -8372,11 +8447,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 8376 "fe/idl.tab.cpp"
+#line 8451 "fe/idl.tab.cpp"
     break;
 
-  case 450:
-#line 5159 "fe/idl.ypp"
+  case 452:
+#line 5210 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Decl *d = ScopeAsDecl (s);
@@ -8412,11 +8487,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 8416 "fe/idl.tab.cpp"
+#line 8491 "fe/idl.tab.cpp"
     break;
 
-  case 453:
-#line 5204 "fe/idl.ypp"
+  case 455:
+#line 5255 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -8442,70 +8517,72 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 8446 "fe/idl.tab.cpp"
+#line 8521 "fe/idl.tab.cpp"
     break;
 
-  case 454:
-#line 5233 "fe/idl.ypp"
+  case 456:
+#line 5284 "fe/idl.ypp"
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          AST_Component *c = 0;
+          FE_ComponentHeader *&component_header = (yyvsp[0].chval);
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          AST_Component *component = 0;
 
           /*
            * Make a new component node and add it to the enclosing scope.
            */
-          if (s != 0 && (yyvsp[0].chval) != 0)
+          if (scope && component_header)
             {
-              c =
-                idl_global->gen ()->create_component (
-                                        (yyvsp[0].chval)->name (),
-                                        (yyvsp[0].chval)->base_component (),
-                                        (yyvsp[0].chval)->supports (),
-                                        (yyvsp[0].chval)->n_supports (),
-                                        (yyvsp[0].chval)->supports_flat (),
-                                        (yyvsp[0].chval)->n_supports_flat ()
-                                      );
-              AST_Interface *i = AST_Interface::narrow_from_decl (c);
-              AST_Interface::fwd_redefinition_helper (i,
-                                                      s);
+              component = idl_global->gen ()->create_component (
+                component_header->name (),
+                component_header->base_component (),
+                component_header->supports (),
+                component_header->n_supports (),
+                component_header->supports_flat (),
+                component_header->n_supports_flat ());
+              AST_Interface *component_as_interface =
+                dynamic_cast<AST_Interface*> (component);
+              AST_Interface::fwd_redefinition_helper (
+                component_as_interface, scope);
+
               /*
                * Add the component to its definition scope.
                */
-              c = AST_Component::narrow_from_decl (i);
-              (void) s->fe_add_component (c);
+              scope->fe_add_component (component);
 
               // This FE_ComponentHeader class isn't destroyed with the AST.
-              (yyvsp[0].chval)->destroy ();
-              delete (yyvsp[0].chval);
-              (yyvsp[0].chval) = 0;
+              component_header->destroy ();
+              delete component_header;
+              component_header = 0;
             }
 
           /*
            * Push it on the scope stack.
            */
-          idl_global->scopes ().push (c);
-        }
-#line 8489 "fe/idl.tab.cpp"
-    break;
+          idl_global->scopes ().push (component);
 
-  case 455:
-#line 5272 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ComponentSqSeen);
+          (yyval.dcval) = component;
         }
-#line 8497 "fe/idl.tab.cpp"
-    break;
-
-  case 456:
-#line 5276 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ComponentBodySeen);
-        }
-#line 8505 "fe/idl.tab.cpp"
+#line 8566 "fe/idl.tab.cpp"
     break;
 
   case 457:
-#line 5280 "fe/idl.ypp"
+#line 5325 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ComponentSqSeen);
+        }
+#line 8574 "fe/idl.tab.cpp"
+    break;
+
+  case 458:
+#line 5329 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ComponentBodySeen);
+        }
+#line 8582 "fe/idl.tab.cpp"
+    break;
+
+  case 459:
+#line 5333 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ComponentQsSeen);
 
@@ -8514,29 +8591,29 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
 
-          (yyval.dcval) = 0;
+          (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 8520 "fe/idl.tab.cpp"
-    break;
-
-  case 458:
-#line 5295 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ComponentIDSeen);
-        }
-#line 8528 "fe/idl.tab.cpp"
-    break;
-
-  case 459:
-#line 5299 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
-        }
-#line 8536 "fe/idl.tab.cpp"
+#line 8597 "fe/idl.tab.cpp"
     break;
 
   case 460:
-#line 5303 "fe/idl.ypp"
+#line 5348 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ComponentIDSeen);
+        }
+#line 8605 "fe/idl.tab.cpp"
+    break;
+
+  case 461:
+#line 5352 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
+        }
+#line 8613 "fe/idl.tab.cpp"
+    break;
+
+  case 462:
+#line 5356 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
 
@@ -8570,147 +8647,173 @@ yyreduce:
               (yyvsp[-2].idlist) = 0;
             }
         }
-#line 8574 "fe/idl.tab.cpp"
-    break;
-
-  case 461:
-#line 5340 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
-        }
-#line 8582 "fe/idl.tab.cpp"
-    break;
-
-  case 462:
-#line 5344 "fe/idl.ypp"
-        {
-          (yyval.idlist) = (yyvsp[0].idlist);
-        }
-#line 8590 "fe/idl.tab.cpp"
+#line 8651 "fe/idl.tab.cpp"
     break;
 
   case 463:
-#line 5348 "fe/idl.ypp"
+#line 5393 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
+        }
+#line 8659 "fe/idl.tab.cpp"
+    break;
+
+  case 464:
+#line 5397 "fe/idl.ypp"
+        {
+          (yyval.idlist) = (yyvsp[0].idlist);
+        }
+#line 8667 "fe/idl.tab.cpp"
+    break;
+
+  case 465:
+#line 5401 "fe/idl.ypp"
         {
           (yyval.idlist) = 0;
         }
-#line 8598 "fe/idl.tab.cpp"
+#line 8675 "fe/idl.tab.cpp"
     break;
 
   case 466:
-#line 5360 "fe/idl.ypp"
+#line 5408 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ProvidesDeclSeen);
-        }
-#line 8606 "fe/idl.tab.cpp"
-    break;
-
-  case 467:
-#line 5364 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 8614 "fe/idl.tab.cpp"
-    break;
-
-  case 468:
-#line 5368 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_UsesDeclSeen);
-        }
-#line 8622 "fe/idl.tab.cpp"
-    break;
-
-  case 469:
-#line 5372 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 8630 "fe/idl.tab.cpp"
-    break;
-
-  case 470:
-#line 5376 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_EmitsDeclSeen);
-        }
-#line 8638 "fe/idl.tab.cpp"
-    break;
-
-  case 471:
-#line 5380 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 8646 "fe/idl.tab.cpp"
-    break;
-
-  case 472:
-#line 5384 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_PublishesDeclSeen);
-        }
-#line 8654 "fe/idl.tab.cpp"
-    break;
-
-  case 473:
-#line 5388 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 8662 "fe/idl.tab.cpp"
-    break;
-
-  case 474:
-#line 5392 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConsumesDeclSeen);
-        }
-#line 8670 "fe/idl.tab.cpp"
-    break;
-
-  case 475:
-#line 5396 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 8678 "fe/idl.tab.cpp"
-    break;
-
-  case 476:
-#line 5400 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
-        }
-#line 8686 "fe/idl.tab.cpp"
-    break;
-
-  case 477:
-#line 5404 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          AST_Annotation_Appls *&annotations = (yyvsp[-1].annotations_val);
+          AST_Decl *&node = (yyvsp[0].dcval);
+          if (node)
+            {
+              node->annotation_appls (*annotations);
+            }
+          else
+            {
+              idl_global->err ()-> unsupported_warning (
+                "Annotating this is not supported");
+            }
+          delete annotations;
         }
 #line 8694 "fe/idl.tab.cpp"
     break;
 
-  case 478:
-#line 5408 "fe/idl.ypp"
+  case 469:
+#line 5428 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_ProvidesDeclSeen);
         }
 #line 8702 "fe/idl.tab.cpp"
     break;
 
-  case 479:
-#line 5412 "fe/idl.ypp"
+  case 470:
+#line 5432 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          (yyval.dcval) = (yyvsp[-2].dcval);
         }
-#line 8710 "fe/idl.tab.cpp"
+#line 8711 "fe/idl.tab.cpp"
+    break;
+
+  case 471:
+#line 5437 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_UsesDeclSeen);
+        }
+#line 8719 "fe/idl.tab.cpp"
+    break;
+
+  case 472:
+#line 5441 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          (yyval.dcval) = (yyvsp[-2].dcval);
+        }
+#line 8728 "fe/idl.tab.cpp"
+    break;
+
+  case 473:
+#line 5446 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_EmitsDeclSeen);
+        }
+#line 8736 "fe/idl.tab.cpp"
+    break;
+
+  case 474:
+#line 5450 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          (yyval.dcval) = (yyvsp[-2].dcval);
+        }
+#line 8745 "fe/idl.tab.cpp"
+    break;
+
+  case 475:
+#line 5455 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_PublishesDeclSeen);
+        }
+#line 8753 "fe/idl.tab.cpp"
+    break;
+
+  case 476:
+#line 5459 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          (yyval.dcval) = (yyvsp[-2].dcval);
+        }
+#line 8762 "fe/idl.tab.cpp"
+    break;
+
+  case 477:
+#line 5464 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConsumesDeclSeen);
+        }
+#line 8770 "fe/idl.tab.cpp"
+    break;
+
+  case 478:
+#line 5468 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          (yyval.dcval) = (yyvsp[-2].dcval);
+        }
+#line 8779 "fe/idl.tab.cpp"
+    break;
+
+  case 479:
+#line 5473 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
+        }
+#line 8787 "fe/idl.tab.cpp"
     break;
 
   case 480:
-#line 5418 "fe/idl.ypp"
+#line 5477 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          (yyval.dcval) = (yyvsp[-2].dcval);
+        }
+#line 8796 "fe/idl.tab.cpp"
+    break;
+
+  case 481:
+#line 5482 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
+        }
+#line 8804 "fe/idl.tab.cpp"
+    break;
+
+  case 482:
+#line 5486 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          (yyval.dcval) = (yyvsp[-2].dcval);
+        }
+#line 8813 "fe/idl.tab.cpp"
+    break;
+
+  case 483:
+#line 5493 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -8771,6 +8874,8 @@ yyreduce:
                 }
             }
 
+          AST_Provides *provides = 0;
+
           if (so_far_so_good)
             {
               AST_Type *port_interface_type =
@@ -8782,11 +8887,10 @@ yyreduce:
               UTL_ScopedName sn ((yyvsp[0].idval),
                                  0);
 
-              AST_Provides *p =
-                idl_global->gen ()->create_provides (&sn,
-                                                     port_interface_type);
+              provides = idl_global->gen ()->create_provides (
+                &sn, port_interface_type);
 
-              (void) s->fe_add_provides (p);
+              (void) s->fe_add_provides (provides);
             }
 
           (yyvsp[-1].idlist)->destroy ();
@@ -8796,22 +8900,24 @@ yyreduce:
           (yyvsp[0].idval)->destroy ();
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
+
+          (yyval.dcval) = dynamic_cast<AST_Decl *> (provides);
         }
-#line 8801 "fe/idl.tab.cpp"
+#line 8907 "fe/idl.tab.cpp"
     break;
 
-  case 481:
-#line 5508 "fe/idl.ypp"
+  case 484:
+#line 5586 "fe/idl.ypp"
         {
           // Lookups and checking are done where the 'interface_type'
           // token is used, in 'provides_decl' and 'uses_decl'.
           (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 8811 "fe/idl.tab.cpp"
+#line 8917 "fe/idl.tab.cpp"
     break;
 
-  case 482:
-#line 5514 "fe/idl.ypp"
+  case 485:
+#line 5592 "fe/idl.ypp"
         {
           Identifier *corba_id = 0;
 
@@ -8834,11 +8940,11 @@ yyreduce:
                                       conc_name),
                           1);
         }
-#line 8838 "fe/idl.tab.cpp"
+#line 8944 "fe/idl.tab.cpp"
     break;
 
-  case 483:
-#line 5539 "fe/idl.ypp"
+  case 486:
+#line 5617 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -8899,6 +9005,8 @@ yyreduce:
                 }
             }
 
+          AST_Uses *uses = 0;
+
           if (so_far_so_good)
             {
               AST_Type *port_interface_type =
@@ -8910,18 +9018,15 @@ yyreduce:
               UTL_ScopedName sn ((yyvsp[0].idval),
                                  0);
 
-              AST_Uses *u =
-                idl_global->gen ()->create_uses (&sn,
-                                                 port_interface_type,
-                                                 (yyvsp[-2].bval));
-
-              (void) s->fe_add_uses (u);
+              uses = idl_global->gen ()->create_uses (
+                &sn, port_interface_type, (yyvsp[-2].bval));
+              s->fe_add_uses (uses);
 
               AST_Component *c =
                 AST_Component::narrow_from_scope (s);
 
               if (c != 0
-                  && u->is_multiple ()
+                  && uses->is_multiple ()
                   && !idl_global->using_ifr_backend ()
                   && !idl_global->ignore_idl3 ()
                   && nt != AST_Decl::NT_param_holder)
@@ -8929,7 +9034,7 @@ yyreduce:
                   // These datatypes must be created in the
                   // front end so they can be looked up
                   // when compiling the generated executor IDL.
-                  FE_Utils::create_uses_multiple_stuff (c, u);
+                  FE_Utils::create_uses_multiple_stuff (c, uses);
                 }
             }
 
@@ -8940,38 +9045,40 @@ yyreduce:
           (yyvsp[0].idval)->destroy ();
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
+
+          (yyval.dcval) = uses;
         }
-#line 8945 "fe/idl.tab.cpp"
+#line 9052 "fe/idl.tab.cpp"
     break;
 
-  case 484:
-#line 5645 "fe/idl.ypp"
+  case 487:
+#line 5724 "fe/idl.ypp"
         {
           // We use this extra rule here to use in both uses_decl and
           // extended_uses_decl, so the LALR(1) parser can avoid conflicts.
           (yyval.bval) = (yyvsp[0].bval);
         }
-#line 8955 "fe/idl.tab.cpp"
+#line 9062 "fe/idl.tab.cpp"
     break;
 
-  case 485:
-#line 5654 "fe/idl.ypp"
+  case 488:
+#line 5733 "fe/idl.ypp"
         {
           (yyval.bval) = true;
         }
-#line 8963 "fe/idl.tab.cpp"
+#line 9070 "fe/idl.tab.cpp"
     break;
 
-  case 486:
-#line 5658 "fe/idl.ypp"
+  case 489:
+#line 5737 "fe/idl.ypp"
         {
           (yyval.bval) = false;
         }
-#line 8971 "fe/idl.tab.cpp"
+#line 9078 "fe/idl.tab.cpp"
     break;
 
-  case 487:
-#line 5664 "fe/idl.ypp"
+  case 490:
+#line 5744 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -9015,6 +9122,8 @@ yyreduce:
                 }
             }
 
+          AST_Emits *e = 0;
+
           if (so_far_so_good)
             {
               AST_Type *event_type =
@@ -9026,9 +9135,7 @@ yyreduce:
               UTL_ScopedName sn ((yyvsp[0].idval),
                                  0);
 
-              AST_Emits *e =
-                idl_global->gen ()->create_emits (&sn,
-                                                  event_type);
+              e = idl_global->gen ()->create_emits (&sn, event_type);
 
               (void) s->fe_add_emits (e);
             }
@@ -9040,12 +9147,14 @@ yyreduce:
           (yyvsp[0].idval)->destroy ();
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
+
+          (yyval.dcval) = e;
         }
-#line 9045 "fe/idl.tab.cpp"
+#line 9154 "fe/idl.tab.cpp"
     break;
 
-  case 488:
-#line 5736 "fe/idl.ypp"
+  case 491:
+#line 5819 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -9089,6 +9198,8 @@ yyreduce:
                 }
             }
 
+          AST_Publishes *p = 0;
+
           if (so_far_so_good)
             {
               AST_Type *event_type =
@@ -9097,14 +9208,9 @@ yyreduce:
               // Strip off _cxx_, if any, for port name.
               FE_Utils::original_local_name ((yyvsp[0].idval));
 
-              UTL_ScopedName sn ((yyvsp[0].idval),
-                                 0);
-
-              AST_Publishes *p =
-                idl_global->gen ()->create_publishes (&sn,
-                                                      event_type);
-
-              (void) s->fe_add_publishes (p);
+              UTL_ScopedName sn ((yyvsp[0].idval), 0);
+              p = idl_global->gen ()->create_publishes (&sn, event_type);
+              s->fe_add_publishes (p);
             }
 
           (yyvsp[-1].idlist)->destroy ();
@@ -9114,12 +9220,14 @@ yyreduce:
           (yyvsp[0].idval)->destroy ();
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
+
+          (yyval.dcval) = p;
         }
-#line 9119 "fe/idl.tab.cpp"
+#line 9227 "fe/idl.tab.cpp"
     break;
 
-  case 489:
-#line 5808 "fe/idl.ypp"
+  case 492:
+#line 5891 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -9163,6 +9271,8 @@ yyreduce:
                 }
             }
 
+          AST_Consumes *c = 0;
+
           if (so_far_so_good)
             {
               AST_Type *event_type =
@@ -9174,9 +9284,7 @@ yyreduce:
               UTL_ScopedName sn ((yyvsp[0].idval),
                                  0);
 
-              AST_Consumes *c =
-                idl_global->gen ()->create_consumes (&sn,
-                                                     event_type);
+              c = idl_global->gen ()->create_consumes (&sn, event_type);
 
               (void) s->fe_add_consumes (c);
             }
@@ -9188,12 +9296,14 @@ yyreduce:
           (yyvsp[0].idval)->destroy ();
           delete (yyvsp[0].idval);
           (yyvsp[0].idval) = 0;
+
+          (yyval.dcval) = c;
        }
-#line 9193 "fe/idl.tab.cpp"
+#line 9303 "fe/idl.tab.cpp"
     break;
 
-  case 490:
-#line 5881 "fe/idl.ypp"
+  case 493:
+#line 5966 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Home *h = 0;
@@ -9230,11 +9340,11 @@ yyreduce:
            */
           idl_global->scopes ().push (h);
         }
-#line 9234 "fe/idl.tab.cpp"
+#line 9344 "fe/idl.tab.cpp"
     break;
 
-  case 491:
-#line 5918 "fe/idl.ypp"
+  case 494:
+#line 6003 "fe/idl.ypp"
         {
           /*
            * Done with this component - pop it off the scopes stack.
@@ -9243,59 +9353,59 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9247 "fe/idl.tab.cpp"
-    break;
-
-  case 492:
-#line 5930 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_HomeSeen);
-        }
-#line 9255 "fe/idl.tab.cpp"
-    break;
-
-  case 493:
-#line 5934 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_HomeIDSeen);
-        }
-#line 9263 "fe/idl.tab.cpp"
-    break;
-
-  case 494:
-#line 5938 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
-        }
-#line 9271 "fe/idl.tab.cpp"
+#line 9357 "fe/idl.tab.cpp"
     break;
 
   case 495:
-#line 5942 "fe/idl.ypp"
+#line 6015 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_HomeSeen);
         }
-#line 9279 "fe/idl.tab.cpp"
+#line 9365 "fe/idl.tab.cpp"
     break;
 
   case 496:
-#line 5946 "fe/idl.ypp"
+#line 6019 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ManagesSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_HomeIDSeen);
         }
-#line 9287 "fe/idl.tab.cpp"
+#line 9373 "fe/idl.tab.cpp"
     break;
 
   case 497:
-#line 5950 "fe/idl.ypp"
+#line 6023 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ManagesIDSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
         }
-#line 9295 "fe/idl.tab.cpp"
+#line 9381 "fe/idl.tab.cpp"
     break;
 
   case 498:
-#line 5954 "fe/idl.ypp"
+#line 6027 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
+        }
+#line 9389 "fe/idl.tab.cpp"
+    break;
+
+  case 499:
+#line 6031 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ManagesSeen);
+        }
+#line 9397 "fe/idl.tab.cpp"
+    break;
+
+  case 500:
+#line 6035 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ManagesIDSeen);
+        }
+#line 9405 "fe/idl.tab.cpp"
+    break;
+
+  case 501:
+#line 6039 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PrimaryKeySpecSeen);
 
@@ -9341,107 +9451,107 @@ yyreduce:
               (yyvsp[-6].nlval) = 0;
             }
         }
-#line 9345 "fe/idl.tab.cpp"
-    break;
-
-  case 499:
-#line 6003 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
-        }
-#line 9353 "fe/idl.tab.cpp"
-    break;
-
-  case 500:
-#line 6007 "fe/idl.ypp"
-        {
-          (yyval.idlist) = (yyvsp[0].idlist);
-        }
-#line 9361 "fe/idl.tab.cpp"
-    break;
-
-  case 501:
-#line 6011 "fe/idl.ypp"
-        {
-          (yyval.idlist) = 0;
-        }
-#line 9369 "fe/idl.tab.cpp"
+#line 9455 "fe/idl.tab.cpp"
     break;
 
   case 502:
-#line 6019 "fe/idl.ypp"
+#line 6088 "fe/idl.ypp"
         {
-          (yyval.idlist) = (yyvsp[0].idlist);
+          idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
         }
-#line 9377 "fe/idl.tab.cpp"
+#line 9463 "fe/idl.tab.cpp"
     break;
 
   case 503:
-#line 6023 "fe/idl.ypp"
+#line 6092 "fe/idl.ypp"
         {
-          (yyval.idlist) = 0;
+          (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 9385 "fe/idl.tab.cpp"
+#line 9471 "fe/idl.tab.cpp"
     break;
 
   case 504:
-#line 6030 "fe/idl.ypp"
+#line 6096 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_HomeSqSeen);
+          (yyval.idlist) = 0;
         }
-#line 9393 "fe/idl.tab.cpp"
+#line 9479 "fe/idl.tab.cpp"
     break;
 
   case 505:
-#line 6034 "fe/idl.ypp"
+#line 6104 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_HomeBodySeen);
+          (yyval.idlist) = (yyvsp[0].idlist);
         }
-#line 9401 "fe/idl.tab.cpp"
+#line 9487 "fe/idl.tab.cpp"
     break;
 
   case 506:
-#line 6038 "fe/idl.ypp"
+#line 6108 "fe/idl.ypp"
+        {
+          (yyval.idlist) = 0;
+        }
+#line 9495 "fe/idl.tab.cpp"
+    break;
+
+  case 507:
+#line 6115 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_HomeSqSeen);
+        }
+#line 9503 "fe/idl.tab.cpp"
+    break;
+
+  case 508:
+#line 6119 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_HomeBodySeen);
+        }
+#line 9511 "fe/idl.tab.cpp"
+    break;
+
+  case 509:
+#line 6123 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeQsSeen);
         }
-#line 9409 "fe/idl.tab.cpp"
-    break;
-
-  case 510:
-#line 6051 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_FactoryDeclSeen);
-        }
-#line 9417 "fe/idl.tab.cpp"
-    break;
-
-  case 511:
-#line 6055 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 9425 "fe/idl.tab.cpp"
-    break;
-
-  case 512:
-#line 6059 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_FinderDeclSeen);
-        }
-#line 9433 "fe/idl.tab.cpp"
+#line 9519 "fe/idl.tab.cpp"
     break;
 
   case 513:
-#line 6063 "fe/idl.ypp"
+#line 6136 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          idl_global->set_parse_state (IDL_GlobalData::PS_FactoryDeclSeen);
         }
-#line 9441 "fe/idl.tab.cpp"
+#line 9527 "fe/idl.tab.cpp"
     break;
 
   case 514:
-#line 6071 "fe/idl.ypp"
+#line 6140 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+        }
+#line 9535 "fe/idl.tab.cpp"
+    break;
+
+  case 515:
+#line 6144 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_FinderDeclSeen);
+        }
+#line 9543 "fe/idl.tab.cpp"
+    break;
+
+  case 516:
+#line 6148 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+        }
+#line 9551 "fe/idl.tab.cpp"
+    break;
+
+  case 517:
+#line 6156 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9464,19 +9574,19 @@ yyreduce:
            */
           idl_global->scopes ().push (f);
         }
-#line 9468 "fe/idl.tab.cpp"
+#line 9578 "fe/idl.tab.cpp"
     break;
 
-  case 515:
-#line 6094 "fe/idl.ypp"
+  case 518:
+#line 6179 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
         }
-#line 9476 "fe/idl.tab.cpp"
+#line 9586 "fe/idl.tab.cpp"
     break;
 
-  case 516:
-#line 6098 "fe/idl.ypp"
+  case 519:
+#line 6183 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
@@ -9494,11 +9604,11 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
         }
-#line 9498 "fe/idl.tab.cpp"
+#line 9608 "fe/idl.tab.cpp"
     break;
 
-  case 517:
-#line 6120 "fe/idl.ypp"
+  case 520:
+#line 6205 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9525,19 +9635,19 @@ yyreduce:
            */
           idl_global->scopes ().push (f);
         }
-#line 9529 "fe/idl.tab.cpp"
+#line 9639 "fe/idl.tab.cpp"
     break;
 
-  case 518:
-#line 6147 "fe/idl.ypp"
+  case 521:
+#line 6232 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpParsCompleted);
         }
-#line 9537 "fe/idl.tab.cpp"
+#line 9647 "fe/idl.tab.cpp"
     break;
 
-  case 519:
-#line 6151 "fe/idl.ypp"
+  case 522:
+#line 6236 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
@@ -9555,11 +9665,11 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
         }
-#line 9559 "fe/idl.tab.cpp"
+#line 9669 "fe/idl.tab.cpp"
     break;
 
-  case 525:
-#line 6184 "fe/idl.ypp"
+  case 528:
+#line 6269 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9584,11 +9694,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9588 "fe/idl.tab.cpp"
+#line 9698 "fe/idl.tab.cpp"
     break;
 
-  case 526:
-#line 6214 "fe/idl.ypp"
+  case 529:
+#line 6299 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           UTL_ScopedName n ((yyvsp[0].idval),
@@ -9613,11 +9723,11 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9617 "fe/idl.tab.cpp"
+#line 9727 "fe/idl.tab.cpp"
     break;
 
-  case 527:
-#line 6243 "fe/idl.ypp"
+  case 530:
+#line 6328 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_EventType *e = 0;
@@ -9661,27 +9771,27 @@ yyreduce:
           delete (yyvsp[-1].idval);
           (yyvsp[-1].idval) = 0;
         }
-#line 9665 "fe/idl.tab.cpp"
+#line 9775 "fe/idl.tab.cpp"
     break;
 
-  case 528:
-#line 6287 "fe/idl.ypp"
+  case 531:
+#line 6372 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeSqSeen);
         }
-#line 9673 "fe/idl.tab.cpp"
+#line 9783 "fe/idl.tab.cpp"
     break;
 
-  case 529:
-#line 6291 "fe/idl.ypp"
+  case 532:
+#line 6376 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeBodySeen);
         }
-#line 9681 "fe/idl.tab.cpp"
+#line 9791 "fe/idl.tab.cpp"
     break;
 
-  case 530:
-#line 6295 "fe/idl.ypp"
+  case 533:
+#line 6380 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeQsSeen);
 
@@ -9692,19 +9802,19 @@ yyreduce:
 
           (yyval.dcval) = 0;
         }
-#line 9696 "fe/idl.tab.cpp"
+#line 9806 "fe/idl.tab.cpp"
     break;
 
-  case 531:
-#line 6311 "fe/idl.ypp"
+  case 534:
+#line 6396 "fe/idl.ypp"
         {
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9704 "fe/idl.tab.cpp"
+#line 9814 "fe/idl.tab.cpp"
     break;
 
-  case 532:
-#line 6320 "fe/idl.ypp"
+  case 535:
+#line 6405 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeIDSeen);
 
@@ -9717,29 +9827,29 @@ yyreduce:
                       ACE_TEXT (" custom yet\n")));
           (yyval.idval) = 0;
         }
-#line 9721 "fe/idl.tab.cpp"
+#line 9831 "fe/idl.tab.cpp"
     break;
 
-  case 533:
-#line 6337 "fe/idl.ypp"
+  case 536:
+#line 6422 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeIDSeen);
 
           (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9731 "fe/idl.tab.cpp"
+#line 9841 "fe/idl.tab.cpp"
     break;
 
-  case 534:
-#line 6346 "fe/idl.ypp"
+  case 537:
+#line 6431 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritSpecSeen);
         }
-#line 9739 "fe/idl.tab.cpp"
+#line 9849 "fe/idl.tab.cpp"
     break;
 
-  case 535:
-#line 6350 "fe/idl.ypp"
+  case 538:
+#line 6435 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_SupportSpecSeen);
 
@@ -9768,50 +9878,49 @@ yyreduce:
               (yyvsp[-2].nlval) = 0;
             }
         }
-#line 9772 "fe/idl.tab.cpp"
+#line 9882 "fe/idl.tab.cpp"
     break;
 
-  case 536:
-#line 6383 "fe/idl.ypp"
+  case 539:
+#line 6468 "fe/idl.ypp"
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          AST_EventType *e = 0;
-          AST_Interface *i = 0;
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          Identifier *&event_id = (yyvsp[-1].idval);
+          FE_OBVHeader *&event_header = (yyvsp[0].vhval);
+          AST_EventType *eventtype = 0;
 
-          if (s != 0 && (yyvsp[-1].idval) != 0)
+          if (scope && event_header)
             {
               // We create the scoped name here instead of with the
-              // FE_EventHeader because there is a token for it only here.
-              UTL_ScopedName sn ((yyvsp[-1].idval),
-                                 0);
-              e =
-                idl_global->gen ()->create_eventtype (
-                    &sn,
-                    (yyvsp[0].vhval)->inherits (),
-                    (yyvsp[0].vhval)->n_inherits (),
-                    (yyvsp[0].vhval)->inherits_concrete (),
-                    (yyvsp[0].vhval)->inherits_flat (),
-                    (yyvsp[0].vhval)->n_inherits_flat (),
-                    (yyvsp[0].vhval)->supports (),
-                    (yyvsp[0].vhval)->n_supports (),
-                    (yyvsp[0].vhval)->supports_concrete (),
-                    false,
-                    (yyvsp[0].vhval)->truncatable (),
-                    false
-                  );
-              i = AST_Interface::narrow_from_decl (e);
-              AST_Interface::fwd_redefinition_helper (i,
-                                                      s);
+              // FE_OBVHeader because there is a token for it only here.
+              UTL_ScopedName sn (event_id, 0);
+              eventtype = idl_global->gen ()->create_eventtype (
+                &sn,
+                event_header->inherits (),
+                event_header->n_inherits (),
+                event_header->inherits_concrete (),
+                event_header->inherits_flat (),
+                event_header->n_inherits_flat (),
+                event_header->supports (),
+                event_header->n_supports (),
+                event_header->supports_concrete (),
+                false,
+                event_header->truncatable (),
+                false);
+              AST_Interface *eventtype_as_interface =
+                dynamic_cast<AST_Interface *> (eventtype);
+              AST_Interface::fwd_redefinition_helper (
+                eventtype_as_interface, scope);
+
               /*
                * Add the eventetype to its definition scope
                */
-              e = AST_EventType::narrow_from_decl (i);
-              (void) s->fe_add_eventtype (e);
+              scope->fe_add_eventtype (eventtype);
 
-              // FE_EventHeader is not automatically destroyed in the AST
-              (yyvsp[0].vhval)->destroy ();
-              delete (yyvsp[0].vhval);
-              (yyvsp[0].vhval) = 0;
+              // FE_OBVHeader is not automatically destroyed in the AST
+              event_header->destroy ();
+              delete event_header;
+              event_header = 0;
 
               sn.destroy ();
             }
@@ -9819,29 +9928,31 @@ yyreduce:
           /*
            * Push it on the scope stack.
            */
-          idl_global->scopes ().push (e);
+          idl_global->scopes ().push (eventtype);
+
+          (yyval.dcval) = eventtype;
         }
-#line 9825 "fe/idl.tab.cpp"
+#line 9936 "fe/idl.tab.cpp"
     break;
 
-  case 537:
-#line 6432 "fe/idl.ypp"
+  case 540:
+#line 6518 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeSqSeen);
         }
-#line 9833 "fe/idl.tab.cpp"
+#line 9944 "fe/idl.tab.cpp"
     break;
 
-  case 538:
-#line 6436 "fe/idl.ypp"
+  case 541:
+#line 6522 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeBodySeen);
         }
-#line 9841 "fe/idl.tab.cpp"
+#line 9952 "fe/idl.tab.cpp"
     break;
 
-  case 539:
-#line 6440 "fe/idl.ypp"
+  case 542:
+#line 6526 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_EventTypeQsSeen);
 
@@ -9850,110 +9961,110 @@ yyreduce:
            */
           idl_global->scopes ().pop ();
 
-          (yyval.dcval) = 0;
+          (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 9856 "fe/idl.tab.cpp"
-    break;
-
-  case 540:
-#line 6454 "fe/idl.ypp"
-        {
-          (yyval.idval) = (yyvsp[0].idval);
-        }
-#line 9864 "fe/idl.tab.cpp"
-    break;
-
-  case 541:
-#line 6458 "fe/idl.ypp"
-        {
-          (yyval.idval) = (yyvsp[0].idval);
-        }
-#line 9872 "fe/idl.tab.cpp"
-    break;
-
-  case 542:
-#line 6465 "fe/idl.ypp"
-        {
-          (yyval.ntval) = AST_Decl::NT_type;
-        }
-#line 9880 "fe/idl.tab.cpp"
+#line 9967 "fe/idl.tab.cpp"
     break;
 
   case 543:
-#line 6469 "fe/idl.ypp"
+#line 6540 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_struct;
+          (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9888 "fe/idl.tab.cpp"
+#line 9975 "fe/idl.tab.cpp"
     break;
 
   case 544:
-#line 6473 "fe/idl.ypp"
+#line 6544 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_union;
+          (yyval.idval) = (yyvsp[0].idval);
         }
-#line 9896 "fe/idl.tab.cpp"
+#line 9983 "fe/idl.tab.cpp"
     break;
 
   case 545:
-#line 6477 "fe/idl.ypp"
+#line 6551 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_eventtype;
+          (yyval.ntval) = AST_Decl::NT_type;
         }
-#line 9904 "fe/idl.tab.cpp"
+#line 9991 "fe/idl.tab.cpp"
     break;
 
   case 546:
-#line 6481 "fe/idl.ypp"
+#line 6555 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_sequence;
+          (yyval.ntval) = AST_Decl::NT_struct;
         }
-#line 9912 "fe/idl.tab.cpp"
+#line 9999 "fe/idl.tab.cpp"
     break;
 
   case 547:
-#line 6485 "fe/idl.ypp"
+#line 6559 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_interface;
+          (yyval.ntval) = AST_Decl::NT_union;
         }
-#line 9920 "fe/idl.tab.cpp"
+#line 10007 "fe/idl.tab.cpp"
     break;
 
   case 548:
-#line 6489 "fe/idl.ypp"
+#line 6563 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_valuetype;
+          (yyval.ntval) = AST_Decl::NT_eventtype;
         }
-#line 9928 "fe/idl.tab.cpp"
+#line 10015 "fe/idl.tab.cpp"
     break;
 
   case 549:
-#line 6493 "fe/idl.ypp"
+#line 6567 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_enum;
+          (yyval.ntval) = AST_Decl::NT_sequence;
         }
-#line 9936 "fe/idl.tab.cpp"
+#line 10023 "fe/idl.tab.cpp"
     break;
 
   case 550:
-#line 6497 "fe/idl.ypp"
+#line 6571 "fe/idl.ypp"
         {
-          (yyval.ntval) = AST_Decl::NT_except;
+          (yyval.ntval) = AST_Decl::NT_interface;
         }
-#line 9944 "fe/idl.tab.cpp"
+#line 10031 "fe/idl.tab.cpp"
     break;
 
   case 551:
-#line 6501 "fe/idl.ypp"
+#line 6575 "fe/idl.ypp"
+        {
+          (yyval.ntval) = AST_Decl::NT_valuetype;
+        }
+#line 10039 "fe/idl.tab.cpp"
+    break;
+
+  case 552:
+#line 6579 "fe/idl.ypp"
+        {
+          (yyval.ntval) = AST_Decl::NT_enum;
+        }
+#line 10047 "fe/idl.tab.cpp"
+    break;
+
+  case 553:
+#line 6583 "fe/idl.ypp"
+        {
+          (yyval.ntval) = AST_Decl::NT_except;
+        }
+#line 10055 "fe/idl.tab.cpp"
+    break;
+
+  case 554:
+#line 6587 "fe/idl.ypp"
         {
           (yyval.ntval) = AST_Decl::NT_const;
           t_param_const_type = (yyvsp[0].etval);
         }
-#line 9953 "fe/idl.tab.cpp"
+#line 10064 "fe/idl.tab.cpp"
     break;
 
-  case 552:
-#line 6509 "fe/idl.ypp"
+  case 555:
+#line 6595 "fe/idl.ypp"
         {
           if ((yyvsp[0].plval) == 0)
             {
@@ -9981,11 +10092,11 @@ yyreduce:
 
           (yyval.plval) = (yyvsp[0].plval);
         }
-#line 9985 "fe/idl.tab.cpp"
+#line 10096 "fe/idl.tab.cpp"
     break;
 
-  case 553:
-#line 6540 "fe/idl.ypp"
+  case 556:
+#line 6626 "fe/idl.ypp"
         {
           if ((yyvsp[-2].plval) == 0)
             {
@@ -9998,19 +10109,19 @@ yyreduce:
           delete (yyvsp[0].pival);
           (yyvsp[0].pival) = 0;
         }
-#line 10002 "fe/idl.tab.cpp"
+#line 10113 "fe/idl.tab.cpp"
     break;
 
-  case 554:
-#line 6553 "fe/idl.ypp"
+  case 557:
+#line 6639 "fe/idl.ypp"
         {
           (yyval.plval) = 0;
         }
-#line 10010 "fe/idl.tab.cpp"
+#line 10121 "fe/idl.tab.cpp"
     break;
 
-  case 555:
-#line 6560 "fe/idl.ypp"
+  case 558:
+#line 6646 "fe/idl.ypp"
         {
 
           ACE_NEW_RETURN ((yyval.pival),
@@ -10035,11 +10146,11 @@ yyreduce:
               tao_enum_constant_decl = 0;
             }
         }
-#line 10039 "fe/idl.tab.cpp"
+#line 10150 "fe/idl.tab.cpp"
     break;
 
-  case 556:
-#line 6585 "fe/idl.ypp"
+  case 559:
+#line 6671 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.pival),
                           FE_Utils::T_Param_Info,
@@ -10054,19 +10165,19 @@ yyreduce:
           ACE::strdelete ((yyvsp[0].strval));
           (yyvsp[0].strval) = 0;
         }
-#line 10058 "fe/idl.tab.cpp"
+#line 10169 "fe/idl.tab.cpp"
     break;
 
-  case 557:
-#line 6603 "fe/idl.ypp"
+  case 560:
+#line 6689 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.slval), UTL_StrList ((yyvsp[-1].sval), (yyvsp[0].slval)), 1);
         }
-#line 10066 "fe/idl.tab.cpp"
+#line 10177 "fe/idl.tab.cpp"
     break;
 
-  case 558:
-#line 6610 "fe/idl.ypp"
+  case 561:
+#line 6696 "fe/idl.ypp"
         {
           UTL_StrList *sl = 0;
           ACE_NEW_RETURN (sl, UTL_StrList ((yyvsp[0].sval), 0), 1);
@@ -10081,154 +10192,124 @@ yyreduce:
               (yyval.slval) = (yyvsp[-2].slval);
             }
         }
-#line 10085 "fe/idl.tab.cpp"
+#line 10196 "fe/idl.tab.cpp"
     break;
 
-  case 559:
-#line 6625 "fe/idl.ypp"
+  case 562:
+#line 6711 "fe/idl.ypp"
         {
           (yyval.slval) = 0;
         }
-#line 10093 "fe/idl.tab.cpp"
+#line 10204 "fe/idl.tab.cpp"
     break;
 
-  case 560:
-#line 6632 "fe/idl.ypp"
+  case 563:
+#line 6718 "fe/idl.ypp"
         {
           ACE_NEW_RETURN ((yyval.sval),
                           UTL_String ((yyvsp[0].strval), true),
                           1);
         }
-#line 10103 "fe/idl.tab.cpp"
-    break;
-
-  case 561:
-#line 6641 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSeen);
-        }
-#line 10111 "fe/idl.tab.cpp"
-    break;
-
-  case 562:
-#line 6645 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeIDSeen);
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-
-          Identifier id ((yyvsp[0].strval));
-          ACE::strdelete ((yyvsp[0].strval));
-          (yyvsp[0].strval) = 0;
-
-          UTL_ScopedName sn (&id, 0);
-          AST_PortType *p =
-            idl_global->gen ()->create_porttype (&sn);
-
-          (void) s->fe_add_porttype (p);
-
-          // Push it on the scopes stack.
-          idl_global->scopes ().push (p);
-
-          delete (yyvsp[-1].annotations_val);
-        }
-#line 10135 "fe/idl.tab.cpp"
-    break;
-
-  case 563:
-#line 6665 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSqSeen);
-        }
-#line 10143 "fe/idl.tab.cpp"
+#line 10214 "fe/idl.tab.cpp"
     break;
 
   case 564:
-#line 6669 "fe/idl.ypp"
+#line 6727 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeBodySeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSeen);
         }
-#line 10151 "fe/idl.tab.cpp"
+#line 10222 "fe/idl.tab.cpp"
     break;
 
   case 565:
-#line 6673 "fe/idl.ypp"
+#line 6731 "fe/idl.ypp"
+        {
+          char *&id_value = (yyvsp[0].strval);
+          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeIDSeen);
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+
+          Identifier id (id_value);
+          ACE::strdelete (id_value);
+          id_value = 0;
+
+          UTL_ScopedName scoped_name (&id, 0);
+          AST_PortType *porttype = idl_global->gen ()->create_porttype (
+            &scoped_name);
+          scope->fe_add_porttype (porttype);
+          (yyval.dcval) = porttype;
+
+          // Push it on the scopes stack.
+          idl_global->scopes ().push (porttype);
+        }
+#line 10245 "fe/idl.tab.cpp"
+    break;
+
+  case 566:
+#line 6750 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSqSeen);
+        }
+#line 10253 "fe/idl.tab.cpp"
+    break;
+
+  case 567:
+#line 6758 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeBodySeen);
+        }
+#line 10261 "fe/idl.tab.cpp"
+    break;
+
+  case 568:
+#line 6762 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeQsSeen);
 
           // Done with this port type - pop it off the scopes stack.
           idl_global->scopes ().pop ();
 
-          (yyval.dcval) = 0;
+          (yyval.dcval) = (yyvsp[-5].dcval);
         }
-#line 10164 "fe/idl.tab.cpp"
-    break;
-
-  case 566:
-#line 6685 "fe/idl.ypp"
-        {
-        }
-#line 10171 "fe/idl.tab.cpp"
-    break;
-
-  case 567:
-#line 6691 "fe/idl.ypp"
-        {
-        }
-#line 10178 "fe/idl.tab.cpp"
-    break;
-
-  case 568:
-#line 6694 "fe/idl.ypp"
-        {
-        }
-#line 10185 "fe/idl.tab.cpp"
+#line 10274 "fe/idl.tab.cpp"
     break;
 
   case 569:
-#line 6700 "fe/idl.ypp"
+#line 6774 "fe/idl.ypp"
         {
+          AST_Annotation_Appls *&annotations = (yyvsp[-1].annotations_val);
+          AST_Decl *&node = (yyvsp[0].dcval);
+          if (node)
+            {
+              node->annotation_appls (*annotations);
+            }
+          else
+            {
+              idl_global->err ()-> unsupported_warning (
+                "Annotating this is not supported");
+            }
+          delete annotations;
         }
-#line 10192 "fe/idl.tab.cpp"
-    break;
-
-  case 570:
-#line 6703 "fe/idl.ypp"
-        {
-        }
-#line 10199 "fe/idl.tab.cpp"
-    break;
-
-  case 571:
-#line 6706 "fe/idl.ypp"
-        {
-        }
-#line 10206 "fe/idl.tab.cpp"
-    break;
-
-  case 572:
-#line 6709 "fe/idl.ypp"
-        {
-        }
-#line 10213 "fe/idl.tab.cpp"
-    break;
-
-  case 573:
-#line 6712 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
-        }
-#line 10221 "fe/idl.tab.cpp"
-    break;
-
-  case 574:
-#line 6716 "fe/idl.ypp"
-        {
-        }
-#line 10228 "fe/idl.tab.cpp"
+#line 10293 "fe/idl.tab.cpp"
     break;
 
   case 575:
-#line 6722 "fe/idl.ypp"
+#line 6800 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
+        }
+#line 10301 "fe/idl.tab.cpp"
+    break;
+
+  case 576:
+#line 6804 "fe/idl.ypp"
+        {
+          (yyval.dcval) = (yyvsp[-2].dcval);
+        }
+#line 10309 "fe/idl.tab.cpp"
+    break;
+
+  case 577:
+#line 6811 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
@@ -10254,21 +10335,17 @@ yyreduce:
                 }
             }
 
+          AST_Extended_Port *ep = 0;
+
           if (so_far_so_good)
             {
               Identifier id ((yyvsp[0].strval));
               ACE::strdelete ((yyvsp[0].strval));
               (yyvsp[0].strval) = 0;
 
-              UTL_ScopedName sn (&id,
-                                 0);
-
-              AST_Extended_Port *ep =
-                idl_global->gen ()->create_extended_port (
-                  &sn,
-                  pt);
-
-              (void) s->fe_add_extended_port (ep);
+              UTL_ScopedName sn (&id, 0);
+              ep = idl_global->gen ()->create_extended_port (&sn, pt);
+              s->fe_add_extended_port (ep);
 
               // Create (in the AST) the struct(s) and sequence(s)
               // needed for multiplex uses ports, if any.
@@ -10296,12 +10373,14 @@ yyreduce:
           (yyvsp[-1].idlist)->destroy ();
           delete (yyvsp[-1].idlist);
           (yyvsp[-1].idlist) = 0;
+
+          (yyval.dcval) = ep;
         }
-#line 10301 "fe/idl.tab.cpp"
+#line 10380 "fe/idl.tab.cpp"
     break;
 
-  case 576:
-#line 6791 "fe/idl.ypp"
+  case 578:
+#line 6878 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_MirrorPortDeclSeen);
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
@@ -10327,32 +10406,30 @@ yyreduce:
                  }
              }
 
+          AST_Mirror_Port *mp = 0;
+
           if (so_far_so_good)
             {
               Identifier id ((yyvsp[0].strval));
               ACE::strdelete ((yyvsp[0].strval));
               (yyvsp[0].strval) = 0;
 
-              UTL_ScopedName sn (&id,
-                                 0);
-
-              AST_Mirror_Port *mp =
-                idl_global->gen ()->create_mirror_port (
-                  &sn,
-                  pt);
-
-              (void) s->fe_add_mirror_port (mp);
+              UTL_ScopedName sn (&id, 0);
+              mp = idl_global->gen ()->create_mirror_port (&sn, pt);
+              s->fe_add_mirror_port (mp);
             }
 
           (yyvsp[-1].idlist)->destroy ();
           delete (yyvsp[-1].idlist);
           (yyvsp[-1].idlist) = 0;
+
+          (yyval.dcval) = mp;
         }
-#line 10352 "fe/idl.tab.cpp"
+#line 10429 "fe/idl.tab.cpp"
     break;
 
-  case 577:
-#line 6841 "fe/idl.ypp"
+  case 579:
+#line 6926 "fe/idl.ypp"
         {
           if ((yyvsp[0].alval) == 0)
             {
@@ -10365,11 +10442,11 @@ yyreduce:
           (yyvsp[0].alval)->enqueue_head ((yyvsp[-1].dcval));
           (yyval.alval) = (yyvsp[0].alval);
         }
-#line 10369 "fe/idl.tab.cpp"
+#line 10446 "fe/idl.tab.cpp"
     break;
 
-  case 578:
-#line 6857 "fe/idl.ypp"
+  case 580:
+#line 6942 "fe/idl.ypp"
         {
           if ((yyvsp[-3].alval) == 0)
             {
@@ -10382,19 +10459,19 @@ yyreduce:
           (yyvsp[-3].alval)->enqueue_tail ((yyvsp[0].dcval));
           (yyval.alval) = (yyvsp[-3].alval);
         }
-#line 10386 "fe/idl.tab.cpp"
+#line 10463 "fe/idl.tab.cpp"
     break;
 
-  case 579:
-#line 6870 "fe/idl.ypp"
+  case 581:
+#line 6955 "fe/idl.ypp"
         {
           (yyval.alval) = 0;
         }
-#line 10394 "fe/idl.tab.cpp"
+#line 10471 "fe/idl.tab.cpp"
     break;
 
-  case 580:
-#line 6877 "fe/idl.ypp"
+  case 582:
+#line 6962 "fe/idl.ypp"
         {
           // To avoid grammar conflicts with this LALR(1) parser,
           // we take advantage of the fact that an expression can
@@ -10450,35 +10527,35 @@ yyreduce:
                   0);
             }
         }
-#line 10454 "fe/idl.tab.cpp"
-    break;
-
-  case 581:
-#line 6936 "fe/idl.ypp"
-        {
-          (yyval.dcval) = 0;
-        }
-#line 10462 "fe/idl.tab.cpp"
-    break;
-
-  case 582:
-#line 6943 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorSeen);
-        }
-#line 10470 "fe/idl.tab.cpp"
+#line 10531 "fe/idl.tab.cpp"
     break;
 
   case 583:
-#line 6947 "fe/idl.ypp"
+#line 7021 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorIDSeen);
+          (yyval.dcval) = 0;
         }
-#line 10478 "fe/idl.tab.cpp"
+#line 10539 "fe/idl.tab.cpp"
     break;
 
   case 584:
-#line 6951 "fe/idl.ypp"
+#line 7028 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorSeen);
+        }
+#line 10547 "fe/idl.tab.cpp"
+    break;
+
+  case 585:
+#line 7032 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorIDSeen);
+        }
+#line 10555 "fe/idl.tab.cpp"
+    break;
+
+  case 586:
+#line 7036 "fe/idl.ypp"
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Connector *parent = 0;
@@ -10532,102 +10609,102 @@ yyreduce:
 
           delete (yyvsp[-3].annotations_val);
         }
-#line 10536 "fe/idl.tab.cpp"
-    break;
-
-  case 585:
-#line 7008 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorSqSeen);
-        }
-#line 10544 "fe/idl.tab.cpp"
-    break;
-
-  case 586:
-#line 7012 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorBodySeen);
-        }
-#line 10552 "fe/idl.tab.cpp"
+#line 10613 "fe/idl.tab.cpp"
     break;
 
   case 587:
-#line 7016 "fe/idl.ypp"
+#line 7093 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorSqSeen);
+        }
+#line 10621 "fe/idl.tab.cpp"
+    break;
+
+  case 588:
+#line 7097 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorBodySeen);
+        }
+#line 10629 "fe/idl.tab.cpp"
+    break;
+
+  case 589:
+#line 7101 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_ConnectorQsSeen);
 
           // Done with this connector - pop it off the scope stack.
           idl_global->scopes ().pop ();
         }
-#line 10563 "fe/idl.tab.cpp"
-    break;
-
-  case 590:
-#line 7031 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ProvidesDeclSeen);
-        }
-#line 10571 "fe/idl.tab.cpp"
-    break;
-
-  case 591:
-#line 7035 "fe/idl.ypp"
-        {
-          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
-        }
-#line 10579 "fe/idl.tab.cpp"
+#line 10640 "fe/idl.tab.cpp"
     break;
 
   case 592:
-#line 7039 "fe/idl.ypp"
+#line 7116 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_UsesDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_ProvidesDeclSeen);
         }
-#line 10587 "fe/idl.tab.cpp"
+#line 10648 "fe/idl.tab.cpp"
     break;
 
   case 593:
-#line 7043 "fe/idl.ypp"
+#line 7120 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 10595 "fe/idl.tab.cpp"
+#line 10656 "fe/idl.tab.cpp"
     break;
 
   case 594:
-#line 7047 "fe/idl.ypp"
+#line 7124 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_UsesDeclSeen);
         }
-#line 10603 "fe/idl.tab.cpp"
+#line 10664 "fe/idl.tab.cpp"
     break;
 
   case 595:
-#line 7051 "fe/idl.ypp"
+#line 7128 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 10611 "fe/idl.tab.cpp"
+#line 10672 "fe/idl.tab.cpp"
     break;
 
   case 596:
-#line 7055 "fe/idl.ypp"
+#line 7132 "fe/idl.ypp"
         {
-          idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
+          idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
         }
-#line 10619 "fe/idl.tab.cpp"
+#line 10680 "fe/idl.tab.cpp"
     break;
 
   case 597:
-#line 7059 "fe/idl.ypp"
+#line 7136 "fe/idl.ypp"
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
-#line 10627 "fe/idl.tab.cpp"
+#line 10688 "fe/idl.tab.cpp"
+    break;
+
+  case 598:
+#line 7140 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_ExtendedPortDeclSeen);
+        }
+#line 10696 "fe/idl.tab.cpp"
+    break;
+
+  case 599:
+#line 7144 "fe/idl.ypp"
+        {
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+        }
+#line 10704 "fe/idl.tab.cpp"
     break;
 
 
-#line 10631 "fe/idl.tab.cpp"
+#line 10708 "fe/idl.tab.cpp"
 
       default: break;
     }
@@ -10821,7 +10898,7 @@ yyreturn:
   return yyresult;
 }
 
-#line 7064 "fe/idl.ypp"
+#line 7149 "fe/idl.ypp"
 
 /* programs */
 

--- a/TAO/TAO_IDL/fe/idl.tab.hpp
+++ b/TAO/TAO_IDL/fe/idl.tab.hpp
@@ -147,7 +147,7 @@ extern int tao_yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 162 "fe/idl.ypp"
+#line 163 "fe/idl.ypp"
 
   AST_Decl                      *dcval;         /* Decl value           */
   UTL_StrList                   *slval;         /* String list          */

--- a/TAO/TAO_IDL/fe/idl.ypp
+++ b/TAO/TAO_IDL/fe/idl.ypp
@@ -1520,19 +1520,21 @@ visibility
 state_member
         : visibility member_i
         {
-          if ($2)
+          AST_Field::Visibility &visibility = $1;
+          AST_Decls *&decls_ptr = $2;
+          if (decls_ptr)
             {
-              AST_Decls &decls = *$2;
+              AST_Decls &decls = *decls_ptr;
               for (size_t i = 0; i < decls.size (); i++)
                 {
-                  AST_Field * field = dynamic_cast<AST_Field*> (decls[i]);
+                  AST_Field *field = dynamic_cast<AST_Field *> (decls[i]);
                   if (field)
                     {
-                      field->visibility ($1);
+                      field->visibility (visibility);
                     }
                 }
             }
-          $$ = $2;
+          $$ = decls_ptr;
         }
         ;
 

--- a/TAO/TAO_IDL/fe/idl.ypp
+++ b/TAO/TAO_IDL/fe/idl.ypp
@@ -70,73 +70,74 @@ trademarks or registered trademarks of Sun Microsystems, Inc.
 /* Declarations */
 
 %{
-#include "utl_identifier.h"
-#include "utl_err.h"
-#include "utl_string.h"
-#include "utl_strlist.h"
-#include "utl_namelist.h"
-#include "utl_exprlist.h"
-#include "utl_labellist.h"
-#include "utl_decllist.h"
+#include <utl_identifier.h>
+#include <utl_err.h>
+#include <utl_string.h>
+#include <utl_strlist.h>
+#include <utl_namelist.h>
+#include <utl_exprlist.h>
+#include <utl_labellist.h>
+#include <utl_decllist.h>
 
-#include "global_extern.h"
-#include "nr_extern.h"
+#include <global_extern.h>
+#include <nr_extern.h>
 
-#include "ast_argument.h"
-#include "ast_array.h"
-#include "ast_attribute.h"
-#include "ast_field.h"
-#include "ast_fixed.h"
-#include "ast_expression.h"
-#include "ast_operation.h"
-#include "ast_generator.h"
-#include "ast_template_module.h"
-#include "ast_template_module_inst.h"
-#include "ast_template_module_ref.h"
-#include "ast_typedef.h"
-#include "ast_valuebox.h"
-#include "ast_valuetype.h"
-#include "ast_valuetype_fwd.h"
-#include "ast_eventtype.h"
-#include "ast_eventtype_fwd.h"
-#include "ast_component.h"
-#include "ast_component_fwd.h"
-#include "ast_home.h"
-#include "ast_porttype.h"
-#include "ast_connector.h"
-#include "ast_uses.h"
-#include "ast_constant.h"
-#include "ast_union.h"
-#include "ast_union_fwd.h"
-#include "ast_structure_fwd.h"
-#include "ast_extern.h"
-#include "ast_enum.h"
-#include "ast_root.h"
-#include "ast_sequence.h"
-#include "ast_string.h"
-#include "ast_factory.h"
-#include "ast_finder.h"
-#include "ast_exception.h"
-#include "ast_param_holder.h"
-#include "ast_visitor_tmpl_module_inst.h"
-#include "ast_visitor_tmpl_module_ref.h"
-#include "ast_visitor_context.h"
-#include "ast_annotation_appl.h"
-#include "ast_union_branch.h"
-#include "ast_enum_val.h"
-#include "ast_annotation_member.h"
+#include <ast_argument.h>
+#include <ast_array.h>
+#include <ast_attribute.h>
+#include <ast_field.h>
+#include <ast_fixed.h>
+#include <ast_expression.h>
+#include <ast_operation.h>
+#include <ast_generator.h>
+#include <ast_template_module.h>
+#include <ast_template_module_inst.h>
+#include <ast_template_module_ref.h>
+#include <ast_typedef.h>
+#include <ast_valuebox.h>
+#include <ast_valuetype.h>
+#include <ast_valuetype_fwd.h>
+#include <ast_eventtype.h>
+#include <ast_eventtype_fwd.h>
+#include <ast_component.h>
+#include <ast_component_fwd.h>
+#include <ast_home.h>
+#include <ast_porttype.h>
+#include <ast_connector.h>
+#include <ast_uses.h>
+#include <ast_constant.h>
+#include <ast_union.h>
+#include <ast_union_fwd.h>
+#include <ast_structure_fwd.h>
+#include <ast_extern.h>
+#include <ast_enum.h>
+#include <ast_root.h>
+#include <ast_sequence.h>
+#include <ast_string.h>
+#include <ast_factory.h>
+#include <ast_finder.h>
+#include <ast_exception.h>
+#include <ast_param_holder.h>
+#include <ast_visitor_tmpl_module_inst.h>
+#include <ast_visitor_tmpl_module_ref.h>
+#include <ast_visitor_context.h>
+#include <ast_annotation_appl.h>
+#include <ast_union_branch.h>
+#include <ast_enum_val.h>
+#include <ast_annotation_member.h>
+#include <ast_provides.h>
+#include <ast_emits.h>
+#include <ast_publishes.h>
+#include <ast_consumes.h>
+#include <ast_extended_port.h>
+#include <ast_mirror_port.h>
 
-#include "fe_declarator.h"
-#include "fe_interface_header.h"
-#include "fe_obv_header.h"
-#include "fe_component_header.h"
-#include "fe_home_header.h"
-#include "fe_utils.h"
-
-#if (defined(apollo) || defined(hpux)) && defined(__cplusplus)
-extern  "C" int tao_yywrap();
-#endif  // (defined(apollo) || defined(hpux)) && defined(__cplusplus)
-
+#include <fe_declarator.h>
+#include <fe_interface_header.h>
+#include <fe_obv_header.h>
+#include <fe_component_header.h>
+#include <fe_home_header.h>
+#include <fe_utils.h>
 
 void tao_yyerror (const char *);
 int tao_yylex (void);
@@ -321,6 +322,9 @@ bool stack_based_lookup_for_primary_expr = false;
 %type <dcval>   porttype_decl connector_decl value_def
 %type <dcval>   valuetype value_abs_decl value_forward_decl value_box_decl
 %type <dcval>   value_concrete_decl component_forward_decl component_decl
+%type <dcval>   init_decl provides_decl uses_decl port_export
+%type <dcval>   component_export emits_decl publishes_decl consumes_decl
+%type <dcval>   extended_port_decl
 
 %type <idlist>  scoped_name interface_type component_inheritance_spec
 %type <idlist>  home_inheritance_spec primary_key_spec module_header
@@ -390,8 +394,8 @@ bool stack_based_lookup_for_primary_expr = false;
 %type <annotation_param_val> named_annotation_appl_param
 %type <decl_annotations_pair_val> seq_head
 
-%type <decls_val> member_i;
-%type <vival> visibility;
+%type <decls_val> member_i state_member value_element
+%type <vival> visibility
 %%
 
 /*
@@ -406,27 +410,25 @@ definitions
 
 at_least_one_definition
         /*
-         * This is broken up into 2 rules to avoid a grammer ambiguity caused
-         * by annotations which causes shift/reduce conflicts in bison.
+         * This is broken up into 2 rules to avoid a grammer ambiguity which
+         * manifests as bison complaining about shift/reduce conflicts.
          */
         : definitions at_least_one_annotation definition
         {
-          AST_Annotation_Appls *annotations = $2;
-          AST_Decl *d = $3;
-          if (d)
+          AST_Annotation_Appls *&annotations = $2;
+          AST_Decl *&node = $3;
+          if (node)
             {
-              d->annotation_appls (*annotations);
+              node->annotation_appls (*annotations);
             }
           else
             {
-              idl_global->err ()-> unsupported_warning(
+              idl_global->err ()-> unsupported_warning (
                 "Annotating this is not supported");
             }
           delete annotations;
         }
         | definitions definition
-        {
-        }
         ;
 
 definition
@@ -550,7 +552,7 @@ fixed_definition
         }
         | error
         {
-          idl_global->err()->syntax_error (idl_global->parse_state());
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
         ';'
         {
@@ -1106,7 +1108,7 @@ valuetype
         : IDL_CUSTOM value_concrete_decl
         {
           idl_global->err ()->unsupported_error ("custom is not supported");
-          $$ = 0;
+          $<dcval>$ = $2;
         }
         | value_concrete_decl
         ;
@@ -1114,46 +1116,48 @@ valuetype
 value_concrete_decl :
         value_header
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          AST_ValueType *v = 0;
-          AST_Interface *i = 0;
+          FE_OBVHeader *valuetype_header = $1;
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          AST_ValueType *valuetype = 0;
 
-          if (s != 0 && $1 != 0)
+          if (scope && valuetype_header)
             {
-              v =
-                idl_global->gen ()->create_valuetype (
-                  $1->name (),
-                  $1->inherits (),
-                  $1->n_inherits (),
-                  $1->inherits_concrete (),
-                  $1->inherits_flat (),
-                  $1->n_inherits_flat (),
-                  $1->supports (),
-                  $1->n_supports (),
-                  $1->supports_concrete (),
-                  false,
-                  $1->truncatable (),
-                  false);
+              valuetype = idl_global->gen ()->create_valuetype (
+                valuetype_header->name (),
+                valuetype_header->inherits (),
+                valuetype_header->n_inherits (),
+                valuetype_header->inherits_concrete (),
+                valuetype_header->inherits_flat (),
+                valuetype_header->n_inherits_flat (),
+                valuetype_header->supports (),
+                valuetype_header->n_supports (),
+                valuetype_header->supports_concrete (),
+                false,
+                valuetype_header->truncatable (),
+                false);
 
-              i = AST_Interface::narrow_from_decl (v);
-              AST_Interface::fwd_redefinition_helper (i,
-                                                      s);
+              AST_Interface* valuetype_as_interface =
+                dynamic_cast<AST_Interface*> (valuetype);
+              AST_Interface::fwd_redefinition_helper (
+                valuetype_as_interface, scope);
+
               /*
                * Add the valuetype to its definition scope
                */
-              v = AST_ValueType::narrow_from_decl (i);
-              (void) s->fe_add_valuetype (v);
+              scope->fe_add_valuetype (valuetype);
 
               // FE_OBVHeader is not automatically destroyed in the AST
-              $1->destroy ();
-              delete $1;
-              $1 = 0;
+              valuetype_header->destroy ();
+              delete valuetype_header;
+              valuetype_header = ($1 = 0);
             }
 
           /*
            * Push it on the scope stack
            */
-          idl_global->scopes ().push (v);
+          idl_global->scopes ().push (valuetype);
+
+          $<dcval>$ = valuetype;
         }
         '{'
         {
@@ -1182,7 +1186,7 @@ value_concrete_decl :
            */
           idl_global->scopes ().pop ();
 
-          $$ = 0;
+          $$ = $<dcval>2;
         }
         ;
 
@@ -1446,15 +1450,60 @@ value_box_decl
         ;
 
 value_elements
-        : value_elements value_element
+        : value_elements at_least_one_annotation value_element
+        {
+          AST_Annotation_Appls *&annotations = $2;
+          AST_Decls *&decls = $3;
+          if (decls)
+            {
+              for (size_t i = 0; i < decls->size (); i++)
+                {
+                  (*decls)[i]->annotation_appls (*annotations);
+                }
+            }
+          else
+            {
+              idl_global->err ()-> unsupported_warning (
+                "Annotating this is not supported");
+            }
+          delete annotations;
+          delete decls;
+        }
+        | value_elements value_element
+        {
+          delete $2;
+        }
         | %empty
         ;
 
 value_element
         : state_member
         | export
+        {
+          AST_Decl *&node = $1;
+          AST_Decls *value = 0;
+          if (node)
+            {
+              value = new AST_Decls;
+              value->push_back (node);
+            }
+          $$ = value;
+        }
         | init_decl
+        {
+          AST_Decl *&node = $1;
+          AST_Decls *value = 0;
+          if (node)
+            {
+              value = new AST_Decls;
+              value->push_back (node);
+            }
+          $<decls_val>$ = value;
+        }
         ';'
+        {
+          $$ = $<decls_val>2;
+        }
         ;
 
 visibility
@@ -1476,14 +1525,14 @@ state_member
               AST_Decls &decls = *$2;
               for (size_t i = 0; i < decls.size (); i++)
                 {
-                  AST_Field * field = dynamic_cast<AST_Field*>(decls[i]);
+                  AST_Field * field = dynamic_cast<AST_Field*> (decls[i]);
                   if (field)
                     {
                       field->visibility ($1);
                     }
                 }
             }
-          delete $2;
+          $$ = $2;
         }
         ;
 
@@ -1503,14 +1552,12 @@ at_least_one_export
             }
           else
             {
-              idl_global->err ()-> unsupported_warning(
+              idl_global->err ()-> unsupported_warning (
                 "Annotating this is not supported");
             }
           delete annotations;
         }
         | exports export
-        {
-        }
         ;
 
 export
@@ -1544,7 +1591,7 @@ export
         }
         ';'
         {
-          idl_global->set_parse_state(IDL_GlobalData::PS_NoState);
+          idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
         }
         | exception
         {
@@ -1572,7 +1619,7 @@ export
         }
         | error
         {
-          idl_global->err()->syntax_error (idl_global->parse_state());
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
         ';'
         {
@@ -1801,7 +1848,7 @@ interface_forward :
           delete $2;
           $2 = 0;
 
-          $$ = dynamic_cast<AST_Decl*>(f);
+          $$ = dynamic_cast<AST_Decl*> (f);
         }
         ;
 
@@ -2094,7 +2141,7 @@ unary_expr
         | '-' primary_expr
         {
           $$ =
-            idl_global->gen()->create_expr (
+            idl_global->gen ()->create_expr (
                                    AST_Expression::EC_u_minus,
                                    $2,
                                    0
@@ -2103,7 +2150,7 @@ unary_expr
         | '~' primary_expr
         {
           $$ =
-            idl_global->gen()->create_expr (
+            idl_global->gen ()->create_expr (
                                    AST_Expression::EC_bit_neg,
                                    $2,
                                    0
@@ -3161,7 +3208,7 @@ member_i :
         }
         | error
         {
-          idl_global->err()->syntax_error (idl_global->parse_state ());
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
         ';'
         {
@@ -3506,7 +3553,7 @@ case_branch :
         }
         | error
         {
-          idl_global->err()->syntax_error (idl_global->parse_state());
+          idl_global->err ()->syntax_error (idl_global->parse_state ());
         }
         ';'
         {
@@ -3576,7 +3623,7 @@ case_label
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_LabelColonSeen);
 
-          $$ = idl_global->gen()->create_union_label (
+          $$ = idl_global->gen ()->create_union_label (
                                       AST_UnionLabel::UL_label,
                                       $3
                                     );
@@ -3598,8 +3645,7 @@ element_spec :
           if ($1 != 0
               && AST_illegal_recursive_type ($1))
             {
-              idl_global->err()->error1 (UTL_Error::EIDL_RECURSIVE_TYPE,
-                                         $1);
+              idl_global->err ()->error1 (UTL_Error::EIDL_RECURSIVE_TYPE, $1);
 
               $$ = 0;
             }
@@ -3825,7 +3871,7 @@ sequence_type_spec
           /*
            * Remove sequence marker from scopes stack.
            */
-          if (idl_global->scopes ().top() == 0)
+          if (idl_global->scopes ().top () == 0)
             {
               idl_global->scopes ().pop ();
             }
@@ -4462,32 +4508,35 @@ exception :
         }
         defining_id
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          UTL_ScopedName n ($3,
-                            0);
-          AST_Exception *e = 0;
+          Identifier *&id = $3;
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          UTL_ScopedName scoped_name (id, 0);
+          AST_Exception *exception = 0;
           idl_global->set_parse_state (IDL_GlobalData::PS_ExceptIDSeen);
 
           /*
            * Create a node representing an exception and add it to
            * the enclosing scope.
            */
-          if (s != 0)
+          if (scope)
             {
-              e = idl_global->gen ()->create_exception (&n,
-                                                        s->is_local (),
-                                                        s->is_abstract ());
-              (void) s->fe_add_exception (e);
+              exception = idl_global->gen ()->create_exception (
+                &scoped_name,
+                scope->is_local (),
+                scope->is_abstract ());
+              scope->fe_add_exception (exception);
             }
 
           /*
            * Push the exception scope on the scope stack.
            */
-          idl_global->scopes ().push (e);
+          idl_global->scopes ().push (exception);
 
-          $3->destroy ();
-          delete $3;
-          $3 = 0;
+          id->destroy ();
+          delete id;
+          id = 0;
+
+          $<dcval>$ = exception;
         }
         '{'
         {
@@ -4505,7 +4554,7 @@ exception :
            */
           idl_global->scopes ().pop ();
 
-          $$ = 0;
+          $$ = $<dcval>4;
         }
         ;
 
@@ -4650,7 +4699,7 @@ init_decl
           //@@ PS_FactorySeen?
           idl_global->set_parse_state (IDL_GlobalData::PS_OpTypeSeen);
         }
-        annotations_maybe IDENTIFIER
+        IDENTIFIER
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
 
@@ -4667,9 +4716,9 @@ init_decl
               idl_global->set_err_count (idl_global->err_count () + 1);
             }
 
-          Identifier id ($4);
-          ACE::strdelete ($4);
-          $4 = 0;
+          Identifier id ($3);
+          ACE::strdelete ($3);
+          $3 = 0;
 
           UTL_ScopedName n (&id,
                             0);
@@ -4691,7 +4740,7 @@ init_decl
            */
           idl_global->scopes ().push (factory);
 
-          delete $3;
+          $<dcval>$ = factory;
         }
         init_parameter_list
         {
@@ -4701,14 +4750,16 @@ init_decl
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_OpRaiseCompleted);
 
-          if ($8 != 0)
+          if ($7)
             {
               UTL_Scope *s = idl_global->scopes ().top_non_null ();
               AST_Factory *f = AST_Factory::narrow_from_scope (s);
-              (void) f->fe_add_exceptions ($8);
+              (void) f->fe_add_exceptions ($7);
             }
 
           idl_global->scopes ().pop ();
+
+          $$ = $<dcval>4;
         }
         ;
 
@@ -5231,42 +5282,44 @@ component_forward_decl :
 component_decl :
         component_header
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          AST_Component *c = 0;
+          FE_ComponentHeader *&component_header = $1;
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          AST_Component *component = 0;
 
           /*
            * Make a new component node and add it to the enclosing scope.
            */
-          if (s != 0 && $1 != 0)
+          if (scope && component_header)
             {
-              c =
-                idl_global->gen ()->create_component (
-                                        $1->name (),
-                                        $1->base_component (),
-                                        $1->supports (),
-                                        $1->n_supports (),
-                                        $1->supports_flat (),
-                                        $1->n_supports_flat ()
-                                      );
-              AST_Interface *i = AST_Interface::narrow_from_decl (c);
-              AST_Interface::fwd_redefinition_helper (i,
-                                                      s);
+              component = idl_global->gen ()->create_component (
+                component_header->name (),
+                component_header->base_component (),
+                component_header->supports (),
+                component_header->n_supports (),
+                component_header->supports_flat (),
+                component_header->n_supports_flat ());
+              AST_Interface *component_as_interface =
+                dynamic_cast<AST_Interface*> (component);
+              AST_Interface::fwd_redefinition_helper (
+                component_as_interface, scope);
+
               /*
                * Add the component to its definition scope.
                */
-              c = AST_Component::narrow_from_decl (i);
-              (void) s->fe_add_component (c);
+              scope->fe_add_component (component);
 
               // This FE_ComponentHeader class isn't destroyed with the AST.
-              $1->destroy ();
-              delete $1;
-              $1 = 0;
+              component_header->destroy ();
+              delete component_header;
+              component_header = 0;
             }
 
           /*
            * Push it on the scope stack.
            */
-          idl_global->scopes ().push (c);
+          idl_global->scopes ().push (component);
+
+          $<dcval>$ = component;
         }
         '{'
         {
@@ -5285,7 +5338,7 @@ component_decl :
            */
           idl_global->scopes ().pop ();
 
-          $$ = 0;
+          $$ = $<dcval>2;
         }
         ;
 
@@ -5340,7 +5393,7 @@ component_inheritance_spec
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_InheritColonSeen);
         }
-          scoped_name
+        scoped_name
         {
           $<idlist>$ = $3;
         }
@@ -5351,7 +5404,22 @@ component_inheritance_spec
         ;
 
 component_exports
-        : component_exports component_export
+        : component_exports at_least_one_annotation component_export
+        {
+          AST_Annotation_Appls *&annotations = $2;
+          AST_Decl *&node = $3;
+          if (node)
+            {
+              node->annotation_appls (*annotations);
+            }
+          else
+            {
+              idl_global->err ()-> unsupported_warning (
+                "Annotating this is not supported");
+            }
+          delete annotations;
+        }
+        | component_exports component_export
         | %empty
         ;
 
@@ -5363,6 +5431,7 @@ component_export
         ';'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          $$ = $1;
         }
         | uses_decl
         {
@@ -5371,6 +5440,7 @@ component_export
         ';'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          $$ = $1;
         }
         | emits_decl
         {
@@ -5379,6 +5449,7 @@ component_export
         ';'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          $$ = $1;
         }
         | publishes_decl
         {
@@ -5387,6 +5458,7 @@ component_export
         ';'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          $$ = $1;
         }
         | consumes_decl
         {
@@ -5395,6 +5467,7 @@ component_export
         ';'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          $$ = $1;
         }
         | attribute
         {
@@ -5403,6 +5476,7 @@ component_export
         ';'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          $$ = $1;
         }
         | extended_port_decl
         {
@@ -5411,6 +5485,7 @@ component_export
         ';'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_NoState);
+          $$ = $1;
         }
         ;
 
@@ -5475,6 +5550,8 @@ provides_decl : IDL_PROVIDES interface_type id
                 }
             }
 
+          AST_Provides *provides = 0;
+
           if (so_far_so_good)
             {
               AST_Type *port_interface_type =
@@ -5486,11 +5563,10 @@ provides_decl : IDL_PROVIDES interface_type id
               UTL_ScopedName sn ($3,
                                  0);
 
-              AST_Provides *p =
-                idl_global->gen ()->create_provides (&sn,
-                                                     port_interface_type);
+              provides = idl_global->gen ()->create_provides (
+                &sn, port_interface_type);
 
-              (void) s->fe_add_provides (p);
+              (void) s->fe_add_provides (provides);
             }
 
           $2->destroy ();
@@ -5500,6 +5576,8 @@ provides_decl : IDL_PROVIDES interface_type id
           $3->destroy ();
           delete $3;
           $3 = 0;
+
+          $$ = dynamic_cast<AST_Decl *> (provides);
         }
         ;
 
@@ -5596,6 +5674,8 @@ uses_decl : uses_opt_multiple interface_type id
                 }
             }
 
+          AST_Uses *uses = 0;
+
           if (so_far_so_good)
             {
               AST_Type *port_interface_type =
@@ -5607,18 +5687,15 @@ uses_decl : uses_opt_multiple interface_type id
               UTL_ScopedName sn ($3,
                                  0);
 
-              AST_Uses *u =
-                idl_global->gen ()->create_uses (&sn,
-                                                 port_interface_type,
-                                                 $1);
-
-              (void) s->fe_add_uses (u);
+              uses = idl_global->gen ()->create_uses (
+                &sn, port_interface_type, $1);
+              s->fe_add_uses (uses);
 
               AST_Component *c =
                 AST_Component::narrow_from_scope (s);
 
               if (c != 0
-                  && u->is_multiple ()
+                  && uses->is_multiple ()
                   && !idl_global->using_ifr_backend ()
                   && !idl_global->ignore_idl3 ()
                   && nt != AST_Decl::NT_param_holder)
@@ -5626,7 +5703,7 @@ uses_decl : uses_opt_multiple interface_type id
                   // These datatypes must be created in the
                   // front end so they can be looked up
                   // when compiling the generated executor IDL.
-                  FE_Utils::create_uses_multiple_stuff (c, u);
+                  FE_Utils::create_uses_multiple_stuff (c, uses);
                 }
             }
 
@@ -5637,6 +5714,8 @@ uses_decl : uses_opt_multiple interface_type id
           $3->destroy ();
           delete $3;
           $3 = 0;
+
+          $$ = uses;
         }
         ;
 
@@ -5660,7 +5739,8 @@ opt_multiple
         }
         ;
 
-emits_decl : IDL_EMITS scoped_name id
+emits_decl
+        : IDL_EMITS scoped_name id
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -5704,6 +5784,8 @@ emits_decl : IDL_EMITS scoped_name id
                 }
             }
 
+          AST_Emits *e = 0;
+
           if (so_far_so_good)
             {
               AST_Type *event_type =
@@ -5715,9 +5797,7 @@ emits_decl : IDL_EMITS scoped_name id
               UTL_ScopedName sn ($3,
                                  0);
 
-              AST_Emits *e =
-                idl_global->gen ()->create_emits (&sn,
-                                                  event_type);
+              e = idl_global->gen ()->create_emits (&sn, event_type);
 
               (void) s->fe_add_emits (e);
             }
@@ -5729,10 +5809,13 @@ emits_decl : IDL_EMITS scoped_name id
           $3->destroy ();
           delete $3;
           $3 = 0;
+
+          $$ = e;
         }
         ;
 
-publishes_decl : IDL_PUBLISHES scoped_name id
+publishes_decl
+        : IDL_PUBLISHES scoped_name id
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -5776,6 +5859,8 @@ publishes_decl : IDL_PUBLISHES scoped_name id
                 }
             }
 
+          AST_Publishes *p = 0;
+
           if (so_far_so_good)
             {
               AST_Type *event_type =
@@ -5784,14 +5869,9 @@ publishes_decl : IDL_PUBLISHES scoped_name id
               // Strip off _cxx_, if any, for port name.
               FE_Utils::original_local_name ($3);
 
-              UTL_ScopedName sn ($3,
-                                 0);
-
-              AST_Publishes *p =
-                idl_global->gen ()->create_publishes (&sn,
-                                                      event_type);
-
-              (void) s->fe_add_publishes (p);
+              UTL_ScopedName sn ($3, 0);
+              p = idl_global->gen ()->create_publishes (&sn, event_type);
+              s->fe_add_publishes (p);
             }
 
           $2->destroy ();
@@ -5801,10 +5881,13 @@ publishes_decl : IDL_PUBLISHES scoped_name id
           $3->destroy ();
           delete $3;
           $3 = 0;
+
+          $$ = p;
         }
         ;
 
-consumes_decl : IDL_CONSUMES scoped_name id
+consumes_decl
+        : IDL_CONSUMES scoped_name id
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           bool so_far_so_good = true;
@@ -5848,6 +5931,8 @@ consumes_decl : IDL_CONSUMES scoped_name id
                 }
             }
 
+          AST_Consumes *c = 0;
+
           if (so_far_so_good)
             {
               AST_Type *event_type =
@@ -5859,9 +5944,7 @@ consumes_decl : IDL_CONSUMES scoped_name id
               UTL_ScopedName sn ($3,
                                  0);
 
-              AST_Consumes *c =
-                idl_global->gen ()->create_consumes (&sn,
-                                                     event_type);
+              c = idl_global->gen ()->create_consumes (&sn, event_type);
 
               (void) s->fe_add_consumes (c);
             }
@@ -5873,11 +5956,13 @@ consumes_decl : IDL_CONSUMES scoped_name id
           $3->destroy ();
           delete $3;
           $3 = 0;
-       }
-        ;
 
-home_decl :
-        home_header
+          $$ = c;
+       }
+       ;
+
+home_decl
+        : home_header
         {
           UTL_Scope *s = idl_global->scopes ().top_non_null ();
           AST_Home *h = 0;
@@ -5925,8 +6010,8 @@ home_decl :
         }
         ;
 
-home_header :
-        IDL_HOME
+home_header
+        : IDL_HOME
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_HomeSeen);
         }
@@ -6381,44 +6466,43 @@ event_decl :
         event_header
         event_rest_of_header
         {
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
-          AST_EventType *e = 0;
-          AST_Interface *i = 0;
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
+          Identifier *&event_id = $1;
+          FE_OBVHeader *&event_header = $2;
+          AST_EventType *eventtype = 0;
 
-          if (s != 0 && $1 != 0)
+          if (scope && event_header)
             {
               // We create the scoped name here instead of with the
-              // FE_EventHeader because there is a token for it only here.
-              UTL_ScopedName sn ($1,
-                                 0);
-              e =
-                idl_global->gen ()->create_eventtype (
-                    &sn,
-                    $2->inherits (),
-                    $2->n_inherits (),
-                    $2->inherits_concrete (),
-                    $2->inherits_flat (),
-                    $2->n_inherits_flat (),
-                    $2->supports (),
-                    $2->n_supports (),
-                    $2->supports_concrete (),
-                    false,
-                    $2->truncatable (),
-                    false
-                  );
-              i = AST_Interface::narrow_from_decl (e);
-              AST_Interface::fwd_redefinition_helper (i,
-                                                      s);
+              // FE_OBVHeader because there is a token for it only here.
+              UTL_ScopedName sn (event_id, 0);
+              eventtype = idl_global->gen ()->create_eventtype (
+                &sn,
+                event_header->inherits (),
+                event_header->n_inherits (),
+                event_header->inherits_concrete (),
+                event_header->inherits_flat (),
+                event_header->n_inherits_flat (),
+                event_header->supports (),
+                event_header->n_supports (),
+                event_header->supports_concrete (),
+                false,
+                event_header->truncatable (),
+                false);
+              AST_Interface *eventtype_as_interface =
+                dynamic_cast<AST_Interface *> (eventtype);
+              AST_Interface::fwd_redefinition_helper (
+                eventtype_as_interface, scope);
+
               /*
                * Add the eventetype to its definition scope
                */
-              e = AST_EventType::narrow_from_decl (i);
-              (void) s->fe_add_eventtype (e);
+              scope->fe_add_eventtype (eventtype);
 
-              // FE_EventHeader is not automatically destroyed in the AST
-              $2->destroy ();
-              delete $2;
-              $2 = 0;
+              // FE_OBVHeader is not automatically destroyed in the AST
+              event_header->destroy ();
+              delete event_header;
+              event_header = 0;
 
               sn.destroy ();
             }
@@ -6426,7 +6510,9 @@ event_decl :
           /*
            * Push it on the scope stack.
            */
-          idl_global->scopes ().push (e);
+          idl_global->scopes ().push (eventtype);
+
+          $<dcval>$ = eventtype;
         }
         '{'
         {
@@ -6445,7 +6531,7 @@ event_decl :
            */
           idl_global->scopes ().pop ();
 
-          $$ = 0;
+          $$ = $<dcval>3;
         }
         ;
 
@@ -6641,30 +6727,33 @@ porttype_decl
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSeen);
         }
-        annotations_maybe IDENTIFIER
+        IDENTIFIER
         {
+          char *&id_value = $3;
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeIDSeen);
-          UTL_Scope *s = idl_global->scopes ().top_non_null ();
+          UTL_Scope *scope = idl_global->scopes ().top_non_null ();
 
-          Identifier id ($4);
-          ACE::strdelete ($4);
-          $4 = 0;
+          Identifier id (id_value);
+          ACE::strdelete (id_value);
+          id_value = 0;
 
-          UTL_ScopedName sn (&id, 0);
-          AST_PortType *p =
-            idl_global->gen ()->create_porttype (&sn);
-
-          (void) s->fe_add_porttype (p);
+          UTL_ScopedName scoped_name (&id, 0);
+          AST_PortType *porttype = idl_global->gen ()->create_porttype (
+            &scoped_name);
+          scope->fe_add_porttype (porttype);
+          $<dcval>$ = porttype;
 
           // Push it on the scopes stack.
-          idl_global->scopes ().push (p);
-
-          delete $3;
+          idl_global->scopes ().push (porttype);
         }
         '{'
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeSqSeen);
         }
+        /**
+         * NOTE: IDL4.2 spec has a different definition of what can go inside a
+         * portype.
+         */
         at_least_one_port_export
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_PorttypeBodySeen);
@@ -6676,44 +6765,44 @@ porttype_decl
           // Done with this port type - pop it off the scopes stack.
           idl_global->scopes ().pop ();
 
-          $$ = 0;
+          $$ = $<dcval>4;
         }
         ;
 
 at_least_one_port_export
-        : port_export port_exports
+        : port_exports at_least_one_annotation port_export
         {
+          AST_Annotation_Appls *&annotations = $2;
+          AST_Decl *&node = $3;
+          if (node)
+            {
+              node->annotation_appls (*annotations);
+            }
+          else
+            {
+              idl_global->err ()-> unsupported_warning (
+                "Annotating this is not supported");
+            }
+          delete annotations;
         }
+        | port_exports port_export
         ;
 
 port_exports
-        : port_exports port_export
-        {
-        }
+        : at_least_one_port_export
         | %empty
-        {
-        }
         ;
 
 port_export
-        : provides_decl
-        {
-        }
-        ';'
-        {
-        }
-        | uses_decl
-        {
-        }
-        ';'
-        {
-        }
+        : provides_decl ';'
+        | uses_decl ';'
         | attribute
         {
           idl_global->set_parse_state (IDL_GlobalData::PS_AttrDeclSeen);
         }
         ';'
         {
+          $$ = $1;
         }
         ;
 
@@ -6744,21 +6833,17 @@ extended_port_decl
                 }
             }
 
+          AST_Extended_Port *ep = 0;
+
           if (so_far_so_good)
             {
               Identifier id ($3);
               ACE::strdelete ($3);
               $3 = 0;
 
-              UTL_ScopedName sn (&id,
-                                 0);
-
-              AST_Extended_Port *ep =
-                idl_global->gen ()->create_extended_port (
-                  &sn,
-                  pt);
-
-              (void) s->fe_add_extended_port (ep);
+              UTL_ScopedName sn (&id, 0);
+              ep = idl_global->gen ()->create_extended_port (&sn, pt);
+              s->fe_add_extended_port (ep);
 
               // Create (in the AST) the struct(s) and sequence(s)
               // needed for multiplex uses ports, if any.
@@ -6786,6 +6871,8 @@ extended_port_decl
           $2->destroy ();
           delete $2;
           $2 = 0;
+
+          $$ = ep;
         }
         | IDL_MIRRORPORT scoped_name IDENTIFIER
         {
@@ -6813,26 +6900,24 @@ extended_port_decl
                  }
              }
 
+          AST_Mirror_Port *mp = 0;
+
           if (so_far_so_good)
             {
               Identifier id ($3);
               ACE::strdelete ($3);
               $3 = 0;
 
-              UTL_ScopedName sn (&id,
-                                 0);
-
-              AST_Mirror_Port *mp =
-                idl_global->gen ()->create_mirror_port (
-                  &sn,
-                  pt);
-
-              (void) s->fe_add_mirror_port (mp);
+              UTL_ScopedName sn (&id, 0);
+              mp = idl_global->gen ()->create_mirror_port (&sn, pt);
+              s->fe_add_mirror_port (mp);
             }
 
           $2->destroy ();
           delete $2;
           $2 = 0;
+
+          $$ = mp;
         }
         ;
 

--- a/TAO/TAO_IDL/fe/idl.yy.cpp
+++ b/TAO/TAO_IDL/fe/idl.yy.cpp
@@ -1,6 +1,6 @@
-#line 1 "fe/idl.yy.cpp"
+#line 2 "fe/idl.yy.cpp"
 
-#line 3 "fe/idl.yy.cpp"
+#line 4 "fe/idl.yy.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1297,9 +1297,9 @@ static AST_Decl *           idl_find_node (const char *);
 #undef ECHO
 #endif
 
-#line 1302 "fe/idl.yy.cpp"
+#line 1303 "fe/idl.yy.cpp"
 /* SO we don't choke on files that use \r\n */
-#line 1304 "fe/idl.yy.cpp"
+#line 1305 "fe/idl.yy.cpp"
 
 #define INITIAL 0
 
@@ -1522,7 +1522,7 @@ YY_DECL
 #line 123 "fe/idl.ll"
 
 
-#line 1527 "fe/idl.yy.cpp"
+#line 1528 "fe/idl.yy.cpp"
 
     while ( /*CONSTCOND*/1 )        /* loops until end-of-file is reached */
         {
@@ -2307,7 +2307,7 @@ YY_RULE_SETUP
 #line 418 "fe/idl.ll"
 ECHO;
     YY_BREAK
-#line 2312 "fe/idl.yy.cpp"
+#line 2313 "fe/idl.yy.cpp"
 case YY_STATE_EOF(INITIAL):
     yyterminate();
 

--- a/TAO/TAO_IDL/include/utl_err.h
+++ b/TAO/TAO_IDL/include/utl_err.h
@@ -163,7 +163,9 @@ public:
   };
 
   ErrorCode last_error;
+  long last_error_lineno;
   ErrorCode last_warning;
+  long last_warning_lineno;
 
   // Operations
 
@@ -463,6 +465,9 @@ public:
    */
   void annotation_param_missing_error (
     AST_Annotation_Appl *appl, AST_Annotation_Member *member);
+
+  /// Reset recent warning and error information
+  void reset_last_error_and_warning ();
 };
 
 #endif           // _UTL_ERR_UTL_ERR_HH

--- a/TAO/TAO_IDL/util/utl_err.cpp
+++ b/TAO/TAO_IDL/util/utl_err.cpp
@@ -279,11 +279,13 @@ static void
 idl_error_header (UTL_Error::ErrorCode c, long lineno, ACE_CString s)
 {
   idl_global->err ()->last_error = c;
+  const long line_number = lineno == -1 ? idl_global->lineno () : lineno;
+  idl_global->err ()->last_error_lineno = line_number;
   ACE_ERROR ((LM_ERROR,
               "Error - %C: \"%C\", line %d: %C",
               idl_global->prog_name (),
               s.c_str (),
-              lineno == -1 ? idl_global->lineno () : lineno,
+              line_number,
               error_string (c)));
   idl_global->set_err_count (idl_global->err_count () + 1);
 }
@@ -302,11 +304,13 @@ static void
 idl_warning_header (UTL_Error::ErrorCode c, long lineno, ACE_CString s)
 {
   idl_global->err ()->last_warning = c;
+  const long line_number = lineno == -1 ? idl_global->lineno () : lineno;
+  idl_global->err ()->last_warning_lineno = lineno;
   ACE_ERROR ((LM_WARNING,
               "Warning - %C: \"%C\", line %d: %C",
               idl_global->prog_name (),
               s.c_str (),
-              lineno == -1 ? idl_global->lineno () : lineno,
+              line_number,
               error_string (c)));
 }
 static void
@@ -712,7 +716,9 @@ parse_state_to_error_message (IDL_GlobalData::ParseState ps)
 
 UTL_Error::UTL_Error ()
   : last_error (EIDL_OK),
-    last_warning (EIDL_OK)
+    last_error_lineno (-1),
+    last_warning (EIDL_OK),
+    last_warning_lineno (-1)
 {
 }
 
@@ -1662,4 +1668,12 @@ UTL_Error::direct_warning (
       idl_warning_header (error_code, lineno, filename);
       ACE_ERROR ((LM_WARNING, ACE_TEXT ("%C\n"), reason));
     }
+}
+
+void UTL_Error::reset_last_error_and_warning ()
+{
+  last_error = EIDL_OK;
+  last_error_lineno = -1;
+  last_warning = EIDL_OK;
+  last_warning_lineno = -1;
 }

--- a/TAO/tests/IDLv4/annotations/Annotation_Test.h
+++ b/TAO/tests/IDLv4/annotations/Annotation_Test.h
@@ -1,32 +1,33 @@
-#include "ace/OS_NS_stdlib.h"
-#include "ace/OS_NS_string.h"
-#include "ace/OS_NS_stdio.h"
+#include <ast_annotation_decl.h>
+#include <ast_annotation_member.h>
+#include <utl_identifier.h>
+#include <ast_generator.h>
+#include <utl_scope.h>
+#include <fe_declarator.h>
+#include <ast_field.h>
+#include <ast_typedef.h>
+#include <ast_sequence.h>
+#include <ast_union.h>
+#include <ast_enum_val.h>
+#include <utl_string.h>
+#include <ast_array.h>
+#include <ast_interface.h>
 
+#include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_string.h>
+#include <ace/OS_NS_stdio.h>
 #ifndef ACE_LACKS_IOSTREAM_TOTALLY
-#  include "ace/streams.h"
+#  include <ace/streams.h>
 #endif
 
-#include "ast_annotation_decl.h"
-#include "ast_annotation_member.h"
-#include "utl_identifier.h"
-#include "ast_generator.h"
-#include "utl_scope.h"
-#include "fe_declarator.h"
-#include "ast_field.h"
-#include "ast_typedef.h"
-#include "ast_sequence.h"
-#include "ast_union.h"
-#include "ast_enum_val.h"
-#include "utl_string.h"
-#include "ast_array.h"
-#include "ast_interface.h"
+#include <string>
 
 struct Failed {};
 
 class Annotation_Test {
 public:
-  const char *name_;
-  const char *idl_;
+  std::string name_;
+  std::string idl_;
   bool failed_;
   int error_count_;
   UTL_Error::ErrorCode last_error_, last_warning_;
@@ -36,11 +37,11 @@ public:
   static unsigned failed_test_count_;
   static unsigned total_test_count_;
 
-  explicit Annotation_Test (const char *name);
+  explicit Annotation_Test (const std::string &name);
 
   ~Annotation_Test ();
 
-  void failed (const char *message = 0);
+  void failed (const std::string &message = "");
 
   Annotation_Test &error_count (int error_count);
 
@@ -48,7 +49,7 @@ public:
 
   Annotation_Test &last_warning (UTL_Error::ErrorCode last_warning);
 
-  Annotation_Test &run (const char *idl);
+  Annotation_Test &run (const std::string &idl);
 
   AST_Decl *assert_node (const char *name, UTL_Scope *from = 0);
 
@@ -104,6 +105,8 @@ public:
   void set_scope (AST_Decl *scope_node);
 
   void disable_output ();
+
+  void print_idl_with_line_numbers ();
 
   static void results ();
 };

--- a/TAO/tests/IDLv4/annotations/README.md
+++ b/TAO/tests/IDLv4/annotations/README.md
@@ -2,4 +2,5 @@
 
 This is a instance of the `tao_idl` compiler that doesn't produces any output
 and just verifies annotations can be defined and read by the backend and that
-annotation data is correct. This testing is taking place in `be_init.cpp`.
+annotation data is correct. This testing is taking place in
+`annotation_tests.cpp`.

--- a/TAO/tests/IDLv4/annotations/annotation_tests.cpp
+++ b/TAO/tests/IDLv4/annotations/annotation_tests.cpp
@@ -1,5 +1,112 @@
 #include "Annotation_Test.h"
 
+#include <ast_valuetype.h>
+#include <ast_porttype.h>
+#include <ast_eventtype.h>
+#include <ast_component.h>
+
+#include <string>
+
+namespace {
+
+  void assert_node_has_annotation (
+    Annotation_Test &t, const char *node_name, AST_Annotation_Decl *annotation)
+  {
+    AST_Decl *node = t.assert_node (node_name);
+    t.assert_annotation_appl_count (node, 1);
+    t.assert_annotation_appl (node, 0, annotation);
+  }
+
+  /**
+   * Common Test IDL for what the IDL4 grammer calls "attr_dcl"
+   */
+  const std::string common_attr_dcl_idl =
+    "  @test_annotation_1\n"
+    "  attribute short rw_attribute;\n"
+    "  @test_annotation_1\n"
+    "  readonly attribute short ro_attribute;\n";
+
+  void assert_common_attr_dcl_idl (
+    Annotation_Test &t, AST_Annotation_Decl *test_annotation_1)
+  {
+    assert_node_has_annotation (t, "rw_attribute", test_annotation_1);
+    assert_node_has_annotation (t, "ro_attribute", test_annotation_1);
+  }
+
+  /**
+   * Common Test IDL for what the IDL4 grammer calls "export"
+   */
+  const std::string common_export_idl =
+    // op_dcl
+    "  @test_annotation_1\n"
+    "  void operation();\n"
+    // attr_decl
+    + common_attr_dcl_idl +
+    // type_dcl
+    "  @test_annotation_1\n"
+    "  struct struct_in_export {\n"
+    "    short value;\n"
+    "  };\n"
+    // const_dcl
+    "  @test_annotation_1\n"
+    "  const short const_value = 3;\n"
+    // except_dcl
+    "  @test_annotation_1\n"
+    "  exception exception_in_export {\n"
+    "    short value;\n"
+    "  };\n"
+    // Use expection
+    "  @test_annotation_1\n"
+    "  void operation_with_exception() raises (exception_in_export);\n"
+    // type_id_dcl (Doesn't work)
+    // type_prefix_dcl (No grammar issues, but a type_prefix isn't something
+    //  that's part of the AST, so I'm not sure how this would work).
+    // "  @test_annotation_1\n"
+    // "  typeprefix struct_in_export \"electric_plants\";\n"
+    // import_dcl (TAO_IDL has import as a keyword, but doesn't support it in the grammer)
+    // op_oneway_dcl
+    "  @test_annotation_1\n"
+    "  oneway void oneway_op();\n";
+
+  void assert_common_export_idl (
+    Annotation_Test &t, AST_Annotation_Decl *test_annotation_1)
+  {
+    assert_node_has_annotation (t, "operation", test_annotation_1);
+    assert_common_attr_dcl_idl (t, test_annotation_1);
+    assert_node_has_annotation (t, "struct_in_export", test_annotation_1);
+    assert_node_has_annotation (t, "const_value", test_annotation_1);
+    assert_node_has_annotation (t, "exception_in_export", test_annotation_1);
+    assert_node_has_annotation (t, "operation_with_exception", test_annotation_1);
+    assert_node_has_annotation (t, "oneway_op", test_annotation_1);
+  }
+
+  /**
+   * Common Test IDL for what the IDL4 grammer calls "value_element"
+   */
+  const std::string common_value_element_idl =
+    // export
+    common_export_idl +
+
+    // state_member
+    "  @test_annotation_1\n"
+    "  public short public_state_member;\n"
+    "  @test_annotation_1\n"
+    "  private short private_state_member;\n"
+
+    // init_dcl
+    "  @test_annotation_1\n"
+    "  factory factory_thing();\n";
+
+  void assert_common_value_element_idl (
+    Annotation_Test &t, AST_Annotation_Decl *test_annotation_1)
+  {
+    assert_common_export_idl (t, test_annotation_1);
+    assert_node_has_annotation (t, "public_state_member", test_annotation_1);
+    assert_node_has_annotation (t, "private_state_member", test_annotation_1);
+    assert_node_has_annotation (t, "factory_thing", test_annotation_1);
+  }
+}
+
 /*
  * Notes About These Tests
  * =========================================================================
@@ -312,7 +419,7 @@ annotation_tests ()
         ACE_ERROR ((LM_ERROR, ACE_TEXT ("Annotation Test Error: %C:\n")
           ACE_TEXT ("expected one annotation on test_seq_t base type, ")
           ACE_TEXT ("it has %d annotations!\n"),
-          t.name_, count));
+          t.name_.c_str (), count));
         t.failed ();
       }
     AST_Annotation_Appl *annotation = annotations[0];
@@ -328,7 +435,7 @@ annotation_tests ()
         ACE_ERROR ((LM_ERROR, ACE_TEXT ("Annotation Test Error: %C:\n")
           ACE_TEXT ("expected annotation for test_seq_t base type to be ")
           ACE_TEXT ("test_annotation_1, but it was %C\n"),
-          t.name_, name));
+          t.name_.c_str (), name));
         if (scopedname)
           {
             delete [] name;
@@ -442,7 +549,7 @@ annotation_tests ()
         ACE_ERROR ((LM_ERROR, ACE_TEXT ("Annotation Test Error: %C:\n")
           ACE_TEXT ("expected one annotation on test_union discriminator, ")
           ACE_TEXT ("it has %d annotations!\n"),
-          t.name_, count));
+          t.name_.c_str (), count));
         t.failed ();
       }
     AST_Annotation_Appl *annotation = annotations[0];
@@ -458,7 +565,7 @@ annotation_tests ()
         ACE_ERROR ((LM_ERROR, ACE_TEXT ("Annotation Test Error: %C:\n")
           ACE_TEXT ("expected annotation for test_union discriminator to be ")
           ACE_TEXT ("test_annotation_1, but it was %C\n"),
-          t.name_, name));
+          t.name_.c_str (), name));
         if (scopedname)
           {
             delete [] name;
@@ -512,7 +619,7 @@ annotation_tests ()
   try {
     idl_global->unknown_annotations_ =
       IDL_GlobalData::UNKNOWN_ANNOTATIONS_ERROR;
-    Annotation_Test t ("Optionally, Unknown Annotation Application Causes Err");
+    Annotation_Test t ("Optionally, Unknown Annotation Application Causes Err0r");
                 // Any mention of "Error" will be picked up by scoreboard ^^^
     t.last_error (UTL_Error::EIDL_LOOKUP_ERROR).error_count (1);
     t.disable_output ();
@@ -634,7 +741,7 @@ annotation_tests ()
         ACE_ERROR ((LM_ERROR, ACE_TEXT ("Annotation Test Error: %C:\n")
           ACE_TEXT ("expected one annotation on struct12Array base type, ")
           ACE_TEXT ("it has %d annotations!\n"),
-          t.name_, count));
+          t.name_.c_str (), count));
         t.failed ();
       }
     AST_Annotation_Appl *annotation = annotations[0];
@@ -650,7 +757,7 @@ annotation_tests ()
         ACE_ERROR ((LM_ERROR, ACE_TEXT ("Annotation Test Error: %C:\n")
           ACE_TEXT ("expected annotation for struct12Array base type to be ")
           ACE_TEXT ("test_annotation_1, but it was %C\n"),
-          t.name_, name));
+          t.name_.c_str (), name));
         if (scopedname)
           {
             delete [] name;
@@ -717,49 +824,130 @@ annotation_tests ()
 
   try {
     Annotation_Test t ("Annotations on and in Interfaces");
-    t.run (
+    t.run ((std::string () +
       "@test_annotation_1\n"
       "interface interface1 {\n"
-      "  @test_annotation_1\n"
-      "  struct struct_in_interface1 {\n"
-      "    short value;\n"
-      "  };\n"
-      "  @test_annotation_1\n"
-      "  void operation();\n"
-      "  @test_annotation_1\n"
-      "  const short const_value = 3;\n"
-      "  @test_annotation_1\n"
-      "  attribute short rw_attribute;\n"
-      "  @test_annotation_1\n"
-      "  readonly attribute short ro_attribute;\n"
+      // export
+      + common_export_idl +
       "};\n"
-    );
+    ).c_str ());
 
     AST_Interface *interface1 = t.assert_node<AST_Interface> ("interface1");
     t.assert_annotation_appl_count (interface1, 1);
     t.assert_annotation_appl (interface1, 0, test_annotation_1);
-
     t.set_scope (interface1);
+    assert_common_export_idl (t, test_annotation_1);
+  } catch (Failed const &) {}
 
-    AST_Decl *struct_in_interface1 = t.assert_node ("struct_in_interface1");
-    t.assert_annotation_appl_count (struct_in_interface1, 1);
-    t.assert_annotation_appl (struct_in_interface1, 0, test_annotation_1);
+  try {
+    Annotation_Test t ("Annotations on and in Valuetypes");
+    t.run ((std::string () +
+      "@test_annotation_1\n"
+      "valuetype valuetype1 {\n"
+      // value_element
+      + common_value_element_idl +
+      "};\n"
+    ).c_str ());
 
-    AST_Decl *operation = t.assert_node ("operation");
-    t.assert_annotation_appl_count (operation, 1);
-    t.assert_annotation_appl (operation, 0, test_annotation_1);
+    AST_ValueType *valuetype1 = t.assert_node<AST_ValueType> ("valuetype1");
+    t.assert_annotation_appl_count (valuetype1, 1);
+    t.assert_annotation_appl (valuetype1, 0, test_annotation_1);
+    t.set_scope (valuetype1);
+    assert_common_value_element_idl (t, test_annotation_1);
+  } catch (Failed const &) {}
 
-    AST_Decl *const_value = t.assert_node ("const_value");
-    t.assert_annotation_appl_count (const_value, 1);
-    t.assert_annotation_appl (const_value, 0, test_annotation_1);
+  try {
+    Annotation_Test t ("Annotations on and in Porttypes");
+    t.run ((std::string () +
+      "@test_annotation_1\n"
+      "porttype port_with_provides {\n"
+      // port_ref
+      "  @test_annotation_1\n"
+      "  provides interface1 provides_value;\n"
+      // port_export
+      + common_attr_dcl_idl +
+      "};\n"
+      "\n"
+      "@test_annotation_1\n"
+      "porttype port_with_uses {\n"
+      // port_ref
+      "  @test_annotation_1\n"
+      "  uses interface1 uses_value;\n"
+      // port_export
+      + common_attr_dcl_idl +
+      "};\n"
+    ).c_str ());
 
-    AST_Decl *rw_attribute = t.assert_node ("rw_attribute");
-    t.assert_annotation_appl_count (rw_attribute, 1);
-    t.assert_annotation_appl (rw_attribute, 0, test_annotation_1);
+    AST_PortType *port_with_provides =
+      t.assert_node<AST_PortType> ("port_with_provides");
+    t.assert_annotation_appl_count (port_with_provides, 1);
+    t.assert_annotation_appl (port_with_provides, 0, test_annotation_1);
+    t.set_scope (port_with_provides);
+    assert_node_has_annotation (t, "provides_value", test_annotation_1);
+    assert_common_attr_dcl_idl (t, test_annotation_1);
 
-    AST_Decl *ro_attribute = t.assert_node ("ro_attribute");
-    t.assert_annotation_appl_count (ro_attribute, 1);
-    t.assert_annotation_appl (ro_attribute, 0, test_annotation_1);
+    AST_PortType *port_with_uses =
+      t.assert_node<AST_PortType> ("port_with_uses");
+    t.assert_annotation_appl_count (port_with_uses, 1);
+    t.assert_annotation_appl (port_with_uses, 0, test_annotation_1);
+    t.set_scope (port_with_uses);
+    assert_node_has_annotation (t, "uses_value", test_annotation_1);
+    assert_common_attr_dcl_idl (t, test_annotation_1);
+  } catch (Failed const &) {}
+
+  try {
+    Annotation_Test t ("Annotations on and in Eventtypes");
+    t.run ((std::string () +
+      "@test_annotation_1\n"
+      "eventtype event1 {\n"
+      + common_value_element_idl +
+      "};\n"
+    ).c_str ());
+    AST_EventType *event1 = t.assert_node<AST_EventType> ("event1");
+    t.assert_annotation_appl_count (event1, 1);
+    t.assert_annotation_appl (event1, 0, test_annotation_1);
+    t.set_scope (event1);
+    assert_common_value_element_idl (t, test_annotation_1);
+  } catch (Failed const &) {}
+
+  try {
+    Annotation_Test t ("Annotations on and in Components");
+    t.run ((std::string () +
+      "@test_annotation_1\n"
+      "component component1 {\n"
+      // provides_dcl
+      "  @test_annotation_1\n"
+      "  provides interface1 provides_value;\n"
+      // uses_dcl
+      "  @test_annotation_1\n"
+      "  uses interface1 uses_value;\n"
+      // attr_dcl
+      + common_attr_dcl_idl +
+      // port_dcl
+      "  @test_annotation_1\n"
+      "  port port_with_uses port_value;\n"
+      // emits_dcl
+      "  @test_annotation_1\n"
+      "  emits event1 emits_value;\n"
+      // publishes_dcl
+      "  @test_annotation_1\n"
+      "  publishes event1 publishes_value;\n"
+      // consumes_dcl
+      "  @test_annotation_1\n"
+      "  consumes event1 consumes_value;\n"
+      "};\n"
+    ).c_str ());
+    AST_Component *component1 = t.assert_node<AST_Component> ("component1");
+    t.assert_annotation_appl_count (component1, 1);
+    t.assert_annotation_appl (component1, 0, test_annotation_1);
+    t.set_scope (component1);
+    assert_node_has_annotation (t, "provides_value", test_annotation_1);
+    assert_node_has_annotation (t, "uses_value", test_annotation_1);
+    assert_common_attr_dcl_idl (t, test_annotation_1);
+    assert_node_has_annotation (t, "port_value", test_annotation_1);
+    assert_node_has_annotation (t, "emits_value", test_annotation_1);
+    assert_node_has_annotation (t, "publishes_value", test_annotation_1);
+    assert_node_has_annotation (t, "consumes_value", test_annotation_1);
   } catch (Failed const &) {}
 
   /*
@@ -796,7 +984,7 @@ annotation_tests ()
 
     AST_Annotation_Decl *range_like_test_annotation =
       t.assert_annotation_decl ("::@range_test_annotation");
-    AST_Decl *RangedFloat = t.assert_node(
+    AST_Decl *RangedFloat = t.assert_node (
       "::range_test_annoation_module::RangedFloat");
     t.assert_annotation_appl_count (RangedFloat, 3);
     t.assert_annotation_appl (RangedFloat, 0, range_like_test_annotation);


### PR DESCRIPTION
Annotation support extended to on the following types and their
contents:
 - Interfaces
 - Porttypes
 - Eventtypes
 - Components

Annotations on Valuetypes and most of their possible contents are also
supported. The exceptions to this are these types of valuetype
statements:
  - import: not supported by TAO
  - typeid: not supported by TAO on valuetypes
  - typeprefix: No corresponding AST Node to attach annotations to