### PR TITLE
Make use of std::unique_ptr instead of auto_ptr

### DIFF
--- a/ACE/ACEXML/common/Attributes_Def_Builder.h
+++ b/ACE/ACEXML/common/Attributes_Def_Builder.h
@@ -19,7 +19,7 @@
 
 #include "ACEXML/common/XML_Types.h"
 #include "ACEXML/common/SAXExceptions.h"
-#include "ace/Auto_Ptr.h"
+#include <memory>
 
 /**
  * @class ACEXML_Attribute_Def_Builder
@@ -33,8 +33,7 @@
 class ACEXML_Export ACEXML_Attribute_Def_Builder
 {
 public:
-
-  typedef auto_ptr<ACEXML_Attribute_Def_Builder> VAR;
+  typedef std::unique_ptr<ACEXML_Attribute_Def_Builder> VAR;
 
   enum ATT_TYPE {
     CDATA,
@@ -110,8 +109,7 @@ public:
 class ACEXML_Export ACEXML_Attributes_Def_Builder
 {
 public:
-
-  typedef auto_ptr<ACEXML_Attributes_Def_Builder> VAR;
+  typedef std::unique_ptr<ACEXML_Attributes_Def_Builder> VAR;
 
   virtual ~ACEXML_Attributes_Def_Builder () = 0;
 
@@ -138,7 +136,7 @@ public:
   /**
    * Dump the content of the attribute definition.
    */
-  virtual void dump (void) = 0;
+  virtual void dump () = 0;
 };
 
 #include /**/ "ace/post.h"

--- a/ACE/ACEXML/common/Element_Def_Builder.h
+++ b/ACE/ACEXML/common/Element_Def_Builder.h
@@ -17,9 +17,9 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Auto_Ptr.h"
 #include "ACEXML/common/XML_Types.h"
 #include "ACEXML/common/SAXExceptions.h"
+#include <memory>
 
 /**
  * @class ACEXML_Element_Def_Builder
@@ -33,8 +33,7 @@
 class ACEXML_Export ACEXML_Element_Def_Builder
 {
 public:
-
-  typedef auto_ptr<ACEXML_Element_Def_Builder> VAR;
+  typedef std::unique_ptr<ACEXML_Element_Def_Builder> VAR;
 
   typedef enum {
     EMPTY,
@@ -118,7 +117,7 @@ public:
   /**
    * Dump the content of the attribute definition.
    */
-  virtual void dump (void) = 0;
+  virtual void dump () = 0;
 };
 
 

--- a/ACE/examples/Bounded_Packet_Relay/Thread_Bounded_Packet_Relay.cpp
+++ b/ACE/examples/Bounded_Packet_Relay/Thread_Bounded_Packet_Relay.cpp
@@ -375,7 +375,7 @@ User_Input_Task::end_transmission (void *)
             ACE_DEBUG ((LM_DEBUG,
                         "\nEnd transmission: "
                         "no transmission in progress\n"));
-            /* Fall through to next case */
+            /* Fallthrough */
           case 0:
             // Cancel any remaining timers.
             this->clear_all_timers ();
@@ -524,7 +524,7 @@ Send_Handler::handle_timeout (const ACE_Time_Value &,
       case 0:
         // Decrement count of packets to relay.
         --send_count_;
-        /* Fall through to next case. */
+        /* Fallthrough */
       case 1:
         if (send_count_ > 0)
           {

--- a/ACE/examples/Bounded_Packet_Relay/bpr_thread.cpp
+++ b/ACE/examples/Bounded_Packet_Relay/bpr_thread.cpp
@@ -5,13 +5,16 @@
  *
  *  Exercises drivers for a bounded packet relay, based on threaded timer queues.
  *
- *  @author Chris Gill           <cdgill@cs.wustl.edu>  and Douglas C. Schmidt   <d.schmidt@vanderbilt.edu> Based on the Timer Queue Test example written by Carlos O'Ryan        <coryan@cs.wustl.edu>  and Douglas C. Schmidt   <d.schmidt@vanderbilt.edu> and Sergio Flores-Gaitan <sergio@cs.wustl.edu>
+ *  @author Chris Gill <cdgill@cs.wustl.edu>
+ *  @author Douglas C. Schmidt   <d.schmidt@vanderbilt.edu>
+ *
+ * Based on the Timer Queue Test example written by Carlos O'Ryan <coryan@cs.wustl.edu>
+ * and Douglas C. Schmidt <d.schmidt@vanderbilt.edu> and Sergio Flores-Gaitan <sergio@cs.wustl.edu>
  */
 //=============================================================================
 
-
-#include "ace/Auto_Ptr.h"
 #include "Thread_Bounded_Packet_Relay.h"
+#include <memory>
 
 typedef Bounded_Packet_Relay_Driver<Thread_Timer_Queue>
   THREAD_BOUNDED_PACKET_RELAY_DRIVER;
@@ -33,7 +36,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
   ACE_NEW_RETURN (input_task_mgr,
                   ACE_Thread_Manager,
                   -1);
-  auto_ptr <ACE_Thread_Manager> mgr (input_task_mgr);
+  std::unique_ptr <ACE_Thread_Manager> mgr (input_task_mgr);
 
   // Construct a new input device wrapper.  Auto ptr ensures memory is
   // freed when we exit this scope.
@@ -43,7 +46,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
                                              sizeof (input_text),
                                              input_text),
                   -1);
-  auto_ptr <Text_Input_Device_Wrapper> input (input_device);
+  std::unique_ptr <Text_Input_Device_Wrapper> input (input_device);
 
   // Construct a new output device wrapper.  Auto ptr ensures memory
   // is freed when we exit this scope.
@@ -51,7 +54,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
   ACE_NEW_RETURN (output_device,
                   Text_Output_Device_Wrapper,
                   -1);
-  auto_ptr <Text_Output_Device_Wrapper> output (output_device);
+  std::unique_ptr <Text_Output_Device_Wrapper> output (output_device);
 
   // Construct a new bounded packet relay.  Auto ptr ensures memory is
   // freed when we exit this scope.
@@ -61,7 +64,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
                                         input_device,
                                         output_device),
                   -1);
-  auto_ptr <Bounded_Packet_Relay> relay (packet_relay);
+  std::unique_ptr <Bounded_Packet_Relay> relay (packet_relay);
 
   // Construct a receive input callback command for the relay, and register
   // it with the input device.  Auto ptr ensures memory is freed when we exit
@@ -71,7 +74,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
                   INPUT_CALLBACK (*packet_relay,
                                   &Bounded_Packet_Relay::receive_input),
                   -1);
-  auto_ptr <INPUT_CALLBACK> callback (input_callback);
+  std::unique_ptr <INPUT_CALLBACK> callback (input_callback);
   if (input_device->set_send_input_msg_cmd (input_callback) < 0)
     {
       ACE_ERROR_RETURN ((LM_ERROR,
@@ -87,7 +90,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
                   Thread_Bounded_Packet_Relay_Driver (packet_relay),
                   -1);
 
-  auto_ptr <THREAD_BOUNDED_PACKET_RELAY_DRIVER> driver (tbprd);
+  std::unique_ptr <THREAD_BOUNDED_PACKET_RELAY_DRIVER> driver (tbprd);
 
   return driver->run ();
   // All dynamically allocated memory is released when main() returns.

--- a/ACE/examples/C++NPv2/TP_Reactor_Logging_Server.cpp
+++ b/ACE/examples/C++NPv2/TP_Reactor_Logging_Server.cpp
@@ -5,7 +5,6 @@
 // FUZZ: disable check_for_streams_include
 #include "ace/streams.h"
 
-#include "ace/Auto_Ptr.h"
 #include "ace/Reactor.h"
 #include "ace/TP_Reactor.h"
 #include "ace/Thread_Manager.h"
@@ -13,11 +12,12 @@
 #if defined (ACE_WIN32) && (!defined (ACE_HAS_STANDARD_CPP_LIBRARY) || \
                             (ACE_HAS_STANDARD_CPP_LIBRARY == 0) || \
                             defined (ACE_USES_OLD_IOSTREAMS))
-#  include <stdio.h>
+# include <stdio.h>
 #else
-#  include <string>
+# include <string>
 #endif
 
+#include <memory>
 #include "Reactor_Logging_Server_T.h"
 #include "Logging_Acceptor_Ex.h"
 
@@ -95,7 +95,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
   const size_t N_THREADS = 4;
   ACE_TP_Reactor tp_reactor;
   ACE_Reactor reactor (&tp_reactor);
-  auto_ptr<ACE_Reactor> delete_instance
+  std::unique_ptr<ACE_Reactor> delete_instance
     (ACE_Reactor::instance (&reactor));
 
   Server_Logging_Daemon *server;

--- a/ACE/examples/Reactor/TP_Reactor/AcceptHandler.cpp
+++ b/ACE/examples/Reactor/TP_Reactor/AcceptHandler.cpp
@@ -8,10 +8,9 @@
 #include "AcceptHandler.h"
 #include "ReadHandler.h"
 
-#include <ace/Auto_Ptr.h>
 #include <ace/INET_Addr.h>
 #include <ace/Log_Msg.h>
-
+#include <memory>
 
 AcceptHandler:: AcceptHandler(ACE_Reactor *reactor) :
         ACE_Event_Handler(),
@@ -69,8 +68,8 @@ int AcceptHandler::handle_input(ACE_HANDLE) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l: Failed to allocate ")
                         ACE_TEXT ("reader. (errno = %i: %m)\n"), ACE_ERRNO_GET), -1);
 
-    // put reader in an auto pointer so we can use ACE_ERROR_RETURN safely
-    auto_ptr<ReadHandler> pReader(reader);
+    // put reader in an unique pointer so we can use ACE_ERROR_RETURN safely
+    std::unique_ptr<ReadHandler> pReader(reader);
 
     // accept the connection using the reader's stream
     if (mAcceptor.accept(reader->getStream(), &clientAddr) == -1)

--- a/ACE/examples/Shared_Malloc/test_multiple_mallocs.cpp
+++ b/ACE/examples/Shared_Malloc/test_multiple_mallocs.cpp
@@ -4,10 +4,8 @@
 #include "ace/OS_NS_string.h"
 #include "ace/Malloc_T.h"
 #include "ace/MMAP_Memory_Pool.h"
-#include "ace/Auto_Ptr.h"
 #include "ace/Process_Mutex.h"
-
-
+#include <memory>
 
 typedef ACE_Malloc <ACE_MMAP_MEMORY_POOL, ACE_Process_Mutex> TEST_MALLOC;
 
@@ -42,7 +40,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
                                                       &request_options),
                   1);
 
-  auto_ptr <ACE_Allocator_Adapter<TEST_MALLOC> > shmem_request (adapter_ptr);
+  std::unique_ptr <ACE_Allocator_Adapter<TEST_MALLOC> > shmem_request (adapter_ptr);
   ACE_MMAP_Memory_Pool_Options response_options (RESPONSE_BASE_ADDR);
 
   TEST_MALLOC *ptr = 0;
@@ -52,7 +50,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
                                ACE_TEXT("response_lock"),
                                &response_options),
                   1);
-  auto_ptr <TEST_MALLOC> shmem_response (ptr);
+  std::unique_ptr <TEST_MALLOC> shmem_response (ptr);
   void *data = 0;
 
   // If we find "foo" then we're running the "second" time, so we must

--- a/ACE/examples/Shared_Malloc/test_position_independent_malloc.cpp
+++ b/ACE/examples/Shared_Malloc/test_position_independent_malloc.cpp
@@ -7,12 +7,10 @@
 #include "ace/PI_Malloc.h"
 #include "ace/Based_Pointer_T.h"
 #include "ace/Get_Opt.h"
-#include "ace/Auto_Ptr.h"
 #include "ace/Process_Mutex.h"
 #include "ace/Malloc_T.h"
 #include "ace/MMAP_Memory_Pool.h"
-
-
+#include <memory>
 
 #if (ACE_HAS_POSITION_INDEPENDENT_POINTERS == 1)
 typedef ACE_PI_Control_Block CONTROL_BLOCK;
@@ -152,7 +150,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                                ACE_TEXT("test_lock"),
                                &options),
                   1);
-  auto_ptr <TEST_MALLOC> allocator (ptr);
+  std::unique_ptr <TEST_MALLOC> allocator (ptr);
   void *data = 0;
 
   // This is the first time in, so we allocate the memory and bind it

--- a/ACE/examples/Timer_Queue/main_async.cpp
+++ b/ACE/examples/Timer_Queue/main_async.cpp
@@ -11,11 +11,10 @@
  */
 //=============================================================================
 
-
 #include "ace/OS_main.h"
-#include "ace/Auto_Ptr.h"
 #include "Driver.h"
 #include "Async_Timer_Queue_Test.h"
+#include <memory>
 
 typedef Timer_Queue_Test_Driver<Async_Timer_Queue *,
                                 Async_Timer_Queue,
@@ -27,9 +26,9 @@ ACE_TMAIN (int, ACE_TCHAR *[])
 {
   ASYNC_TIMER_QUEUE_TEST_DRIVER *tqtd;
   ACE_NEW_RETURN (tqtd, Async_Timer_Queue_Test_Driver, -1);
-  // Auto ptr ensures that the driver memory is released
+  // unique ptr ensures that the driver memory is released
   // automatically.
-  auto_ptr <ASYNC_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
+  std::unique_ptr <ASYNC_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
 
   return driver->run_test ();
 }

--- a/ACE/examples/Timer_Queue/main_reactor.cpp
+++ b/ACE/examples/Timer_Queue/main_reactor.cpp
@@ -7,15 +7,14 @@
  *    This code exercises the Timer_Queue_Test_Driver class using
  *    a reactor.
  *
- *  @author Douglas Schmidt      <d.schmidt@vanderbilt.edu> && Sergio Flores-Gaitan <sergio@cs.wustl.edu>
+ *  @author Douglas Schmidt <d.schmidt@vanderbilt.edu> && Sergio Flores-Gaitan <sergio@cs.wustl.edu>
  */
 //=============================================================================
 
-
 #include "ace/OS_main.h"
-#include "ace/Auto_Ptr.h"
 #include "Reactor_Timer_Queue_Test.h"
 #include "Driver.h"
+#include <memory>
 
 typedef Timer_Queue_Test_Driver <ACE_Timer_Heap,
                                  Input_Handler,
@@ -27,9 +26,9 @@ ACE_TMAIN (int, ACE_TCHAR *[])
 {
   REACTOR_TIMER_QUEUE_TEST_DRIVER *tqtd;
   ACE_NEW_RETURN (tqtd, Reactor_Timer_Queue_Test_Driver, -1);
-  // Auto ptr ensures that the driver memory is released
+  // unique ptr ensures that the driver memory is released
   // automatically.
-  auto_ptr <REACTOR_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
+  std::unique_ptr <REACTOR_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
 
   return driver->run_test ();
 }

--- a/ACE/examples/Timer_Queue/main_thread.cpp
+++ b/ACE/examples/Timer_Queue/main_thread.cpp
@@ -11,11 +11,10 @@
  */
 //=============================================================================
 
-
 #include "ace/OS_main.h"
-#include "ace/Auto_Ptr.h"
 #include "Driver.h"
 #include "Thread_Timer_Queue_Test.h"
+#include <memory>
 
 typedef Timer_Queue_Test_Driver<Thread_Timer_Queue,
                                 Input_Task,
@@ -25,12 +24,12 @@ typedef Timer_Queue_Test_Driver<Thread_Timer_Queue,
 int
 ACE_TMAIN (int, ACE_TCHAR *[])
 {
-  // Auto ptr ensures that the driver memory is released
+  // unique ptr ensures that the driver memory is released
   // automatically.
   THREAD_TIMER_QUEUE_TEST_DRIVER *tqtd;
   ACE_NEW_RETURN (tqtd, Thread_Timer_Queue_Test_Driver, -1);
 
-  auto_ptr <THREAD_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
+  std::unique_ptr <THREAD_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
 
   return driver->run_test ();
 }

--- a/ACE/examples/Timer_Queue/main_thread_custom_handler.cpp
+++ b/ACE/examples/Timer_Queue/main_thread_custom_handler.cpp
@@ -13,9 +13,9 @@
 
 
 #include "ace/OS_main.h"
-#include "ace/Auto_Ptr.h"
 #include "Driver.h"
 #include "Thread_Timer_Queue_Custom_Handler_Test.h"
+#include <memory>
 
 typedef Timer_Queue_Test_Driver<Thread_Timer_Queue,
                                 Custom_Handler_Input_Task,
@@ -25,12 +25,12 @@ typedef Timer_Queue_Test_Driver<Thread_Timer_Queue,
 int
 ACE_TMAIN (int, ACE_TCHAR *[])
 {
-    // Auto ptr ensures that the driver memory is released
+    // unique ptr ensures that the driver memory is released
     // automatically.
     THREAD_TIMER_QUEUE_TEST_DRIVER *tqtd = 0;
     ACE_NEW_RETURN (tqtd, Thread_Timer_Queue_Custom_Handler_Test, -1);
 
-    auto_ptr <THREAD_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
+    std::unique_ptr <THREAD_TIMER_QUEUE_TEST_DRIVER> driver (tqtd);
 
     return driver->run_test ();
 }

--- a/ACE/protocols/ace/TMCast/Group.cpp
+++ b/ACE/protocols/ace/TMCast/Group.cpp
@@ -121,7 +121,7 @@ namespace ACE_TMCast
       try
       {
         sock_.join (addr_);
-        auto_ptr<LinkListener> ll (new LinkListener (sock_, in_link_data_));
+        std::unique_ptr<LinkListener> ll (new LinkListener (sock_, in_link_data_));
 
         {
           AutoLock lock (mutex_);
@@ -469,7 +469,7 @@ namespace ACE_TMCast
     MessageQueue  in_recv_data_;
     MessageQueue  in_control_;
 
-    auto_ptr<Scheduler> scheduler_;
+    std::unique_ptr<Scheduler> scheduler_;
 
     MessageQueue& out_data_;
   };

--- a/ACE/protocols/ace/TMCast/Group.hpp
+++ b/ACE/protocols/ace/TMCast/Group.hpp
@@ -3,10 +3,9 @@
 #ifndef TMCAST_GROUP_HPP
 #define TMCAST_GROUP_HPP
 
-#include <ace/Auto_Ptr.h>
 #include <ace/INET_Addr.h>
-
 #include "Export.hpp"
+#include <memory>
 
 namespace ACE_TMCast
 {
@@ -36,7 +35,7 @@ namespace ACE_TMCast
 
   private:
     class GroupImpl;
-    auto_ptr<GroupImpl> pimpl_;
+    std::unique_ptr<GroupImpl> pimpl_;
 
   private:
     Group (Group const&);

--- a/ACE/protocols/ace/TMCast/MTQueue.hpp
+++ b/ACE/protocols/ace/TMCast/MTQueue.hpp
@@ -3,11 +3,11 @@
 #ifndef TMCAST_MT_QUEUE_HPP
 #define TMCAST_MT_QUEUE_HPP
 
-#include "ace/Auto_Ptr.h"
 #include "ace/Unbounded_Set.h"
 #include "ace/Unbounded_Queue.h"
 #include "ace/os_include/sys/os_types.h"
 #include "ace/Condition_T.h"
+#include <memory>
 
 namespace ACE_TMCast
 {
@@ -154,7 +154,7 @@ namespace ACE_TMCast
     }
 
   private:
-    auto_ptr<MutexType> mutexp_;
+    std::unique_ptr<MutexType> mutexp_;
     MutexType& mutex_;
     QueueType queue_;
 


### PR DESCRIPTION
    * ACE/ACEXML/common/Attributes_Def_Builder.h:
    * ACE/ACEXML/common/Element_Def_Builder.h:
    * ACE/examples/Bounded_Packet_Relay/Thread_Bounded_Packet_Relay.cpp:
    * ACE/examples/Bounded_Packet_Relay/bpr_thread.cpp:
    * ACE/examples/C++NPv2/TP_Reactor_Logging_Server.cpp:
    * ACE/examples/Reactor/TP_Reactor/AcceptHandler.cpp:
    * ACE/examples/Shared_Malloc/test_multiple_mallocs.cpp:
    * ACE/examples/Shared_Malloc/test_position_independent_malloc.cpp:
    * ACE/examples/Timer_Queue/main_async.cpp:
    * ACE/examples/Timer_Queue/main_reactor.cpp:
    * ACE/examples/Timer_Queue/main_thread.cpp:
    * ACE/examples/Timer_Queue/main_thread_custom_handler.cpp:
    * ACE/protocols/ace/TMCast/Group.cpp:
    * ACE/protocols/ace/TMCast/Group.hpp:
    * ACE/protocols/ace/TMCast/MTQueue.hpp: