### PR TITLE
Fix for issue #1550 - empty case evaluation on unions with enum discriminators 

### DIFF
--- a/TAO/TAO_IDL/ast/ast_union_branch.cpp
+++ b/TAO/TAO_IDL/ast/ast_union_branch.cpp
@@ -1,5 +1,3 @@
-// $Id$
-
 /*
 
 COPYRIGHT

--- a/TAO/TAO_IDL/ast/ast_union_branch.cpp
+++ b/TAO/TAO_IDL/ast/ast_union_branch.cpp
@@ -187,9 +187,9 @@ AST_UnionBranch::add_labels (AST_Union *u)
        i.next ())
     {
       if (AST_UnionLabel::UL_default == i.item ()->label_kind ())
-      {
-        continue;
-      }
+        {
+          continue;
+        }
 
       AST_Expression *ex = i.item ()->label_val ();
       UTL_ScopedName *n = ex->n ();

--- a/TAO/TAO_IDL/ast/ast_union_branch.cpp
+++ b/TAO/TAO_IDL/ast/ast_union_branch.cpp
@@ -1,3 +1,5 @@
+// $Id$
+
 /*
 
 COPYRIGHT
@@ -181,22 +183,16 @@ AST_UnionBranch::label_list_length (void)
 void
 AST_UnionBranch::add_labels (AST_Union *u)
 {
+  const bool enum_labels = (u->udisc_type () == AST_Expression::EV_enum);
   for (UTL_LabellistActiveIterator i (this->pd_ll);
        !i.is_done ();
        i.next ())
     {
       if (AST_UnionLabel::UL_default == i.item ()->label_kind ())
-        {
-          return;
-        }
-    }
+      {
+        continue;
+      }
 
-  const bool enum_labels = (u->udisc_type () == AST_Expression::EV_enum);
-
-  for (UTL_LabellistActiveIterator i (this->pd_ll);
-       !i.is_done ();
-       i.next ())
-    {
       AST_Expression *ex = i.item ()->label_val ();
       UTL_ScopedName *n = ex->n ();
 

--- a/TAO/tests/IDLv4/annotations/annotation_tests.cpp
+++ b/TAO/tests/IDLv4/annotations/annotation_tests.cpp
@@ -1088,9 +1088,10 @@ annotation_tests ()
     test_union->field(af, 2);
     AST_UnionBranch *ub = dynamic_cast<AST_UnionBranch *>(*af);
     AST_UnionLabel *ul = ub->label ();
-    if (ul->label_val()->ev()->u.ulval != 2) {
-     t.failed("did not get the correct label value");
-    }
+    if (ul->label_val()->ev()->u.ulval != 2)
+      {
+        t.failed("did not get the correct label value");
+      }
   } catch (Failed const &) {}
 
   // Done, Print Overall Results

--- a/TAO/tests/IDLv4/annotations/annotation_tests.cpp
+++ b/TAO/tests/IDLv4/annotations/annotation_tests.cpp
@@ -1085,7 +1085,7 @@ annotation_tests ()
                "default: float cfloat;\n"
                "};\n").assert_node<AST_Union>("::empty_union");
     AST_Field **af = 0;
-    test_union->field(af,2);
+    test_union->field(af, 2);
     AST_UnionBranch *ub = dynamic_cast<AST_UnionBranch *>(*af);
     AST_UnionLabel *ul = ub->label ();
     if (ul->label_val()->ev()->u.ulval != 2) {

--- a/TAO/tests/IDLv4/annotations/annotation_tests.cpp
+++ b/TAO/tests/IDLv4/annotations/annotation_tests.cpp
@@ -4,7 +4,9 @@
 #include <ast_porttype.h>
 #include <ast_eventtype.h>
 #include <ast_component.h>
-
+#include <ast_union_branch.h>
+#include <ast_union_label.h>
+#include <ast_expression.h>
 #include <string>
 
 namespace {
@@ -1058,6 +1060,37 @@ annotation_tests ()
           static_cast<unsigned> (member->visibility ()));
         t.failed (&buffer[0]);
       }
+  } catch (Failed const &) {}
+
+  /* -------------------------------------------------------------------------
+   * Empty union cases aliasing the default case must always be evaluated
+   * -------------------------------------------------------------------------
+   * When the union has an enum discriminator, and one or more empty cases
+   * acting as an alias to the default case the IDL compiler was failing to
+   * resolve the ordinal value for these empty labels and this causes trouble
+   * for at least OpenDDS.
+   *
+   * This test is designed to verify that the condition is corrected by
+   * parsing a specially crafted union and validating the value of the
+   * label aliasing the default case.
+   */
+  try {
+    Annotation_Test t ("empty union branch label");
+    AST_Union *test_union = t.run (
+               "enum disc {A, B, C};\n"
+               "union empty_union switch (disc) {\n"
+               "case A: long along;\n"
+               "case B: short bshort;\n"
+               "case C:\n"
+               "default: float cfloat;\n"
+               "};\n").assert_node<AST_Union>("::empty_union");
+    AST_Field **af = 0;
+    test_union->field(af,2);
+    AST_UnionBranch *ub = dynamic_cast<AST_UnionBranch *>(*af);
+    AST_UnionLabel *ul = ub->label ();
+    if (ul->label_val()->ev()->u.ulval != 2) {
+     t.failed("did not get the correct label value");
+    }
   } catch (Failed const &) {}
 
   // Done, Print Overall Results


### PR DESCRIPTION
see issue #1550 for detailed description of the issue. 

Briefly, the IDL compiler incorrectly fails to evaluate union branch labels that serve as aliases of default cases.