### PR TITLE
Removed strtoll and strtoull prototypes, not used in any config file …

### DIFF
--- a/ACE/ace/os_include/os_stdlib.h
+++ b/ACE/ace/os_include/os_stdlib.h
@@ -56,14 +56,6 @@ extern "C"
   int mkstemp (char *);
 #endif /* ACE_LACKS_MKSTEMP_PROTOTYPE */
 
-#if defined (ACE_LACKS_STRTOLL_PROTOTYPE)
-  long long strtoll (const char *, char **, int);
-#endif /* ACE_LACKS_STRTOLL_PROTOTYPE */
-
-#if defined (ACE_LACKS_STRTOULL_PROTOTYPE)
-  unsigned long long strtoull (const char *, char **, int);
-#endif /* ACE_LACKS_STRTOULL_PROTOTYPE */
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
…anymore

    * ACE/ace/os_include/os_stdlib.h: