### PR TITLE
[ACE6] Fix SocketConnect::ip_check() Concurrency and Too-Early Request Issues for Windows

### DIFF
--- a/ACE/ace/Sock_Connect.cpp
+++ b/ACE/ace/Sock_Connect.cpp
@@ -1473,6 +1473,9 @@ ip_check (int &ipvn_enabled, int pf)
     {
 
 #if defined (ACE_WIN32)
+      static int recursing = 0;
+      if (recursing) return recursing;
+
       // as of the release of Windows 2008, even hosts that have IPv6 interfaces disabled
       // will still permit the creation of a PF_INET6 socket, thus rendering the socket
       // creation test inconsistent. The recommended solution is to get the list of
@@ -1480,14 +1483,22 @@ ip_check (int &ipvn_enabled, int pf)
       ACE_INET_Addr *if_addrs = 0;
       size_t if_cnt = 0;
 
-      ipvn_enabled = 1; // assume enabled to avoid recursion during interface lookup.
+      // assume enabled to avoid recursion during interface lookup.
+      recursing = 1;
       ACE::get_ip_interfaces (if_cnt, if_addrs);
-      ipvn_enabled = 0;
-      for (size_t i = 0; ipvn_enabled == 0 && i < if_cnt; i++)
+      recursing = 0;
+
+      bool found = false;
+      for (size_t i = 0; !found && i < if_cnt; i++)
         {
-          ipvn_enabled = (if_addrs[i].get_type () == pf);
+          found = (if_addrs[i].get_type () == pf);
         }
       delete [] if_addrs;
+
+      // If the list of interfaces is empty, we've tried too quickly. Assume enabled, but don't cache the result
+      if (!if_cnt) return true;
+
+      ipvn_enabled = found ? 1 : 0;
 #else
       // Determine if the kernel has IPv6 support by attempting to
       // create a PF_INET6 socket and see if it fails.

--- a/ACE/ace/Sock_Connect.cpp
+++ b/ACE/ace/Sock_Connect.cpp
@@ -1474,7 +1474,7 @@ ip_check (int &ipvn_enabled, int pf)
 
 #if defined (ACE_WIN32)
       static int recursing = 0;
-      if (recursing) return recursing;
+      if (recursing) return 1;
 
       // as of the release of Windows 2008, even hosts that have IPv6 interfaces disabled
       // will still permit the creation of a PF_INET6 socket, thus rendering the socket
@@ -1496,7 +1496,7 @@ ip_check (int &ipvn_enabled, int pf)
       delete [] if_addrs;
 
       // If the list of interfaces is empty, we've tried too quickly. Assume enabled, but don't cache the result
-      if (!if_cnt) return true;
+      if (!if_cnt) return 1;
 
       ipvn_enabled = found ? 1 : 0;
 #else

--- a/ACE/ace/Sock_Connect.cpp
+++ b/ACE/ace/Sock_Connect.cpp
@@ -1473,7 +1473,7 @@ ip_check (int &ipvn_enabled, int pf)
     {
 
 #if defined (ACE_WIN32)
-      static int recursing = 0;
+      static bool recursing = false;
       if (recursing) return 1;
 
       // as of the release of Windows 2008, even hosts that have IPv6 interfaces disabled
@@ -1484,9 +1484,9 @@ ip_check (int &ipvn_enabled, int pf)
       size_t if_cnt = 0;
 
       // assume enabled to avoid recursion during interface lookup.
-      recursing = 1;
+      recursing = true;
       ACE::get_ip_interfaces (if_cnt, if_addrs);
-      recursing = 0;
+      recursing = false;
 
       bool found = false;
       for (size_t i = 0; !found && i < if_cnt; i++)


### PR DESCRIPTION
Problems:

On Windows, SocketConnect::ip_check() will attempt to get the list of IP addresses associated with local network interfaces in order to determine if IPv6 or IPv4 is enabled, and then it will set a global flag in order to cache the result of this expensive check. Unfortunately, the global flag is toggled back and forth during this check, which is not thread safe. In addition, it appears as though this check can be done "too early" within a windows process (particularly if done as part of a static initialization) which will cause & cache a false negative, since no interfaces addresses are found.

Solutions:
1) Protect the global flag from modification until a real answer is available, and protect against recursive calls using a static initialized behind the existing mutex.
2) Protect against the "too early" problem by defaulting to "enabled" when answers aren't available, but defer caching the result until a real answer is available.
