### PR TITLE
Don't print the exception, causes the scoreboard scripts to flag this…

### DIFF
--- a/TAO/tests/ORB_portspan/server.cpp
+++ b/TAO/tests/ORB_portspan/server.cpp
@@ -21,9 +21,9 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
       orb->run();
     }
-  catch (const CORBA::Exception& ex)
+  catch (const CORBA::Exception&)
     {
-      ex._tao_print_exception ("Exception in main():");
+      ACE_DEBUG ((LM_DEBUG, "server failed to start\n"));
       return 1;
     }
 


### PR DESCRIPTION
… test as error, the exception is expected

    * TAO/tests/ORB_portspan/server.cpp: