### PR TITLE
TP Reactor was excessively calling select

### DIFF
--- a/ACE/ace/TP_Reactor.inl
+++ b/ACE/ace/TP_Reactor.inl
@@ -105,12 +105,22 @@ ACE_TP_Reactor::clear_handle_read_set (ACE_HANDLE handle)
 }
 
 ACE_INLINE void
-ACE_TP_Reactor::clear_dispatch_mask (ACE_HANDLE ,
-                                     ACE_Reactor_Mask )
+ACE_TP_Reactor::clear_dispatch_mask (ACE_HANDLE handle,
+                                     ACE_Reactor_Mask mask)
 {
-  this->ready_set_.rd_mask_.reset ();
-  this->ready_set_.wr_mask_.reset ();
-  this->ready_set_.ex_mask_.reset ();
+  if (ACE_BIT_ENABLED (mask, ACE_Event_Handler::READ_MASK) ||
+      ACE_BIT_ENABLED (mask, ACE_Event_Handler::ACCEPT_MASK))
+    {
+      this->ready_set_.rd_mask_.clr_bit (handle);
+    }
+  if (ACE_BIT_ENABLED (mask, ACE_Event_Handler::WRITE_MASK))
+    {
+      this->ready_set_.wr_mask_.clr_bit (handle);
+    }
+  if (ACE_BIT_ENABLED (mask, ACE_Event_Handler::EXCEPT_MASK))
+    {
+      this->ready_set_.ex_mask_.clr_bit (handle);
+    }
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
The TP Reactor implementation of the clear_dispatch_mask was implemented
by clearing the entire ready set instead of just removing the handler
that was suspended.  This forced the TP Reactor to potentially dispatch
only a single handler before re-calling an expensive select() call and
restarting the dispatch with the new set returned from select().  This
heavily favored lower order fds and was inefficient.  This originated
with the fix for ACE bugzilla 1890 which appears to have mainly focused
on the single threaded select reactor.