### PR TITLE
Removed check for ACE_LACKS_PLACEMENT_OPERATOR_DELETE, supported by a…

### DIFF
--- a/ACE/ace/Svc_Handler.cpp
+++ b/ACE/ace/Svc_Handler.cpp
@@ -10,7 +10,6 @@
 #include "ace/OS_NS_sys_time.h"
 #include "ace/Object_Manager.h"
 #include "ace/Connection_Recycling_Strategy.h"
-
 #include "ace/Dynamic.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -22,14 +21,12 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t, void *p)
   return p;
 }
 
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
 template <typename PEER_STREAM, typename SYNCH_TRAITS> void
 ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator delete (void *, void *)
 {
   ACE_TRACE ("ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator delete (NOOP, 2 parameters)");
   return;
 }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 
 template <typename PEER_STREAM, typename SYNCH_TRAITS> void *
 ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t n)
@@ -85,7 +82,6 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t n,
     }
 }
 
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
 template <typename PEER_STREAM, typename SYNCH_TRAITS> void
 ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator delete (void *p,
                                          const ACE_nothrow_t&) throw()
@@ -93,7 +89,6 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator delete (void *p,
   ACE_TRACE("ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator delete(nothrow)");
   ::delete [] static_cast <char *> (p);
 }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 
 #endif /* ACE_HAS_NEW_NOTHROW */
 

--- a/ACE/ace/Svc_Handler.h
+++ b/ACE/ace/Svc_Handler.h
@@ -176,9 +176,7 @@ public:
   /// itself up correctly whether or not it's allocated statically or
   /// dynamically.
   void *operator new (size_t n, const ACE_nothrow_t&) throw();
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   void operator delete (void *p, const ACE_nothrow_t&) throw ();
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif
 
   /// This operator permits "placement new" on a per-object basis.
@@ -202,14 +200,12 @@ public:
    */
   void operator delete (void *);
 
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   /**
    * This operator is necessary to complement the class-specific
    * operator new above.  Unfortunately, it's not portable to all C++
    * compilers...
    */
   void operator delete (void *, void *);
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 
   /// Close down the descriptor and unregister from the Reactor
   void shutdown ();

--- a/ACE/ace/config-hpux-11.00.h
+++ b/ACE/ace/config-hpux-11.00.h
@@ -52,12 +52,6 @@
 // Platform lacks streambuf "linebuffered ()".
 #    define ACE_LACKS_LINEBUFFERED_STREAMBUF 1
 
-// Lack of (and broken) support for placement operator delete is a known
-// bug by HP, up until aC++ A.03.55.02.
-#    if (__HP_aCC < 35502)
-#      define ACE_LACKS_PLACEMENT_OPERATOR_DELETE
-#    endif /* __HP_aCC < 35502 */
-
 // Compiler's 'new' throws exceptions on failure, regardless of whether or
 // not exception handling is enabled in the compiler options. Fortunately,
 // new(nothrow_t) is offered.

--- a/ACE/ace/config-sunos5.5.h
+++ b/ACE/ace/config-sunos5.5.h
@@ -47,8 +47,6 @@
 #     define ACE_HAS_THR_C_DEST
 #   endif /* __SUNPRO_CC_COMPAT >= 5 */
 #   define ACE_HAS_NEW_NOTHROW
-# elif (__SUNPRO_CC == 0x420) || (__SUNPRO_CC == 0x410)
-# define ACE_LACKS_PLACEMENT_OPERATOR_DELETE
 # endif /* __SUNPRO_CC >= 0x500 */
 # endif /* __SUNPRO_CC >= 0x420 */
 

--- a/ACE/examples/DLL/Newsweek.cpp
+++ b/ACE/examples/DLL/Newsweek.cpp
@@ -24,13 +24,11 @@ Newsweek::operator new (size_t bytes, const ACE_nothrow_t&)
 {
   return ::new (ACE_nothrow) char[bytes];
 }
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
 void
 Newsweek::operator delete (void *p, const ACE_nothrow_t&) throw ()
 {
   delete [] static_cast <char *> (p);
 }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif
 void
 Newsweek::operator delete (void *ptr)

--- a/ACE/examples/DLL/Newsweek.h
+++ b/ACE/examples/DLL/Newsweek.h
@@ -44,9 +44,7 @@ public:
 #if defined (ACE_HAS_NEW_NOTHROW)
   // Overloaded new operator, nothrow_t variant.
   void *operator new (size_t bytes, const ACE_nothrow_t&);
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   void operator delete (void *p, const ACE_nothrow_t&) throw ();
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif
   void operator delete (void *ptr);
 };

--- a/ACE/examples/DLL/Today.cpp
+++ b/ACE/examples/DLL/Today.cpp
@@ -25,13 +25,11 @@ Today::operator new (size_t bytes, const ACE_nothrow_t&)
 {
   return ::new (ACE_nothrow) char[bytes];
 }
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
 void
 Today::operator delete (void *p, const ACE_nothrow_t&) throw ()
 {
   delete [] static_cast <char *> (p);
 }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif
 void
 Today::operator delete (void *ptr)

--- a/ACE/examples/DLL/Today.h
+++ b/ACE/examples/DLL/Today.h
@@ -45,9 +45,7 @@ public:
 #if defined (ACE_HAS_NEW_NOTHROW)
   // Overloaded new operator, nothrow_t variant.
   void *operator new (size_t bytes, const ACE_nothrow_t&);
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   void operator delete (void *p, const ACE_nothrow_t&) throw ();
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif
   void operator delete (void *ptr);
 };

--- a/ACE/examples/Shared_Malloc/test_persistence.cpp
+++ b/ACE/examples/Shared_Malloc/test_persistence.cpp
@@ -64,12 +64,10 @@ public:
   {
     return shmem_allocator->malloc (sizeof (Employee));
   }
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   void operator delete (void *p, const ACE_nothrow_t&) throw ()
   {
     shmem_allocator->free (p);
   }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif
 
   void operator delete (void *pointer)

--- a/ACE/tests/DLL_Test_Impl.cpp
+++ b/ACE/tests/DLL_Test_Impl.cpp
@@ -61,14 +61,12 @@ Hello_Impl::operator new (size_t bytes, const ACE_nothrow_t &nt)
   return ::new (nt) char[bytes];
 }
 
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
 void
 Hello_Impl::operator delete (void *ptr, const ACE_nothrow_t&) throw ()
 {
   ACE_DEBUG ((LM_INFO, "Hello_Impl::delete\n"));
   ::delete [] static_cast<char *> (ptr);
 }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 
 #endif /* ACE_HAS_NEW_NOTHROW */
 

--- a/ACE/tests/DLL_Test_Impl.h
+++ b/ACE/tests/DLL_Test_Impl.h
@@ -53,9 +53,7 @@ public:
 #if defined (ACE_HAS_NEW_NOTHROW)
   /// Overloaded new operator, nothrow_t variant.
   void *operator new (size_t bytes, const ACE_nothrow_t &nt);
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   void operator delete (void *p, const ACE_nothrow_t&) throw ();
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif /* ACE_HAS_NEW_NOTHROW */
 
   void operator delete (void *ptr);

--- a/ACE/tests/Dynamic_Test.cpp
+++ b/ACE/tests/Dynamic_Test.cpp
@@ -26,18 +26,14 @@ public:
 
 #if defined (ACE_HAS_NEW_NOTHROW)
   void *operator new (size_t n, const ACE_nothrow_t&) throw();
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   void operator delete (void *p, const ACE_nothrow_t&) throw ();
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif
 
   void * operator new (size_t n, void *p);
 
   void operator delete (void *);
 
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
   void operator delete (void *, void *);
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 
   /// Have we been dynamically created?
   bool dynamic_;
@@ -92,13 +88,11 @@ A::operator new (size_t n, const ACE_nothrow_t&) throw()
     }
 }
 
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
 void
 A::operator delete (void *p, const ACE_nothrow_t&) throw()
 {
   ::delete [] static_cast <char *> (p);
 }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 
 #endif /* ACE_HAS_NEW_NOTHROW */
 

--- a/TAO/tests/POA/DSI/Database_i.cpp
+++ b/TAO/tests/POA/DSI/Database_i.cpp
@@ -359,13 +359,11 @@ DatabaseImpl::Employee::operator new (size_t size, const ACE_nothrow_t &)
   return DATABASE::instance ()->malloc (size);
 }
 
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
 void
 DatabaseImpl::Employee::operator delete (void *ptr, const ACE_nothrow_t&) throw ()
 {
   DATABASE::instance ()->free (ptr);
 }
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 
 #endif /* ACE_HAS_NEW_NOTHROW */
 

--- a/TAO/tests/POA/DSI/Database_i.h
+++ b/TAO/tests/POA/DSI/Database_i.h
@@ -115,9 +115,7 @@ public:
 #if defined (ACE_HAS_NEW_NOTHROW)
   /// Overloaded new operator, nothrow_t variant.
    void *operator new (size_t bytes, const ACE_nothrow_t &nt);
-#if !defined (ACE_LACKS_PLACEMENT_OPERATOR_DELETE)
    void operator delete (void *p, const ACE_nothrow_t&) throw ();
-#endif /* ACE_LACKS_PLACEMENT_OPERATOR_DELETE */
 #endif /* ACE_HAS_NEW_NOTHROW */
 
     void *operator new (size_t);


### PR DESCRIPTION
…ll compilers supporting C++11

    * ACE/ace/Svc_Handler.cpp:
    * ACE/ace/Svc_Handler.h:
    * ACE/ace/config-hpux-11.00.h:
    * ACE/ace/config-sunos5.5.h:
    * ACE/examples/DLL/Newsweek.cpp:
    * ACE/examples/DLL/Newsweek.h:
    * ACE/examples/DLL/Today.cpp:
    * ACE/examples/DLL/Today.h:
    * ACE/examples/Shared_Malloc/test_persistence.cpp:
    * ACE/tests/DLL_Test_Impl.cpp:
    * ACE/tests/DLL_Test_Impl.h:
    * ACE/tests/Dynamic_Test.cpp:
    * TAO/tests/POA/DSI/Database_i.cpp:
    * TAO/tests/POA/DSI/Database_i.h: