### PR TITLE
Remove fast_memcpy, according to the related documentation it could b…

### DIFF
--- a/ACE/ace/OS_NS_string.cpp
+++ b/ACE/ace/OS_NS_string.cpp
@@ -278,37 +278,6 @@ ACE_OS::strnstr (const ACE_WCHAR_T *s1, const ACE_WCHAR_T *s2, size_t len2)
   return 0;
 }
 
-#if defined (ACE_HAS_MEMCPY_LOOP_UNROLL)
-void *
-ACE_OS::fast_memcpy (void *t, const void *s, size_t len)
-{
-  unsigned char* to = static_cast<unsigned char*> (t) ;
-  const unsigned char* from = static_cast<const unsigned char*> (s) ;
-  // Unroll the loop...
-  switch (len)
-    {
-    case 16: to[15] = from[15];
-    case 15: to[14] = from[14];
-    case 14: to[13] = from[13];
-    case 13: to[12] = from[12];
-    case 12: to[11] = from[11];
-    case 11: to[10] = from[10];
-    case 10: to[9] = from[9];
-    case  9: to[8] = from[8];
-    case  8: to[7] = from[7];
-    case  7: to[6] = from[6];
-    case  6: to[5] = from[5];
-    case  5: to[4] = from[4];
-    case  4: to[3] = from[3];
-    case  3: to[2] = from[2];
-    case  2: to[1] = from[1];
-    case  1: to[0] = from[0];
-    case  0: return t;
-    default: return ::memcpy (t, s, len);
-    }
-}
-#endif /* ACE_HAS_MEMCPY_LOOP_UNROLL */
-
 #if defined (ACE_LACKS_STRRCHR)
 char *
 ACE_OS::strrchr_emulation (char *s, int c)

--- a/ACE/ace/OS_NS_string.h
+++ b/ACE/ace/OS_NS_string.h
@@ -67,16 +67,6 @@ namespace ACE_OS {
   ACE_NAMESPACE_INLINE_FUNCTION
   void *memcpy (void *t, const void *s, size_t len);
 
-#if defined (ACE_HAS_MEMCPY_LOOP_UNROLL)
-/*
- * Version of memcpy where the copy loop is unrolled.
- * On certain platforms this results in better performance.
- * This is determined and set via autoconf.
- */
-  extern ACE_Export
-  void *fast_memcpy (void *t, const void *s, size_t len);
-#endif
-
   /// Moves one buffer to another.
   ACE_NAMESPACE_INLINE_FUNCTION
   void *memmove (void *t, const void *s, size_t len);

--- a/ACE/ace/OS_NS_string.inl
+++ b/ACE/ace/OS_NS_string.inl
@@ -33,11 +33,7 @@ ACE_OS::memcmp (const void *t, const void *s, size_t len)
 ACE_INLINE void *
 ACE_OS::memcpy (void *t, const void *s, size_t len)
 {
-#if defined (ACE_HAS_MEMCPY_LOOP_UNROLL)
-  return fast_memcpy (t, s, len);
-#else
   return ::memcpy (t, s, len);
-#endif /* ACE_HAS_MEMCPY_LOOP_UNROLL */
 }
 
 ACE_INLINE void *

--- a/ACE/ace/config-kfreebsd.h
+++ b/ACE/ace/config-kfreebsd.h
@@ -117,10 +117,6 @@
 /* Define to 1 if platform has memchr(). */
 #define ACE_HAS_MEMCHR 1
 
-/* Define to 1 if unrolled ACE_OS::fast_memcpy() is faster than system
-   memcpy() */
-#define ACE_HAS_MEMCPY_LOOP_UNROLL 1
-
 /* Define to 1 if platform has mkdir(). */
 #define ACE_HAS_MKDIR 1
 


### PR DESCRIPTION
…e enabled by autoconf which we don't support anymore

    * ACE/ace/OS_NS_string.cpp:
    * ACE/ace/OS_NS_string.h:
    * ACE/ace/OS_NS_string.inl:
    * ACE/ace/config-kfreebsd.h: