### PR TITLE
[ACE6] platform_g++_common.GNU: Remove ARFLAGS += -c

### DIFF
--- a/ACE/include/makeinclude/platform_g++_common.GNU
+++ b/ACE/include/makeinclude/platform_g++_common.GNU
@@ -260,6 +260,3 @@ pipes ?= 1
 
 FLAGS_C_CC += -Wall -W -Wpointer-arith
 CCFLAGS += -Wnon-virtual-dtor
-
-# Suppress "ar: creating *.a" Message
-ARFLAGS += -c


### PR DESCRIPTION
Older GNU ar may not have this option and this just suppresses an extra log output, so we can remove it.

Not doing this for master, as I'm assuming we're dropping support for the older toolchains that are missing this option.