### PR TITLE
Removed memchr emulation, not used anymore by any platform config file

### DIFF
--- a/ACE/ace/OS_NS_string.cpp
+++ b/ACE/ace/OS_NS_string.cpp
@@ -14,23 +14,6 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_LACKS_MEMCHR)
-const void *
-ACE_OS::memchr_emulation (const void *s, int c, size_t len)
-{
-  const unsigned char *t = (const unsigned char *) s;
-  const unsigned char *e = (const unsigned char *) s + len;
-
-  while (t < e)
-    if (((int) *t) == c)
-      return t;
-    else
-      ++t;
-
-  return 0;
-}
-#endif /* ACE_LACKS_MEMCHR */
-
 #if (defined (ACE_LACKS_STRDUP) && !defined (ACE_STRDUP_EQUIVALENT)) \
   || defined (ACE_HAS_STRDUP_EMULATION)
 char *

--- a/ACE/ace/OS_NS_string.h
+++ b/ACE/ace/OS_NS_string.h
@@ -53,12 +53,6 @@ namespace ACE_OS {
   ACE_NAMESPACE_INLINE_FUNCTION
   void *memchr (void *s, int c, size_t len);
 
-#if defined (ACE_LACKS_MEMCHR)
-  /// Emulated memchr - Finds a character in a buffer.
-  extern ACE_Export
-  const void *memchr_emulation (const void *s, int c, size_t len);
-#endif /* ACE_LACKS_MEMCHR */
-
   /// Compares two buffers.
   ACE_NAMESPACE_INLINE_FUNCTION
   int memcmp (const void *t, const void *s, size_t len);

--- a/ACE/ace/OS_NS_string.inl
+++ b/ACE/ace/OS_NS_string.inl
@@ -9,11 +9,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 ACE_INLINE const void *
 ACE_OS::memchr (const void *s, int c, size_t len)
 {
-#if !defined (ACE_LACKS_MEMCHR)
   return ::memchr (s, c, len);
-#else /* ACE_LACKS_MEMCHR */
-  return ACE_OS::memchr_emulation (s, c, len);
-#endif /* !ACE_LACKS_MEMCHR */
 }
 
 ACE_INLINE void *


### PR DESCRIPTION
    * ACE/ace/OS_NS_string.cpp:
    * ACE/ace/OS_NS_string.h:
    * ACE/ace/OS_NS_string.inl: