### PR TITLE
Defer Including rules.tao.GNU for gnuace

### DIFF
--- a/ACE/bin/MakeProjectCreator/templates/gnu.mpd
+++ b/ACE/bin/MakeProjectCreator/templates/gnu.mpd
@@ -200,6 +200,7 @@ VSHDIR = <%targetoutdir%>.shobj/
 include $(ACE_ROOT)/include/makeinclude/wrapper_macros.GNU
 
 <%marker(extension)%>
+<%marker(deferred-extension)%>
 
 <%if(version)%>
 GNUACE_PROJECT_VERSION = <%version%>

--- a/TAO/MPC/config/tao_rules.mpb
+++ b/TAO/MPC/config/tao_rules.mpb
@@ -1,5 +1,5 @@
 project {
-  verbatim(gnuace, extension, 1) {
+  verbatim(gnuace, deferred-extension, 1) {
     include $(TAO_ROOT)/rules.tao.GNU
   }
 }


### PR DESCRIPTION
Alternative fix for https://github.com/objectcomputing/OpenDDS/pull/2559. See there for details.

https://github.com/DOCGroup/ACE_TAO/pull/1296 changed the order of includes of rules make files to effectively being how the base projects that set them are included. This can lead to the order of `GNUACE_PROJECT_VERSION ?=` being set differently than what the case was in ACE6/TAO2. The result in OpenDDS is that so library files get TAO's version number.

This tires to fix that by including `tao.rules.GNU` at a marker after the `extension` marker.