### PR TITLE
Only check valgrind_keep_debuginfo when valgrind is 1

### DIFF
--- a/ACE/include/makeinclude/wrapper_macros.GNU
+++ b/ACE/include/makeinclude/wrapper_macros.GNU
@@ -705,12 +705,12 @@ zlib ?= 1
 valgrind ?=
 ifeq ($(valgrind),1)
   CPPFLAGS += -DACE_HAS_VALGRIND
-endif
-# Does the valgrind version support --keep-debug-info, if not
-# we disable dlclose in ACE to get complete callstacks
-valgrind_keep_debuginfo ?=
-ifeq ($(valgrind_keep_debuginfo),0)
-  CPPFLAGS += -DACE_LACKS_DLCLOSE
+  # Does the valgrind version support --keep-debug-info, if not
+  # we disable dlclose in ACE to get complete callstacks
+  valgrind_keep_debuginfo ?=
+  ifeq ($(valgrind_keep_debuginfo),0)
+    CPPFLAGS += -DACE_LACKS_DLCLOSE
+  endif
 endif
 
 profile ?=


### PR DESCRIPTION
    * ACE/include/makeinclude/wrapper_macros.GNU: