### PR TITLE
Remove Visual Studio 2015 as IDE for which we ship generated solution…

### DIFF
--- a/ACE/docs/Download.html
+++ b/ACE/docs/Download.html
@@ -83,7 +83,7 @@ case.  You may want to understand the DOC group's <A
 HREF="http://htmlpreview.github.com/?https://github.com/DOCGroup/ACE_TAO/blob/master/ACE/docs/ACE-bug-process.html">
 bug fixing policies</A> when you make this decision.  </P>The full
 packages do contain all sources with pre generated makefiles for GNU
-make, Visual Studio 2015/2017/2019. The
+make, Visual Studio 2017/2019. The
 sources-only packages just contain the source code, you have to generate
 your own makefiles with MPC.  </P>
 <P>


### PR DESCRIPTION
…s as part of the release

    * ACE/docs/Download.html: