### PR TITLE
Moved anonymous IDL constructs to their own files

### DIFF
--- a/TAO/tests/IDL_Test/IDL_Test.mpc
+++ b/TAO/tests/IDL_Test/IDL_Test.mpc
@@ -15,6 +15,7 @@ project(*IDL): taoserver, messaging, gen_ostream {
   }
 
   IDL_Files {
+    array.idl
     Bug_2350_Regression.idl
     Bug_2577_Regression.idl
     Bug_2582_Regression.idl
@@ -41,22 +42,24 @@ project(*IDL): taoserver, messaging, gen_ostream {
     old_union2.idl
     params.idl
     reopened_modules.idl
+    sequence.idl
     struct.idl
     string_value.idl
     reopen_include1.idl
     reopen_include2.idl
     typeprefix.idl
+    union.idl
   }
 
   IDL_Files {
     idlflags += -as
     enum_in_struct.idl
-    array.idl
+    array_anonymous.idl
     array_anon_nested.idl
     included.idl
     including.idl
-    sequence.idl
-    union.idl
+    sequence_anonymous.idl
+    union_anonymous.idl
     anyunion.idl
     valuetype.idl
   }
@@ -109,6 +112,8 @@ project(*DLL): taoidldefaults, taolib, messaging {
     anyunionS.cpp
     arrayC.cpp
     arrayS.cpp
+    array_anonymousC.cpp
+    array_anonymousS.cpp
     array_anon_nestedC.cpp
     array_anon_nestedS.cpp
     array_onlyA.cpp
@@ -201,6 +206,8 @@ project(*DLL): taoidldefaults, taolib, messaging {
     repo_id_modS.cpp
     sequenceC.cpp
     sequenceS.cpp
+    sequence_anonymousC.cpp
+    sequence_anonymousS.cpp
     simple2C.cpp
     simple2S.cpp
     simpleC.cpp
@@ -219,6 +226,8 @@ project(*DLL): taoidldefaults, taolib, messaging {
     typeprefixS.cpp
     unionC.cpp
     unionS.cpp
+    union_anonymousC.cpp
+    union_anonymousS.cpp
     valuetypeC.cpp
     valuetypeS.cpp
   }
@@ -261,6 +270,7 @@ project(*NDDS_IDL): ndds_cck_ts_defaults {
   NDDSTypeSupport_Files {
     anonymous.idl
     array.idl
+    array_anonymous.idl
     array_only.idl
     attribute.idl
     Bug_2350_Regression.idl
@@ -301,6 +311,7 @@ project(*NDDS_IDL): ndds_cck_ts_defaults {
     reopen_include2.idl
     repo_id_mod.idl
     sequence.idl
+    sequence_anonymous.idl
     simple.idl
     simple2.idl
     struct.idl
@@ -308,6 +319,7 @@ project(*NDDS_IDL): ndds_cck_ts_defaults {
     typedef.idl
     typeprefix.idl
     union.idl
+    union_anonymous.idl
     valuetype.idl
   }
 }
@@ -318,6 +330,7 @@ project(*CoreDX_IDL): coredx_ts_defaults {
   CoreDXTypeSupport_Files {
     anonymous.idl
     array.idl
+    array_anonymous.idl
     array_only.idl
     attribute.idl
     Bug_2350_Regression.idl
@@ -358,6 +371,7 @@ project(*CoreDX_IDL): coredx_ts_defaults {
     reopen_include2.idl
     repo_id_mod.idl
     sequence.idl
+    sequence_anonymous.idl
     simple.idl
     simple2.idl
     struct.idl
@@ -365,6 +379,7 @@ project(*CoreDX_IDL): coredx_ts_defaults {
     typedef.idl
     typeprefix.idl
     union.idl
+    uion_anonymous.idl
     valuetype.idl
   }
 }
@@ -390,6 +405,9 @@ project(*NDDS_Lib): taolib, messaging, gen_ostream, nddslib {
     array.cxx
     arrayPlugin.cxx
     arraySupport.cxx
+    array_anonymous.cxx
+    array_anonymousPlugin.cxx
+    array_anonymousSupport.cxx
     array_only.cxx
     array_onlyPlugin.cxx
     array_onlySupport.cxx
@@ -500,6 +518,9 @@ project(*NDDS_Lib): taolib, messaging, gen_ostream, nddslib {
 //    sequence.cxx
 //    sequencePlugin.cxx
 //    sequenceSupport.cxx
+//    sequence_anonymous.cxx
+//    sequence_anonymousPlugin.cxx
+//    sequence_anonymousSupport.cxx
     simple.cxx
     simple2.cxx
     simple2Plugin.cxx
@@ -521,6 +542,9 @@ project(*NDDS_Lib): taolib, messaging, gen_ostream, nddslib {
 //    union.cxx
 //    unionPlugin.cxx
 //    unionSupport.cxx
+//    union_anonymous.cxx
+//    union_anonymousPlugin.cxx
+//    union_anonymousSupport.cxx
 //    valuetype.cxx
 //    valuetypePlugin.cxx
 //    valuetypeSupport.cxx

--- a/TAO/tests/IDL_Test/array.idl
+++ b/TAO/tests/IDL_Test/array.idl
@@ -32,40 +32,6 @@ struct wrap
   };
 
 typedef wrap outside_array[10];
-
-
-// Once a problem with expressions in the brackets,
-// as well as the typedef'd/anonymous thing.
-
-interface tdef
-{
-  const short byteslen = 12;
-  typedef octet Bytes[byteslen + 1];
-
-  struct bytes_or_longs
-    {
-      Bytes the_bytes;            // typedef'd
-      long Longs[byteslen];       // anonymous
-    };
-};
-
-// To test that all the octet arrays build and link as
-// unique types.
-module ABCModule
-{
-  struct RmtPhysicalInfo
-  {
-    octet rmtNodeId[22];
-    octet rmtDetails[22];
-  };
-
-  struct bbbBubBubBubBaby
-  {
-    octet rmtNodeId[22];
-    octet rmtDetails[22];
-  };
-};
-
 typedef octet oa1[22];
 typedef octet oa2[22];
 
@@ -158,5 +124,15 @@ module bug_2126
     case TRUE: BdMyStruct second_union_struct_member;
     case FALSE: long wibble;
   };
+};
+
+typedef long B41[2][3];
+typedef long B42[2];
+typedef long B43[4];
+
+union B85 switch (long) {
+  case 1: B42 b_85_1;
+  case 2: B43 b_85_2;
+  case 3: B41 b_85_3;
 };
 

--- a/TAO/tests/IDL_Test/array_anonymous.idl
+++ b/TAO/tests/IDL_Test/array_anonymous.idl
@@ -1,0 +1,47 @@
+
+//=============================================================================
+/**
+ *  @file    array_anonymous.idl
+ *
+ *  This file contains examples of IDL code that has
+ *  caused problems in the past for the TAO IDL
+ *  compiler. This test is to make sure the problems
+ *  stay fixed.
+ *
+ *  @author Jeff Parsons <parsons@cs.wustl.edu> and TAO users.
+ */
+//=============================================================================
+
+// Once a problem with expressions in the brackets,
+// as well as the typedef'd/anonymous thing.
+interface tdef
+{
+  const short byteslen = 12;
+  typedef octet Bytes[byteslen + 1];
+
+  struct bytes_or_longs
+    {
+      Bytes the_bytes;            // typedef'd
+      long Longs[byteslen];       // anonymous
+    };
+};
+
+// To test that all the octet arrays build and link as
+// unique types.
+module ABCModule
+{
+  struct RmtPhysicalInfo
+  {
+    octet rmtNodeId[22];
+    octet rmtDetails[22];
+  };
+
+  struct bbbBubBubBubBaby
+  {
+    octet rmtNodeId[22];
+    octet rmtDetails[22];
+  };
+};
+
+
+

--- a/TAO/tests/IDL_Test/sequence.idl
+++ b/TAO/tests/IDL_Test/sequence.idl
@@ -35,39 +35,11 @@ exception nasty
 // tao/OctetSeqC.h is ever removed.
 typedef sequence<CORBA::OctetSeq> OctetSeqSeq;
 
-// Bounded string elements of a sequence,
-// require the use of CORBA_Any::to_char.
-
-interface seqTest
-{
-  typedef sequence< string<12> > dozens;
-
-  void send_dozen (inout dozens bouquets);
-};
-
 local interface seqLocal
 {
 };
 
 typedef sequence<seqLocal> seqLocalSeq;
-
-// Anonymous sequence members must be unique types even if the
-// sequence itself is not, so the member name has been
-// incorported into the sequence class name. #if !defined guards
-// are generated around code for the inner anonymous sequences.
-struct twinStruct
-  {
-    sequence<sequence<short> > and_;
-    sequence<sequence<short> > or_;
-  };
-
-// Nested sequences
-typedef sequence<sequence<short, 5> > outside;
-
-struct nestedSeqStruct
-{
-  sequence<sequence<outside>, 7> inside;
-};
 
 // Tests deeply nested recursive type.
 module Deployment

--- a/TAO/tests/IDL_Test/sequence_anonymous.idl
+++ b/TAO/tests/IDL_Test/sequence_anonymous.idl
@@ -1,0 +1,41 @@
+//=============================================================================
+/**
+ *  @file    sequence_anonymous.idl
+ *
+ *  This file contains examples of IDL code that has
+ *  caused problems in the past for the TAO IDL
+ *  compiler. This test is to make sure the problems
+ *  stay fixed.
+ *
+ *
+ *  @author Jeff Parsons <parsons@cs.wustl.edu> and TAO users.
+ */
+//=============================================================================
+
+// Bounded string elements of a sequence,
+// require the use of CORBA_Any::to_char.
+interface seqTest
+{
+  typedef sequence< string<12> > dozens;
+
+  void send_dozen (inout dozens bouquets);
+};
+
+// Anonymous sequence members must be unique types even if the
+// sequence itself is not, so the member name has been
+// incorported into the sequence class name. #if !defined guards
+// are generated around code for the inner anonymous sequences.
+struct twinStruct
+  {
+    sequence<sequence<short> > and_;
+    sequence<sequence<short> > or_;
+  };
+
+// Nested sequences
+typedef sequence<sequence<short, 5> > outside;
+
+struct nestedSeqStruct
+{
+  sequence<sequence<outside>, 7> inside;
+};
+

--- a/TAO/tests/IDL_Test/union.idl
+++ b/TAO/tests/IDL_Test/union.idl
@@ -225,21 +225,6 @@ struct Field
   FieldValue value;
 };
 
-// Tricky case of lookup for a recursive union. When defined
-// inside another datatype like this, the union is referenced
-// inside itself before the closing brace is seen, but not
-// declared yet.
-struct Element
-{
-  union ValueUnion switch (short)
-  {
-    case 0:
-      long lvalue;
-    case 1:
-      sequence<ValueUnion> VUValue;
-  } Value;
-};
-
 // A fix to the IDL compiler's typecode generation created
 // a problem with unions that have more than one member,
 // where any member except the last is itself a scoped type.
@@ -261,46 +246,5 @@ union TestUnion switch (short)
 {
   case 1: TestOneEnum oneEnum;
   case 2: TestTwoEnum twoEnum;
-};
-
-// Test for various kinds of declarations inside a union,
-// similar to the example in enum_in_struct.idl.
-
-typedef long NamedLongArray[10];
-
-union decl_heavy_union switch (short)
-{
-  case 1:
-    enum which
-    {
-      ZERO,
-      ONE,
-      TWO
-    } m_which;
-  case 2:
-    enum en
-    {
-      a,
-      b,
-      c
-    } m_en_arr[10];
-  case 3:
-    struct st
-    {
-      long a;
-      char b;
-    } m_st_arr[10];
-  case 4:
-    union un switch (long)
-    {
-      case 1: long a;
-      case 2: char b;
-    } m_un_arr[10];
-  // The following caused compile problems once
-  // when generating ostream ops
-  case 5:
-    NamedLongArray m_named_long_array;
-  case 6:
-    long m_anon_long_array[10];
 };
 

--- a/TAO/tests/IDL_Test/union_anonymous.idl
+++ b/TAO/tests/IDL_Test/union_anonymous.idl
@@ -1,0 +1,68 @@
+//=============================================================================
+/**
+ *  @file    union_anonymous.idl
+ *
+ *  This file contains examples of IDL code that has
+ *  caused problems in the past for the TAO IDL
+ *  compiler. This test is to make sure the problems
+ *  stay fixed.
+ *
+ *
+ *  @author Jeff Parsons <parsons@cs.wustl.edu> and TAO users.
+ */
+//=============================================================================
+
+// Tricky case of lookup for a recursive union. When defined
+// inside another datatype like this, the union is referenced
+// inside itself before the closing brace is seen, but not
+// declared yet.
+struct Element
+{
+  union ValueUnion switch (short)
+  {
+    case 0:
+      long lvalue;
+    case 1:
+      sequence<ValueUnion> VUValue;
+  } Value;
+};
+
+// Test for various kinds of declarations inside a union,
+// similar to the example in enum_in_struct.idl.
+typedef long NamedLongArray[10];
+
+union decl_heavy_union switch (short)
+{
+  case 1:
+    enum which
+    {
+      ZERO,
+      ONE,
+      TWO
+    } m_which;
+  case 2:
+    enum en
+    {
+      a,
+      b,
+      c
+    } m_en_arr[10];
+  case 3:
+    struct st
+    {
+      long a;
+      char b;
+    } m_st_arr[10];
+  case 4:
+    union un switch (long)
+    {
+      case 1: long a;
+      case 2: char b;
+    } m_un_arr[10];
+  // The following caused compile problems once
+  // when generating ostream ops
+  case 5:
+    NamedLongArray m_named_long_array;
+  case 6:
+    long m_anon_long_array[10];
+};


### PR DESCRIPTION
    * TAO/tests/IDL_Test/array_anonymous.idl:
    * TAO/tests/IDL_Test/sequence_anonymous.idl:
    * TAO/tests/IDL_Test/union_anonymous.idl:
      Added.

    * TAO/tests/IDL_Test/IDL_Test.mpc:
    * TAO/tests/IDL_Test/array.idl:
    * TAO/tests/IDL_Test/sequence.idl:
    * TAO/tests/IDL_Test/union.idl: