### PR TITLE
Fix building DLL_Manager.cpp on AIX

### DIFF
--- a/ACE/ace/DLL_Manager.cpp
+++ b/ACE/ace/DLL_Manager.cpp
@@ -157,7 +157,7 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
                     }
                   open_mode |= RTLD_MEMBER;
 
-                  if (this->open_i (aix_pathname, open_mode))
+                  if (this->open_i (aix_pathname, open_mode, errors))
                     break;
                 }
 #endif /* AIX */


### PR DESCRIPTION
```shell
DLL_Manager.cpp: In member function 'int ACE_DLL_Handle::open(const ACE_TCHAR*, int, void*, ACE_DLL_Handle::ERROR_STACK*)':
DLL_Manager.cpp:160:60: error: no matching function for call to 'ACE_DLL_Handle::open_i(ACE_TCHAR [1025], int&)'
DLL_Manager.h:171:8: note: candidate is: bool ACE_DLL_Handle::open_i(const ACE_TCHAR*, int, ACE_DLL_Handle::ERROR_STACK*)
```