### PR TITLE
We require each platform to provide std iostreams so define ACE_HAS_C…

### DIFF
--- a/ACE/ace/Time_Value.cpp
+++ b/ACE/ace/Time_Value.cpp
@@ -302,7 +302,7 @@ ACE_Time_Value::operator *= (double d)
   return *this;
 }
 
-ostream &operator<<(std::ostream &o, const ACE_Time_Value &v)
+std::ostream &operator<<(std::ostream &o, const ACE_Time_Value &v)
 {
   char const oldFiller = o.fill ();
   o.fill ('0');

--- a/ACE/ace/Time_Value.cpp
+++ b/ACE/ace/Time_Value.cpp
@@ -12,7 +12,6 @@
 #include "ace/If_Then_Else.h"
 #include "ace/OS_NS_math.h"
 #include "ace/Time_Policy.h"
-#include <ostream>
 #include <iomanip>
 #include <cstdlib>
 #include <cmath>

--- a/ACE/ace/Time_Value.cpp
+++ b/ACE/ace/Time_Value.cpp
@@ -12,12 +12,8 @@
 #include "ace/If_Then_Else.h"
 #include "ace/OS_NS_math.h"
 #include "ace/Time_Policy.h"
-
-#ifdef ACE_HAS_CPP98_IOSTREAMS
-# include <ostream>
-# include <iomanip>
-#endif /* ACE_HAS_CPP98_IOSTREAMS */
-
+#include <ostream>
+#include <iomanip>
 #include <cstdlib>
 #include <cmath>
 
@@ -306,8 +302,7 @@ ACE_Time_Value::operator *= (double d)
   return *this;
 }
 
-#ifdef ACE_HAS_CPP98_IOSTREAMS
-ostream &operator<<(ostream &o, const ACE_Time_Value &v)
+ostream &operator<<(std::ostream &o, const ACE_Time_Value &v)
 {
   char const oldFiller = o.fill ();
   o.fill ('0');
@@ -330,6 +325,5 @@ ostream &operator<<(ostream &o, const ACE_Time_Value &v)
   o.fill (oldFiller);
   return o;
 }
-#endif /* ACE_HAS_CPP98_IOSTREAMS */
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Time_Value.h
+++ b/ACE/ace/Time_Value.h
@@ -20,8 +20,9 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "ace/os_include/os_time.h"
-#include <chrono>
 #include "ace/Truncate.h"
+#include <chrono>
+#include <ostream>
 
 // Define some helpful constants.
 // Not type-safe, and signed.  For backward compatibility.
@@ -31,9 +32,6 @@ suseconds_t const ACE_ONE_SECOND_IN_USECS = 1000000;
 
 // needed for ACE_UINT64
 #include "ace/Basic_Types.h"
-
-// needed to determine if iostreams are present
-#include "ace/iosfwd.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Time_Value.h
+++ b/ACE/ace/Time_Value.h
@@ -460,7 +460,7 @@ private:
 #endif /* ACE_HAS_TIME_T_LONG_MISMATCH */
 };
 
-extern ACE_Export ostream &operator<<(std::ostream &o, const ACE_Time_Value &v );
+extern ACE_Export std::ostream &operator<<(std::ostream &o, const ACE_Time_Value &v );
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Time_Value.h
+++ b/ACE/ace/Time_Value.h
@@ -460,9 +460,7 @@ private:
 #endif /* ACE_HAS_TIME_T_LONG_MISMATCH */
 };
 
-#ifdef ACE_HAS_CPP98_IOSTREAMS
-extern ACE_Export ostream &operator<<( ostream &o, const ACE_Time_Value &v );
-#endif
+extern ACE_Export ostream &operator<<(std::ostream &o, const ACE_Time_Value &v );
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/iosfwd.h
+++ b/ACE/ace/iosfwd.h
@@ -29,11 +29,13 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+// We except that each platform does support std streams
+#define ACE_HAS_CPP98_IOSTREAMS 1
+
 #if !defined (ACE_LACKS_IOSTREAM_TOTALLY)
 
 #if !defined (ACE_USES_OLD_IOSTREAMS)
 #   include /**/ <iosfwd>
-#define ACE_HAS_CPP98_IOSTREAMS 1
 #else
   // @note If these forward declarations don't work (e.g. aren't
   //       portable), we may have to include "ace/streams.h" as a last

--- a/ACE/tests/Time_Value_Test.cpp
+++ b/ACE/tests/Time_Value_Test.cpp
@@ -19,9 +19,7 @@
 
 #include "ace/Numeric_Limits.h"
 
-#ifdef ACE_HAS_CPP98_IOSTREAMS
 #include <sstream>
-#endif
 
 int
 run_main (int, ACE_TCHAR *[])
@@ -175,7 +173,6 @@ run_main (int, ACE_TCHAR *[])
                 ACE_TEXT ("set_msec test failed: %d usecs should be 555000\n"),
                 msec_test3.usec ()));
 
-#ifdef ACE_HAS_CPP98_IOSTREAMS
   std::ostringstream ost;
   ost << ACE_Time_Value(1);
   ACE_TEST_ASSERT( ost.str() == "1" );
@@ -194,7 +191,6 @@ run_main (int, ACE_TCHAR *[])
   ost.str("");
   ost << ACE_Time_Value();
   ACE_TEST_ASSERT( ost.str() == "0" );
-#endif
 
   ACE_END_TEST;
 


### PR DESCRIPTION
…PP98_IOSTREAMS always for backwards compability and removed the checks for it

    * ACE/ace/Time_Value.cpp:
    * ACE/ace/Time_Value.h:
    * ACE/ace/iosfwd.h:
    * ACE/tests/Time_Value_Test.cpp: