### PR TITLE
Cleanup basic types now that we are using all C++11 standard defined …

### DIFF
--- a/ACE/ace/Basic_Types.h
+++ b/ACE/ace/Basic_Types.h
@@ -70,15 +70,6 @@
 #  include <inttypes.h>
 # endif
 
-# define ACE_HAS_INT8_T
-# define ACE_HAS_UINT8_T
-# define ACE_HAS_INT16_T
-# define ACE_HAS_UINT16_T
-# define ACE_HAS_INT32_T
-# define ACE_HAS_UINT32_T
-# define ACE_HAS_INT64_T
-# define ACE_HAS_UINT64_T
-
 #ifdef ACE_LACKS_INTPTR_T
 # include "ace/If_Then_Else.h"
 
@@ -93,7 +84,6 @@
 // i.e. determining the type at compile-time rather than at
 // preprocessing-time, will work for all platforms, and does not
 // depend on ACE developer-defined configuration parameters.
-
 typedef ACE::If_Then_Else<
   (sizeof (void*) == sizeof (signed int)),
   signed int,
@@ -210,115 +200,23 @@ typedef ACE::If_Then_Else<
 #   endif
 # endif /* !defined (ACE_SIZEOF_LONG_LONG) */
 
-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-// The sizes of the commonly implemented types are now known.  Set up
-// typedefs for whatever we can.  Some of these are needed for certain
-// cases of ACE_UINT64, so do them before the 64-bit stuff.
-
-#if defined (ACE_HAS_INT8_T)
-  typedef int8_t                ACE_INT8;
-#elif defined (ACE_INT8_TYPE)
-  typedef ACE_INT8_TYPE         ACE_INT8;
-#elif !defined (ACE_LACKS_SIGNED_CHAR)
-  typedef signed char           ACE_INT8;
-#else
-  typedef char                  ACE_INT8;
-#endif /* defined (ACE_INT8_TYPE) */
-
-#if defined (ACE_HAS_UINT8_T)
-  typedef uint8_t               ACE_UINT8;
-#elif defined (ACE_UINT8_TYPE)
-  typedef ACE_UINT8_TYPE        ACE_UINT8;
-#else
-  typedef unsigned char         ACE_UINT8;
-#endif /* defined (ACE_UINT8_TYPE) */
-
-#if defined (ACE_HAS_INT16_T)
-  typedef int16_t               ACE_INT16;
-#elif defined (ACE_INT16_TYPE)
-  typedef ACE_INT16_TYPE        ACE_INT16;
-#elif ACE_SIZEOF_SHORT == 2
-  typedef short                 ACE_INT16;
-#elif ACE_SIZEOF_INT == 2
-  typedef int                   ACE_INT16;
-#else
-# error Have to add to the ACE_INT16 type setting
-#endif  /* defined (ACE_INT16_TYPE) */
-
-#if defined (ACE_HAS_UINT16_T)
-  typedef uint16_t              ACE_UINT16;
-#elif defined (ACE_UINT16_TYPE)
-  typedef ACE_UINT16_TYPE       ACE_UINT16;
-#elif ACE_SIZEOF_SHORT == 2
-  typedef unsigned short        ACE_UINT16;
-#elif ACE_SIZEOF_INT == 2
-  typedef unsigned int          ACE_UINT16;
-#else
-# error Have to add to the ACE_UINT16 type setting
-#endif /* defined (ACE_UINT16_TYPE) */
-
-#if defined (ACE_HAS_INT32_T)
-  typedef int32_t               ACE_INT32;
-#elif defined (ACE_INT32_TYPE)
-  typedef ACE_INT32_TYPE        ACE_INT32;
-#elif ACE_SIZEOF_INT == 4
-  typedef int                   ACE_INT32;
-#elif ACE_SIZEOF_LONG == 4
-  typedef long                  ACE_INT32;
-#else
-# error Have to add to the ACE_INT32 type setting
-#endif /* defined (ACE_INT32_TYPE) */
-
-#if defined (ACE_HAS_UINT32_T)
-  typedef uint32_t              ACE_UINT32;
-#elif defined (ACE_UINT32_TYPE)
-  typedef ACE_UINT32_TYPE       ACE_UINT32;
-#elif ACE_SIZEOF_INT == 4
-  typedef unsigned int          ACE_UINT32;
-#elif ACE_SIZEOF_LONG == 4
-  typedef unsigned long         ACE_UINT32;
-#else
-# error Have to add to the ACE_UINT32 type setting
-#endif /* defined (ACE_UINT32_TYPE) */
-
-#if defined (ACE_HAS_INT64_T)
-  typedef int64_t               ACE_INT64;
-#elif defined (ACE_INT64_TYPE)
-  typedef ACE_INT64_TYPE        ACE_INT64;
-#elif ACE_SIZEOF_LONG == 8
-  typedef long                  ACE_INT64;
-#elif ACE_SIZEOF_LONG_LONG == 8
-# ifdef __GNUC__
-  // Silence g++ "-pedantic" warnings regarding use of "long long"
-  // type.
-  __extension__
-# endif  /* __GNUC__ */
-  typedef long long             ACE_INT64;
-#endif /* defined (ACE_INT64_TYPE) */
-
-#if defined (ACE_HAS_UINT64_T)
-  typedef uint64_t              ACE_UINT64;
-#elif defined (ACE_UINT64_TYPE)
-  typedef ACE_UINT64_TYPE       ACE_UINT64;
-#elif ACE_SIZEOF_LONG == 8
-  typedef unsigned long         ACE_UINT64;
-#elif ACE_SIZEOF_LONG_LONG == 8
-# ifdef __GNUC__
-  // Silence g++ "-pedantic" warnings regarding use of "long long"
-  // type.
-  __extension__
-# endif  /* __GNUC__ */
-  typedef unsigned long long    ACE_UINT64;
-#endif /* defined (ACE_UINT64_TYPE) */
+// The sizes of the commonly implemented types are known.
+typedef int8_t   ACE_INT8;
+typedef uint8_t  ACE_UINT8;
+typedef int16_t  ACE_INT16;
+typedef uint16_t ACE_UINT16;
+typedef int32_t  ACE_INT32;
+typedef uint32_t ACE_UINT32;
+typedef int64_t  ACE_INT64;
+typedef uint64_t ACE_UINT64;
 
 /// Define a generic byte for use in codecs
 typedef unsigned char ACE_Byte;
 
 // Define a pseudo wide character type when wchar is not supported so we
 // can support basic wide character string operations.
-
 #if defined (ACE_HAS_WCHAR) || defined (ACE_HAS_XPG4_MULTIBYTE_CHAR)
 #  define ACE_WINT_T wint_t
 #  define ACE_WCHAR_T wchar_t

--- a/ACE/ace/README
+++ b/ACE/ace/README
@@ -692,48 +692,6 @@ ACE_LACKS_UINTMAX_T                     Platform lacks the uintmax_t type.
 ACE_LACKS_INTPTR_T                      Platform lacks the intptr_t type
 ACE_LACKS_UINTPTR_T                     Platform lacks the uintptr_t type.
 
-ACE_HAS_INT8_T                          Platform provides the int8_t type.
-ACE_HAS_INT16_T                         Platform provides the int16_t type.
-ACE_HAS_INT32_T                         Platform provides the int32_t type.
-ACE_HAS_INT64_T                         Platform provides the int64_t type.
-ACE_HAS_UINT8_T                         Platform provides the uint8_t type.
-ACE_HAS_UINT16_T                        Platform provides the uint16_t type.
-ACE_HAS_UINT32_T                        Platform provides the uint32_t type.
-ACE_HAS_UINT64_T                        Platform provides the uint64_t type.
-
-ACE_INT8_TYPE                           Specific type to use for ACE_INT8.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_INT8_T has been defined
-ACE_INT16_TYPE                          Specific type to use for ACE_INT16.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_INT16_T has been defined
-ACE_INT32_TYPE                          Specific type to use for ACE_INT32.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_INT32_T has been defined
-ACE_INT64_TYPE                          Specific type to use for ACE_INT64.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_INT64_T has been defined
-ACE_UINT8_TYPE                          Specific type to use for ACE_UINT8.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_UINT8_T has been defined
-ACE_UINT16_TYPE                         Specific type to use for ACE_UINT16.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_UINT16_T has been defined
-ACE_UINT32_TYPE                         Specific type to use for ACE_UINT32.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_UINT32_T has been defined
-ACE_UINT64_TYPE                         Specific type to use for ACE_UINT64.
-                                        If not defined, ACE will attempt to
-                                        determine the correct type
-                                        unless ACE_HAS_UINT64_T has been defined
-
 ACE_INT8_FORMAT_SPECIFIER               String literal containing *printf
                                         format specifier (including the '%')
                                         to be used for ACE_INT8 values.  If

--- a/ACE/ace/config-kfreebsd.h
+++ b/ACE/ace/config-kfreebsd.h
@@ -90,17 +90,6 @@
 #define ACE_HAS_ICMP_SUPPORT 1
 
 /* Define to 1 if the system has the type `int16_t'. */
-#define ACE_HAS_INT16_T 1
-
-/* Define to 1 if the system has the type `int32_t'. */
-#define ACE_HAS_INT32_T 1
-
-/* Define to 1 if the system has the type `int64_t'. */
-#define ACE_HAS_INT64_T 1
-
-/* Define to 1 if the system has the type `int8_t'. */
-#define ACE_HAS_INT8_T 1
-
 /* Platform supports IPv6 */
 #define ACE_HAS_IPV6 1
 
@@ -328,18 +317,6 @@
 /* Define to 1 if the system has the type `ucontext_t'. */
 #define ACE_HAS_UCONTEXT_T 1
 
-/* Define to 1 if the system has the type `uint16_t'. */
-#define ACE_HAS_UINT16_T 1
-
-/* Define to 1 if the system has the type `uint32_t'. */
-#define ACE_HAS_UINT32_T 1
-
-/* Define to 1 if the system has the type `uint64_t'. */
-#define ACE_HAS_UINT64_T 1
-
-/* Define to 1 if the system has the type `uint8_t'. */
-#define ACE_HAS_UINT8_T 1
-
 /* Define to 1 if platform has vasprintf(). */
 #define ACE_HAS_VASPRINTF 1
 
@@ -367,9 +344,6 @@
 
 /* Platform has Xt Intrinsics Toolkit */
 #define ACE_HAS_XT 1
-
-/* Define to signed 64 bit integer type */
-#define ACE_INT64_TYPE signed long long
 
 /* Define to the type of arg 2 for `ioctl'. */
 #define ACE_IOCTL_TYPE_ARG2 int
@@ -458,9 +432,6 @@
 
 /* Size of the native "wchar_t" type */
 #define ACE_SIZEOF_WCHAR 4
-
-/* Define to unsigned 64 bit integer type */
-#define ACE_UINT64_TYPE unsigned long long
 
 /* Enable IPv6 support on platforms that don't have IPv6 turned on by default
    */

--- a/ACE/ace/config-netbsd.h
+++ b/ACE/ace/config-netbsd.h
@@ -127,9 +127,6 @@
 #define ACE_SIZEOF_VOID_P 8
 #define ACE_SIZEOF_WCHAR 4
 
-typedef unsigned long ACE_UINT64;
-typedef   signed long ACE_INT64;
-
 #define ACE_SSIZE_T_FORMAT_SPECIFIER_ASCII  "%ld"
 #define ACE_SIZE_T_FORMAT_SPECIFIER_ASCII "%lu"
 
@@ -144,9 +141,6 @@ typedef   signed long ACE_INT64;
 #define ACE_SIZEOF_SHORT 2
 #define ACE_SIZEOF_VOID_P 4
 #define ACE_SIZEOF_WCHAR 4
-
-typedef unsigned long long ACE_UINT64;
-typedef   signed long long ACE_INT64;
 
 #else
 # error unknown CPU architecture

--- a/ACE/ace/config-win32-common.h
+++ b/ACE/ace/config-win32-common.h
@@ -335,16 +335,6 @@
 
 #define ACE_SIZEOF_LONG_LONG 8
 
-#if !defined (__MINGW32__)
-#define ACE_INT64_TYPE  signed __int64
-#define ACE_UINT64_TYPE unsigned __int64
-#endif
-
-#if defined (__MINGW32__)
-#define ACE_INT64_TYPE  signed long long
-#define ACE_UINT64_TYPE unsigned long long
-#endif
-
 // Optimize ACE_Handle_Set for select().
 #define ACE_HAS_HANDLE_SET_OPTIMIZED_FOR_SELECT
 


### PR DESCRIPTION
…(u)int{8/16/32/64)_t types

    * ACE/ace/Basic_Types.h:
    * ACE/ace/README:
    * ACE/ace/config-kfreebsd.h:
    * ACE/ace/config-netbsd.h:
    * ACE/ace/config-win32-common.h: