### PR TITLE
make_release.py: Use Branches for Latest 

### DIFF
--- a/ACE/bin/make_release.py
+++ b/ACE/bin/make_release.py
@@ -53,7 +53,7 @@ class ArgParser:
         else:
             options, arguments = self.real_parser.parse_args ()
             if arguments:
-                self.real_parser.error ("Extranous arguments: " + ' '.join(arguments))
+                self.real_parser.error ("Extraneous arguments: " + ' '.join(arguments))
         return options
 
 ##################################################
@@ -101,7 +101,7 @@ def parse_args ():
                        help="Create a micro release.", default=None, const="micro")
 
     parser.add_option ("--tag", dest="tag", action="store_true",
-                       help="Tag the repositorie with all needed tags", default=False)
+                       help="Update tags and branches of the repositories", default=False)
     parser.add_option ("--update", dest="update", action="store_true",
                        help="Update the version numbers", default=False)
     parser.add_option ("--push", dest="push", action="store_true",
@@ -219,8 +219,6 @@ def commit (files):
             ex ("cd $DOC_ROOT/ACE_TAO && git add " + file)
 
         ex ("cd $DOC_ROOT/ACE_TAO && git commit -m\"" + version + "\"")
-
-#        print "Checked in files, resuling in revision ", rev.number
 
 def check_workspace ():
     """ Checks that the DOC and MPC repositories are up to date.  """
@@ -742,7 +740,7 @@ def move_packages (name, stage_dir, package_dir):
 def create_file_lists (base_dir, prefix, exclude):
     """ Creates two lists of files:  files that need CR->CRLF
     conversions (useful for zip files) and those that don't,
-    excluding filies/directories found in exclude. """
+    excluding files/directories found in exclude. """
     import os
 
     text_files = list ()

--- a/ACE/docs/bczar/bczar.html
+++ b/ACE/docs/bczar/bczar.html
@@ -97,17 +97,17 @@
           Make sure your release system has all the needed tools. This can be achieved on Fedora
           using:
           <ul>
-            <li><code>yum install perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool GitPython</code></li>
+            <li><code>yum install perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool GitPython python3</code></li>
             <li><code>yum update</code></li>
           </ul>
           or on OpenSuSE
           <ul>
-            <li><code>zypper install perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool python-gitpython</code></li>
+            <li><code>zypper install perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool python-gitpython python3</code></li>
             <li><code>zypper update</code></li>
           </ul>
           If you want to perform a full build with qt support, than run:
           <ul>
-            <li><code>yum install deltarpm ntp rubygem-rmagick bison xerces-c-devel psmisc yum-utils gdb unzip glibc-devel libasan bison redhat-lsb perl-Pod-Usage rubygems clang make patch libcgroup-devel ant setuptool system-config-network-tui system-config-firewall-tui lcov gnuplot java-1.8.0-openjdk perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool gcc-c++ boost-devel valgrind openssl-devel gcc qt4 fltk-devel bzip2-devel rsync openssl lzo-devel zziplib-devel acpid acpi nfs-utils java xerces-c xerces-c-devel mc qt qt-devel icecream ruby ruby-devel lksctp-tools-devel git telnet GitPython NetworkManager wget mailx</code></li>
+            <li><code>yum install deltarpm ntp rubygem-rmagick bison xerces-c-devel psmisc yum-utils gdb unzip glibc-devel libasan bison redhat-lsb perl-Pod-Usage rubygems clang make patch libcgroup-devel ant setuptool system-config-network-tui system-config-firewall-tui lcov gnuplot java-1.8.0-openjdk perl screen automake doxygen bzip2 tar gzip openssh graphviz zip libtool gcc-c++ boost-devel valgrind openssl-devel gcc qt4 fltk-devel bzip2-devel rsync openssl lzo-devel zziplib-devel acpid acpi nfs-utils java xerces-c xerces-c-devel mc qt qt-devel icecream ruby ruby-devel lksctp-tools-devel git telnet GitPython NetworkManager wget mailx python3</code></li>
           </ul>
           For some optional i686 packages run
           <ul>


### PR DESCRIPTION
Part of Fix for #940

Assume `Latest_Major`, `Latest_Minor`, and `Latest_Micro`/`Latest_Beta` and the MPC equivalents are branches instead of tags.

The other part of the fix is actually changing the tags into branches.

Also updated the script to work with Python 3 (it still should work with Python 2.7 though), and tried to do some future proofing, mostly by wrapping the argument parser, because `optparse` is deprecated.

Also did some clean up. Simplifying some code, and using more normal Python patterns.

Use of non read-only global variables should be eliminated, because it's unusual to use them in Python, at least nowadays. I started to do this, but back tracked, because it was taking longer to do so than I would've liked to spend on it.