### PR TITLE
Ensure correct variant of CORBA::is_nil gets called.

### DIFF
--- a/TAO/tao/Object.cpp
+++ b/TAO/tao/Object.cpp
@@ -345,7 +345,8 @@ CORBA::Object::is_nil_i (CORBA::Object_ptr obj)
 
   // If the profile length is zero for a non-evaluted IOR it is a
   // null-object.
-  if ((!obj->is_evaluated ()) && obj->ior ().profiles.length () == 0)
+  if ((!obj->is_evaluated ()) &&
+      obj->ior_ && obj->ior ().profiles.length () == 0)
     return true;
 
   // To accomodate new definitions.

--- a/TAO/tao/Object.h
+++ b/TAO/tao/Object.h
@@ -85,9 +85,7 @@ namespace CORBA
   typedef TAO_Pseudo_Var_T<Object> Object_var;
   typedef TAO_Pseudo_Out_T<Object> Object_out;
 
-  template<>
-  TAO_Export Boolean
-  is_nil<> (Object_ptr);
+  TAO_INLINE Boolean is_nil (Object_ptr);
 
   /**
    * @class Object

--- a/TAO/tao/Object.inl
+++ b/TAO/tao/Object.inl
@@ -3,10 +3,9 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // ****************************************************************
 
-template<>
 ACE_INLINE
 CORBA::Boolean
-CORBA::is_nil<> (CORBA::Object_ptr obj)
+CORBA::is_nil (CORBA::Object_ptr obj)
 {
   if (obj == 0)
     {


### PR DESCRIPTION
The template specialization for CORBA::is_nil was only called if the
passed-in type was an exact match for CORBA::Object_ptr, but not if
a pointer to a derived class was called. In those cases the generic
template was called instead. Use function overload instead of
template specialization.
Fixes issue #1203 