### PR TITLE
Make use of C++11 using in the generated code and more reduced code g…

### DIFF
--- a/TAO/TAO_IDL/be/be_interface.cpp
+++ b/TAO/TAO_IDL/be/be_interface.cpp
@@ -788,17 +788,15 @@ be_interface::gen_var_out_seq_decls ()
 
   *os << be_nl_2
       << "class " << lname << ";" << be_nl
-      << "typedef " << lname << " *" << lname << "_ptr;";
+      << "using " << lname << "_ptr = " << lname << "*;";
 
   *os << be_nl
-      << "typedef TAO_Objref_Var_T<"
+      << "using " << lname << "_var = TAO_Objref_Var_T<"
       << lname
-      << "> "
-      << lname << "_var;" << be_nl
-      << "typedef TAO_Objref_Out_T<"
+      << ">;" << be_nl
+      << "using " << lname << "_out = TAO_Objref_Out_T<"
       << lname
-      << "> "
-      << lname << "_out;" << be_nl;
+      << ">;";
 
   os->gen_endif ();
 
@@ -807,8 +805,7 @@ be_interface::gen_var_out_seq_decls ()
 
 // ****************************************************************
 
-TAO_IDL_Inheritance_Hierarchy_Worker::~TAO_IDL_Inheritance_Hierarchy_Worker (
-    )
+TAO_IDL_Inheritance_Hierarchy_Worker::~TAO_IDL_Inheritance_Hierarchy_Worker ()
 {
 }
 

--- a/TAO/TAO_IDL/be/be_type.cpp
+++ b/TAO/TAO_IDL/be/be_type.cpp
@@ -264,28 +264,23 @@ be_type::gen_common_varout (TAO_OutStream *os)
                                                     : "class ")
       << this->local_name () << ";";
 
-  *os << be_nl_2
-      << "typedef" << be_idt_nl
+  *os << be_nl
+      << "using " << this->local_name () << "_var = "
       << (st == AST_Type::FIXED ? "::TAO_Fixed_Var_T<"
                                 : "::TAO_Var_Var_T<")
-      << be_idt << be_idt_nl
-      << this->local_name () << be_uidt_nl
-      << ">" << be_uidt_nl
-      << this->local_name () << "_var;" << be_uidt << be_nl_2;
+      << this->local_name () << ">;" << be_nl;
 
   if (st == AST_Type::FIXED)
     {
-      *os << "typedef" << be_idt_nl
-          << this->local_name () << " &" << be_nl
-          << this->local_name () << "_out;" << be_uidt;
+      *os << "using " << this->local_name () << "_out = "
+          << this->local_name () << "&;";
     }
   else
     {
-      *os << "typedef" << be_idt_nl
-          << "::TAO_Out_T<" << be_idt << be_idt_nl
-          << this->local_name () << be_uidt_nl
-          << ">" << be_uidt_nl
-          << this->local_name () << "_out;" << be_uidt;
+      *os << "using " << this->local_name ()
+          << "_out = ::TAO_Out_T<"
+          << this->local_name ()
+          << ">;";
     }
 
   this->common_varout_gen_ = true;
@@ -308,8 +303,8 @@ be_type::gen_stub_decls (TAO_OutStream *os)
 
   if (i != nullptr)
     {
-      *os << "typedef " << this->local_name ()
-          << (v == nullptr ? "_ptr" : " *") << " _ptr_type;";
+      *os << "using _ptr_type = " << this->local_name ()
+          << (v == nullptr ? "_ptr" : "*") << ";";
     }
 
   bool skip_varout = false;
@@ -327,10 +322,8 @@ be_type::gen_stub_decls (TAO_OutStream *os)
   if (!skip_varout)
     {
       *os << be_nl
-          << "typedef " << this->local_name ()
-          << "_var _var_type;" << be_nl
-          << "typedef " << this->local_name ()
-          << "_out _out_type;";
+          << "using _var_type = " << this->local_name () << "_var;" << be_nl
+          << "using _out_type = " << this->local_name () << "_out;";
     }
 
   bool gen_any_destructor =

--- a/TAO/TAO_IDL/be/be_valuetype.cpp
+++ b/TAO/TAO_IDL/be/be_valuetype.cpp
@@ -571,16 +571,8 @@ be_valuetype::gen_var_out_seq_decls ()
 
   *os << be_nl_2
       << "class " << lname << ";" << be_nl
-      << "typedef" << be_idt_nl
-      << "TAO_Value_Var_T<" << be_idt << be_idt_nl
-      << lname << be_uidt_nl
-      << ">" << be_uidt_nl
-      << lname << "_var;" << be_uidt_nl << be_nl
-      << "typedef" << be_idt_nl
-      << "TAO_Value_Out_T<" << be_idt << be_idt_nl
-      << lname << be_uidt_nl
-      << ">" << be_uidt_nl
-      << lname << "_out;" << be_uidt;
+      << "using " << lname << "_var = TAO_Value_Var_T<" << lname << ">;" << be_nl
+      << "using " << lname << "_out = TAO_Value_Out_T<" << lname << ">;";
 
   os->gen_endif ();
 

--- a/TAO/TAO_IDL/be/be_visitor_interface/amh_sh.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface/amh_sh.cpp
@@ -349,9 +349,9 @@ be_visitor_amh_interface_sh::create_amh_class (ACE_CString name)
   be_interface *amh_class = nullptr;
   ACE_NEW_RETURN (amh_class,
                   be_interface (amh_class_name, // name
-                                nullptr,              // list of inherited
+                                nullptr,        // list of inherited
                                 0,              // number of inherited
-                                nullptr,              // list of ancestors
+                                nullptr,        // list of ancestors
                                 0,              // number of ancestors
                                 0,              // non-local
                                 0),             // non-abstract

--- a/TAO/TAO_IDL/be/be_visitor_operation/arglist.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_operation/arglist.cpp
@@ -18,8 +18,7 @@
 // ************************************************************
 
 be_visitor_operation_arglist::be_visitor_operation_arglist (
-    be_visitor_context *ctx
-  )
+    be_visitor_context *ctx)
   : be_visitor_operation (ctx),
     unused_ (false)
 {
@@ -33,14 +32,14 @@ int
 be_visitor_operation_arglist::visit_operation (be_operation *node)
 {
   TAO_OutStream *os = this->ctx_->stream ();
-  bool has_args = node->argument_count () > 0;
+  bool const has_args = node->argument_count () > 0;
 
-  *os << " (" << be_idt_nl;
+  *os << " (";
 
   switch (this->ctx_->state ())
     {
     case TAO_CodeGen::TAO_OPERATION_ARGLIST_PROXY_IMPL_XS:
-      *os << "::CORBA::Object *_collocated_tao_target_";
+      *os << be_idt_nl << "::CORBA::Object *_collocated_tao_target_";
 
       if (has_args)
         {
@@ -49,6 +48,14 @@ be_visitor_operation_arglist::visit_operation (be_operation *node)
 
       break;
     default:
+      if (has_args)
+        {
+          *os << be_idt_nl;
+        }
+      else
+        {
+          *os << be_idt;
+        }
       break;
     }
 
@@ -60,11 +67,6 @@ be_visitor_operation_arglist::visit_operation (be_operation *node)
                          "visit_operation - "
                          "codegen for scope failed\n"),
                         -1);
-    }
-
-  if (!has_args)
-    {
-      *os << "void";
     }
 
   *os << ")" << be_uidt;

--- a/TAO/TAO_IDL/be/be_visitor_valuetype/valuetype_ci.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuetype/valuetype_ci.cpp
@@ -48,7 +48,7 @@ be_visitor_valuetype_ci::visit_valuetype (be_valuetype *node)
 
   if (node->is_amh_excep_holder ())
     {
-      *os << "  : exception (0)" << be_nl;
+      *os << "  : exception (nullptr)" << be_nl;
     }
 
   if (node->truncatable())

--- a/TAO/TAO_IDL/be/be_visitor_valuetype/valuetype_init_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuetype/valuetype_init_ch.cpp
@@ -92,14 +92,12 @@ be_visitor_valuetype_init_ch::visit_valuetype (be_valuetype *node)
       //@@ Boris: create_for_unmarshal is still public...
       // generate create_for_unmarshal
       os << be_nl_2
-         << "virtual ::CORBA::ValueBase *" << be_nl
-         << "create_for_unmarshal ();";
+         << "virtual ::CORBA::ValueBase *create_for_unmarshal ();";
 
       if (node->supports_abstract ())
         {
           os << be_nl_2
-             << "virtual ::CORBA::AbstractBase_ptr" << be_nl
-             << "create_for_unmarshal_abstract ();" << be_uidt;
+             << "virtual ::CORBA::AbstractBase_ptr create_for_unmarshal_abstract ();" << be_uidt;
         }
     }
 


### PR DESCRIPTION
…eneration when an operation doesn't have arguments

    * TAO/TAO_IDL/be/be_interface.cpp:
    * TAO/TAO_IDL/be/be_type.cpp:
    * TAO/TAO_IDL/be/be_valuetype.cpp:
    * TAO/TAO_IDL/be/be_visitor_interface/amh_sh.cpp:
    * TAO/TAO_IDL/be/be_visitor_operation/arglist.cpp: