### PR TITLE
When valgrind_keep_debuginfo is set to 0 we add ACE_LACKS_DLCLOSE to …

### DIFF
--- a/ACE/include/makeinclude/wrapper_macros.GNU
+++ b/ACE/include/makeinclude/wrapper_macros.GNU
@@ -704,6 +704,12 @@ valgrind ?=
 ifeq ($(valgrind),1)
   CPPFLAGS += -DACE_HAS_VALGRIND
 endif
+# Does the valgrind version support --keep-debug-info, if not
+# we disable dlclose in ACE to get complete callstacks
+valgrind_keep_debuginfo ?=
+ifeq ($(valgrind_keep_debuginfo),0)
+  CPPFLAGS += -DACE_LACKS_DLCLOSE
+endif
 
 profile ?=
 ifeq ($(profile),0)


### PR DESCRIPTION
…the compiler flags