### PR TITLE
Replace auto_ptr with std::unique_ptr and fixed missing break

### DIFF
--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/Control.cpp
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/Control.cpp
@@ -15,6 +15,7 @@
 #include "ace/Sample_History.h"
 #include "ace/Basic_Stats.h"
 #include "ace/Auto_Ptr.h"
+#include <memory>
 
 Control::Control (size_t peers_expected,
                   size_t iterations,
@@ -91,8 +92,8 @@ Control::join (Federated_Test::Peer_ptr peer)
 
       /// ... and automatically disconnect the loopbacks ...
       typedef Auto_Disconnect<Federated_Test::Loopback> Loopback_Disconnect;
-      ACE_Auto_Basic_Array_Ptr<auto_ptr<Loopback_Disconnect> > disconnects (
-          new auto_ptr<Loopback_Disconnect>[2*this->peers_count_]
+      ACE_Auto_Basic_Array_Ptr<std::unique_ptr<Loopback_Disconnect> > disconnects (
+          new std::unique_ptr<Loopback_Disconnect>[2*this->peers_count_]
           );
 
       ACE_DEBUG ((LM_DEBUG,

--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/RTClient_Setup.cpp
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/RTClient_Setup.cpp
@@ -23,9 +23,6 @@ RTClient_Setup::RTClient_Setup (int use_rt_corba,
 {
   if (use_rt_corba)
     {
-      ACE_auto_ptr_reset (this->rtcorba_setup_,
-                          new RTCORBA_Setup (orb,
-                                             rt_class,
-                                             nthreads));
+      this->rtcorba_setup_.reset (new RTCORBA_Setup (orb, rt_class, nthreads));
     }
 }

--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/RTClient_Setup.h
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/RTClient_Setup.h
@@ -11,7 +11,7 @@
 #include "RTCORBA_Setup.h"
 #include "PriorityBand_Setup.h"
 #include "SyncScope_Setup.h"
-#include "ace/Auto_Ptr.h"
+#include <memory>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -42,7 +42,7 @@ public:
 private:
   int use_rt_corba_;
 
-  auto_ptr<RTCORBA_Setup> rtcorba_setup_;
+  std::unique_ptr<RTCORBA_Setup> rtcorba_setup_;
   SyncScope_Setup syncscope_setup_;
 };
 

--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/RTEC_Initializer.cpp
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/RTEC_Initializer.cpp
@@ -29,12 +29,11 @@ RTEC_Initializer::create (PortableServer::POA_ptr consumer_poa,
 
   TAO_EC_Factory *body =
     ACE_Dynamic_Service<TAO_EC_Factory>::instance ("EC_Factory");
-  auto_ptr<TAO_EC_Factory> factory (
+  std::unique_ptr<TAO_EC_Factory> factory (
       new TAO_EC_RTCORBA_Factory (body,
                                   rtcorba_setup->lanes ()));
 
-  TAO_EC_Event_Channel *ec =
-    new TAO_EC_Event_Channel (attr, factory.get (), 1);
+  TAO_EC_Event_Channel *ec = new TAO_EC_Event_Channel (attr, factory.get (), 1);
   factory.release ();
 
   return ec;

--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/RTServer_Setup.cpp
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/RTServer_Setup.cpp
@@ -23,20 +23,14 @@ RTServer_Setup::RTServer_Setup (int use_rt_corba,
                     rt_class,
                     nthreads)
 {
-
   if (use_rt_corba)
     {
-      ACE_auto_ptr_reset (this->rtpoa_setup_,
-                          new RTPOA_Setup (orb,
-                                           *this->rtcorba_setup ()));
+      this->rtpoa_setup_.reset (new RTPOA_Setup (orb, *this->rtcorba_setup ()));
 
-      this->poa_ =
-        this->rtpoa_setup_->poa ();
+      this->poa_ = this->rtpoa_setup_->poa ();
     }
   else
     {
-      this->poa_ =
-        RIR_Narrow<RTPortableServer::POA>::resolve (orb,
-                                                    "RootPOA");
+      this->poa_ = RIR_Narrow<RTPortableServer::POA>::resolve (orb, "RootPOA");
     }
 }

--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/RTServer_Setup.h
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/RTServer_Setup.h
@@ -10,6 +10,7 @@
 
 #include "RTClient_Setup.h"
 #include "RTPOA_Setup.h"
+#include <memory>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -35,7 +36,7 @@ public:
 private:
   PortableServer::POA_var poa_;
 
-  auto_ptr<RTPOA_Setup> rtpoa_setup_;
+  std::unique_ptr<RTPOA_Setup> rtpoa_setup_;
 };
 
 #if defined(__ACE_INLINE__)

--- a/TAO/orbsvcs/tests/FtRtEvent/consumer.cpp
+++ b/TAO/orbsvcs/tests/FtRtEvent/consumer.cpp
@@ -3,7 +3,6 @@
 #include "orbsvcs/Event_Utilities.h"
 #include "PushConsumer.h"
 #include "ace/Get_Opt.h"
-#include "ace/Auto_Ptr.h"
 #include "orbsvcs/FtRtEvent/Utils/resolve_init.h"
 #include "orbsvcs/FtRtEvent/Utils/FTEC_Gateway.h"
 
@@ -12,9 +11,10 @@
 
 /// include this file to statically linked with Transaction Depth
 #include "orbsvcs/FtRtEvent/ClientORB/FTRT_ClientORB_Loader.h"
+#include <memory>
 
 CORBA::ORB_var orb;
-auto_ptr<TAO_FTRTEC::FTEC_Gateway> gateway;
+std::unique_ptr<TAO_FTRTEC::FTEC_Gateway> gateway;
 
 RtecEventChannelAdmin::EventChannel_ptr
 get_event_channel(int argc, ACE_TCHAR** argv)
@@ -65,7 +65,7 @@ get_event_channel(int argc, ACE_TCHAR** argv)
 
     if (use_gateway)
     {
-      ACE_auto_ptr_reset (gateway, new TAO_FTRTEC::FTEC_Gateway(orb.in(), channel.in()));
+      gateway.reset (new TAO_FTRTEC::FTEC_Gateway(orb.in(), channel.in()));
       return gateway->_this();
     }
     else

--- a/TAO/orbsvcs/tests/FtRtEvent/consumer.cpp
+++ b/TAO/orbsvcs/tests/FtRtEvent/consumer.cpp
@@ -49,7 +49,6 @@ get_event_channel(int argc, ACE_TCHAR** argv)
       }
     }
 
-
     if (CORBA::is_nil(channel.in()))
     {
       CosNaming::Name name(1);
@@ -114,7 +113,6 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       qos);
 
     orb->run();
-
   }
   catch (const CORBA::Exception& ex){
     ex._tao_print_exception ("A CORBA Exception occurred.");

--- a/TAO/orbsvcs/tests/FtRtEvent/supplier.cpp
+++ b/TAO/orbsvcs/tests/FtRtEvent/supplier.cpp
@@ -55,7 +55,6 @@ get_event_channel(int argc, ACE_TCHAR** argv)
       }
     }
 
-
     if (CORBA::is_nil(channel.in()))
     {
       /// Find the FTRTEC from the Naming Service
@@ -108,14 +107,11 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     RtecEventComm::PushSupplier_var
       supplier = push_supplier._this();
 
-
     orb->run();
-
   }
   catch (const CORBA::Exception& ex){
       ex._tao_print_exception ("A CORBA Exception occurred.");
   }
-
 
   return 0;
 }

--- a/TAO/orbsvcs/tests/FtRtEvent/supplier.cpp
+++ b/TAO/orbsvcs/tests/FtRtEvent/supplier.cpp
@@ -2,7 +2,6 @@
 #include "orbsvcs/FtRtecEventChannelAdminC.h"
 #include "PushSupplier.h"
 #include "ace/Get_Opt.h"
-#include "ace/Auto_Ptr.h"
 #include "ace/OS_NS_stdlib.h"
 #include "orbsvcs/FtRtEvent/Utils/resolve_init.h"
 #include "orbsvcs/FtRtEvent/Utils/FTEC_Gateway.h"
@@ -12,10 +11,11 @@
 
 /// include this file to statically linked with Transaction Depth
 #include "orbsvcs/FtRtEvent/ClientORB/FTRT_ClientORB_Loader.h"
+#include <memory>
 
 ACE_Time_Value timer_interval(1,0);
 CORBA::ORB_var orb;
-auto_ptr<TAO_FTRTEC::FTEC_Gateway> gateway;
+std::unique_ptr<TAO_FTRTEC::FTEC_Gateway> gateway;
 
 RtecEventChannelAdmin::EventChannel_ptr
 get_event_channel(int argc, ACE_TCHAR** argv)
@@ -40,6 +40,7 @@ get_event_channel(int argc, ACE_TCHAR** argv)
         break;
       case 't':
         timer_interval.set(ACE_OS::atof(get_opt.opt_arg ()));
+        break;
       case 'h':
       case '?':
         ACE_DEBUG((LM_DEBUG,
@@ -72,7 +73,7 @@ get_event_channel(int argc, ACE_TCHAR** argv)
     if (use_gateway)
     {
       // use local gateway to communicate with FTRTEC
-      ACE_auto_ptr_reset (gateway, new TAO_FTRTEC::FTEC_Gateway (orb.in (), channel.in ()));
+      gateway.reset (new TAO_FTRTEC::FTEC_Gateway (orb.in (), channel.in ()));
       return gateway->_this ();
     }
     else

--- a/TAO/orbsvcs/tests/Trading/colocated_test.cpp
+++ b/TAO/orbsvcs/tests/Trading/colocated_test.cpp
@@ -1,4 +1,3 @@
-#include "ace/Auto_Ptr.h"
 #include "ace/Get_Opt.h"
 #include "tao/Utils/ORB_Manager.h"
 #include "Offer_Exporter.h"
@@ -6,6 +5,7 @@
 #include "Service_Type_Exporter.h"
 #include "orbsvcs/Trader/Trader.h"
 #include "orbsvcs/Trader/Service_Type_Repository.h"
+#include <memory>
 
 int
 parse_args (int argc, ACE_TCHAR *argv[],
@@ -65,7 +65,7 @@ int failure = 0;
       // Start of Trading service scope.
       {
         TAO_Service_Type_Repository type_repos;
-        auto_ptr<TAO_Trader_Factory::TAO_TRADER> trader (TAO_Trader_Factory::create_trader (argc, argv));
+        std::unique_ptr<TAO_Trader_Factory::TAO_TRADER> trader (TAO_Trader_Factory::create_trader (argc, argv));
         TAO_Support_Attributes_i& sup_attr = trader->support_attributes ();
         TAO_Trading_Components_i& trd_comp = trader->trading_components ();
 


### PR DESCRIPTION
    * TAO/orbsvcs/performance-tests/RTEvent/lib/Control.cpp:
    * TAO/orbsvcs/performance-tests/RTEvent/lib/RTClient_Setup.cpp:
    * TAO/orbsvcs/performance-tests/RTEvent/lib/RTClient_Setup.h:
    * TAO/orbsvcs/performance-tests/RTEvent/lib/RTEC_Initializer.cpp:
    * TAO/orbsvcs/performance-tests/RTEvent/lib/RTServer_Setup.cpp:
    * TAO/orbsvcs/performance-tests/RTEvent/lib/RTServer_Setup.h:
    * TAO/orbsvcs/tests/FtRtEvent/consumer.cpp:
    * TAO/orbsvcs/tests/FtRtEvent/supplier.cpp:
    * TAO/orbsvcs/tests/Trading/colocated_test.cpp: