### PR TITLE
Create ACE_GCC_NO_RETURN, Add to ACE_OS::_exit

### DIFF
--- a/ACE/ace/OS_NS_stdlib.h
+++ b/ACE/ace/OS_NS_stdlib.h
@@ -100,10 +100,10 @@ namespace ACE_OS {
    */
   //@{
   ACE_NAMESPACE_INLINE_FUNCTION
-  void _exit (int status = 0);
+  void _exit (int status = 0) ACE_GCC_NO_RETURN;
 
   ACE_NAMESPACE_INLINE_FUNCTION
-  void abort (void);
+  void abort (void) ACE_GCC_NO_RETURN;
 
   /**
    * Register an at exit hook. The @a name can be used to analyze shutdown

--- a/ACE/ace/OS_NS_stdlib.inl
+++ b/ACE/ace/OS_NS_stdlib.inl
@@ -28,9 +28,9 @@ ACE_OS::_exit (int status)
 #elif defined (ACE_HAS_WINCE)
   ::TerminateProcess (::GetCurrentProcess (), status);
 #elif defined (ACE_MQX)
-   _mqx_exit (status);
+  _mqx_exit (status);
 #elif !defined (ACE_LACKS__EXIT)
-   ::_exit (status);
+  ::_exit (status);
 #else
   ACE_UNUSED_ARG (status);
 

--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -182,5 +182,9 @@
 #endif
 #endif /* ACE_HAS_THREADS */
 
+#if (__GNUC__ > 2) || ((__GNUC__ == 2) && (__GNUC_MINOR__ >= 5))
+#  define ACE_GCC_NO_RETURN __attribute__ ((__noreturn__))
+#endif
+
 #include /**/ "ace/post.h"
 #endif /* ACE_GNUG_COMMON_H */

--- a/ACE/ace/config-macros.h
+++ b/ACE/ace/config-macros.h
@@ -718,4 +718,8 @@ extern "C" u_long CLS##_Export _get_dll_unload_policy (void) \
 #  endif
 #endif
 
+#ifndef ACE_GCC_NO_RETURN
+#  define ACE_GCC_NO_RETURN
+#endif
+
 #endif /* ACE_CONFIG_MACROS_H */


### PR DESCRIPTION
To fix fallthrough warning in ACE.cpp. Also added to `ACE_OS::abort`.