### PR TITLE
Removed setting of cidl, not used anymore for ACE/TAO

### DIFF
--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -949,7 +949,6 @@ EOF
 
 cat > $ACE_ROOT/bin/MakeProjectCreator/config/default.features <<EOF
 ssl=1
-cidl=0
 EOF
 
 %if %{?_with_bzip2:1}%{!?_with_bzip2:0}


### PR DESCRIPTION
    * ACE/rpmbuild/ace-tao.spec: