### PR TITLE
Add precious files support and template cleanup

### DIFF
--- a/ACE/bin/MakeProjectCreator/modules/GNUACEProjectCreator.pm
+++ b/ACE/bin/MakeProjectCreator/modules/GNUACEProjectCreator.pm
@@ -52,24 +52,6 @@ sub fill_value {
       return 'VPATH = .:' . $str . $self->crlf();
     }
   }
-  elsif ($name eq 'tao') {
-    my($incs) = $self->get_assignment('includes');
-    my($libs) = $self->get_assignment('libpaths');
-    return ((defined $incs && $incs =~ /tao/i) ||
-            (defined $libs && $libs =~ /tao/i));
-  }
-  elsif ($name eq 'ciao') {
-    my($incs) = $self->get_assignment('includes');
-    my($libs) = $self->get_assignment('libpaths');
-    return ((defined $incs && $incs =~ /ciao/i) ||
-            (defined $libs && $libs =~ /ciao/i));
-  }
-  elsif ($name eq 'dance') {
-    my($incs) = $self->get_assignment('includes');
-    my($libs) = $self->get_assignment('libpaths');
-    return ((defined $incs && $incs =~ /DAnCE/i) ||
-            (defined $libs && $libs =~ /DAnCE/i));
-  }
   elsif ($name eq 'genins') {
     my $ins = '';
     $self->get_install_info(sub { $ins .= '#' . $_[0] });

--- a/ACE/bin/MakeProjectCreator/templates/gnu.mpd
+++ b/ACE/bin/MakeProjectCreator/templates/gnu.mpd
@@ -209,15 +209,6 @@ VSHDIR = <%targetoutdir%>.shobj/
 include $(ACE_ROOT)/include/makeinclude/wrapper_macros.GNU
 
 <%marker(extension)%>
-<%if(ciao)%>
-include $(CIAO_ROOT)/rules.ciao.GNU
-<%endif%>
-<%if(dance)%>
-include $(DANCE_ROOT)/rules.dance.GNU
-<%endif%>
-<%if(tao)%>
-include $(TAO_ROOT)/rules.tao.GNU
-<%endif%>
 
 <%if(version)%>
 GNUACE_PROJECT_VERSION = <%version%>
@@ -579,6 +570,9 @@ export PATH              := $(PATH):<%custom_type->libpath%>$(if $(ARCH),:<%cust
 <%foreach(custom_type->input_files)%>
 <%if(custom_type->input_file->output_files)%>
 GENERATED_DIRTY +=<%foreach(custom_type->input_file->output_files)%> <%if(flag_overrides(custom_type->input_file, gendir))%><%if(!compares(flag_overrides(custom_type->input_file, gendir),.))%><%flag_overrides(custom_type->input_file, gendir)%>/<%endif%><%basename(custom_type->input_file->output_file)%><%else%><%custom_type->input_file->output_file%><%endif%><%endfor%>
+<%if(precious_files)%>
+PRECIOUS_FILES +=<%foreach(precious_files)%><%foreach(custom_type->input_file->output_files)%><%if(contains(custom_type->input_file->output_file, precious_file))%> <%custom_type->input_file->output_file%><%endif%><%endfor%><%endfor%>
+<%endif%>
 <%if(custom_type->input_file->non_source_output_files)%>
 OBJS_DEPEND_ON_GENERATED = 1
 <%endif%>
@@ -744,7 +738,7 @@ incremental_depend_idl::
 
 realclean: clean
 ifneq ($(GENERATED_DIRTY),)
-	-$(RM) -r $(GENERATED_DIRTY)
+	-$(RM) -r $(filter-out $(PRECIOUS_FILES),$(GENERATED_DIRTY))
 endif
 <%if(postclean)%>
 	-<%eval(postclean)%>

--- a/TAO/MPC/config/tao_rules.mpb
+++ b/TAO/MPC/config/tao_rules.mpb
@@ -1,0 +1,5 @@
+project {
+  verbatim(gnuace, extension, 1) {
+    include $(TAO_ROOT)/rules.tao.GNU
+  }
+}

--- a/TAO/MPC/config/taodefaults.mpb
+++ b/TAO/MPC/config/taodefaults.mpb
@@ -1,5 +1,5 @@
 // -*- MPC -*-
-project : tao_vc8warnings {
+project : tao_rules, tao_vc8warnings {
   staticflags += TAO_AS_STATIC_LIBS
   includes    += $(TAO_ROOT)
   libpaths    += $(ACE_ROOT)/lib

--- a/TAO/TAO_IDL/tao_idl.mpc
+++ b/TAO/TAO_IDL/tao_idl.mpc
@@ -1,5 +1,5 @@
 // -*- MPC -*-cr
-project(TAO_IDL_EXE) : aceexe, install, tao_output, tao_idl_fe {
+project(TAO_IDL_EXE) : aceexe, install, tao_rules, tao_output, tao_idl_fe {
   exename      = tao_idl
   exeout       = $(ACE_ROOT)/bin
   after       += TAO_IDL_BE gperf

--- a/TAO/TAO_IDL/tao_idl_be.mpc
+++ b/TAO/TAO_IDL/tao_idl_be.mpc
@@ -1,5 +1,5 @@
 // -*- MPC -*-
-project(TAO_IDL_BE) : acelib, conv_lib, tao_output, tao_vc8warnings, tao_idl_fe {
+project(TAO_IDL_BE) : acelib, conv_lib, tao_rules, tao_output, tao_vc8warnings, tao_idl_fe {
   sharedname   = TAO_IDL_BE
   dynamicflags += TAO_IDL_BE_BUILD_DLL
   includes    += $(TAO_ROOT)

--- a/TAO/TAO_IDL/tao_idl_fe.mpc
+++ b/TAO/TAO_IDL/tao_idl_fe.mpc
@@ -50,7 +50,7 @@ project(TAO_IDL_GEN) {
   }
 }
 
-project(TAO_IDL_FE) : acelib, conv_lib, tao_output {
+project(TAO_IDL_FE) : acelib, conv_lib, tao_rules, tao_output {
   sharedname   = TAO_IDL_FE
   dynamicflags += TAO_IDL_FE_BUILD_DLL
   includes    += $(TAO_ROOT)


### PR DESCRIPTION
    * TAO/MPC/config/tao_rules.mpb:
      Added.

    * ACE/bin/MakeProjectCreator/templates/gnu.mpd:
      Add precious files support leveraging MPC change providing extended "contains" template function

    * ACE/bin/MakeProjectCreator/modules/GNUACEProjectCreator.pm:
    * TAO/MPC/config/taodefaults.mpb:
    * TAO/TAO_IDL/tao_idl.mpc:
    * TAO/TAO_IDL/tao_idl_be.mpc:
    * TAO/TAO_IDL/tao_idl_fe.mpc: