### PR TITLE
Export TAO::ORB::default_svc_conf_entries so that it can be used according to t…

### DIFF
--- a/ACE/ace/ARGV.h
+++ b/ACE/ace/ARGV.h
@@ -55,6 +55,12 @@ public:
    */
   ACE_ARGV_Queue_Entry_T (const ACE_ARGV_Queue_Entry_T<CHAR_TYPE> &entry);
 
+#if defined (ACE_HAS_CPP11)
+  ACE_ARGV_Queue_Entry_T (ACE_ARGV_Queue_Entry_T&&) = default;
+  ACE_ARGV_Queue_Entry_T &operator = (const ACE_ARGV_Queue_Entry_T &) = default;
+  ACE_ARGV_Queue_Entry_T &operator = (ACE_ARGV_Queue_Entry_T &&)  = default;
+#endif /* ACE_HAS_CPP11 */
+
   /// We need this destructor to keep some compilers from complaining.
   /// It's just a no-op, however.
   ~ACE_ARGV_Queue_Entry_T (void);

--- a/TAO/docs/configurations.html
+++ b/TAO/docs/configurations.html
@@ -679,7 +679,7 @@ components. <P>
 
   <li><p>If you don't want the application users to worry about
       setting up or knowing about <code>svc.conf</code> files, you can
-      call <code>TAO_Internal::default_svc_conf_entries()</code>
+      call <code>TAO::ORB::default_svc_conf_entries()</code>
       before calling the first <code>ORB_init()</code> in your program
       to set up the default svc.conf entries.  In this case, if a TAO
       application cannot find a svc.conf file, it will configure TAO's
@@ -696,7 +696,7 @@ components. <P>
             <code>svc.conf</code> in the start-up directory will be
             evaluated, if one exist.
         <li>Default entries set by
-            <code>TAO_Internal::default_svc_conf_entries()</code>, if
+            <code>TAO::ORB::default_svc_conf_entries()</code>, if
             ones exist.
         <li>Default configuration as specified in <a
             href="Options.html">this document</a>.
@@ -706,7 +706,7 @@ components. <P>
       always the ones take effect.  For example, if you set the entries
       for <code>Resource_Factory</code> and
       <code>Server_Strategy_Factory</code> using
-      <code>TAO_Internal::default_svc_conf_entries()</code> in a
+      <code>TAO::ORB::default_svc_conf_entries()</code> in a
       program and you also have a file called <code>svc.conf</code>
       which has an entry for <code>Resource_Factory</code>.  This
       program will use the entry for <code>Resource_Factory</code> in

--- a/TAO/tao/TAO_Internal.cpp
+++ b/TAO/tao/TAO_Internal.cpp
@@ -544,9 +544,18 @@ TAO::ORB::default_svc_conf_entries (char const * rf_args,
                                     char const * ssf_args,
                                     char const * csf_args)
 {
-  resource_factory_args        = rf_args;
-  server_strategy_factory_args = ssf_args;
-  client_strategy_factory_args = csf_args;
+  if (rf_args)
+    {
+      resource_factory_args        = rf_args;
+    }
+  if (ssf_args)
+    {
+      server_strategy_factory_args = ssf_args;
+    }
+  if (csf_args)
+    {
+      client_strategy_factory_args = csf_args;
+    }
 }
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/TAO_Internal.h
+++ b/TAO/tao/TAO_Internal.h
@@ -75,8 +75,11 @@ namespace TAO
     int close_services (ACE_Intrusive_Auto_Ptr<ACE_Service_Gestalt> pcfg);
 
     /**
-     * Set default @c `svc.conf' content.
+     * Set default @c `svc.conf' content, only non-null values are set.
      * This function must be called before first ORB initialization.
+     * @arg rf_args Resource factory settings
+     * @arg ssf_args Server strategy factory settings
+     * @arg csf_args Client strategy factory settings
      */
     TAO_Export void default_svc_conf_entries (char const * rf_args,
                                               char const * ssf_args,

--- a/TAO/tao/TAO_Internal.h
+++ b/TAO/tao/TAO_Internal.h
@@ -15,6 +15,7 @@
 
 #include /**/ "ace/pre.h"
 
+#include /**/ "tao/TAO_Export.h"
 #include "tao/orbconf.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
@@ -34,18 +35,21 @@ namespace TAO
   /**
    * @namespace ORB
    *
-   * @brief This @c namespace encapsulates some private behaviors and
-   *        global data structures used internal to TAO.  No
-   *        application should EVER see them which is why they are not
+   * @brief This @c namespace encapsulates some behaviors and
+   *        global data structures used by TAO.
+   *        Only default_svc_conf_entries() is exported because it is
+   *        documented as a way for applications to setup default svc.conf
+   *        settings. The other operations are internal and
+   *        application should NEVER use them which is why they are not
    *        exported.
    */
   namespace ORB
   {
-
     /**
      * If never done it before, extract ACE Service Configurator arguments from the given
-     * argument vector, and initialize the _global_ configuration gestalt. Return value 0 means OK,
-     * -1 spells major trouble ...
+     * argument vector, and initialize the _global_ configuration gestalt.
+     * @retval 0 means OK,
+     * @retval -1 spells major trouble
      */
     int open_global_services (int argc, ACE_TCHAR** argv);
 
@@ -65,8 +69,8 @@ namespace TAO
      * only actually close things down on the last call.  It is fully
      * thread-safe.
      *
-     * @return @c 0 if successful, @c -1 with @c errno set if
-     *         failure.
+     * @retval 0 if successful
+     * @retval -1 failure with @c errno set
      */
     int close_services (ACE_Intrusive_Auto_Ptr<ACE_Service_Gestalt> pcfg);
 
@@ -74,12 +78,12 @@ namespace TAO
      * Set default @c `svc.conf' content.
      * This function must be called before first ORB initialization.
      */
-    void default_svc_conf_entries (char const * rf_args,
-                                   char const * ssf_args,
-                                   char const * csf_args);
-
+    TAO_Export void default_svc_conf_entries (char const * rf_args,
+                                              char const * ssf_args,
+                                              char const * csf_args);
   }
 }
+
 TAO_END_VERSIONED_NAMESPACE_DECL
 
 #include /**/ "ace/post.h"


### PR DESCRIPTION
…he documentation, fixes debian bug #628571

    * TAO/docs/configurations.html:
    * TAO/tao/TAO_Internal.h: