### PR TITLE
Instead of checking for the linux define use ACE_LINUX, the first doe…

### DIFF
--- a/TAO/DevGuideExamples/RTCORBA/README
+++ b/TAO/DevGuideExamples/RTCORBA/README
@@ -1,5 +1,3 @@
-
-
 DevGuideExamples/RTCORBA/README
 
 This directory contains an RTCORBA example illustrating a simple client and

--- a/TAO/DevGuideExamples/RTCORBA/common.cpp
+++ b/TAO/DevGuideExamples/RTCORBA/common.cpp
@@ -3,7 +3,7 @@
 CORBA::ULong
 get_total_lanes()
 {
-#if defined (linux)
+#if defined (ACE_LINUX)
   return 1;
 #elif defined (ACE_CONFIG_WIN32_H)
   return 3;

--- a/TAO/orbsvcs/LoadBalancer/LoadManager.cpp
+++ b/TAO/orbsvcs/LoadBalancer/LoadManager.cpp
@@ -8,9 +8,9 @@
 
 #include "tao/IORTable/IORTable.h"
 
-#if defined (linux) && defined (ACE_HAS_THREADS)
+#if defined (ACE_LINUX) && defined (ACE_HAS_THREADS)
 # include "ace/Signal.h"
-#endif /* linux && ACE_HAS_THREADS */
+#endif /* ACE_LINUX && ACE_HAS_THREADS */
 
 static const ACE_TCHAR *lm_ior_file = ACE_TEXT("lm.ior");
 static int ping_timeout_milliseconds = 2000;
@@ -83,7 +83,7 @@ parse_args (int argc,
     }
 }
 
-#if defined (linux) && defined (ACE_HAS_THREADS)
+#if defined (ACE_LINUX) && defined (ACE_HAS_THREADS)
 // Only the main thread can handle signals in Linux.  Run the
 // LoadManager in thread other than main().
 extern "C"
@@ -210,7 +210,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       ACE_OS::fprintf (lm_ior, "%s", str.in ());
       ACE_OS::fclose (lm_ior);
 
-#if defined (linux) && defined (ACE_HAS_THREADS)
+#if defined (ACE_LINUX) && defined (ACE_HAS_THREADS)
       if (ACE_Thread_Manager::instance ()->spawn (::TAO_LB_run_load_manager,
                                                   orb.in ()) == -1)
         {

--- a/TAO/orbsvcs/LoadBalancer/LoadMonitor.cpp
+++ b/TAO/orbsvcs/LoadBalancer/LoadMonitor.cpp
@@ -98,7 +98,7 @@ parse_args (int argc, ACE_TCHAR *argv[])
     }
 }
 
-#if defined (linux) && defined (ACE_HAS_THREADS)
+#if defined (ACE_LINUX) && defined (ACE_HAS_THREADS)
 // Only the main thread can handle signals in Linux.  Run the
 // LoadManager in thread other than main().
 extern "C"
@@ -278,7 +278,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                                reactor,
                                timer_id);
 
-#if defined (linux) && defined (ACE_HAS_THREADS)
+#if defined (ACE_LINUX) && defined (ACE_HAS_THREADS)
       if (ACE_Thread_Manager::instance ()->spawn (::TAO_LB_run_load_monitor,
                                                   orb.in ()) == -1)
         {

--- a/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_CPU_Load_Average_Monitor.cpp
+++ b/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_CPU_Load_Average_Monitor.cpp
@@ -107,7 +107,7 @@ TAO_LB_CPU_Load_Average_Monitor::loads ()
       load = ((system_ll - idle_ll) * 100 / system_ll)  / sys_info.dwNumberOfProcessors;
     }
 
-#elif defined (linux) || defined (sun)
+#elif defined (ACE_LINUX) || defined (sun)
 
   // Only bother getting the load average over the last minute.
   //
@@ -115,7 +115,7 @@ TAO_LB_CPU_Load_Average_Monitor::loads ()
   //       last 5 and 15 minutes can be used instead.
   double loadavg[1];
 
-# if defined (linux) \
+# if defined (ACE_LINUX) \
      && ((defined (__GLIBC__) && defined (__GLIBC_MINOR__) \
           && __GLIBC__ == 2 && __GLIBC_MINOR__ < 2) \
          || (!defined (_BSD_SOURCE) && !defined (_GNU_SOURCE)))
@@ -217,8 +217,7 @@ TAO_LB_CPU_Load_Average_Monitor::loads ()
 
 #endif
 
-#if defined (linux) || defined (sun) || defined (__hpux) || defined(__NetBSD__) || defined (__APPLE__)
-
+#if defined (ACE_LINUX) || defined (sun) || defined (__hpux) || defined(__NetBSD__) || defined (__APPLE__)
   CosLoadBalancing::LoadList * tmp = 0;
   ACE_NEW_THROW_EX (tmp,
                     CosLoadBalancing::LoadList (1),

--- a/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_CPU_Utilization_Monitor.cpp
+++ b/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_CPU_Utilization_Monitor.cpp
@@ -124,8 +124,7 @@ TAO_LB_CPU_Utilization_Monitor::loads ()
 {
   CORBA::Float load = 0;
 
-#if defined (linux) || defined (sun)
-
+#if defined (ACE_LINUX) || defined (sun)
   double load_double = calc_cpu_loading ();
   load = load_double;
 

--- a/TAO/tests/Time_Policy/main.cpp
+++ b/TAO/tests/Time_Policy/main.cpp
@@ -25,7 +25,7 @@
      defined (ACE_WIN32) || \
      (defined (ghs) && defined (ACE_HAS_PENTIUM)) || \
      ((defined (__GNUG__) || defined (__INTEL_COMPILER)) && !defined(ACE_VXWORKS) && defined (ACE_HAS_PENTIUM)) || \
-     (defined (linux) && defined (ACE_HAS_ALPHA_TIMER)) || \
+     (defined (ACE_LINUX) && defined (ACE_HAS_ALPHA_TIMER)) || \
      (defined (ACE_HAS_POWERPC_TIMER) && (defined (ghs) || defined (__GNUG__))) || \
      (defined (ACE_HAS_CLOCK_GETTIME) && defined (ACE_HAS_CLOCK_GETTIME_MONOTONIC)))
 


### PR DESCRIPTION
…sn't seem to be set on RHEL75

    * TAO/DevGuideExamples/RTCORBA/README:
    * TAO/DevGuideExamples/RTCORBA/common.cpp:
    * TAO/orbsvcs/LoadBalancer/LoadManager.cpp:
    * TAO/orbsvcs/LoadBalancer/LoadMonitor.cpp:
    * TAO/orbsvcs/orbsvcs/LoadBalancing/LB_CPU_Load_Average_Monitor.cpp:
    * TAO/orbsvcs/orbsvcs/LoadBalancing/LB_CPU_Utilization_Monitor.cpp:
    * TAO/tests/Time_Policy/main.cpp: