### PR TITLE
TTY_IO enhancements

### DIFF
--- a/ACE/ace/TTY_IO.cpp
+++ b/ACE/ace/TTY_IO.cpp
@@ -301,6 +301,8 @@ int ACE_TTY_IO::control (Control_Mode cmd, Serial_Params *arg) const
 
       if (arg->databits < 8)
         devpar.c_iflag |= ISTRIP;
+      else
+        devpar.c_iflag &= ~ISTRIP;
 
 #if defined (IGNBRK)
       // If device is not a modem set to ignore break points
@@ -345,6 +347,21 @@ int ACE_TTY_IO::control (Control_Mode cmd, Serial_Params *arg) const
       // Disable SIGINTR, SIGSUSP, SIGDSUSP and SIGQUIT signals
       devpar.c_lflag &= ~ISIG;
 #endif /* ISIG */
+
+#if defined (IGNCR)
+      // Do not discard CR characters
+      devpar.c_iflag &= ~IGNCR;
+#endif /* IGNCR */
+
+#if defined (ICRNL)
+      // Disable CR to NL conversion
+      devpar.c_iflag &= ~ICRNL;
+#endif /* ICRNL */
+
+#if defined (INLCR)
+      // Disable NL to CR conversion
+      devpar.c_iflag &= ~INLCR;
+#endif /* INLCR */
 
 #if defined (OPOST)
       // Disable post-processing of output data

--- a/ACE/ace/TTY_IO.cpp
+++ b/ACE/ace/TTY_IO.cpp
@@ -36,6 +36,7 @@ ACE_TTY_IO::Serial_Params::Serial_Params ()
   readmincharacters = 0;
   readtimeoutmsec = 10000;
   paritymode = ACE_TTY_IO_NONE;
+  inpckenb = true;
   ctsenb = false;
   rtsenb = 0;
   xinenb = false;
@@ -243,14 +244,20 @@ int ACE_TTY_IO::control (Control_Mode cmd, Serial_Params *arg) const
               devpar.c_cflag |=  PARENB;
               devpar.c_cflag |=  PARODD;
               devpar.c_iflag &= ~IGNPAR;
-              devpar.c_iflag |=  INPCK | PARMRK;
+              if(arg->inpckenb)
+                devpar.c_iflag |= INPCK | PARMRK;
+              else
+                devpar.c_iflag &= ~(INPCK | PARMRK);
             }
           else if (ACE_OS::strcasecmp (arg->paritymode, ACE_TTY_IO_EVEN) == 0)
             {
               devpar.c_cflag |=  PARENB;
               devpar.c_cflag &= ~PARODD;
               devpar.c_iflag &= ~IGNPAR;
-              devpar.c_iflag |=  INPCK | PARMRK;
+              if(arg->inpckenb)
+                devpar.c_iflag |= INPCK | PARMRK;
+              else
+                devpar.c_iflag &= ~(INPCK | PARMRK);
             }
           else if (ACE_OS::strcasecmp (arg->paritymode, ACE_TTY_IO_NONE) == 0)
             {

--- a/ACE/ace/TTY_IO.h
+++ b/ACE/ace/TTY_IO.h
@@ -66,6 +66,9 @@ public:
         "odd" parity. Additionally Win32 supports "mark" and "space"
         parity modes. */
     const char *paritymode;
+    /** Enable/disable input parity checking. This option is only applicable
+        on systems which support the POSIX termios API */
+    bool inpckenb;
     /** Enable & set CTS mode. Note that RTS & CTS are enabled/disabled
         together on some systems (RTS/CTS is enabled if either
         <code>ctsenb</code> or <code>rtsenb</code> is set). */


### PR DESCRIPTION
This PR contains fixes and improvements to ACE TTY_IO on systems using POSIX termios API.

- Disable character conversions CR->NL, NL->CR
- Disable ISTRIP when databits == 8
- Added a new option to disable input parity checking

Tested on Linux (kernel 5.11.22)