### PR TITLE
Revert "Use unspecified_bool_type instead of bool."

### DIFF
--- a/ACE/ace/Refcounted_Auto_Ptr.h
+++ b/ACE/ace/Refcounted_Auto_Ptr.h
@@ -44,10 +44,6 @@ template <class X, class ACE_LOCK> class ACE_Refcounted_Auto_Ptr;
 template <class X, class ACE_LOCK>
 class ACE_Refcounted_Auto_Ptr
 {
-  /// Used to define a proper boolean conversion for "if (sp) ..."
-  static void unspecified_bool(ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>***){};
-  typedef void (*unspecified_bool_type)(ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>***);
-
 public:
   /// Constructor that initializes an ACE_Refcounted_Auto_Ptr to
   /// the specified pointer value.
@@ -90,7 +86,7 @@ public:
   bool operator !() const;
 
   /// Check rep easily.
-  operator unspecified_bool_type() const;
+  operator bool () const;
 
   /// Releases the reference to the underlying representation object.
   /// @retval The pointer value prior to releasing it.

--- a/ACE/ace/Refcounted_Auto_Ptr.inl
+++ b/ACE/ace/Refcounted_Auto_Ptr.inl
@@ -128,9 +128,9 @@ ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>::operator !() const
 }
 
 template<class X, class ACE_LOCK> inline
-ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>::operator unspecified_bool_type () const
+ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>::operator bool () const
 {
-  return this->rep_->get () != 0 ? unspecified_bool : 0;
+  return this->rep_->get () != 0;
 }
 
 template <class X, class ACE_LOCK> inline X*


### PR DESCRIPTION
Reverts DOCGroup/ACE_TAO#995

Failed to compile with vc7.1

```
WIN32_Proactor.cpp
..\ace\Refcounted_Auto_Ptr.inl(131) : error C2833: 'operator unspecified_bool_type' is not a recognized operator or type
..\ace\Refcounted_Auto_Ptr.inl(134) : fatal error C1903: unable to recover from previous error(s); stopping compilation
```