### PR TITLE
Fix server-side fragmentation

### DIFF
--- a/ACE/ace/CDR_Stream.h
+++ b/ACE/ace/CDR_Stream.h
@@ -165,7 +165,7 @@ public:
                  ACE_CDR::Octet giop_minor_version = ACE_CDR_GIOP_MINOR_VERSION);
 
   /// destructor
-  ~ACE_OutputCDR (void);
+  virtual ~ACE_OutputCDR (void);
 
   /**
    * Disambiguate overload when inserting booleans, octets, chars, and
@@ -523,20 +523,14 @@ public:
   void unregister_monitor (void);
 #endif /* ACE_HAS_MONITOR_POINTS==1 */
 
-private:
-  // Find the message block in the chain of message blocks
-  // that the provide location locates.
-  ACE_Message_Block* find (char* loc);
+protected:
 
-  /// disallow copying...
-  ACE_OutputCDR (const ACE_OutputCDR& rhs);
-  ACE_OutputCDR& operator= (const ACE_OutputCDR& rhs);
-
-  ACE_CDR::Boolean write_1 (const ACE_CDR::Octet *x);
-  ACE_CDR::Boolean write_2 (const ACE_CDR::UShort *x);
-  ACE_CDR::Boolean write_4 (const ACE_CDR::ULong *x);
-  ACE_CDR::Boolean write_8 (const ACE_CDR::ULongLong *x);
-  ACE_CDR::Boolean write_16 (const ACE_CDR::LongDouble *x);
+  // These are virtual to support GIOP fragmentation at the TAO layer.
+  virtual ACE_CDR::Boolean write_1 (const ACE_CDR::Octet *x);
+  virtual ACE_CDR::Boolean write_2 (const ACE_CDR::UShort *x);
+  virtual ACE_CDR::Boolean write_4 (const ACE_CDR::ULong *x);
+  virtual ACE_CDR::Boolean write_8 (const ACE_CDR::ULongLong *x);
+  virtual ACE_CDR::Boolean write_16 (const ACE_CDR::LongDouble *x);
 
   /**
    * write an array of @a length elements, each of @a size bytes and the
@@ -549,12 +543,26 @@ private:
    * but for several elements @c memcpy should be more efficient, it
    * could be interesting to find the break even point and optimize
    * for that case, but that would be too platform dependent.
+   * 
+   * This is virtual to support GIOP fragmentation at the TAO layer.
    */
-  ACE_CDR::Boolean write_array (const void *x,
-                                size_t size,
-                                size_t align,
-                                ACE_CDR::ULong length);
+  virtual ACE_CDR::Boolean write_array (const void *x,
+                                        size_t size,
+                                        size_t align,
+                                        ACE_CDR::ULong length);
 
+  // Overrides of the above functions may need to set this bit.
+  void good_bit (bool bit) { good_bit_ = bit; }
+
+private:
+
+  // Find the message block in the chain of message blocks
+  // that the provide location locates.
+  ACE_Message_Block* find (char* loc);
+
+  /// disallow copying...
+  ACE_OutputCDR (const ACE_OutputCDR& rhs);
+  ACE_OutputCDR& operator= (const ACE_OutputCDR& rhs);
 
   ACE_CDR::Boolean write_wchar_array_i (const ACE_CDR::WChar* x,
                                         ACE_CDR::ULong length);

--- a/TAO/tao/CDR.h
+++ b/TAO/tao/CDR.h
@@ -188,6 +188,7 @@ public:
    */
   bool fragment_stream (ACE_CDR::ULong pending_alignment,
                         ACE_CDR::ULong pending_length);
+  ACE_CDR::ULong fragment_bytes_available(ACE_CDR::ULong pending_alignment);
 
   /// Are there more data fragments to come?
   bool more_fragments (void) const;
@@ -239,6 +240,18 @@ public:
   /// Calculate the offset between pos and current wr_ptr.
   int offset (char* pos);
 
+protected:
+  // These are overridden to support GIOP fragmentation.
+  virtual ACE_CDR::Boolean write_1 (const ACE_CDR::Octet *x);
+  virtual ACE_CDR::Boolean write_2 (const ACE_CDR::UShort *x);
+  virtual ACE_CDR::Boolean write_4 (const ACE_CDR::ULong *x);
+  virtual ACE_CDR::Boolean write_8 (const ACE_CDR::ULongLong *x);
+  virtual ACE_CDR::Boolean write_16 (const ACE_CDR::LongDouble *x);
+
+  virtual ACE_CDR::Boolean write_array (const void *x,
+                                        size_t size,
+                                        size_t align,
+                                        ACE_CDR::ULong length);
 private:
   // disallow copying...
   TAO_OutputCDR (const TAO_OutputCDR& rhs);

--- a/TAO/tao/CDR.inl
+++ b/TAO/tao/CDR.inl
@@ -331,28 +331,19 @@ TAO_InputCDR::reset_vt_indirect_maps ()
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       CORBA::Short x)
 {
-  return
-    os.fragment_stream (ACE_CDR::SHORT_ALIGN,
-                        sizeof (CORBA::Short))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       CORBA::UShort x)
 {
-  return
-    os.fragment_stream (ACE_CDR::SHORT_ALIGN,
-                        sizeof (CORBA::UShort))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       CORBA::Long x)
 {
-  return
-    os.fragment_stream (ACE_CDR::LONG_ALIGN,
-                        sizeof (CORBA::Long))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
@@ -367,66 +358,43 @@ ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       CORBA::LongLong x)
 {
-  return
-    os.fragment_stream (ACE_CDR::LONGLONG_ALIGN,
-                        sizeof (CORBA::LongLong))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       CORBA::ULongLong x)
 {
-  return
-    os.fragment_stream (ACE_CDR::LONGLONG_ALIGN,
-                        sizeof (CORBA::ULongLong))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR& os,
                                       CORBA::LongDouble x)
 {
-  return
-    os.fragment_stream (ACE_CDR::LONGDOUBLE_ALIGN,
-                        sizeof (CORBA::LongDouble))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       CORBA::Float x)
 {
-  return
-    os.fragment_stream (ACE_CDR::LONG_ALIGN,
-                        sizeof (CORBA::Float))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       CORBA::Double x)
 {
-  return
-    os.fragment_stream (ACE_CDR::LONGLONG_ALIGN,
-                        sizeof (CORBA::Double))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       const char * x)
 {
-  return
-    os.fragment_stream (ACE_CDR::OCTET_ALIGN,
-                        sizeof (char))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       const CORBA::WChar * x)
 {
-  return
-    os.fragment_stream ((sizeof (CORBA::WChar) == 2
-                         ? ACE_CDR::SHORT_ALIGN
-                         : ACE_CDR::LONG_ALIGN),
-                        sizeof (CORBA::WChar))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
@@ -455,10 +423,7 @@ ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       const std::string &x)
 {
 #if defined (ACE_HAS_CPP11)
-  return
-    os.fragment_stream (ACE_CDR::OCTET_ALIGN,
-                        sizeof (char))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 #else
   return os << x.c_str ();
 #endif
@@ -480,12 +445,7 @@ ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       const std::wstring &x)
 {
 #if defined (ACE_HAS_CPP11)
-  return
-    os.fragment_stream ((sizeof (CORBA::WChar) == 2
-                         ? ACE_CDR::SHORT_ALIGN
-                         : ACE_CDR::LONG_ALIGN),
-                        sizeof (CORBA::WChar))
-    && static_cast<ACE_OutputCDR &> (os) << x;
+  return static_cast<ACE_OutputCDR &> (os) << x;
 #else
   return os << x.c_str ();
 #endif

--- a/TAO/tao/GIOP_Fragmentation_Strategy.h
+++ b/TAO/tao/GIOP_Fragmentation_Strategy.h
@@ -67,6 +67,9 @@ public:
                         ACE_CDR::ULong pending_alignment,
                         ACE_CDR::ULong pending_length) = 0;
 
+  virtual ACE_CDR::ULong available (TAO_OutputCDR & cdr,
+                                    ACE_CDR::ULong pending_alignment) = 0;
+
 private:
   // Disallow copying and assignment.
   TAO_GIOP_Fragmentation_Strategy (TAO_GIOP_Fragmentation_Strategy const &);

--- a/TAO/tao/Null_Fragmentation_Strategy.cpp
+++ b/TAO/tao/Null_Fragmentation_Strategy.cpp
@@ -11,3 +11,9 @@ TAO_Null_Fragmentation_Strategy::fragment (TAO_OutputCDR &,
 {
   return 0;
 }
+
+ACE_CDR::ULong
+TAO_Null_Fragmentation_Strategy::available (TAO_OutputCDR &, ACE_CDR::ULong)
+{
+  return 0xFFFFFFFF;
+}

--- a/TAO/tao/Null_Fragmentation_Strategy.h
+++ b/TAO/tao/Null_Fragmentation_Strategy.h
@@ -44,7 +44,7 @@ public:
   TAO_Null_Fragmentation_Strategy (void) {}
   virtual ~TAO_Null_Fragmentation_Strategy (void);
   virtual int fragment (TAO_OutputCDR &, ACE_CDR::ULong, ACE_CDR::ULong);
-
+  virtual ACE_CDR::ULong available (TAO_OutputCDR &, ACE_CDR::ULong);
 private:
 
   // Disallow copying and assignment.

--- a/TAO/tao/On_Demand_Fragmentation_Strategy.cpp
+++ b/TAO/tao/On_Demand_Fragmentation_Strategy.cpp
@@ -12,8 +12,17 @@ TAO_On_Demand_Fragmentation_Strategy::TAO_On_Demand_Fragmentation_Strategy (
   TAO_Transport * transport,
   CORBA::ULong max_message_size)
   : transport_ (transport)
-  , max_message_size_ (max_message_size)
+  , max_message_size_ ((max_message_size < 24
+                        ? 24 : max_message_size)
+                       & ~(ACE_CDR::MAX_ALIGNMENT - 1))
 {
+  // this->max_message_size_ must be >= 24 bytes, i.e.:
+  //   12 for GIOP protocol header
+  //  + 4 for GIOP fragment header
+  //  + 8 for payload (including padding)
+  // since fragments must be aligned on an 8 byte boundary.
+  // Make it a multiple of 8 to avoid checking for this repeatedly
+  // at runtime. 
 }
 
 TAO_On_Demand_Fragmentation_Strategy::~TAO_On_Demand_Fragmentation_Strategy (
@@ -48,19 +57,7 @@ TAO_On_Demand_Fragmentation_Strategy::fragment (
         ACE_align_binary (cdr.total_length (), pending_alignment)
         + pending_length);
 
-  // Except for the last fragment, fragmented GIOP messages must
-  // always be aligned on an 8-byte boundary.  Padding will be added
-  // if necessary.
-  ACE_CDR::ULong const aligned_length =
-      ACE_Utils::truncate_cast<ACE_CDR::ULong> (
-          ACE_align_binary (total_pending_length, ACE_CDR::MAX_ALIGNMENT));
-
-  // this->max_message_size_ must be >= 24 bytes, i.e.:
-  //   12 for GIOP protocol header
-  //  + 4 for GIOP fragment header
-  //  + 8 for payload (including padding)
-  // since fragments must be aligned on an 8 byte boundary.
-  if (aligned_length > this->max_message_size_)
+  if (total_pending_length > this->max_message_size_)
     {
       // Pad the outgoing fragment if necessary.
       if (cdr.align_write_ptr (ACE_CDR::MAX_ALIGNMENT) != 0)
@@ -92,4 +89,20 @@ TAO_On_Demand_Fragmentation_Strategy::fragment (
     }
 
   return 0;
+}
+
+ACE_CDR::ULong
+TAO_On_Demand_Fragmentation_Strategy::available (
+  TAO_OutputCDR & cdr,
+  ACE_CDR::ULong pending_alignment)
+{
+  // Determine increase in CDR stream length if pending data is
+  // marshaled, taking into account the alignment for the given data
+  // type.
+  ACE_CDR::ULong const total_starting_length =
+    ACE_Utils::truncate_cast<ACE_CDR::ULong> (
+        ACE_align_binary (cdr.total_length (), pending_alignment));
+
+  return (total_starting_length > this->max_message_size_
+          ? 0 : this->max_message_size_ - total_starting_length);
 }

--- a/TAO/tao/On_Demand_Fragmentation_Strategy.h
+++ b/TAO/tao/On_Demand_Fragmentation_Strategy.h
@@ -51,6 +51,9 @@ public:
                         ACE_CDR::ULong pending_alignment,
                         ACE_CDR::ULong pending_length);
 
+  virtual ACE_CDR::ULong available (TAO_OutputCDR & cdr, 
+                                    ACE_CDR::ULong pending_alignment);
+
 private:
   // Disallow copying and assignment.
   TAO_On_Demand_Fragmentation_Strategy (TAO_On_Demand_Fragmentation_Strategy const &);


### PR DESCRIPTION
This fixes issue #1201.

The existing implementation attempted to implement fragmentation in the
TAO_OutputCDR inserters, but this did not work because array
and sequence types, including strings, were implemented at
the ACE_OutputCDR layer, which remained oblivious to fragmentation.
The old implementation also left TAO_OutputCDR with a dangerous
interface. The write_xxx functions inherited from ACE_OutputCDR did
not fragment, only the inserters did.

The proposed implementation fragments in the low-level write_1, write_2,
write_4, write_8, write_16, and write_array functions, making these
virtual to ensure that constructed types like arrays and sequences
correctly fragment their elements, and similar for structs, etc.