### PR TITLE
Revert "Revert "Use unspecified_bool_type instead of bool.""

### DIFF
--- a/ACE/ace/Refcounted_Auto_Ptr.h
+++ b/ACE/ace/Refcounted_Auto_Ptr.h
@@ -44,6 +44,10 @@ template <class X, class ACE_LOCK> class ACE_Refcounted_Auto_Ptr;
 template <class X, class ACE_LOCK>
 class ACE_Refcounted_Auto_Ptr
 {
+  /// Used to define a proper boolean conversion for "if (sp) ..."
+  static void unspecified_bool(ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>***){};
+  typedef void (*unspecified_bool_type)(ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>***);
+
 public:
   /// Constructor that initializes an ACE_Refcounted_Auto_Ptr to
   /// the specified pointer value.
@@ -86,7 +90,7 @@ public:
   bool operator !() const;
 
   /// Check rep easily.
-  operator bool () const;
+  operator unspecified_bool_type() const;
 
   /// Releases the reference to the underlying representation object.
   /// @retval The pointer value prior to releasing it.

--- a/ACE/ace/Refcounted_Auto_Ptr.inl
+++ b/ACE/ace/Refcounted_Auto_Ptr.inl
@@ -128,9 +128,9 @@ ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>::operator !() const
 }
 
 template<class X, class ACE_LOCK> inline
-ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>::operator bool () const
+ACE_Refcounted_Auto_Ptr<X, ACE_LOCK>::operator unspecified_bool_type () const
 {
-  return this->rep_->get () != 0;
+  return this->rep_->get () != 0 ? unspecified_bool : 0;
 }
 
 template <class X, class ACE_LOCK> inline X*


### PR DESCRIPTION
Reverts DOCGroup/ACE_TAO#1227 

Should now not be a problem now Visual Studio 7.1 is not supported anymore for ACE 7