### PR TITLE
Removed workaround include for MacOSX, let us see on github actions w…

### DIFF
--- a/ACE/ace/iosfwd.h
+++ b/ACE/ace/iosfwd.h
@@ -31,12 +31,6 @@
 
 #if !defined (ACE_LACKS_IOSTREAM_TOTALLY)
 
-#if defined (__APPLE_CC__)
-// Should this really be here?  dhinton
-// FUZZ: disable check_for_streams_include
-# include "ace/streams.h"
-#endif
-
 #if defined (ACE_HAS_STANDARD_CPP_LIBRARY)  && \
     (ACE_HAS_STANDARD_CPP_LIBRARY != 0)
 


### PR DESCRIPTION
…hether this is still required

    * ACE/ace/iosfwd.h: