### PR TITLE
Fixed compile errors due to auto_ptr to unqiue_ptr changes

### DIFF
--- a/TAO/tests/Bug_3251_Regression/DllOrb.cpp
+++ b/TAO/tests/Bug_3251_Regression/DllOrb.cpp
@@ -74,7 +74,7 @@ DllOrb::init (int argc, ACE_TCHAR *argv[])
     return -1;
   }
 
-  ACE_auto_ptr_reset (ma_barrier_, new ACE_Thread_Barrier (threadCnt + 1));
+  ma_barrier_.reset (new ACE_Thread_Barrier (threadCnt + 1));
 
   this->activate(
     THR_NEW_LWP|THR_JOINABLE|THR_INHERIT_SCHED,
@@ -106,7 +106,7 @@ DllOrb::fini (void)
     wait();
     ACE_DEBUG ((LM_ERROR, ACE_TEXT ("wait() done\n")));
 
-    ACE_auto_ptr_reset (ma_barrier_, static_cast<ACE_Thread_Barrier *> (0));
+    ma_barrier_.reset ();
   }
   catch (...)
   {

--- a/TAO/tests/Bug_3542_Regression/DllOrb.cpp
+++ b/TAO/tests/Bug_3542_Regression/DllOrb.cpp
@@ -71,7 +71,7 @@ DllOrb::init (int argc, ACE_TCHAR *argv[])
     return -1;
   }
 
-  ACE_auto_ptr_reset (ma_barrier_, new ACE_Thread_Barrier (threadCnt + 1));
+  ma_barrier_.reset (new ACE_Thread_Barrier (threadCnt + 1));
 
   this->activate(
     THR_NEW_LWP|THR_JOINABLE|THR_INHERIT_SCHED,
@@ -103,7 +103,7 @@ DllOrb::fini (void)
     wait();
     ACE_DEBUG ((LM_ERROR, ACE_TEXT ("wait() done\n")));
 
-    ACE_auto_ptr_reset (ma_barrier_, static_cast<ACE_Thread_Barrier *> (0));
+    ma_barrier_.reset ();
   }
   catch (...)
   {

--- a/TAO/tests/Oneway_Send_Timeouts/Client_Task.h
+++ b/TAO/tests/Oneway_Send_Timeouts/Client_Task.h
@@ -4,6 +4,7 @@
 #include "Client.h"
 
 #include "ace/ARGV.h"
+#include "ace/Task.h"
 
 class Client_Task : public ACE_Task_Base
 {

--- a/TAO/tests/Oneway_Send_Timeouts/main.cpp
+++ b/TAO/tests/Oneway_Send_Timeouts/main.cpp
@@ -38,9 +38,9 @@ bool MyMain::init_server (const ACE_TCHAR* args)
   int thread_pool = 2;
 
 #ifdef ACE_HAS_CPP14
-  server_ = std::make_unique<Server> (my_args);
+  server_task_ = std::make_unique<Server_Task> (my_args);
 #else
-  server_.reset (new Server (my_args);
+  server_task_.reset (new Server_Task (my_args);
 #endif
 
   ACE_ASSERT (server_task_);


### PR DESCRIPTION
    * TAO/tests/Bug_3251_Regression/DllOrb.cpp:
    * TAO/tests/Bug_3542_Regression/DllOrb.cpp:
    * TAO/tests/Oneway_Send_Timeouts/Client_Task.h:
    * TAO/tests/Oneway_Send_Timeouts/main.cpp: