### PR TITLE
[ACE6] Support Building with Android NDK Directly

### DIFF
--- a/ACE/ACE-INSTALL.html
+++ b/ACE/ACE-INSTALL.html
@@ -1671,6 +1671,7 @@ build directly using the NDK or using
 <a href="#android-toolchain">a generated standalone toolchain</a>. Generating a
 toolchain is optional and only really makes sense if you're building for just
 one architecture/API level pair and don't need to keep the entire NDK around.
+Using the NDK directly requires Android NDK r19 or later.
 
 <h3><a name="android-toolchain">Choosing the Target</a></h3>
 

--- a/ACE/ACE-INSTALL.html
+++ b/ACE/ACE-INSTALL.html
@@ -1631,7 +1631,8 @@ symbols are necessary when you want to debug your code.</p>
 <h2><a name="android">Building and Installing ACE on Android</a></h2>
 
 <ul>
-  <li><a href="#android-toolchain">Generating a Toolchain</a></li>
+  <li><a href="#android-target">Choosing the Target</a></li>
+  <li><a href="#android-toolchain">Generating a Toolchain (Optional)</a></li>
   <li><a href="#android-oldndks">Using Older NDKs</a></li>
   <li><a href="#android-building">Building</a></li>
   <li><a href="#android-install">Installing ACE on Android</a></li>
@@ -1642,11 +1643,12 @@ symbols are necessary when you want to debug your code.</p>
 <p>ACE can be built for Android by using the <a
 href="https://developer.android.com/ndk/">Android Native Development Kit
 (NDK)</a>. This is different than the standard way of writing Android
-applications in Java which run the on Android Runtime or the older Dalvik
-Virtual Machine. Applications built using the NDK are native Linux applications
-written in C or C++ specifically compiled to run on Android systems. In
-addition, applications built using the NDK have access to Android-specific APIs
-much like the ones available to Java-based Android applications.
+applications in Java which run the on the Android Runtime or the older Dalvik
+Virtual Machine. Applications and libraries built using the NDK are native
+Linux applications written in C or C++ specifically compiled to run on Android
+systems and libraries can be included in normal Android apps. In addition,
+applications and libraries built using the NDK have access to Android-specific
+APIs much like the ones available to Java-based Android applications.
 </p>
 
 <div class="boxed">
@@ -1663,11 +1665,17 @@ addition to the Windows version of the Android NDK, you will also need
 <a href="https://www.msys2.org">MSYS2 for Unix utilities that ACE needs</a>.
 </div>
 
-<h3><a name="android-toolchain">Generating a Toolchain</a></h3>
+After downloading the NDK, you will have to decide on what target you want to
+build for, which is covered in the next section, then decide if you want to
+build directly using the NDK or using
+<a href="#android-toolchain">a generated standalone toolchain</a>. Generating a
+toolchain is optional and only really makes sense if you're building for just
+one architecture/API level pair and don't need to keep the entire NDK around.
 
-<p>To build ACE for Android you need to download the NDK and generate a
-toolchain for the specific Android target you want. The specific target is
-defined by two things:</p>
+<h3><a name="android-toolchain">Choosing the Target</a></h3>
+
+<p>To build ACE for Android you need to know the specific Android target you
+want. The specific target is defined by two things:</p>
 
 <dl class="indent">
   <dt>- The minimal API level to target.</dt>
@@ -1682,10 +1690,10 @@ defined by two things:</p>
     although support for MIPS has been dropped from the NDK. <a
     href="https://developer.android.com/ndk/guides/abis">This is the official
     documentation on the ABIs</a>. These are the ABIs that ACE supports at the
-    time of writing and must be passed to ACE as <code>ANDROID_ABI</code>:
+    time of writing and must be passed to ACE as <code>android_abi</code>:
     <!-- Check to see if any architectures have been added or removed. If so
       update this list and the table below as well-->
-    <dl>
+    <dl id="android_abis">
       <dt><code>armeabi-v7a</code></dt>
         <dd>32-bit ARM, The default ABI for both the NDK and ACE.</dd>
       <dt><code>armeabi-v7a-with-neon</code></dt>
@@ -1700,15 +1708,16 @@ defined by two things:</p>
     <p><b>
       It should be noted that starting in August 2019, the Google Play
       Store will require new apps to have 64-bit libraries if they have native
-      libraries. 32-bit native libraries will still be supported but they must also
-      have 64-bit libraries. Look up any restrictions that may affect
-      apps you want to publish on the Play Store, including minimum API
-      level.
+      libraries. 32-bit native libraries will still be supported but apps must
+      also have 64-bit libraries. Look up any restrictions that may affect apps
+      you want to publish on the Play Store, including targeted API level
+      requirements.
     </b></p>
     </dd>
   </li>
 </dl>
 
+<h3><a name="android-toolchain">Generating a Toolchain (Optional)</a></h3>
 
 <p>To generate a toolchain, one use must use
 <code>build/tools/make_standalone_toolchain.py</code> in the NDK. A destination must be
@@ -1720,10 +1729,11 @@ toolchain targeting 32-bit ARM Android 7.0 "Nougat" (API Level 24) and later: </
 <p><code>$TOOLCHAIN/bin</code> must be in your <code>$PATH</code> when building ACE and
 applications using ACE.</p>
 
-<p>This table shows how the <code>ANDROID_ABI</code> variable and the <code>--arch</code> argument correlate:</p>
-<table class="indent">
+<p>This table shows how the <code>android_abi</code> variable and the
+<code>--arch</code> argument correlate:</p>
+<table class="indent" id="android_abi_toolchain_table">
   <tr>
-    <th><code>ANDROID_ABI</code></th>
+    <th><code>android_abi</code></th>
     <th><code>--arch</code></th>
   </tr>
   <tr>
@@ -1821,6 +1831,9 @@ have caveats:
     <code>platform_android.GNU</code>. <b>This should be set for NDKs before r15.</b>
   </li>
   <li>
+    ACE does not support using the NDK directly before r18.
+  </li>
+  <li>
     There are probably unknown conflicts, especially in the minor revisions
     before the last minor revision of a NDK revision.
   </li>
@@ -1842,14 +1855,19 @@ have caveats:
     </div>
   </li>
   <li>Setup the Android build<ul>
-    <li>Create <code>ace/config.h</code>: <code>#include "ace/config-android.h"</code></li>
+    <li>Create <code>ace/config.h</code>: <code>#include "config-android.h"</code></li>
     <li>Create <code>include/makeinclude/platform_macros.GNU</code>:
       <ul>
         <li>
-          Set <code>ANDROID_ABI</code> to one of the options above. This
-          must match the toolchain <code>--arch</code> argument used according
-          to the table above.
+          Set <code>android_abi</code> to one of
+          <a href="#android_abis">the options above</a>.
+          If using a standalone toolchain this must match the
+          <code>--arch</code> argument used according
+          to <a href="#android_abi_toolchain_table">the table above</a>.
         </li>
+        <li>If using the NDK directly, set <code>android_ndk</code> to the
+          location of the extracted NDK and <code>android_api</code> to the API
+          level desired.</li>
         <li>Set options for debug and optimization options as desired.</li>
           <li>If you want to compile static, add <code>static_libs_only:=1</code></li>
           <li>Must include <code>include $(ACE_ROOT)/include/makeinclude/platform_android.GNU</code>.</li>
@@ -1862,10 +1880,11 @@ have caveats:
     </li>
     </li>
     <li>Generate makefiles (if necessary).</li>
-    <li>Build with GNU make. Make sure you have <code>$TOOLCHAIN/bin</code> in
-      your <code>$PATH</code>.
+    <li>Build with GNU make. If using a standalone toolchain, make sure you
+      have <code>$TOOLCHAIN/bin</code> in your <code>$PATH</code>.
       <div class="boxed indent"><p>
-        <b>Windows Users:</b> Make sure you have <code>%TOOLCHAIN%\bin</code>
+        <b>Windows Users:</b> If using a standalone toolchain,
+        Make sure you have <code>%TOOLCHAIN%\bin</code>
         and MSYS2's <code>bin</code> in your <code>%PATH%</code> when building.
         If you are cross compiling TAO you will also need a preprocessor for
         <code>tao_idl</code> available (See Windows note above).</p>

--- a/ACE/ACE-INSTALL.html
+++ b/ACE/ACE-INSTALL.html
@@ -1856,7 +1856,7 @@ have caveats:
     </div>
   </li>
   <li>Setup the Android build<ul>
-    <li>Create <code>ace/config.h</code>: <code>#include "config-android.h"</code></li>
+    <li>Create <code>ace/config.h</code>: <code>#include "ace/config-android.h"</code></li>
     <li>Create <code>include/makeinclude/platform_macros.GNU</code>:
       <ul>
         <li>

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -17,7 +17,7 @@
 #define ACE_ANDROID
 #define ACE_PLATFORM_CONFIG config-android.h
 
-#include "config-linux-common.h"
+#include "ace/config-linux-common.h"
 
 /*
  * Android NDK Revision Macros

--- a/ACE/ace/config-android.h
+++ b/ACE/ace/config-android.h
@@ -53,14 +53,14 @@
 #  include <android/ndk-version.h>
 #else
 #  ifndef __NDK_MAJOR__
-#    error ndk-version.h is missing, __NDK_MAJOR__ for Android NDK must be defined!
+#    error __NDK_MAJOR__ for Android NDK must be defined!
 #  endif
 #  ifndef __NDK_MINOR__
-#    error ndk-version.h is missing, __NDK_MINOR__ for Android NDK must be defined!
+#    error __NDK_MINOR__ for Android NDK must be defined!
 #  endif
-#  ifndef __NDK_BETA__
-#    define __NDK_BETA__ 0
-#  endif
+#endif
+#ifndef __NDK_BETA__
+#  define __NDK_BETA__ 0
 #endif
 
 // ucontext.h and clock_settime() were added in r10c

--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -24,6 +24,10 @@ project: ipv6, vc_warnings, build_files, test_files, svc_conf_files, ace_unicode
     release::macros += ACE_NDEBUG ACE_USE_RCSID=0
   }
 
+  // Link To Android Logging Library for Log_Msg_Android_Logcat
+  specific(gnuace) {
+    linkflags += $(if $(android_abi),-llog)
+  }
 }
 
 feature(ace_inline) {

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -2,6 +2,9 @@
 
 # This file allows ACE and applications using ACE GNU Makefiles to be built for
 # Android by cross compiling on Linux.
+#
+# See here for latest documentation on how to invoke the NDK:
+# https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md
 
 # We always include config-android.h on Android platforms.
 ACE_PLATFORM_CONFIG ?= config-android.h
@@ -19,8 +22,12 @@ PIE	?= -pie
 #No rwho on Android
 rwho = 0
 
-# Android Studio does not seem to recognize so files with versions
-versioned_so ?= 0
+# Android Studio does not seem to recognize so files with versions, but if
+# trying to add gnuace-built libraries as imported libraries in CMake in a
+# Android Studio project, at runtime apparently the Android loader needs the
+# SONAME be set to the filename or else it was fail trying to load the so file
+# path from the host computer.
+versioned_so = 3
 
 # Only try to use clang, unless this is set to 0, then try to use g++
 android_force_clang ?= 1
@@ -29,7 +36,7 @@ android_force_clang ?= 1
 # As of writing information on ABIs can be found at https://developer.android.com/ndk/guides/abis
 
 ifndef ANDROID_ABI
-  ifdef ANDROID_ARCH # Handle Possiblity of ANDROID_ARCH being passed
+  ifdef ANDROID_ARCH # Handle possibility of ANDROID_ARCH being passed
     ifeq ($(ANDROID_ARCH),arm)
       ANDROID_ABI := armeabi-v7a
     else
@@ -40,53 +47,84 @@ ifndef ANDROID_ABI
   endif
 endif
 
-# Alias neon
-ifeq ($(ANDROID_ABI), neon)
-  ANDROID_ABI := armeabi-v7a-with-neon
+ifndef android_abi
+  ifdef ANDROID_ABI
+    android_abi := $(ANDROID_ABI)
+  else
+    $(error android_abi or ANDROID_ABI must be defined)
+  endif
 endif
 
-android_neon ?= 0
-ifeq ($(ANDROID_ABI),armeabi-v7a-with-neon)
-  ANDROID_ABI := armeabi-v7a
+# Alias neon
+ifeq ($(android_abi), neon)
+  android_abi := armeabi-v7a-with-neon
+endif
+
+android_neon ?= 1
+ifeq ($(android_abi),armeabi-v7a-with-neon)
+  android_abi := armeabi-v7a
   android_neon := 1
 endif
 
-# NDK says -Wl,--fix-cortex-a8 is required for working around a CPU bug
-# in some Cortex-A8 implementations
-
-ifeq ($(ANDROID_ABI),armeabi-v7a)
-  CROSS_COMPILE := arm-linux-androideabi-
+ifeq ($(android_abi),armeabi-v7a)
+  CROSS_COMPILE := armv7a-linux-androideabi
   FLAGS_C_CC += -march=armv7-a -mfloat-abi=softfp
   ifeq ($(android_neon),1)
     FLAGS_C_CC += -mfpu=neon
   else
     FLAGS_C_CC += -mfpu=vfpv3-d16
   endif
-  LDFLAGS    += -march=armv7-a -Wl,--fix-cortex-a8
-endif
+  # NDK says -Wl,--fix-cortex-a8 is required for working around a CPU bug
+  # in some Cortex-A8 implementations
+  LDFLAGS += -march=armv7-a -Wl,--fix-cortex-a8
 
-ifeq ($(ANDROID_ABI),arm64-v8a)
-  CROSS_COMPILE := aarch64-linux-android-
+else ifeq ($(android_abi),arm64-v8a)
+  CROSS_COMPILE := aarch64-linux-android
   FLAGS_C_CC += -march=armv8-a
-  LDFLAGS    += -march=armv8-a
-endif
+  LDFLAGS += -march=armv8-a
 
-ifeq ($(ANDROID_ABI),x86)
-  CROSS_COMPILE := i686-linux-android-
-endif
+else ifeq ($(android_abi),x86)
+  CROSS_COMPILE := i686-linux-android
 
-ifeq ($(ANDROID_ABI),x86_64)
-  CROSS_COMPILE := x86_64-linux-android-
+else ifeq ($(android_abi),x86_64)
+  CROSS_COMPILE := x86_64-linux-android
 endif
 
 ifndef CROSS_COMPILE
-  $(error ANDROID_ABI passed (set to: $(ANDROID_ABI)) is not valid)
+  $(error android_abi $(android_abi) is not valid)
 endif
 
-# Export so child processes can use tools from the same toolchain.
-export CROSS_COMPILE
+ifdef android_ndk
+  ifndef android_api
+    $(error android_ndk also requires defining android_api)
+  endif
+
+  android_ndk_tools ?= $(wildcard $(android_ndk)/toolchains/llvm/prebuilt/*/bin)
+  ifndef android_ndk_tool_prefix
+    android_ndk_tool_prefix := $(CROSS_COMPILE)$(android_api)-
+  endif
+
+  # We dont want this being used again except to signal that this is a
+  # cross-compile build. If it is this command (probably) wont exist.
+  CROSS_COMPILE := THIS_VALUE_SHOULD_NOT_BE_USED
+
+  override_cross_compile = 1
+  CC = $(android_ndk_tools)/$(android_ndk_tool_prefix)clang
+  CXX = $(android_ndk_tools)/$(android_ndk_tool_prefix)clang++
+  AR = $(android_ndk_tools)/llvm-ar
+
+else
+  CROSS_COMPILE := $(CROSS_COMPILE)-
+
+  # Export so child processes can use tools from the same toolchain.
+  export CROSS_COMPILE
+endif
 
 ifeq ($(android_force_clang),0)
+  ifdef android_ndk
+    $(error Must use a standalone toolchain to use GCC)
+  endif
+
   # Determine if the g++ compiler is GCC or Clang.
   # There are at least 3 assumptions being made here:
   #  - There is a g++ command to get the version from
@@ -94,17 +132,18 @@ ifeq ($(android_force_clang),0)
   #  - If g++ is actually clang, then we can replace that with clang++
   gplusplus_version = $(shell $(CROSS_COMPILE)g++$(CROSS_COMPILE_SUFFIX) --version)
   actually_is_clang := $(strip $(findstring clang,$(gplusplus_version)))
+else ifeq ($(android_force_clang),1)
+  actually_is_clang := 1
 else
-  ifeq ($(android_force_clang),1)
-    actually_is_clang := 1
-  else
-    $(error Invalid value for android_force_clang: $(android_force_clang))
-  endif
+  $(error Invalid value for android_force_clang: $(android_force_clang))
 endif
 
-FLAGS_C_CC += -W -Wall -Wpointer-arith
+FLAGS_C_CC += -Wpointer-arith
 ifeq ($(threads),1)
-    CPPFLAGS  += -D_REENTRANT $(PLATFORM_AIO_SUPPORT)
+  CPPFLAGS += -D_REENTRANT
+  ifdef PLATFORM_AIO_SUPPORT
+    CPPFLAGS += $(PLATFORM_AIO_SUPPORT)
+  endif
 endif # threads
 
 # Use -pipes by default
@@ -150,8 +189,8 @@ else
   include $(ACE_ROOT)/include/makeinclude/platform_g++_common.GNU
 endif
 
-ifeq ($(shell echo '\#include "android/ndk-version.h"' | $(CXX) -E - > /dev/null 2>&1; echo $$?), 0)
-  CPPFLAGS += -DACE_ANDROID_NDK_HAS_NDK_VERSION_H
+ifneq ($(shell echo '\#include <android/ndk-version.h>' | $(CXX) -E - > /dev/null 2>&1; echo $$?), 0)
+  CPPFLAGS += -DACE_ANDROID_NDK_MISSING_NDK_VERSION_H
 endif
 
 ifdef __NDK_MAJOR__
@@ -160,6 +199,10 @@ endif
 
 ifdef __NDK_MINOR__
   CPPFLAGS += -D__NDK_MINOR__=$(__NDK_MINOR__)
+endif
+
+ifdef __NDK_BETA__
+  CPPFLAGS += -D__NDK_BETA__=$(__NDK_BETA__)
 endif
 
 OCFLAGS ?= -O3
@@ -182,7 +225,7 @@ LIBS += -llog
 ifeq ($(OS), Windows_NT)
   SHOBJS_FILE = $(VSHDIR)$(MAKEFILE)_object_list.tmp
   CLEANUP_OBJS += $(SHOBJS_FILE)
-  define SHLIBBUILD 
+  define SHLIBBUILD
     $(file >$(SHOBJS_FILE), $^)
     $(SHR_FILTER) $(SOLINK.cc) $(SO_OUTPUT_FLAG) $@ @$(SHOBJS_FILE) $(LDFLAGS) $(ACE_SHLIBS) $(LIBS)
   endef

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -232,9 +232,6 @@ ifeq ($(ssl),1)
   PLATFORM_SSL_LDFLAGS += --exclude-libs libcrypto.a,libssl.a
 endif
 
-# Link To Android Logging Library for Log_Msg_Android_Logcat
-LIBS += -llog
-
 # link step to avoid 'command line too long' error on Windows
 ifeq ($(OS), Windows_NT)
   SHOBJS_FILE = $(VSHDIR)$(MAKEFILE)_object_list.tmp

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -104,17 +104,31 @@ ifdef android_ndk
     android_ndk_tool_prefix := $(CROSS_COMPILE)$(android_api)-
   endif
 
-  # We dont want this being used again except to signal that this is a
-  # cross-compile build. If it is this command (probably) wont exist.
+  # We don't want this being used again except to signal that this is a
+  # cross-compile build. If it is then the resulting command (probably) wont
+  # exist.
   CROSS_COMPILE := THIS_VALUE_SHOULD_NOT_BE_USED
 
+  # Ignore value of CROSS_COMPILE because ar doesn't match clang like in
+  # platform_clang_common.GNU.
   override_cross_compile = 1
   CC = $(android_ndk_tools)/$(android_ndk_tool_prefix)clang
   CXX = $(android_ndk_tools)/$(android_ndk_tool_prefix)clang++
   AR = $(android_ndk_tools)/llvm-ar
 
-else
+else # Standalone Toolchain
   CROSS_COMPILE := $(CROSS_COMPILE)-
+
+  ifeq ($(android_abi),armeabi-v7a)
+    # According to Google the armv7a-linux-androideabi- prefix should be
+    # preferred because it produces more efficient code. However if it doesn't
+    # exist since we're using an older NDK we have to fallback to
+    # arm-linux-androideabi-. This isn't a problem when directly using the NDK
+    # because the NDKs we support for that have armv7a-* clangs.
+    ifeq (,$(shell command -v $(CROSS_COMPILE)clang $(ACE_NUL_STDERR)))
+      CROSS_COMPILE := arm-linux-androideabi-
+    endif
+  endif
 
   # Export so child processes can use tools from the same toolchain.
   export CROSS_COMPILE

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -35,24 +35,22 @@ android_force_clang ?= 1
 # This section deals with selecting the architecture/compiler
 # As of writing information on ABIs can be found at https://developer.android.com/ndk/guides/abis
 
-ifndef ANDROID_ABI
-  ifdef ANDROID_ARCH # Handle possibility of ANDROID_ARCH being passed
-    ifeq ($(ANDROID_ARCH),arm)
-      ANDROID_ABI := armeabi-v7a
-    else
-      ANDROID_ABI := $(ANDROID_ARCH)
-    endif
-  else # Else default to ARMv7
-    ANDROID_ABI := armeabi-v7a
-  endif
-endif
-
 # Make sure android_abi or ANDROID_ABI are defined and they are the same.
+# ANDROID_ABI and ANDROID_ARCH are acceptable for compatibility reasons.
 ifndef android_abi
   ifdef ANDROID_ABI
     android_abi := $(ANDROID_ABI)
   else
-    $(error android_abi or ANDROID_ABI must be defined)
+    ifdef ANDROID_ARCH
+      ifeq ($(ANDROID_ARCH),arm)
+        android_abi := armeabi-v7a
+      else
+        android_abi := $(ANDROID_ARCH)
+      endif
+    else # Default to ARMv7 if nothing is set
+      android_abi := armeabi-v7a
+    endif
+    ANDROID_ABI := $(android_abi)
   endif
 else
   ANDROID_ABI := $(android_abi)
@@ -63,7 +61,7 @@ ifeq ($(android_abi), neon)
   android_abi := armeabi-v7a-with-neon
 endif
 
-android_neon ?= 1
+android_neon ?= 0
 ifeq ($(android_abi),armeabi-v7a-with-neon)
   android_abi := armeabi-v7a
   android_neon := 1

--- a/ACE/include/makeinclude/platform_android.GNU
+++ b/ACE/include/makeinclude/platform_android.GNU
@@ -47,12 +47,15 @@ ifndef ANDROID_ABI
   endif
 endif
 
+# Make sure android_abi or ANDROID_ABI are defined and they are the same.
 ifndef android_abi
   ifdef ANDROID_ABI
     android_abi := $(ANDROID_ABI)
   else
     $(error android_abi or ANDROID_ABI must be defined)
   endif
+else
+  ANDROID_ABI := $(android_abi)
 endif
 
 # Alias neon
@@ -105,8 +108,8 @@ ifdef android_ndk
   endif
 
   # We don't want this being used again except to signal that this is a
-  # cross-compile build. If it is then the resulting command (probably) wont
-  # exist.
+  # cross-compile build. If it is then the resulting command probably won't
+  # exist and cause an error.
   CROSS_COMPILE := THIS_VALUE_SHOULD_NOT_BE_USED
 
   # Ignore value of CROSS_COMPILE because ar doesn't match clang like in

--- a/ACE/include/makeinclude/platform_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_clang_common.GNU
@@ -144,3 +144,6 @@ else
 endif # shared_libs
 
 FLAGS_C_CC += -W -Wall
+
+# Disable "warning: creating *.a" Message
+ARFLAGS += -c

--- a/ACE/include/makeinclude/platform_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_clang_common.GNU
@@ -6,9 +6,12 @@ CCFLAGS += -fdelayed-template-parsing
 ifneq ($(CROSS_COMPILE),)
   CROSS-COMPILE = 1
   # Build using the cross-tools
-  CC  = ${CROSS_COMPILE}clang${CROSS_COMPILE_SUFFIX}
-  CXX = ${CROSS_COMPILE}clang++${CROSS_COMPILE_SUFFIX}
-  AR  = ${CROSS_COMPILE}ar${CROSS_COMPILE_SUFFIX}
+  override_cross_compile ?= 0
+  ifeq ($(override_cross_compile),0)
+    CC  = ${CROSS_COMPILE}clang${CROSS_COMPILE_SUFFIX}
+    CXX = ${CROSS_COMPILE}clang++${CROSS_COMPILE_SUFFIX}
+    AR  = ${CROSS_COMPILE}ar${CROSS_COMPILE_SUFFIX}
+  endif
   # Cross-linker requires this for linked in shared libs that depend
   # themselves on other shared libs (not directly linked in)
   LDFLAGS += -Wl,-rpath-link,$(ACE_ROOT)/lib
@@ -50,7 +53,7 @@ templates ?= automatic
 # If the platform file didn't already set versioned_so, default to 1.
 versioned_so ?= 1
 with_ld ?=
-ifeq ($(versioned_so),1)
+ifneq ($(versioned_so),0)
   ifeq ($(with_ld),hpux)
     SOFLAGS += -Wl,+h -Wl,$(SONAME)
   else

--- a/ACE/include/makeinclude/platform_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_clang_common.GNU
@@ -23,7 +23,7 @@ ifneq ($(CROSS_COMPILE),)
     TAO_IDL3_TO_IDL2_DEP = $(TAO_IDL3_TO_IDL2)
     TAO_IDL3_TO_XMI = $(HOST_ROOT)/bin/tao_idl3_to_xmi
     TAO_IDL3_TO_XMI_DEP = $(TAO_IDL3_TO_XMI)
-    # make sure to use the target compiler, not the cross-compiler
+    # make sure to use the host compiler, not the cross-compiler
     # as preprocessor for the cross-compiled idl tools
     TAO_IDL_PREPROCESSOR = clang
   endif

--- a/ACE/include/makeinclude/platform_g++_common.GNU
+++ b/ACE/include/makeinclude/platform_g++_common.GNU
@@ -253,3 +253,6 @@ pipes ?= 1
 
 FLAGS_C_CC += -Wall -W -Wpointer-arith
 CCFLAGS += -Wnon-virtual-dtor
+
+# Suppress "ar: creating *.a" Message
+ARFLAGS += -c

--- a/ACE/include/makeinclude/platform_g++_common.GNU
+++ b/ACE/include/makeinclude/platform_g++_common.GNU
@@ -26,7 +26,7 @@ else
       TAO_IDL3_TO_IDL2_DEP = $(TAO_IDL3_TO_IDL2)
       TAO_IDL3_TO_XMI = $(HOST_ROOT)/bin/tao_idl3_to_xmi
       TAO_IDL3_TO_XMI_DEP = $(TAO_IDL3_TO_XMI)
-      # make sure to use the target compiler, not the cross-compiler
+      # make sure to use the host compiler, not the cross-compiler
       # as preprocessor for the cross-compiled idl tools
       TAO_IDL_PREPROCESSOR = gcc
     endif

--- a/ACE/include/makeinclude/rules.lib.GNU
+++ b/ACE/include/makeinclude/rules.lib.GNU
@@ -1,6 +1,6 @@
 # -*- Makefile -*-
 #----------------------------------------------------------------------------
-#       
+#
 #
 #       Build libraries (i.e., contain no binary executables)
 #       GNU version
@@ -22,12 +22,12 @@ ifneq ($(versioned_so),0)
   ifeq ($(SOVERSION),)
     ifeq ($(versioned_so),1)
       SOVERSION = .$(GNUACE_PROJECT_VERSION)
+    else ifeq ($(versioned_so),2)
+      SOVERSION = -$(GNUACE_PROJECT_VERSION)
+    else ifeq ($(versioned_so),3)
+      # Nothing
     else
-      ifeq ($(versioned_so),2)
-        SOVERSION = -$(GNUACE_PROJECT_VERSION)
-      else
-        $(error unknown value for versioned_so: $(versioned_so))
-      endif
+      $(error unknown value for versioned_so: $(versioned_so))
     endif
   endif # SOVERSION
 
@@ -36,10 +36,10 @@ ifneq ($(versioned_so),0)
   ifeq ($(SONAME),)
     ifeq ($(versioned_so),1)
       SONAME = $(SHLIB)$(SOVERSION)
-    else
-      ifeq ($(versioned_so),2)
-        SONAME = $(patsubst %.$(SOEXT),%,$(SHLIB))$(SOVERSION).$(SOEXT)
-      endif
+    else ifeq ($(versioned_so),2)
+      SONAME = $(patsubst %.$(SOEXT),%,$(SHLIB))$(SOVERSION).$(SOEXT)
+    else ifeq ($(versioned_so),3)
+      SONAME = $(SHLIB)
     endif
   endif # SONAME
 endif # versioned_so

--- a/ACE/include/makeinclude/wrapper_macros.GNU
+++ b/ACE/include/makeinclude/wrapper_macros.GNU
@@ -82,6 +82,8 @@
 #                   the version will be appended to the name but *before* the
 #                   $(SOEXT) - it should have a lead '-' - else it defaults to
 #                   -ACE_MAJOR.ACE_MINOR.ACE_MICRO.
+#                   If versioned_so is 3, then set the SONAME, but without a
+#                   version.
 #  wfmo             Build with wfmo support (Win32 only)
 #  winregistry      Build with windows registry support (Win32 only)
 #  winnt            Build WinNT-specific projects (Win32 only)

--- a/ACE/tests/Compiler_Features_32_Test.cpp
+++ b/ACE/tests/Compiler_Features_32_Test.cpp
@@ -45,7 +45,7 @@ A::u_type_::~u_type_ ()
 void A::clear ()
 {
 #if defined __clang__ && \
-    (defined __apple_build_version__ && __apple_build_version__ <= 11030032 \
+    (defined __apple_build_version__ && __apple_build_version__ <= 12000322 \
      || __clang_major__ <= 10)
 #define CLANG_WORKAROUND
 #endif


### PR DESCRIPTION
Changes in https://github.com/DOCGroup/ACE_TAO/pull/1318 modified for capability's sake for ACE6.

- Made it easier to use `gnuace`-built libraries in as imported libraries in CMake-based Android Studio native projects.

- Replaced `ANDROID_ABI` with `android_abi`, but kept the former as an alias of the later for compatibility.

- Remove need to pass a macro to compiler about `android/ndk-version.h` unless the NDK is old