### PR TITLE
No need for adding XSC_ROOT/MPC to dynamic_types

### DIFF
--- a/ACE/bin/MakeProjectCreator/config/MPC.cfg
+++ b/ACE/bin/MakeProjectCreator/config/MPC.cfg
@@ -1,3 +1,3 @@
 includes = $CIAO_ROOT/MPC/config, $DANCE_ROOT/MPC/config
-dynamic_types = $ACE_ROOT/bin/MakeProjectCreator, $?DDS_ROOT/MPC, $?TAO_ROOT/MPC, $?XSC_ROOT/MPC
+dynamic_types = $ACE_ROOT/bin/MakeProjectCreator, $?DDS_ROOT/MPC, $?TAO_ROOT/MPC
 main_functions = cplusplus:ACE_TMAIN


### PR DESCRIPTION
    * ACE/bin/MakeProjectCreator/config/MPC.cfg: