### PR TITLE
TAO_IDL: Memory management for eval

### DIFF
--- a/TAO/TAO_IDL/util/utl_global.cpp
+++ b/TAO/TAO_IDL/util/utl_global.cpp
@@ -2023,7 +2023,6 @@ void
 IDL_GlobalData::eval (const char *string, bool disable_output)
 {
   OldState old (disable_output);
-  OldState old2 (disable_output);
 
   // Set up Flex to read from string
   tao_yy_scan_string (string);

--- a/TAO/TAO_IDL/util/utl_global.cpp
+++ b/TAO/TAO_IDL/util/utl_global.cpp
@@ -1953,11 +1953,12 @@ namespace
   {
   public:
     explicit OldState (bool disable_output = false)
-        : old_filename_ (idl_global->filename () ? new UTL_String (idl_global->filename (), true) : 0), // need a copy because IDL_GlobalData::set_filename() destroys previous value
+        : old_filename_ (idl_global->filename () ? new UTL_String (idl_global->filename (), true) : 0),
+          // need a copy because IDL_GlobalData::set_filename() destroys previous value
           old_lineno_ (idl_global->lineno ()),
           old_idl_src_file_ (idl_global->idl_src_file ()),
           disable_output_ (disable_output),
-          default_streambuf_ (0),
+          default_streambuf_ (ACE_DEFAULT_LOG_STREAM->rdbuf ()),
           flags_ (ACE_LOG_MSG->flags ())
       {
         idl_global->in_eval_ = true;
@@ -1971,19 +1972,18 @@ namespace
 
         if (disable_output_)
           {
-            default_streambuf_ = ACE_DEFAULT_LOG_STREAM->rdbuf ();
             ACE_DEFAULT_LOG_STREAM->rdbuf (0);
             ACE_LOG_MSG->clr_flags (ACE_Log_Msg::STDERR);
             ACE_LOG_MSG->clr_flags (ACE_LOG_MSG->flags ());
          }
       }
 
-      UTL_String pseudo_filename ()
+      UTL_String pseudo_filename () const
       {
         // Name this pseudo-file "builtin-N"
         static char buffer[64];
         ACE_OS::snprintf (&buffer[0], sizeof buffer, "builtin-%u", pseudo_filename_counter_);
-        UTL_String filename (&buffer[0], true);
+        const UTL_String filename (&buffer[0], true);
 
         return filename;
       }
@@ -2010,11 +2010,11 @@ namespace
       }
 
     private:
-      UTL_String *old_filename_;
-      long old_lineno_;
-      UTL_String *old_idl_src_file_;
-      bool disable_output_;
-      std::streambuf *default_streambuf_;
+      UTL_String *const old_filename_;
+      const long old_lineno_;
+      UTL_String *const old_idl_src_file_;
+      const bool disable_output_;
+      std::streambuf *const default_streambuf_;
       const unsigned long flags_;
       static unsigned pseudo_filename_counter_;
   };

--- a/TAO/TAO_IDL/util/utl_global.cpp
+++ b/TAO/TAO_IDL/util/utl_global.cpp
@@ -2016,6 +2016,7 @@ void
 IDL_GlobalData::eval (const char *string, bool disable_output)
 {
   OldState old (disable_output);
+  OldState old2 (disable_output);
 
   // Set up Flex to read from string
   tao_yy_scan_string (string);

--- a/TAO/TAO_IDL/util/utl_global.cpp
+++ b/TAO/TAO_IDL/util/utl_global.cpp
@@ -1965,11 +1965,7 @@ namespace
         idl_global->set_lineno (1);
         idl_global->set_filename (0);
 
-        // Name this pseudo-file "builtin-N"
-        static char buffer[64];
-        static unsigned n = 1;
-        ACE_OS::snprintf (&buffer[0], sizeof buffer, "builtin-%u", n++);
-        UTL_String utl_string (&buffer[0], true);
+        UTL_String utl_string = get_filename();
         idl_global->idl_src_file (new UTL_String (&utl_string, true));
         idl_global->set_filename (new UTL_String (&utl_string, true));
 
@@ -1980,6 +1976,17 @@ namespace
             ACE_LOG_MSG->clr_flags (ACE_Log_Msg::STDERR);
             ACE_LOG_MSG->clr_flags (ACE_LOG_MSG->flags ());
          }
+      }
+
+      UTL_String get_filename()
+      {
+        // Name this pseudo-file "builtin-N"
+        static char buffer[64];
+        static unsigned n = 1;
+        ACE_OS::snprintf (&buffer[0], sizeof buffer, "builtin-%u", n++);
+        UTL_String utl_string (&buffer[0], true);
+
+        return utl_string;
       }
 
       ~OldState()

--- a/TAO/TAO_IDL/util/utl_global.cpp
+++ b/TAO/TAO_IDL/util/utl_global.cpp
@@ -2005,7 +2005,7 @@ namespace
           }
 
         tao_yylex_destroy ();
-        pseudo_filename_counter_++;
+        ++pseudo_filename_counter_;
         idl_global->in_eval_ = false;
       }
 

--- a/TAO/TAO_IDL/util/utl_global.cpp
+++ b/TAO/TAO_IDL/util/utl_global.cpp
@@ -1966,9 +1966,14 @@ namespace
         idl_global->set_lineno (1);
         idl_global->set_filename (0);
 
-        UTL_String filename = this->pseudo_filename ();
-        idl_global->idl_src_file (new UTL_String (&filename, true));
-        idl_global->set_filename (new UTL_String (&filename, true));
+        // Name this pseudo-file "builtin-N"
+        static char buffer[64];
+        static unsigned n = 1;
+        ACE_OS::snprintf (&buffer[0], sizeof buffer, "builtin-%u", n++);
+        UTL_String pseudo_filename (&buffer[0], true);
+
+        idl_global->idl_src_file (new UTL_String (&pseudo_filename, true));
+        idl_global->set_filename (new UTL_String (&pseudo_filename, true));
 
         if (disable_output_)
           {
@@ -1976,16 +1981,6 @@ namespace
             ACE_LOG_MSG->clr_flags (ACE_Log_Msg::STDERR);
             ACE_LOG_MSG->clr_flags (ACE_LOG_MSG->flags ());
          }
-      }
-
-      UTL_String pseudo_filename () const
-      {
-        // Name this pseudo-file "builtin-N"
-        static char buffer[64];
-        ACE_OS::snprintf (&buffer[0], sizeof buffer, "builtin-%u", pseudo_filename_counter_);
-        const UTL_String filename (&buffer[0], true);
-
-        return filename;
       }
 
       ~OldState()
@@ -2005,7 +2000,6 @@ namespace
           }
 
         tao_yylex_destroy ();
-        ++pseudo_filename_counter_;
         idl_global->in_eval_ = false;
       }
 
@@ -2016,11 +2010,8 @@ namespace
       const bool disable_output_;
       std::streambuf *const default_streambuf_;
       const unsigned long flags_;
-      static unsigned pseudo_filename_counter_;
   };
 }
-
-unsigned OldState::pseudo_filename_counter_ = 1;
 
 void
 IDL_GlobalData::eval (const char *string, bool disable_output)

--- a/TAO/TAO_IDL/util/utl_global.cpp
+++ b/TAO/TAO_IDL/util/utl_global.cpp
@@ -1953,7 +1953,7 @@ namespace
   {
   public:
     explicit OldState (bool disable_output = false)
-        : old_filename_ (idl_global->filename ()),
+        : old_filename_ (idl_global->filename () == 0 ? 0 : new UTL_String(idl_global->filename (), true)), // need a copy because set_filename() destroys previous value
           old_lineno_ (idl_global->lineno ()),
           old_idl_src_file_ (idl_global->idl_src_file ()),
           disable_output_ (disable_output),


### PR DESCRIPTION
I discovered that with the version introducing the OldState helper class there is a problem with seems to be double delete. This was discovered in our code base that does something similar to store/restore state of IDL_GlobalData before invoking eval().

The easiest way for me to reproduce the error in plain ACE/TAO was to instanciate OldState twice which can seem to be a
little far fetched and shouldn't be there in the final code. So I temporarily did this to make the tests fail, and then fixed the bug before removing the temp code.
Please have a look at the code and let me know it there is a better way to do this.

Before merging to master I'd like to to a final check on the code so we're sure the result is correct.