### PR TITLE
Don't disable dlclose when using valgrind, use --keep-debuginfo=yes a…

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -4,6 +4,13 @@ USER VISIBLE CHANGES BETWEEN ACE-6.5.12 and ACE-7.0.0
 . C++11 is now a mandatory compiler feature which is
   required for ACE
 
+. When valgrind is enabled we don't disable dlclose anymore,
+  this reduces the amount of leaks reported related to dlclose.
+  When you unload your shared libraries before the end of your program
+  you can use `--keep-debuginfo=yes` as valgrind options as alternative
+  or you can disable dlclose yourself by adding
+  `#define ACE_LACKS_DLCLOSE` to your ace/config.h file
+
 USER VISIBLE CHANGES BETWEEN ACE-6.5.11 and ACE-6.5.12
 ======================================================
 

--- a/ACE/ace/OS_NS_dlfcn.cpp
+++ b/ACE/ace/OS_NS_dlfcn.cpp
@@ -1,7 +1,5 @@
 #include "ace/OS_NS_dlfcn.h"
 
-
-
 #if !defined (ACE_HAS_INLINED_OSCALLS)
 # include "ace/OS_NS_dlfcn.inl"
 #endif /* ACE_HAS_INLINED_OSCALLS */

--- a/ACE/ace/config-macros.h
+++ b/ACE/ace/config-macros.h
@@ -78,7 +78,6 @@
 
 # if defined (ACE_HAS_VALGRIND)
 #   define ACE_INITIALIZE_MEMORY_BEFORE_USE
-#   define ACE_LACKS_DLCLOSE
 # endif /* ACE_HAS_VALGRIND */
 
 // =========================================================================


### PR DESCRIPTION
…s valgrind options as alternative when running valgrind

    * ACE/ace/OS_NS_dlfcn.cpp:
    * ACE/ace/config-macros.h: