### PR TITLE
Cleanup usage of ACE_HAS_DINKUM_STL, not set anymore in any config file

### DIFF
--- a/ACE/ace/OS_NS_stdio.inl
+++ b/ACE/ace/OS_NS_stdio.inl
@@ -1127,7 +1127,6 @@ ACE_OS::vsprintf (wchar_t *buffer, const wchar_t *format, va_list argptr)
 {
 # if (defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) >= 500) || \
      (defined (sun) && !(defined(_XOPEN_SOURCE) && (_XOPEN_VERSION-0==4))) || \
-      defined (ACE_HAS_DINKUM_STL) || \
       defined (ACE_HAS_VSWPRINTF) || \
       (defined (_MSC_VER) && !defined (ACE_HAS_WINCE))
 
@@ -1156,7 +1155,7 @@ ACE_OS::vsprintf (wchar_t *buffer, const wchar_t *format, va_list argptr)
   ACE_UNUSED_ARG (argptr);
   ACE_NOTSUP_RETURN (-1);
 
-# endif /* XPG5 || ACE_HAS_DINKUM_STL */
+# endif /* XPG5 */
 }
 #endif /* ACE_HAS_WCHAR */
 
@@ -1208,7 +1207,6 @@ ACE_OS::vsnprintf (wchar_t *buffer, size_t maxlen, const wchar_t *format, va_lis
 {
 # if (defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) >= 500) || \
      (defined (sun) && !(defined(_XOPEN_SOURCE) && (_XOPEN_VERSION-0==4))) || \
-     (defined (ACE_HAS_DINKUM_STL)) || \
       defined (ACE_HAS_VSWPRINTF) || \
       defined (ACE_WIN32)
 

--- a/ACE/ace/README
+++ b/ACE/ace/README
@@ -139,7 +139,6 @@ ACE_HAS_ALT_CUSERID                     Use ACE's alternate cuserid()
                                         ACE_LACKS_PWD_FUNCTIONS to be
                                         undefined and that the
                                         geteuid() system call exists.
-ACE_HAS_DINKUM_STL                      Using the Dinkum STL library
 ACE_DEFAULT_THREAD_KEYS                 Number of TSS keys, with
                                         ACE_HAS_TSS_EMULATION _only_.
                                         Defaults to 64.

--- a/ACE/ace/os_include/os_time.h
+++ b/ACE/ace/os_include/os_time.h
@@ -38,18 +38,16 @@
 #  include /**/ <time.h>
 #endif /* !ACE_LACKS_TIME_H */
 
-# if defined (ACE_USES_STD_NAMESPACE_FOR_STDC_LIB) && \
-             (ACE_USES_STD_NAMESPACE_FOR_STDC_LIB != 0)
+#if defined (ACE_USES_STD_NAMESPACE_FOR_STDC_LIB) && \
+            (ACE_USES_STD_NAMESPACE_FOR_STDC_LIB != 0)
 using std::tm;
-# if !defined (ACE_HAS_DINKUM_STL)
-#  if defined (ACE_WIN32)
+# if defined (ACE_WIN32)
 using std::_timezone;
-#  else
+# else
 using std::timezone;
-#  endif
-# endif
+# endif /* ACE_WIN32 */
 using std::difftime;
-# endif /* ACE_USES_STD_NAMESPACE_FOR_STDC_LIB */
+#endif /* ACE_USES_STD_NAMESPACE_FOR_STDC_LIB */
 
 # if !defined (ACE_HAS_POSIX_TIME)
 // Definition per POSIX.


### PR DESCRIPTION
Resolves #1400 

    * ACE/ace/OS_NS_stdio.inl:
    * ACE/ace/README:
    * ACE/ace/os_include/os_time.h: