### PR TITLE
Added test to confirm CORBA::is_nil works

### DIFF
--- a/TAO/bin/tao_orb_tests.lst
+++ b/TAO/bin/tao_orb_tests.lst
@@ -210,6 +210,7 @@ TAO/tests/Bug_4059_Regression/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MI
 TAO/tests/Bug_4082_Regression/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
 TAO/tests/Bug_4097_Regression/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
 TAO/tests/Bug_4213_Regression/run_test.pl: !Win32
+TAO/tests/CORBA_is_nil/run_test.pl:
 TAO/tests/DIOP/run_test.pl: !ST !NO_DIOP !ACE_FOR_TAO !CORBA_E_MICRO
 TAO/tests/DIOP/run_test_ipv6.pl: IPV6 !ST !NO_DIOP !ACE_FOR_TAO !CORBA_E_MICRO
 TAO/tests/RTCORBA/Activate_Object_Multiple_ORBs/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !ST

--- a/TAO/tests/CORBA_is_nil/.gitignore
+++ b/TAO/tests/CORBA_is_nil/.gitignore
@@ -1,0 +1,7 @@
+.obj
+.depend.CORBA_Is_Nil_Client
+.depend.CORBA_Is_Nil_Server
+.depend.CORBA_Is_Nil_idl
+.depend.CORBA_Is_Nil_idl_Idl1
+client
+server

--- a/TAO/tests/CORBA_is_nil/CORBA_is_nil.mpc
+++ b/TAO/tests/CORBA_is_nil/CORBA_is_nil.mpc
@@ -1,0 +1,33 @@
+// -*- MPC -*-
+project(*idl): taoidldefaults {
+  IDL_Files {
+    Test.idl
+  }
+  custom_only = 1
+}
+
+project(*Server): taoserver {
+  after += *idl
+  Source_Files {
+    Hello.cpp
+    server.cpp
+  }
+  Source_Files {
+    TestC.cpp
+    TestS.cpp
+  }
+  IDL_Files {
+  }
+}
+
+project(*Client): taoclient {
+  after += *idl
+  Source_Files {
+    client.cpp
+  }
+  Source_Files {
+    TestC.cpp
+  }
+  IDL_Files {
+  }
+}

--- a/TAO/tests/CORBA_is_nil/Hello.cpp
+++ b/TAO/tests/CORBA_is_nil/Hello.cpp
@@ -1,0 +1,24 @@
+#include "Hello.h"
+
+Hello::Hello (CORBA::ORB_ptr orb)
+  : orb_ (CORBA::ORB::_duplicate (orb))
+{
+}
+
+char *
+Hello::get_string ()
+{
+  return CORBA::string_dup ("Hello there!");
+}
+
+Test::Hello_ptr
+Hello::get_Hello ()
+{
+   return Test::Hello::_nil();
+}
+
+void
+Hello::shutdown ()
+{
+  this->orb_->shutdown (0);
+}

--- a/TAO/tests/CORBA_is_nil/Hello.h
+++ b/TAO/tests/CORBA_is_nil/Hello.h
@@ -1,0 +1,29 @@
+
+#ifndef HELLO_H
+#define HELLO_H
+#include /**/ "ace/pre.h"
+
+#include "TestS.h"
+
+/// Implement the Test::Hello interface
+class Hello
+  : public virtual POA_Test::Hello
+{
+public:
+  /// Constructor
+  Hello (CORBA::ORB_ptr orb);
+
+  // = The skeleton methods
+  virtual char * get_string ();
+  virtual Test::Hello_ptr get_Hello ();
+
+  virtual void shutdown ();
+
+private:
+  /// Use an ORB reference to convert strings to objects and shutdown
+  /// the application.
+  CORBA::ORB_var orb_;
+};
+
+#include /**/ "ace/post.h"
+#endif /* HELLO_H */

--- a/TAO/tests/CORBA_is_nil/README.md
+++ b/TAO/tests/CORBA_is_nil/README.md
@@ -15,7 +15,9 @@ produces the corrcet result.
 
 This test has the server return a nil object reference and the client
 uses lazy resource usage, to comfirm that CORBA::is_nil corrcetly
-identifies the nil object reference.
+identifies the nil object reference. See issue #1203, which pointed
+out that only CORBA::Object_ptr has a template specialization for
+CORBA::is_nil, but not derived interfaces.
 
 
 

--- a/TAO/tests/CORBA_is_nil/README.md
+++ b/TAO/tests/CORBA_is_nil/README.md
@@ -1,0 +1,21 @@
+# This test confirms that CORBA::is_nil works
+
+TAO implements `CORBA::is_nil` as a function template, which merely
+checks the argument for zero. The template is specialized for
+`CORBA::Object_ptr`, and this specialization additionally checks
+whether a non-NULL argument might be an unevaluated nil object
+reference.
+
+Because template specialization is used and not an ordinary overloaded
+function, the specialized variant is *not* called for pointers to
+derived classes. This will work only if TAO ensures that all nil
+object references that have been narrowed to a derived class are
+converted to null pointers, i.e., to ensure that the generic template
+produces the corrcet result.
+
+This test has the server return a nil object reference and the client
+uses lazy resource usage, to comfirm that CORBA::is_nil corrcetly
+identifies the nil object reference.
+
+
+

--- a/TAO/tests/CORBA_is_nil/Test.idl
+++ b/TAO/tests/CORBA_is_nil/Test.idl
@@ -1,0 +1,21 @@
+
+/// Put the interfaces in a module, to avoid global namespace pollution
+module Test
+{
+  /// A very simple interface
+  interface Hello
+  {
+    /// Return a simple string
+    string get_string ();
+
+    /// Return another instance (returns NULL object reference)
+    Hello get_Hello ();
+
+    /// A method to shutdown the ORB
+    /**
+     * This method is used to simplify the test shutdown process
+     */
+    oneway void shutdown ();
+//    void shutdown ();
+  };
+};

--- a/TAO/tests/CORBA_is_nil/Test.idl
+++ b/TAO/tests/CORBA_is_nil/Test.idl
@@ -16,6 +16,5 @@ module Test
      * This method is used to simplify the test shutdown process
      */
     oneway void shutdown ();
-//    void shutdown ();
   };
 };

--- a/TAO/tests/CORBA_is_nil/client.cpp
+++ b/TAO/tests/CORBA_is_nil/client.cpp
@@ -47,7 +47,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       if (CORBA::is_nil (hello.in ()))
       {
          ACE_ERROR_RETURN ((LM_DEBUG,
-                            "Nil Test::Hello reference <%s>\n",
+                            "Nil Test::Hello reference <%C>\n",
                             ior),
                            1);
       }
@@ -55,7 +55,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       CORBA::String_var the_string = hello->get_string ();
 
       ACE_DEBUG ((LM_DEBUG,
-                  "Hello from file IOR: %s\n",
+                  "Hello from file IOR: %C\n",
                   the_string.in()));
 
       Test::Hello_var helloRef = hello->get_Hello();
@@ -64,7 +64,21 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       {
          ACE_DEBUG ((LM_DEBUG,
                      ACE_TEXT("Correctly detected nil Object reference.\n")));
-         process_result = 0;
+         CORBA::Object_var var = CORBA::Object::_duplicate(helloRef.in());
+         if (CORBA::is_nil(var))
+         {
+            ACE_DEBUG ((LM_DEBUG,
+                        ACE_TEXT("Duplicated Object reference works too.\n")));
+            process_result = 0;
+         }
+         else
+         {
+            ACE_ERROR_RETURN ((LM_DEBUG,
+                               "ERROR:\n%C\n$%C\n",
+                               "CORBA::is_nil(Hello_ptr) returned false!"
+                               "CORBA::is_nil(Object_var) returned true!"),
+                              1);
+         }
       }
       else
       {
@@ -72,13 +86,13 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
          if (CORBA::is_nil(obj))
          {
             ACE_DEBUG ((LM_DEBUG,
-                        "ERROR (causes exception further down):\n%s\n$s\n",
+                        "ERROR (causes exception further down):\n%C\n%C\n",
                         "CORBA::is_nil(Hello_ptr) returned false!"
                         "CORBA::is_nil(Object_ptr) returned true!"));
          }
          CORBA::String_var aString = helloRef->get_string();
          ACE_DEBUG ((LM_DEBUG,
-                     "Received Hello: %s\n",
+                     "Received Hello: %C\n",
                      aString.in()));
       }
 

--- a/TAO/tests/CORBA_is_nil/client.cpp
+++ b/TAO/tests/CORBA_is_nil/client.cpp
@@ -1,9 +1,5 @@
 #include "TestC.h"
 #include "ace/Get_Opt.h"
-#include "tao/ORB_Core.h"
-#include "ace/Reactor.h"
-#include "ace/Event_Handler.h"
-#include <iostream>
 
 const ACE_TCHAR *ior = ACE_TEXT ("file://test.ior");
 

--- a/TAO/tests/CORBA_is_nil/client.cpp
+++ b/TAO/tests/CORBA_is_nil/client.cpp
@@ -58,13 +58,16 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
       CORBA::String_var the_string = hello->get_string ();
 
-      std::cout << "Hello from file IOR: " << the_string.in() << std::endl;
+      ACE_DEBUG ((LM_DEBUG,
+                  "Hello from file IOR: %s\n",
+                  the_string.in()));
 
       Test::Hello_var helloRef = hello->get_Hello();
 
       if (CORBA::is_nil(helloRef.in()))
       {
-         std::cout << "Correctly detected nil Object reference." << std::endl;
+         ACE_DEBUG ((LM_DEBUG,
+                     ACE_TEXT("Correctly detected nil Object reference.\n")));
          process_result = 0;
       }
       else
@@ -72,12 +75,15 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
          CORBA::Object_ptr obj = helloRef.in();
          if (CORBA::is_nil(obj))
          {
-            std::cout << "CORBA::is_nil(Hello_ptr) returned false!\n"
-                      << "CORBA::is_nil(Object_ptr) returned true!"
-                      << std::endl;
+            ACE_DEBUG ((LM_DEBUG,
+                        "ERROR (causes exception further down):\n%s\n$s\n",
+                        "CORBA::is_nil(Hello_ptr) returned false!"
+                        "CORBA::is_nil(Object_ptr) returned true!"));
          }
          CORBA::String_var aString = helloRef->get_string();
-         std::cout << "Received Hello: " << aString.in() << std::endl;
+         ACE_DEBUG ((LM_DEBUG,
+                     "Received Hello: %s\n",
+                     aString.in()));
       }
 
       hello->shutdown ();
@@ -92,4 +98,3 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   return process_result;
 }
-

--- a/TAO/tests/CORBA_is_nil/client.cpp
+++ b/TAO/tests/CORBA_is_nil/client.cpp
@@ -1,0 +1,95 @@
+#include "TestC.h"
+#include "ace/Get_Opt.h"
+#include "tao/ORB_Core.h"
+#include "ace/Reactor.h"
+#include "ace/Event_Handler.h"
+#include <iostream>
+
+const ACE_TCHAR *ior = ACE_TEXT ("file://test.ior");
+
+int process_result = 1;
+
+int parse_args (int argc, ACE_TCHAR *argv[])
+{
+ACE_Get_Opt get_opts (argc, argv, ACE_TEXT("f:"));
+  int c;
+
+  while ((c = get_opts ()) != -1)
+    switch (c)
+      {
+      case 'f':
+        ior = get_opts.opt_arg ();
+        break;
+
+      case '?':
+      default:
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           "usage:  %s "
+                           "-f <ior> "
+                           "\n",
+                           argv [0]),
+                          -1);
+      }
+  // Indicates successful parsing of the command line
+  return 0;
+}
+
+int
+ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb = CORBA::ORB_init (argc, argv);
+
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      CORBA::Object_var tmp = orb->string_to_object(ior);
+
+      Test::Hello_var hello = Test::Hello::_narrow(tmp.in ());
+
+      if (CORBA::is_nil (hello.in ()))
+      {
+         ACE_ERROR_RETURN ((LM_DEBUG,
+                            "Nil Test::Hello reference <%s>\n",
+                            ior),
+                           1);
+      }
+
+      CORBA::String_var the_string = hello->get_string ();
+
+      std::cout << "Hello from file IOR: " << the_string.in() << std::endl;
+
+      Test::Hello_var helloRef = hello->get_Hello();
+
+      if (CORBA::is_nil(helloRef.in()))
+      {
+         std::cout << "Correctly detected nil Object reference." << std::endl;
+         process_result = 0;
+      }
+      else
+      {
+         CORBA::Object_ptr obj = helloRef.in();
+         if (CORBA::is_nil(obj))
+         {
+            std::cout << "CORBA::is_nil(Hello_ptr) returned false!\n"
+                      << "CORBA::is_nil(Object_ptr) returned true!" 
+                      << std::endl;
+         }
+         CORBA::String_var aString = helloRef->get_string();
+         std::cout << "Received Hello: " << aString.in() << std::endl;
+      }
+
+      hello->shutdown ();
+
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception& ex)
+    {
+      ex._tao_print_exception ("Exception caught:");
+      return 1;
+    }
+
+  return process_result;
+}
+

--- a/TAO/tests/CORBA_is_nil/client.cpp
+++ b/TAO/tests/CORBA_is_nil/client.cpp
@@ -73,7 +73,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
          if (CORBA::is_nil(obj))
          {
             std::cout << "CORBA::is_nil(Hello_ptr) returned false!\n"
-                      << "CORBA::is_nil(Object_ptr) returned true!" 
+                      << "CORBA::is_nil(Object_ptr) returned true!"
                       << std::endl;
          }
          CORBA::String_var aString = helloRef->get_string();

--- a/TAO/tests/CORBA_is_nil/run_test.pl
+++ b/TAO/tests/CORBA_is_nil/run_test.pl
@@ -25,8 +25,20 @@ my $client_iorfile = $client->LocalFile ($iorbase);
 $server->DeleteFile($iorbase);
 $client->DeleteFile($iorbase);
 
+$conf_file = "svc$PerlACE::svcconf_ext";
+$client_conf = $client->LocalFile ($conf_file);
+
 $SV = $server->CreateProcess ("server", "-ORBdebuglevel $debug_level -o $server_iorfile");
-$CL = $client->CreateProcess ("client", "-ORBSvcConf svc.conf -ORBdebuglevel $debug_level -f file://$client_iorfile");
+
+# copy the configruation file.
+if ($client->PutFile ($conf_file) == -1) {
+    print STDERR "ERROR: cannot set file <$client_conf>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+$CL = $client->CreateProcess ("client", "-ORBSvcConf $client_conf -ORBdebuglevel $debug_level -f file://$client_iorfile");
+
 $server_status = $SV->Spawn ();
 
 if ($server_status != 0) {

--- a/TAO/tests/CORBA_is_nil/run_test.pl
+++ b/TAO/tests/CORBA_is_nil/run_test.pl
@@ -1,0 +1,75 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+
+# -*- perl -*-
+
+use lib "$ENV{ACE_ROOT}/bin";
+use PerlACE::TestTarget;
+
+$status = 0;
+$debug_level = '0';
+
+foreach $i (@ARGV) {
+    if ($i eq '-debug') {
+        $debug_level = '10';
+    }
+}
+
+my $server = PerlACE::TestTarget::create_target (1) || die "Create target 1 failed\n";
+my $client = PerlACE::TestTarget::create_target (2) || die "Create target 2 failed\n";
+
+my $iorbase = "server.ior";
+my $server_iorfile = $server->LocalFile ($iorbase);
+my $client_iorfile = $client->LocalFile ($iorbase);
+$server->DeleteFile($iorbase);
+$client->DeleteFile($iorbase);
+
+$SV = $server->CreateProcess ("server", "-ORBdebuglevel $debug_level -o $server_iorfile");
+$CL = $client->CreateProcess ("client", "-ORBSvcConf svc.conf -ORBdebuglevel $debug_level -f file://$client_iorfile");
+$server_status = $SV->Spawn ();
+
+if ($server_status != 0) {
+    print STDERR "ERROR: server returned $server_status\n";
+    exit 1;
+}
+
+if ($server->WaitForFileTimed ($iorbase,
+                               $server->ProcessStartWaitInterval()) == -1) {
+    print STDERR "ERROR: cannot find file <$server_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+if ($server->GetFile ($iorbase) == -1) {
+    print STDERR "ERROR: cannot retrieve file <$server_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+if ($client->PutFile ($iorbase) == -1) {
+    print STDERR "ERROR: cannot set file <$client_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+$client_status = $CL->SpawnWaitKill ($client->ProcessStartWaitInterval());
+
+if ($client_status != 0) {
+    print STDERR "ERROR: client returned $client_status\n";
+    $status = 1;
+}
+
+$server_status = $SV->WaitKill ($server->ProcessStopWaitInterval());
+
+if ($server_status != 0) {
+    print STDERR "ERROR: server returned $server_status\n";
+    $status = 1;
+}
+
+$server->GetStderrLog();
+$client->GetStderrLog();
+
+$server->DeleteFile($server_iorfile);
+$client->DeleteFile($client_iorfile);
+
+exit $status;

--- a/TAO/tests/CORBA_is_nil/server.cpp
+++ b/TAO/tests/CORBA_is_nil/server.cpp
@@ -1,0 +1,99 @@
+#include "Hello.h"
+#include "ace/Get_Opt.h"
+#include "ace/OS_NS_stdio.h"
+
+const ACE_TCHAR *ior_output_file = ACE_TEXT ("test.ior");
+
+int
+parse_args (int argc, ACE_TCHAR *argv[])
+{
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT("o:"));
+  int c;
+
+  while ((c = get_opts ()) != -1)
+    switch (c)
+      {
+      case 'o':
+        ior_output_file = get_opts.opt_arg ();
+        break;
+
+      case '?':
+      default:
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           "usage:  %s "
+                           "-o <iorfile>"
+                           "\n",
+                           argv [0]),
+                          -1);
+      }
+  // Indicates successful parsing of the command line
+  return 0;
+}
+
+int
+ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb =
+        CORBA::ORB_init (argc, argv);
+
+      CORBA::Object_var poa_object =
+        orb->resolve_initial_references("RootPOA");
+
+      PortableServer::POA_var root_poa =
+        PortableServer::POA::_narrow (poa_object.in ());
+
+      if (CORBA::is_nil (root_poa.in ()))
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           " (%P|%t) Panic: nil RootPOA\n"),
+                          1);
+
+      PortableServer::POAManager_var poa_manager = root_poa->the_POAManager ();
+
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      Hello *hello_impl = 0;
+      ACE_NEW_RETURN (hello_impl,
+                      Hello (orb.in ()),
+                      1);
+      PortableServer::ServantBase_var owner_transfer(hello_impl);
+
+      PortableServer::ObjectId_var id =
+        root_poa->activate_object (hello_impl);
+
+      CORBA::Object_var object = root_poa->id_to_reference (id.in ());
+
+      Test::Hello_var hello = Test::Hello::_narrow (object.in ());
+
+      CORBA::String_var ior = orb->object_to_string (hello.in ());
+
+      // Output the IOR to the <ior_output_file>
+      FILE *output_file= ACE_OS::fopen (ior_output_file, "w");
+      if (output_file == 0)
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           "Cannot open output file for writing IOR: %s\n",
+                           ior_output_file),
+                           1);
+      ACE_OS::fprintf (output_file, "%s", ior.in ());
+      ACE_OS::fclose (output_file);
+
+      poa_manager->activate ();
+
+      orb->run ();
+
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) server - event loop finished\n"));
+
+      root_poa->destroy (1, 1);
+
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception& ex)
+    {
+      ex._tao_print_exception ("Exception caught:");
+      return 1;
+    }
+
+  return 0;
+}

--- a/TAO/tests/CORBA_is_nil/svc.conf
+++ b/TAO/tests/CORBA_is_nil/svc.conf
@@ -1,0 +1,1 @@
+static Resource_Factory "-ORBResourceUsage lazy"


### PR DESCRIPTION
TAO only specializes Object_ptr, but not pointers derived from
Object, relying on narrowed nil object references having been
converted to NULL pointers. This test confirms that this works
even if the lazy resource mode is used.
This is related to issue #1203