### PR TITLE
Don't generate Visual Studio 2015 solutions as part of the release pr…

### DIFF
--- a/ACE/bin/make_release.py
+++ b/ACE/bin/make_release.py
@@ -861,7 +861,6 @@ def generate_workspaces (stage_dir):
     mpc_option = ' -recurse -hierarchy -relative ACE_ROOT=' + stage_dir + '/ACE_wrappers '
     mpc_option += ' -relative TAO_ROOT=' + stage_dir + '/ACE_wrappers/TAO '
     msvc_exclude_option = ' '
-    vc14_option = ' -name_modifier *_vc14 '
     vs2017_option = ' -name_modifier *_vs2017 '
     vs2019_option = ' -name_modifier *_vs2019 '
 
@@ -871,9 +870,6 @@ def generate_workspaces (stage_dir):
 
     print "\tGenerating GNUmakefiles...."
     ex (mpc_command + " -type gnuace " + exclude_option + workers_option + mpc_option + redirect_option)
-
-    print "\tGenerating VC14 solutions..."
-    ex (mpc_command + " -type vc14 "  + msvc_exclude_option + mpc_option + workers_option + vc14_option + redirect_option)
 
     print "\tGenerating VS2017 solutions..."
     ex (mpc_command + " -type vs2017 "  + msvc_exclude_option + mpc_option + workers_option + vs2017_option + redirect_option)


### PR DESCRIPTION
…ocess, now only 2017/2019 will be shipped by default

    * ACE/bin/make_release.py: