### PR TITLE
Improve Multicast Join by Interface Name on Windows

### DIFF
--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -845,7 +845,6 @@ ACE_SOCK_Dgram::make_multicast_ifaddr6 (ipv6_mreq *ret_mreq,
 #endif /* ACE_LACKS_IF_NAMETOINDEX */
       if (lmreq.ipv6mr_interface == 0)
         return -1;
-
     }
 #else  /* ACE_WIN32 || !ACE_LACKS_IF_NAMETOINDEX */
     ACE_UNUSED_ARG(net_if);

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -673,7 +673,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr (ip_mreq *ret_mreq,
       ACE_INET_Addr interface_addr;
       if (interface_addr.set (mcast_addr.get_port_number (), net_if) == -1)
         {
-#ifdef (ACE_WIN32)
+#if defined (ACE_WIN32)
           IP_ADAPTER_ADDRESSES tmp_addrs;
           // Initial call to determine actual memory size needed
           ULONG bufLen = 0;

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -788,7 +788,6 @@ ACE_SOCK_Dgram::make_multicast_ifaddr6 (ipv6_mreq *ret_mreq,
 
       IP_ADAPTER_ADDRESSES tmp_addrs;
       // Initial call to determine actual memory size needed
-      DWORD dwRetVal;
       ULONG bufLen = 0;
       char *buf = 0;
       if (::GetAdaptersAddresses (AF_INET6, 0, 0, &tmp_addrs, &bufLen)
@@ -799,7 +798,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr6 (ipv6_mreq *ret_mreq,
 
       // Get required output buffer and retrieve info for real.
       PIP_ADAPTER_ADDRESSES pAddrs = reinterpret_cast<PIP_ADAPTER_ADDRESSES> (buf);
-      if ((dwRetVal = ::GetAdaptersAddresses (AF_INET6, 0, 0, pAddrs, &bufLen)) != NO_ERROR)
+      if (::GetAdaptersAddresses (AF_INET6, 0, 0, pAddrs, &bufLen) != NO_ERROR)
         {
           pAddrs = 0;
         }

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -782,7 +782,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr6 (ipv6_mreq *ret_mreq,
     {
 #if defined (ACE_WIN32)
       int if_ix = 0;
-      bool num_if =
+      bool const num_if
         ACE_OS::ace_isdigit (net_if[0]) &&
         (if_ix = ACE_OS::atoi (net_if)) > 0;
 

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -782,7 +782,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr6 (ipv6_mreq *ret_mreq,
     {
 #if defined (ACE_WIN32)
       int if_ix = 0;
-      bool const num_if
+      bool const num_if =
         ACE_OS::ace_isdigit (net_if[0]) &&
         (if_ix = ACE_OS::atoi (net_if)) > 0;
 

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -702,7 +702,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr (ip_mreq *ret_mreq,
                 {
                   PIP_ADAPTER_UNICAST_ADDRESS pUnicast = pAddrs->FirstUnicastAddress;
                   LPSOCKADDR sa = pUnicast->Address.lpSockaddr;
-                  if (sa->sa_family = AF_INET)
+                  if (sa->sa_family == AF_INET)
                     {
                       const void *addr = &(((sockaddr_in *)sa)->sin_addr);
                       set_result = interface_addr.set_address ((const char*) addr, 4, 0);

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -834,20 +834,22 @@ ACE_SOCK_Dgram::make_multicast_ifaddr6 (ipv6_mreq *ret_mreq,
         }
 
       delete[] buf; // clean up
+
 #endif /* ACE_WIN32 */
 #ifndef ACE_LACKS_IF_NAMETOINDEX
       if (lmreq.ipv6mr_interface == 0)
         {
           lmreq.ipv6mr_interface = ACE_OS::if_nametoindex (ACE_TEXT_ALWAYS_CHAR (net_if));
         }
+
 #endif /* ACE_LACKS_IF_NAMETOINDEX */
+      if (lmreq.ipv6mr_interface == 0)
+        return -1;
+
     }
 #else  /* ACE_WIN32 || !ACE_LACKS_IF_NAMETOINDEX */
     ACE_UNUSED_ARG(net_if);
 #endif /* ACE_WIN32 || !ACE_LACKS_IF_NAMETOINDEX */
-
-  if (lmreq.ipv6mr_interface == 0)
-    return -1;
 
   // now set the multicast address
   ACE_OS::memcpy (&lmreq.ipv6mr_multiaddr,

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -673,7 +673,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr (ip_mreq *ret_mreq,
       ACE_INET_Addr interface_addr;
       if (interface_addr.set (mcast_addr.get_port_number (), net_if) == -1)
         {
-#ifdef ACE_WIN32
+#ifdef (ACE_WIN32)
           IP_ADAPTER_ADDRESSES tmp_addrs;
           // Initial call to determine actual memory size needed
           ULONG bufLen = 0;
@@ -827,10 +827,11 @@ ACE_SOCK_Dgram::make_multicast_ifaddr6 (ipv6_mreq *ret_mreq,
         }
 
 #endif /* ACE_LACKS_IF_NAMETOINDEX */
-      if (lmreq.ipv6mr_interface == 0) {
-        errno = EINVAL;
-        return -1;
-      }
+      if (lmreq.ipv6mr_interface == 0)
+        {
+          errno = EINVAL;
+          return -1;
+        }
     }
 #else  /* ACE_WIN32 || !ACE_LACKS_IF_NAMETOINDEX */
     ACE_UNUSED_ARG(net_if);

--- a/ACE/tests/.gitignore
+++ b/ACE/tests/.gitignore
@@ -277,3 +277,4 @@
 /Compiler_Features_37_Test
 /Compiler_Features_38_Test
 /SOCK_Acceptor_Test
+Multicast_Interfaces_Test

--- a/ACE/tests/Multicast_Interfaces_Test.cpp
+++ b/ACE/tests/Multicast_Interfaces_Test.cpp
@@ -31,8 +31,10 @@
 typedef std::set<ACE_TString> nameset;
 
 #ifdef ACE_WIN32
-void get_valid_ipv4_interface_names_win32(nameset& names) {
-  names.clear();
+void
+get_valid_ipv4_interface_names_win32 (nameset &names)
+{
+  names.clear ();
 
   // Initial call to determine actual memory size needed
   IP_ADAPTER_ADDRESSES tmp_addrs;
@@ -60,7 +62,7 @@ void get_valid_ipv4_interface_names_win32(nameset& names) {
           LPSOCKADDR sa = pUnicast->Address.lpSockaddr;
           if (sa->sa_family == AF_INET)
             {
-              names.insert(ACE_TEXT_WCHAR_TO_TCHAR(pAddrs->FriendlyName));
+              names.insert (ACE_TEXT_WCHAR_TO_TCHAR (pAddrs->FriendlyName));
             }
         }
       pAddrs = pAddrs->Next;
@@ -69,9 +71,11 @@ void get_valid_ipv4_interface_names_win32(nameset& names) {
   delete[] buf;
 }
 #elif defined ACE_HAS_GETIFADDRS
-void get_valid_ipv4_interface_names_getifaddrs(nameset& names) {
-  struct ifaddrs *ifap = 0;
-  struct ifaddrs *p_if = 0;
+void
+get_valid_ipv4_interface_names_getifaddrs (nameset &names)
+{
+  ifaddrs *ifap = 0;
+  ifaddrs *p_if = 0;
 
   if (::getifaddrs (&ifap) != 0)
     return;
@@ -81,12 +85,11 @@ void get_valid_ipv4_interface_names_getifaddrs(nameset& names) {
       if (p_if->ifa_flags & IFF_MULTICAST &&
           p_if->ifa_addr->sa_family == AF_INET)
         {
-          struct sockaddr_in *addr =
-            reinterpret_cast<sockaddr_in *> (p_if->ifa_addr);
+          sockaddr_in *addr = reinterpret_cast<sockaddr_in *> (p_if->ifa_addr);
 
           if (addr->sin_addr.s_addr != INADDR_ANY)
             {
-              names.insert(ACE_TEXT_CHAR_TO_TCHAR(p_if->ifa_name));
+              names.insert (ACE_TEXT_CHAR_TO_TCHAR (p_if->ifa_name));
             }
         }
     }
@@ -95,18 +98,22 @@ void get_valid_ipv4_interface_names_getifaddrs(nameset& names) {
 }
 #endif
 
-void get_valid_ipv4_interface_names(nameset& names) {
+void
+get_valid_ipv4_interface_names (nameset &names)
+{
 #ifdef ACE_WIN32
-get_valid_ipv4_interface_names_win32(names);
+  get_valid_ipv4_interface_names_win32 (names);
 #elif defined ACE_HAS_GETIFADDRS
-get_valid_ipv4_interface_names_getifaddrs(names);
+  get_valid_ipv4_interface_names_getifaddrs (names);
 #endif
 }
 
 #ifdef ACE_HAS_IPV6
 #ifdef ACE_WIN32
-void get_valid_ipv6_interface_names_win32(nameset& names) {
-  names.clear();
+void
+get_valid_ipv6_interface_names_win32 (nameset &names)
+{
+  names.clear ();
 
   // Initial call to determine actual memory size needed
   IP_ADAPTER_ADDRESSES tmp_addrs;
@@ -134,7 +141,7 @@ void get_valid_ipv6_interface_names_win32(nameset& names) {
           LPSOCKADDR sa = pUnicast->Address.lpSockaddr;
           if (sa->sa_family == AF_INET6)
             {
-              names.insert(ACE_TEXT_WCHAR_TO_TCHAR(pAddrs->FriendlyName));
+              names.insert (ACE_TEXT_WCHAR_TO_TCHAR (pAddrs->FriendlyName));
             }
         }
       pAddrs = pAddrs->Next;
@@ -143,9 +150,11 @@ void get_valid_ipv6_interface_names_win32(nameset& names) {
   delete[] buf;
 }
 #elif defined ACE_HAS_GETIFADDRS
-void get_valid_ipv6_interface_names_getifaddrs(nameset& names) {
-  struct ifaddrs *ifap = 0;
-  struct ifaddrs *p_if = 0;
+void
+get_valid_ipv6_interface_names_getifaddrs (nameset &names)
+{
+  ifaddrs *ifap = 0;
+  ifaddrs *p_if = 0;
 
   if (::getifaddrs (&ifap) != 0)
     return;
@@ -155,12 +164,11 @@ void get_valid_ipv6_interface_names_getifaddrs(nameset& names) {
       if (p_if->ifa_flags & IFF_MULTICAST &&
           p_if->ifa_addr->sa_family == AF_INET6)
         {
-          struct sockaddr_in6 *addr =
-            reinterpret_cast<sockaddr_in6 *> (p_if->ifa_addr);
+          sockaddr_in6 *addr = reinterpret_cast<sockaddr_in6 *> (p_if->ifa_addr);
 
-          if (!IN6_IS_ADDR_UNSPECIFIED(&addr->sin6_addr))
+          if (!IN6_IS_ADDR_UNSPECIFIED (&addr->sin6_addr))
             {
-              names.insert(ACE_TEXT_CHAR_TO_TCHAR(p_if->ifa_name));
+              names.insert (ACE_TEXT_CHAR_TO_TCHAR (p_if->ifa_name));
             }
         }
     }
@@ -169,21 +177,25 @@ void get_valid_ipv6_interface_names_getifaddrs(nameset& names) {
 }
 #endif
 
-void get_valid_ipv6_interface_names(nameset& names) {
+void
+get_valid_ipv6_interface_names (nameset &names)
+{
 #ifdef ACE_WIN32
-get_valid_ipv6_interface_names_win32(names);
+  get_valid_ipv6_interface_names_win32 (names);
 #elif defined ACE_HAS_GETIFADDRS
-get_valid_ipv6_interface_names_getifaddrs(names);
+  get_valid_ipv6_interface_names_getifaddrs (names);
 #endif
 }
 #endif /* ACE_HAS_IPV6 */
 
-int create_socket_and_join_multicast(const ACE_INET_Addr& mc_addr, const ACE_TString& if_name) {
+int
+create_socket_and_join_multicast (const ACE_INET_Addr &mc_addr, const ACE_TString &if_name)
+{
   int result = 0;
   ACE_SOCK_Dgram_Mcast sock;
-  sock.opts(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO | ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
-  result = sock.join(mc_addr, 1, if_name.empty() ? 0 : if_name.c_str());
-  result |= sock.close();
+  sock.opts (ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO | ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
+  result = sock.join (mc_addr, 1, if_name.empty () ? 0 : if_name.c_str ());
+  result |= sock.close ();
   return result;
 }
 
@@ -203,21 +215,23 @@ run_main (int, ACE_TCHAR *[])
 
   nameset names;
 
-  get_valid_ipv4_interface_names(names);
-  ACE_INET_Addr ipv4_mc_addr("239.255.0.7:1234", AF_INET);
-  result |= create_socket_and_join_multicast(ipv4_mc_addr, ACE_TString());
-  for (nameset::const_iterator it = names.begin(); result == 0 && it != names.end(); ++it) {
-    result |= create_socket_and_join_multicast(ipv4_mc_addr, *it);
-  }
+  get_valid_ipv4_interface_names (names);
+  ACE_INET_Addr ipv4_mc_addr ("239.255.0.7:1234", AF_INET);
+  result |= create_socket_and_join_multicast (ipv4_mc_addr, ACE_TString ());
+  for (nameset::const_iterator it = names.begin (); result == 0 && it != names.end (); ++it)
+    {
+      result |= create_socket_and_join_multicast (ipv4_mc_addr, *it);
+    }
 
 #ifdef ACE_HAS_IPV6
-  names.clear();
-  get_valid_ipv6_interface_names(names);
-  ACE_INET_Addr ipv6_mc_addr("ff03::7:4321", AF_INET6);
-  result |= create_socket_and_join_multicast(ipv6_mc_addr, ACE_TString());
-  for (nameset::const_iterator it = names.begin(); result == 0 && it != names.end(); ++it) {
-    result |= create_socket_and_join_multicast(ipv6_mc_addr, *it);
-  }
+  names.clear ();
+  get_valid_ipv6_interface_names (names);
+  ACE_INET_Addr ipv6_mc_addr ("ff03::7:4321", AF_INET6);
+  result |= create_socket_and_join_multicast (ipv6_mc_addr, ACE_TString ());
+  for (nameset::const_iterator it = names.begin (); result == 0 && it != names.end (); ++it)
+    {
+      result |= create_socket_and_join_multicast (ipv6_mc_addr, *it);
+    }
 #endif /* ACE_HAS_IPV6 */
 
   ACE_END_TEST;

--- a/ACE/tests/Multicast_Interfaces_Test.cpp
+++ b/ACE/tests/Multicast_Interfaces_Test.cpp
@@ -2,21 +2,16 @@
 
 //=============================================================================
 /**
- *  @file    Enum_Interfaces_Test.cpp
+ *  @file    Multicast_Interfaces_Test.cpp
  *
- *   This is a simple test of <ACE::get_ip_interfaces>.  This call
- *   retrieves the IP addresses assigned to the host by
- *   interrogating the kernel.  Network applications typically
- *   assume gethostbyname(uname()) will work, but this is just a
- *   convention. It is also problematic if the resolver code
- *   (DNS/NIS+...) is misconfigured. This happens more than
- *   programmers realize. It is better to find out by asking the
- *   kernel for local address assignments. This API is similar to
- *   what netstat -ni or ifconfig -a produces on UNIX or ipconfig on
- *   Windows NT. In fact, it was by reverse engineering these tools
- *   that this api was created.
+ *   This is a sanity-check test of ACE_SOCK_Dgram_Mcast::join by
+ *   interface name on platforms that support it.
+ *   It retrieves the valid local interface names and attempts to
+ *   perform a multicast join on all interfaces and then on each
+ *   individual interface separately. If IPv6 is enabled, it will
+ *   attempt to join on an IPv6 multicast address as well.
  *
- *  @author Michael R. MacFaden <mrm@cisco.com>
+ *  @author Timothy Simpson <simpsont@objectcomputing.com>
  */
 //=============================================================================
 

--- a/ACE/tests/Multicast_Interfaces_Test.cpp
+++ b/ACE/tests/Multicast_Interfaces_Test.cpp
@@ -1,0 +1,182 @@
+/* -*- C++ -*- */
+
+//=============================================================================
+/**
+ *  @file    Enum_Interfaces_Test.cpp
+ *
+ *   This is a simple test of <ACE::get_ip_interfaces>.  This call
+ *   retrieves the IP addresses assigned to the host by
+ *   interrogating the kernel.  Network applications typically
+ *   assume gethostbyname(uname()) will work, but this is just a
+ *   convention. It is also problematic if the resolver code
+ *   (DNS/NIS+...) is misconfigured. This happens more than
+ *   programmers realize. It is better to find out by asking the
+ *   kernel for local address assignments. This API is similar to
+ *   what netstat -ni or ifconfig -a produces on UNIX or ipconfig on
+ *   Windows NT. In fact, it was by reverse engineering these tools
+ *   that this api was created.
+ *
+ *  @author Michael R. MacFaden <mrm@cisco.com>
+ */
+//=============================================================================
+
+#include "test_config.h"
+
+#include "ace/OS_Memory.h"
+#include "ace/OS_NS_sys_utsname.h"
+#include "ace/SOCK_Dgram_Mcast.h"
+#include "ace/SString.h"
+
+#include <set>
+#include <string>
+
+typedef std::set<ACE_TString> nameset;
+
+#ifdef ACE_WIN32
+void get_valid_ipv4_interface_names_win32(nameset& names) {
+  names.clear();
+
+  // Initial call to determine actual memory size needed
+  IP_ADAPTER_ADDRESSES tmp_addrs;
+  ULONG bufLen = 0;
+  if (GetAdaptersAddresses (AF_INET, 0, 0, &tmp_addrs, &bufLen) != ERROR_BUFFER_OVERFLOW)
+    {
+      return;
+    }
+
+  // Get required output buffer and retrieve info for real.
+  char *buf = 0;
+  ACE_NEW (buf, char[bufLen]);
+  PIP_ADAPTER_ADDRESSES pAddrs = reinterpret_cast<PIP_ADAPTER_ADDRESSES> (buf);
+  if (::GetAdaptersAddresses (AF_INET, 0, 0, pAddrs, &bufLen) != NO_ERROR)
+    {
+      delete[] buf;
+      return;
+    }
+
+  while (pAddrs)
+    {
+      if (!pAddrs->NoMulticast)
+        {
+          PIP_ADAPTER_UNICAST_ADDRESS_LH pUnicast = pAddrs->FirstUnicastAddress;
+          LPSOCKADDR sa = pUnicast->Address.lpSockaddr;
+          if (sa->sa_family == AF_INET)
+            {
+              names.insert(ACE_TEXT_WCHAR_TO_TCHAR(pAddrs->FriendlyName));
+            }
+        }
+      pAddrs = pAddrs->Next;
+    }
+
+  delete[] buf;
+}
+#elif defined ACE_HAS_GETIFADDRS
+void get_valid_ipv4_interface_names_getifaddrs(nameset& names) {
+}
+#endif
+
+void get_valid_ipv4_interface_names(nameset& names) {
+#ifdef ACE_WIN32
+get_valid_ipv4_interface_names_win32(names);
+#elif defined ACE_HAS_GETIFADDRS
+get_valid_ipv4_interface_names_getifaddrs(names);
+#endif
+}
+
+#ifdef ACE_HAS_IPV6
+#ifdef ACE_WIN32
+void get_valid_ipv6_interface_names_win32(nameset& names) {
+  names.clear();
+
+  // Initial call to determine actual memory size needed
+  IP_ADAPTER_ADDRESSES tmp_addrs;
+  ULONG bufLen = 0;
+  if (GetAdaptersAddresses (AF_INET, 0, 0, &tmp_addrs, &bufLen) != ERROR_BUFFER_OVERFLOW)
+    {
+      return;
+    }
+
+  // Get required output buffer and retrieve info for real.
+  char *buf = 0;
+  ACE_NEW (buf, char[bufLen]);
+  PIP_ADAPTER_ADDRESSES pAddrs = reinterpret_cast<PIP_ADAPTER_ADDRESSES> (buf);
+  if (::GetAdaptersAddresses (AF_INET6, 0, 0, pAddrs, &bufLen) != NO_ERROR)
+    {
+      delete[] buf;
+      return;
+    }
+
+  while (pAddrs)
+    {
+      if (!pAddrs->NoMulticast)
+        {
+          PIP_ADAPTER_UNICAST_ADDRESS_LH pUnicast = pAddrs->FirstUnicastAddress;
+          LPSOCKADDR sa = pUnicast->Address.lpSockaddr;
+          if (sa->sa_family == AF_INET6)
+            {
+              names.insert(ACE_TEXT_WCHAR_TO_TCHAR(pAddrs->FriendlyName));
+            }
+        }
+      pAddrs = pAddrs->Next;
+    }
+
+  delete[] buf;
+}
+#elif defined ACE_HAS_GETIFADDRS
+void get_valid_ipv6_interface_names_getifaddrs(nameset& names) {
+}
+#endif
+
+void get_valid_ipv6_interface_names(nameset& names) {
+#ifdef ACE_WIN32
+get_valid_ipv6_interface_names_win32(names);
+#elif defined ACE_HAS_GETIFADDRS
+get_valid_ipv6_interface_names_getifaddrs(names);
+#endif
+}
+#endif /* ACE_HAS_IPV6 */
+
+int create_socket_and_join_multicast(const ACE_INET_Addr& mc_addr, const ACE_TString& if_name) {
+  int result = 0;
+  ACE_SOCK_Dgram_Mcast sock;
+  sock.opts(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO | ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
+  result = sock.join(mc_addr, 1, if_name.empty() ? 0 : if_name.c_str());
+  result |= sock.close();
+  return result;
+}
+
+int
+run_main (int, ACE_TCHAR *[])
+{
+  ACE_START_TEST (ACE_TEXT ("Multicast_Interfaces_Test"));
+
+  int result = 0;
+
+  ACE_utsname uname;
+  ACE_OS::uname (&uname);
+  ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("Machine: %C running on %C\n"),
+              uname.nodename, uname.machine ));
+  ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("Platform: %C, %C, %C\n"),
+              uname.sysname, uname.release, uname.version ));
+
+  nameset names;
+
+  get_valid_ipv4_interface_names(names);
+  ACE_INET_Addr ipv4_mc_addr("239.255.0.7:1234", AF_INET);
+  result |= create_socket_and_join_multicast(ipv4_mc_addr, ACE_TString());
+  for (nameset::const_iterator it = names.begin(); result == 0 && it != names.end(); ++it) {
+    result |= create_socket_and_join_multicast(ipv4_mc_addr, *it);
+  }
+
+#ifdef ACE_HAS_IPV6
+  get_valid_ipv6_interface_names(names);
+  ACE_INET_Addr ipv6_mc_addr("ff03::7:4321", AF_INET6);
+  result |= create_socket_and_join_multicast(ipv6_mc_addr, ACE_TString());
+  for (nameset::const_iterator it = names.begin(); result == 0 && it != names.end(); ++it) {
+    result |= create_socket_and_join_multicast(ipv6_mc_addr, *it);
+  }
+#endif /* ACE_HAS_IPV6 */
+
+  ACE_END_TEST;
+  return result;
+}

--- a/ACE/tests/Multicast_Interfaces_Test.cpp
+++ b/ACE/tests/Multicast_Interfaces_Test.cpp
@@ -30,7 +30,7 @@
 
 typedef std::set<ACE_TString> nameset;
 
-#ifdef ACE_WIN32
+#if defined (ACE_WIN32)
 void
 get_valid_ipv4_interface_names_win32 (nameset &names)
 {
@@ -70,7 +70,7 @@ get_valid_ipv4_interface_names_win32 (nameset &names)
 
   delete[] buf;
 }
-#elif defined ACE_HAS_GETIFADDRS
+#elif defined (ACE_HAS_GETIFADDRS)
 void
 get_valid_ipv4_interface_names_getifaddrs (nameset &names)
 {
@@ -96,20 +96,20 @@ get_valid_ipv4_interface_names_getifaddrs (nameset &names)
 
   ::freeifaddrs (ifap);
 }
-#endif
+#endif /* ACE_WIN32 */
 
 void
 get_valid_ipv4_interface_names (nameset &names)
 {
-#ifdef ACE_WIN32
+#if defined (ACE_WIN32)
   get_valid_ipv4_interface_names_win32 (names);
-#elif defined ACE_HAS_GETIFADDRS
+#elif defined (ACE_HAS_GETIFADDRS)
   get_valid_ipv4_interface_names_getifaddrs (names);
-#endif
+#endif /* ACE_WIN32 */
 }
 
-#ifdef ACE_HAS_IPV6
-#ifdef ACE_WIN32
+#if defined (ACE_HAS_IPV6)
+#if defined (ACE_WIN32)
 void
 get_valid_ipv6_interface_names_win32 (nameset &names)
 {
@@ -149,7 +149,7 @@ get_valid_ipv6_interface_names_win32 (nameset &names)
 
   delete[] buf;
 }
-#elif defined ACE_HAS_GETIFADDRS
+#elif defined (ACE_HAS_GETIFADDRS)
 void
 get_valid_ipv6_interface_names_getifaddrs (nameset &names)
 {
@@ -175,16 +175,16 @@ get_valid_ipv6_interface_names_getifaddrs (nameset &names)
 
   ::freeifaddrs (ifap);
 }
-#endif
+#endif /*ACE_WIN32 */
 
 void
 get_valid_ipv6_interface_names (nameset &names)
 {
-#ifdef ACE_WIN32
+#if defined (ACE_WIN32)
   get_valid_ipv6_interface_names_win32 (names);
-#elif defined ACE_HAS_GETIFADDRS
+#elif defined (ACE_HAS_GETIFADDRS)
   get_valid_ipv6_interface_names_getifaddrs (names);
-#endif
+#endif /* ACE_WIN32 */
 }
 #endif /* ACE_HAS_IPV6 */
 
@@ -223,7 +223,7 @@ run_main (int, ACE_TCHAR *[])
       result |= create_socket_and_join_multicast (ipv4_mc_addr, *it);
     }
 
-#ifdef ACE_HAS_IPV6
+#if defined (ACE_HAS_IPV6)
   names.clear ();
   get_valid_ipv6_interface_names (names);
   ACE_INET_Addr ipv6_mc_addr ("ff03::7:4321", AF_INET6);

--- a/ACE/tests/Multicast_Interfaces_Test.cpp
+++ b/ACE/tests/Multicast_Interfaces_Test.cpp
@@ -54,7 +54,7 @@ void get_valid_ipv4_interface_names_win32(nameset& names) {
 
   while (pAddrs)
     {
-      if (!pAddrs->NoMulticast)
+      if (pAddrs->OperStatus == IfOperStatusUp && !pAddrs->NoMulticast)
         {
           PIP_ADAPTER_UNICAST_ADDRESS_LH pUnicast = pAddrs->FirstUnicastAddress;
           LPSOCKADDR sa = pUnicast->Address.lpSockaddr;
@@ -128,7 +128,7 @@ void get_valid_ipv6_interface_names_win32(nameset& names) {
 
   while (pAddrs)
     {
-      if (!pAddrs->NoMulticast)
+      if (pAddrs->OperStatus == IfOperStatusUp && !pAddrs->NoMulticast)
         {
           PIP_ADAPTER_UNICAST_ADDRESS_LH pUnicast = pAddrs->FirstUnicastAddress;
           LPSOCKADDR sa = pUnicast->Address.lpSockaddr;

--- a/ACE/tests/run_test.lst
+++ b/ACE/tests/run_test.lst
@@ -167,6 +167,7 @@ Monotonic_Manual_Event_Test
 Monotonic_Message_Queue_Test: !ACE_FOR_TAO
 Monotonic_Task_Test: !ACE_FOR_TAO
 Multicast_Test: !ST !NO_MCAST !nsk !LynxOS !LabVIEW_RT
+Multicast_Interfaces_Test: !ST !NO_MCAST !nsk !LynxOS !LabVIEW_RT
 Multihomed_INET_Addr_Test: !ACE_FOR_TAO
 Naming_Test: !NO_OTHER !LynxOS !VxWorks !nsk !ACE_FOR_TAO !PHARLAP
 Network_Adapters_Test: !ACE_FOR_TAO

--- a/ACE/tests/tests.mpc
+++ b/ACE/tests/tests.mpc
@@ -1208,6 +1208,13 @@ project(Multicast Test) : acetest {
   }
 }
 
+project(Multicast Interfaces Test) : acetest {
+  exename = Multicast_Interfaces_Test
+  Source_Files {
+    Multicast_Interfaces_Test.cpp
+  }
+}
+
 project(Multihomed INET Addr Test) : acetest {
   avoids += ace_for_tao
   exename = Multihomed_INET_Addr_Test


### PR DESCRIPTION
Currently on windows, joining multicast by interface name doesn't work for IPV4 addresses (a bug) and it only worked for the name accepted by if_nametoindex() for IPV6 addresses, which aren't particularly user-friendly. A better way to handle this is to make use of GetAdaptersAddresses() and compare the provided interface name against either the adapter name or the friendly name, similarly to how the non-if_nametoindex windows version of the code handles things.

For IPV4, I've added a block to do this. For IPV6, I've pulled the existing ifdef'd code up to run before attempting to match via if_nametoindex, when either are applicable.