### PR TITLE
Removed ACE_HAS_EXCEPTIONS checks, that define is always set

### DIFF
--- a/ACE/ace/CORBA_macros.h
+++ b/ACE/ace/CORBA_macros.h
@@ -41,7 +41,6 @@
 #  define ACE_del_bad_alloc
 #endif
 
-// ACE_HAS_EXCEPTIONS is not the same as ACE_NEW_THROWS_EXCEPTIONS.
 #if defined(ACE_NEW_THROWS_EXCEPTIONS)
 
 # if defined (ACE_HAS_NEW_NOTHROW)

--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -217,15 +217,6 @@ ACE_Log_Msg_Manager::get_lock ()
 void
 ACE_Log_Msg_Manager::close ()
 {
-#if defined (ACE_HAS_STHREADS) && ! defined (ACE_HAS_TSS_EMULATION) && ! defined (ACE_HAS_EXCEPTIONS)
-  // Delete the (main thread's) Log_Msg instance.  I think that this
-  // is only "necessary" if exception handling is not enabled.
-  // Without exception handling, main thread TSS destructors don't
-  // seem to be called.  It's not really necessary anyways, because
-  // this one leak is harmless on Solaris.
-  delete ACE_Log_Msg::instance ();
-#endif /* ACE_HAS_STHREADS && ! TSS_EMULATION && ! ACE_HAS_EXCEPTIONS */
-
   // Ugly, ugly, but don't know a better way.
   delete ACE_Log_Msg_Manager::lock_;
   ACE_Log_Msg_Manager::lock_ = 0;

--- a/ACE/ace/README
+++ b/ACE/ace/README
@@ -273,8 +273,6 @@ ACE_HAS_DLL                             Build ACE using the frigging
                                         PC DLL nonsense...
 ACE_HAS_EBCDIC                          Compile in the ACE code set classes
                                         that support EBCDIC.
-ACE_HAS_EXCEPTIONS                      Compiler supports C++
-                                        exception handling
 ACE_HAS_EXPLICIT_TEMPLATE_INSTANTIATION_EXPORT  When a base-class is a
                                         specialization of a class template
                                         then this class template must be

--- a/ACE/ace/config-kfreebsd.h
+++ b/ACE/ace/config-kfreebsd.h
@@ -57,9 +57,6 @@
    etc. */
 #define ACE_HAS_DIRENT 1
 
-/* Compiler supports C++ exception handling. */
-#define ACE_HAS_EXCEPTIONS 1
-
 /* Define to 1 if platform has getifaddrs(). */
 #define ACE_HAS_GETIFADDRS 1
 

--- a/ACE/tests/Network_Adapters_Test.cpp
+++ b/ACE/tests/Network_Adapters_Test.cpp
@@ -614,19 +614,15 @@ Stop_Handler::handle_input (ACE_HANDLE handle)
       // remove from the reactor's tables all non-null entries
       if (this->handlers_to_stop_[i])
         {
-#if defined ACE_HAS_EXCEPTIONS
-
           // protect from deleted pointer
           try
             {
-#endif // ACE_HAS_EXCEPTIONS
 
               this->reactor ()->cancel_timer (this->handlers_to_stop_[i]);
               this->reactor ()->remove_handler
                 (this->handlers_to_stop_[i],
                  ACE_Event_Handler::ALL_EVENTS_MASK
                  | ACE_Event_Handler::DONT_CALL);
-#if defined ACE_HAS_EXCEPTIONS
             }
           catch (...)
             {
@@ -635,7 +631,6 @@ Stop_Handler::handle_input (ACE_HANDLE handle)
                           ACE_TEXT ("EXCEPTION CATCHED. Most probably ")
                           ACE_TEXT ("handler's pointer has been deleted.\n")));
             }
-#endif // ACE_HAS_EXCEPTIONS
           this->handlers_to_stop_[i] = 0;
         }
     }

--- a/ACE/tests/New_Fail_Test.cpp
+++ b/ACE/tests/New_Fail_Test.cpp
@@ -16,16 +16,10 @@
  */
 //=============================================================================
 
-
 #include "test_config.h"
 #include "ace/Log_Msg.h"
 #include "ace/OS_Memory.h"
 #include "ace/CORBA_macros.h"
-
-
-
-#if (!defined (__SUNPRO_CC) && !defined (__GNUG__)) || \
-  defined (ACE_HAS_EXCEPTIONS)
 
 #include "ace/Numeric_Limits.h"
 
@@ -67,7 +61,6 @@ try_ace_new_noreturn ()
   ACE_NEW_NORETURN (p, char[BIG_BLOCK]);
   return p;
 }
-#endif /* (!__SUNPRO_CC && !__GNUG__) || ACE_HAS_EXCEPTIONS */
 
 int
 run_main (int, ACE_TCHAR *[])
@@ -75,26 +68,11 @@ run_main (int, ACE_TCHAR *[])
   ACE_START_TEST (ACE_TEXT ("New_Fail_Test"));
   int status = 0;
 
-  // Some platforms are known to throw an exception on a failed 'new',
-  // but are customarily built without exception support to improve
-  // performance.  These platforms are noted, and the test passes.
-  // For new ports, it is wise to let this test run.  Depending on
-  // intended conditions, exceptions can be disabled when the port is
-  // complete.
-#if (defined (__SUNPRO_CC) || defined (__GNUG__)) && \
-  !defined (ACE_HAS_EXCEPTIONS)
-    ACE_DEBUG ((LM_NOTICE, ACE_TEXT ("Out-of-memory will throw an unhandled exception\n")));
-  ACE_DEBUG ((LM_NOTICE, ACE_TEXT ("Rebuild with exceptions=1 to prevent this, but it may impair performance.\n")));
-
-#else
-
   char *blocks[MAX_ALLOCS_IN_TEST];
   int i;
 
-#  if defined (ACE_HAS_EXCEPTIONS)
   try
     {
-#  endif /* ACE_HAS_EXCEPTIONS */
       // First part: test ACE_NEW
       for (i = 0; i < MAX_ALLOCS_IN_TEST; i++)
         {
@@ -194,10 +172,7 @@ run_main (int, ACE_TCHAR *[])
         }
       while (i >= 0)
         delete [] blocks[i--];
-
-#  if defined (ACE_HAS_EXCEPTIONS)
     }
-
   catch (...)
     {
       ACE_ERROR ((LM_ERROR,
@@ -209,8 +184,6 @@ run_main (int, ACE_TCHAR *[])
       // Mark test failure
       status = 1;
     }
-#  endif /* ACE_HAS_EXCEPTIONS */
-#endif /* __SUNPRO_CC && !ACE_HAS_EXCEPTIONS */
 
   ACE_END_TEST;
   return status;


### PR DESCRIPTION
    * ACE/ace/Log_Msg.cpp:
    * ACE/ace/README:
    * ACE/ace/config-kfreebsd.h:
    * ACE/tests/Network_Adapters_Test.cpp:
    * ACE/tests/New_Fail_Test.cpp: