### PR TITLE
Only include os_sysctl.h when ACE_HAS_SYSCTL has been defined and wit…

### DIFF
--- a/ACE/ace/OS_NS_unistd.cpp
+++ b/ACE/ace/OS_NS_unistd.cpp
@@ -13,7 +13,9 @@
 #include "ace/Object_Manager_Base.h"
 #include "ace/Auto_Ptr.h"
 #include "ace/os_include/sys/os_pstat.h"
-#include "ace/os_include/sys/os_sysctl.h"
+#if defined (ACE_HAS_SYSCTL)
+# include "ace/os_include/sys/os_sysctl.h"
+#endif /* ACE_HAS_SYSCTL */
 
 #if defined ACE_HAS_VXCPULIB
 # include "vxCpuLib.h"

--- a/ACE/ace/config-linux-common.h
+++ b/ACE/ace/config-linux-common.h
@@ -252,4 +252,8 @@
 #  define ACE_HAS_GETTID // See ACE_OS::thr_gettid()
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION (5,5,0))
+#  define ACE_LACKS_SYS_SYSCTL_H
 #endif
+
+#endif /* ACE_CONFIG_LINUX_COMMON_H */


### PR DESCRIPTION
…h linux kernel >= 5.5.0 sys/sysctl.h has been marked deprecated

    * ACE/ace/OS_NS_unistd.cpp:
    * ACE/ace/config-linux-common.h: