### PR TITLE
Provide optimized copy constructor for ACE_Handle_Set to fix warnings…

### DIFF
--- a/ACE/ace/Handle_Set.cpp
+++ b/ACE/ace/Handle_Set.cpp
@@ -419,11 +419,9 @@ ACE_Handle_Set_Iterator::ACE_Handle_Set_Iterator (const ACE_Handle_Set &hs)
   ACE_TRACE ("ACE_Handle_Set_Iterator::ACE_Handle_Set_Iterator");
 #if !defined (ACE_HANDLE_SET_USES_FD_ARRAY) && !defined (ACE_HAS_BIG_FD_SET)
   // No sense searching further than the max_handle_ + 1;
-  ACE_HANDLE maxhandlep1 =
-    this->handles_.max_handle_ + 1;
+  ACE_HANDLE maxhandlep1 = this->handles_.max_handle_ + 1;
 
-  fd_mask *maskp =
-    (fd_mask *)(this->handles_.mask_.fds_bits);
+  fd_mask *maskp = (fd_mask *)(this->handles_.mask_.fds_bits);
 
   // Loop until we've found the first non-zero bit or we run past the
   // <maxhandlep1> of the bitset.
@@ -454,8 +452,7 @@ ACE_Handle_Set_Iterator::ACE_Handle_Set_Iterator (const ACE_Handle_Set &hs)
       }
     else
       {
-        this->word_num_ =
-          ACE_DIV_BY_WORDSIZE (this->handles_.min_handle_) - 1;
+        this->word_num_ = ACE_DIV_BY_WORDSIZE (this->handles_.min_handle_) - 1;
         this->word_val_ = 0;
       }
 #endif /* !ACE_HANDLE_SET_USES_FD_ARRAY && !ACE_HAS_BIG_FD_SET */
@@ -478,11 +475,9 @@ ACE_Handle_Set_Iterator::reset_state ()
 
 #if !defined (ACE_HANDLE_SET_USES_FD_ARRAY) && !defined (ACE_HAS_BIG_FD_SET)
   // No sense searching further than the max_handle_ + 1;
-  ACE_HANDLE maxhandlep1 =
-    this->handles_.max_handle_ + 1;
+  ACE_HANDLE maxhandlep1 = this->handles_.max_handle_ + 1;
 
-  fd_mask *maskp =
-    (fd_mask *)(this->handles_.mask_.fds_bits);
+  fd_mask *maskp = (fd_mask *)(this->handles_.mask_.fds_bits);
 
   // Loop until we've found the first non-zero bit or we run past the
   // <maxhandlep1> of the bitset.

--- a/ACE/ace/Handle_Set.h
+++ b/ACE/ace/Handle_Set.h
@@ -64,6 +64,7 @@ public:
 
   /// Constructor, initializes the bitmask to all 0s.
   ACE_Handle_Set ();
+  ~ACE_Handle_Set () = default;
 
   /**
    * Constructor, initializes the handle set from a given mask.
@@ -113,9 +114,17 @@ public:
   fd_set *fdset ();
 
 #if defined (ACE_HAS_BIG_FD_SET)
-  /// Assignment operator optimizes for cases where <size_> == 0.
-  ACE_Handle_Set & operator= (const ACE_Handle_Set &);
+  /// Assignment operator optimizes for cases where size_ == 0.
+  ACE_Handle_Set & operator= (const ACE_Handle_Set &rhs);
+  /// Copy constructor optimizes for cases where size_ == 0
+  ACE_Handle_Set (const ACE_Handle_Set &rhs);
+#else
+  ACE_Handle_Set & operator= (const ACE_Handle_Set &) = default;
+  ACE_Handle_Set (const ACE_Handle_Set &) = default;
 #endif /* ACE_HAS_BIG_FD_SET */
+
+  ACE_Handle_Set & operator= (ACE_Handle_Set &&) = default;
+  ACE_Handle_Set (ACE_Handle_Set &&) = default;
 
   /// Dump the state of an object.
   void dump () const;
@@ -175,9 +184,8 @@ class ACE_Export ACE_Handle_Set_Iterator
 public:
   /// Constructor.
   ACE_Handle_Set_Iterator (const ACE_Handle_Set &hs);
-
-  /// Default dtor.
-  ~ACE_Handle_Set_Iterator ();
+  ACE_Handle_Set_Iterator () = delete;
+  ~ACE_Handle_Set_Iterator () = default;
 
   /// Reset the state of the iterator by reinitializing the state
   /// that we maintain.

--- a/ACE/ace/Handle_Set.inl
+++ b/ACE/ace/Handle_Set.inl
@@ -9,16 +9,13 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // Initialize the bitmask to all 0s and reset the associated fields.
-
 ACE_INLINE void
 ACE_Handle_Set::reset ()
 {
   ACE_TRACE ("ACE_Handle_Set::reset");
-  this->max_handle_ =
-    ACE_INVALID_HANDLE;
+  this->max_handle_ = ACE_INVALID_HANDLE;
 #if defined (ACE_HAS_BIG_FD_SET)
-  this->min_handle_ =
-    NUM_WORDS * WORDSIZE;
+  this->min_handle_ = NUM_WORDS * WORDSIZE;
 #endif /* ACE_HAS_BIG_FD_SET */
   this->size_ = 0;
   // #if !defined (ACE_HAS_BIG_FD_SET)      Why is this here?  -Steve Huston
@@ -34,19 +31,35 @@ ACE_Handle_Set::operator = (const ACE_Handle_Set &rhs)
 
   if (rhs.size_ > 0)
     {
-      this->size_ =
-        rhs.size_;
-      this->max_handle_ =
-        rhs.max_handle_;
-      this->min_handle_ =
-        rhs.min_handle_;
-      this->mask_ =
-        rhs.mask_;
+      this->size_ = rhs.size_;
+      this->max_handle_ = rhs.max_handle_;
+      this->min_handle_ = rhs.min_handle_;
+      this->mask_ = rhs.mask_;
     }
   else
-    this->reset ();
+    {
+      this->reset ();
+    }
 
   return *this;
+}
+
+ACE_INLINE
+ACE_Handle_Set::ACE_Handle_Set (const ACE_Handle_Set &rhs)
+{
+  ACE_TRACE ("ACE_Handle_Set::ACE_Handle_Set");
+
+  if (rhs.size_ > 0)
+    {
+      this->size_ = rhs.size_;
+      this->max_handle_ = rhs.max_handle_;
+      this->min_handle_ = rhs.min_handle_;
+      this->mask_ = rhs.mask_;
+    }
+  else
+    {
+      this->reset ();
+    }
 }
 #endif /* ACE_HAS_BIG_FD_SET */
 
@@ -143,8 +156,7 @@ ACE_Handle_Set::num_set () const
 #endif /* ACE_HANDLE_SET_USES_FD_ARRAY */
 }
 
-// Returns a pointer to the underlying fd_set.
-
+/// Returns a pointer to the underlying fd_set.
 ACE_INLINE
 ACE_Handle_Set::operator fd_set *()
 {
@@ -156,8 +168,7 @@ ACE_Handle_Set::operator fd_set *()
     return (fd_set *) 0;
 }
 
-// Returns a pointer to the underlying fd_set.
-
+/// Returns a pointer to the underlying fd_set.
 ACE_INLINE fd_set *
 ACE_Handle_Set::fdset ()
 {
@@ -167,11 +178,6 @@ ACE_Handle_Set::fdset ()
     return (fd_set *) &this->mask_;
   else
     return (fd_set *) 0;
-}
-
-ACE_INLINE
-ACE_Handle_Set_Iterator::~ACE_Handle_Set_Iterator ()
-{
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/tests/Handle_Set_Test.cpp
+++ b/ACE/tests/Handle_Set_Test.cpp
@@ -21,7 +21,7 @@ static void
 test_duplicates (size_t count)
 {
   ACE_DEBUG ((LM_DEBUG,
-              ACE_TEXT ("Testing duplicated\n")));
+              ACE_TEXT ("Testing %B duplicates\n"), count));
 
   size_t duplicates = 0;
   size_t sets = 0;
@@ -58,6 +58,12 @@ test_duplicates (size_t count)
 
   ACE_Handle_Set copy_set (handle_set);
   ACE_TEST_ASSERT (copy_set.num_set () + duplicates == sets);
+
+  ACE_Handle_Set move_set (std::move(handle_set));
+  ACE_TEST_ASSERT (move_set.num_set () + duplicates == sets);
+
+  ACE_Handle_Set move_assign = std::move(copy_set);
+  ACE_TEST_ASSERT (move_assign.num_set () + duplicates == sets);
 }
 
 // This is the vector of handles to test.  These numbers are chosen to

--- a/ACE/tests/Handle_Set_Test.cpp
+++ b/ACE/tests/Handle_Set_Test.cpp
@@ -11,18 +11,18 @@
  */
 //=============================================================================
 
-
 #include "test_config.h"
 #include "ace/OS_NS_stdlib.h"
 #include "ace/Profile_Timer.h"
 #include "ace/Handle_Set.h"
 #include "ace/Containers.h"
 
-
-
 static void
 test_duplicates (size_t count)
 {
+  ACE_DEBUG ((LM_DEBUG,
+              ACE_TEXT ("Testing duplicated\n")));
+
   size_t duplicates = 0;
   size_t sets = 0;
   size_t clears = 0;
@@ -33,29 +33,31 @@ test_duplicates (size_t count)
 
   for (size_t i = 0; i < count; i++)
     {
-      size_t handle =
-        static_cast<size_t> (ACE_OS::rand_r (&seed) % ACE_Handle_Set::MAXSIZE);
+      size_t const handle = static_cast<size_t> (ACE_OS::rand_r (&seed) % ACE_Handle_Set::MAXSIZE);
 
       if (ACE_ODD (handle))
         {
           if (handle_set.is_set ((ACE_HANDLE) handle))
-            duplicates++;
+            ++duplicates;
 
           handle_set.set_bit ((ACE_HANDLE) handle);
-          sets++;
+          ++sets;
         }
       else
         {
           if (handle_set.is_set ((ACE_HANDLE) handle))
-            duplicates--;
+            --duplicates;
 
           handle_set.clr_bit ((ACE_HANDLE) handle);
-          clears++;
+          ++clears;
         }
     }
 
   ACE_TEST_ASSERT (count == sets + clears);
   ACE_TEST_ASSERT (handle_set.num_set () + duplicates == sets);
+
+  ACE_Handle_Set copy_set (handle_set);
+  ACE_TEST_ASSERT (copy_set.num_set () + duplicates == sets);
 }
 
 // This is the vector of handles to test.  These numbers are chosen to
@@ -142,7 +144,7 @@ test_boundaries ()
       ACE_DEBUG ((LM_DEBUG,
                   ACE_TEXT ("obtained handle %d\n"),
                   handle));
-      int done = set.remove (handle);
+      int const done = set.remove (handle);
       ACE_TEST_ASSERT (done == 0);
       count++;
     }


### PR DESCRIPTION
… with newer g++ versions

    * ACE/ace/Handle_Set.cpp:
    * ACE/ace/Handle_Set.h:
    * ACE/ace/Handle_Set.inl:
    * ACE/tests/Handle_Set_Test.cpp: