### PR TITLE
g++ 4 has a problem that it warns when using a std::array containin…

### DIFF
--- a/ACE/include/makeinclude/platform_g++_common.GNU
+++ b/ACE/include/makeinclude/platform_g++_common.GNU
@@ -79,6 +79,12 @@ endif
 # gcc 4 has C++03 as default C++ version, enable this to be C++11
 ifeq ($(findstring $(CXX_MAJOR_VERSION),4),$(CXX_MAJOR_VERSION))
   c++11 ?= 1
+  # gcc 4.8 has a problem that it warnings about missing initializers
+  # for an std::array containing std::string even when {{}} is used
+  # as it should
+  ifeq ($(findstring $(CXX_MINOR_VERSION),8),$(CXX_MINOR_VERSION))
+    FLAGS_C_CC += -Wno-missing-field-initializers
+  endif
 endif
 
 CXX_FULL_VERSION := $(shell $(CXX_FOR_VERSION_TEST) --version)

--- a/ACE/include/makeinclude/platform_g++_common.GNU
+++ b/ACE/include/makeinclude/platform_g++_common.GNU
@@ -79,12 +79,10 @@ endif
 # gcc 4 has C++03 as default C++ version, enable this to be C++11
 ifeq ($(findstring $(CXX_MAJOR_VERSION),4),$(CXX_MAJOR_VERSION))
   c++11 ?= 1
-  # gcc 4.8 has a problem that it warnings about missing initializers
+  # gcc 4 has a problem that it warnings about missing initializers
   # for an std::array containing std::string even when {{}} is used
   # as it should
-  ifeq ($(findstring $(CXX_MINOR_VERSION),8),$(CXX_MINOR_VERSION))
-    FLAGS_C_CC += -Wno-missing-field-initializers
-  endif
+  FLAGS_C_CC += -Wno-missing-field-initializers
 endif
 
 CXX_FULL_VERSION := $(shell $(CXX_FOR_VERSION_TEST) --version)


### PR DESCRIPTION
…g std::string even when {{}} is used, disable this warning only for gcc 4.8

    * ACE/include/makeinclude/platform_g++_common.GNU: