### PR TITLE
Put ERROR in the message when tao_idl can't open a file so that it is…

### DIFF
--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -1132,13 +1132,12 @@ DRV_pre_proc (const char *myfile)
 
   // Rename temporary files so that they have extensions accepted
   // by the preprocessor.
-
   FILE * const file = ACE_OS::fopen (myfile, "r");
 
   if (file == 0)
     {
       ACE_ERROR ((LM_ERROR,
-                  "%C: Unable to open file : %p\n",
+                  "%C: ERROR: Unable to open file : %p\n",
                   idl_global->prog_name (),
                   myfile));
 


### PR DESCRIPTION
… parsed by the scoreboard scripts as error

    * TAO/TAO_IDL/driver/drv_preproc.cpp: