### PR TITLE
With C++11 define a default assignment operator to get rid of C++11 w…

### DIFF
--- a/TAO/tao/CDR.h
+++ b/TAO/tao/CDR.h
@@ -404,9 +404,13 @@ public:
                 TAO_ORB_Core* orb_core = 0);
 
   /// Initialize the contents of one CDR from another, without data
-  /// copying and with minimimum locking overhead.
+  /// copying and with minimum locking overhead.
   TAO_InputCDR (ACE_InputCDR::Transfer_Contents rhs,
                 TAO_ORB_Core* orb_core = 0);
+
+#if defined (ACE_HAS_CPP11)
+  TAO_InputCDR& operator= (const TAO_InputCDR& rhs) = default;
+#endif /* ACE_HAS_CPP11 */
 
   /// Destructor
   virtual ~TAO_InputCDR (void);


### PR DESCRIPTION
…arnings lacking it

    * TAO/tao/CDR.h: