### PR TITLE
Removed define of ACE_LACKS_AUTO_PTR for C++17 in general, gcc doesn'…

### DIFF
--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -68,14 +68,6 @@ protected:
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_HAS_CPP17)
-// C++17 has removed std::auto_ptr but this is heavily used
-// in ACE and TAO tests so for the moment we are providing
-// our own auto_ptr implementation
-# define ACE_LACKS_AUTO_PTR
-# include <memory>
-#endif /* ACE_HAS_CPP17 */
-
 #if !defined (ACE_LACKS_AUTO_PTR) && \
      defined (ACE_HAS_STANDARD_CPP_LIBRARY) && \
             (ACE_HAS_STANDARD_CPP_LIBRARY != 0)


### PR DESCRIPTION
…t remove auto_ptr with C++17 so we have to do this specifically for a compiler who does remove std::auto_ptr with C++17

    * ACE/ace/Auto_Ptr.h: