### PR TITLE
Removed workarounds for very old broken HP compilers

### DIFF
--- a/ACE/ACEXML/common/ZipCharStream.cpp
+++ b/ACE/ACEXML/common/ZipCharStream.cpp
@@ -248,9 +248,4 @@ ACEXML_ZipCharStream::peek_i (void)
 }
 #endif /* ACE_USES_WCHAR */
 
-#else
-#if defined (__HP_aCC)
-static int shut_up_aCC = 0;
-#endif /* __HP_aCC */
-
 #endif /* USE_ZZIP */

--- a/ACE/ace/OS_NS_signal.h
+++ b/ACE/ace/OS_NS_signal.h
@@ -139,22 +139,7 @@ extern "C"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-// This hack is needed to get around an odd and hard-to-reproduce problem
-// with HP aC++. If struct sigaction is defined extern "C" and the sigaction
-// function in namespace ACE_OS, the compiler sometimes gets confused.
-// If we help it with this typedef, it's fine. User code should not use
-// the ACE typedef - it will be removed without warning as soon as we can
-// either drop support for the broken compilers or figure out how to reproduce
-// it so it can be reported to HP and fixed.
-// There's a similar hack in OS_TLI.h for struct t_optmgmt.
-// Also see ChangeLog entries:
-// Mon Jan 23 16:35:40 UTC 2006  Steve Huston  <shuston@riverace.com>
-// Mon Jan 23 22:08:56 UTC 2006  Steve Huston  <shuston@riverace.com>
-#if defined (__HP_aCC) && (__HP_aCC <= 37300)
-typedef extern "C" struct sigaction  ACE_SIGACTION;
-#else
 typedef struct sigaction ACE_SIGACTION;
-#endif
 
 namespace ACE_OS {
 

--- a/ACE/ace/OS_NS_stdio.cpp
+++ b/ACE/ace/OS_NS_stdio.cpp
@@ -863,12 +863,8 @@ namespace { // helpers for vsnprintf_emulation
 
       const long double log = val > 0 ? std::log10 (val) : 0;
       int dig_left = static_cast<int> (1 + ((val >= 1) ? log : 0));
-
-#if defined __HP_aCC && __HP_aCC < 40000
-      int exp = static_cast<int> (log);
-#else
       int exp = static_cast<int> (std::floor (log));
-#endif
+
       if (flags.has (SNPRINTF_FLEXPONENT))
         {
           const int p = precision > 0 ? precision : (precision < 0 ? 6 : 1);

--- a/ACE/ace/OS_TLI.h
+++ b/ACE/ace/OS_TLI.h
@@ -131,24 +131,8 @@ extern "C"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-// This hack is needed to get around an odd and hard-to-reproduce problem
-// with HP aC++. If struct sigaction is defined extern "C" and the sigaction
-// function in namespace ACE_OS, the compiler sometimes gets confused.
-// If we help it with this typedef, it's fine. User code should not use
-// the ACE typedef - it will be removed without warning as soon as we can
-// either drop support for the broken compilers or figure out how to reproduce
-// it so it can be reported to HP and fixed.
-// There's a similar hack in OS_TLI.h for struct t_optmgmt.
-// Also see ChangeLog entries:
-// Mon Jan 23 16:35:40 UTC 2006  Steve Huston  <shuston@riverace.com>
-// Mon Jan 23 22:08:56 UTC 2006  Steve Huston  <shuston@riverace.com>
-#if defined (__HP_aCC) && (__HP_aCC <= 37300)
-typedef extern "C" struct t_optmgmt  ACE_TOPTMGMT;
-typedef extern "C" struct t_bind  ACE_TBIND;
-#else
 typedef struct t_optmgmt ACE_TOPTMGMT;
 typedef struct t_bind  ACE_TBIND;
-#endif
 
 /**
  * @namespace ACE_OS

--- a/ACE/ace/SStringfwd.h
+++ b/ACE/ace/SStringfwd.h
@@ -23,12 +23,6 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#if (defined (__HP_aCC) && (36300 <= __HP_aCC) && (__HP_aCC <= 37300))
-// Due to a bug in the aCC 3.xx compiler need to define the ACE_String_Base
-// template before we can typedef ACE_CString
-# include "ace/String_Base.h"
-#endif /* __HP_aCC */
-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 template <class ACE_CHAR_T> class ACE_String_Base;  // Forward declaration.

--- a/ACE/ace/Stack_Trace.cpp
+++ b/ACE/ace/Stack_Trace.cpp
@@ -741,12 +741,6 @@ ACE_Stack_Trace::generate_trace (ssize_t starting_frame_offset,
 void
 ACE_Stack_Trace::generate_trace (ssize_t, size_t)
 {
-// Call determine_starting_frame() on HP aCC build to resolve declared
-// method never referenced warning.
-#if defined (__HP_aCC)
-  size_t starting_frame = determine_starting_frame (0, 0);
-#endif
-
   ACE_OS::strcpy (&this->buf_[0], UNSUPPORTED);
 }
 #endif

--- a/ACE/tests/Bug_3709_Regression_Test.cpp
+++ b/ACE/tests/Bug_3709_Regression_Test.cpp
@@ -12,21 +12,6 @@
 
 using namespace std;
 
-// MSVC_71_OR_OLDER
-#if defined(_MSC_VER) && _MSC_VER < 1400
-#define BROKEN_TEMPLATE_TEMPLATE
-#endif
-
-#ifdef __SUNPRO_CC
-#define BROKEN_TEMPLATE_TEMPLATE
-#endif
-
-// HP aC++ 03.x fails this
-#if defined(__HP_aCC) && (__HP_aCC < 40000)
-#define BROKEN_TEMPLATE_TEMPLATE
-#endif
-
-#ifndef BROKEN_TEMPLATE_TEMPLATE
 template<template<typename U, typename = std::allocator<U> > class container, typename DT>
 container<DT> initializer(const DT &d)
 {
@@ -34,17 +19,14 @@ container<DT> initializer(const DT &d)
   t.insert(t.end(), d);
   return t;
 }
-#endif
 
 int
 run_main (int, ACE_TCHAR *[])
 {
   ACE_START_TEST (ACE_TEXT ("Bug_3709_Regression_Test"));
 
-#ifndef BROKEN_TEMPLATE_TEMPLATE
   vector<int> v = initializer<vector>(5);
   v.clear ();
-#endif
 
   ACE_END_TEST;
 

--- a/ACE/tests/Compiler_Features_12_Test.cpp
+++ b/ACE/tests/Compiler_Features_12_Test.cpp
@@ -13,13 +13,6 @@
 
 // Similar to Bug_3709_Regression_Test.cpp...
 
-// HP aC++ 03.x fails this
-#if defined(__HP_aCC) && (__HP_aCC < 40000)
-#define BROKEN_TEMPLATE_TEMPLATE
-#endif
-
-#ifndef BROKEN_TEMPLATE_TEMPLATE
-
 template<typename T>
 struct Pair
 {
@@ -41,8 +34,6 @@ struct Array
   Tuple<T> array[5];
 };
 
-#endif /* BROKEN_TEMPLATE_TEMPLATE */
-
 int
 run_main (int, ACE_TCHAR *[])
 {
@@ -52,8 +43,6 @@ run_main (int, ACE_TCHAR *[])
   // failure
   int status = 0;
 
-#ifndef BROKEN_TEMPLATE_TEMPLATE
-
   Array<int, Pair> pairs;
   pairs.array[0].x1 = 0;
   ACE_UNUSED_ARG (pairs);
@@ -61,8 +50,6 @@ run_main (int, ACE_TCHAR *[])
   Array<int, Triple> triples;
   triples.array[1].t3 = 0;
   ACE_UNUSED_ARG (triples);
-
-#endif /* BROKEN_TEMPLATE_TEMPLATE */
 
   ACE_END_TEST;
   return status;

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
@@ -136,11 +136,6 @@ TAO::Security::AccessDecision::map_key_from_objref (CORBA::Object_ptr /*obj */)
   ORBSVCS_ERROR ((LM_ERROR, "map_key_from_objref is currently not implemented\n"));
 
   throw CORBA::NO_IMPLEMENT();
-
-#if defined (__HP_aCC)
-  OBJECT_KEY key;
-  return key;
-#endif /* __HP_aCC */
 }
 
 CORBA::Boolean


### PR DESCRIPTION
    * ACE/ACEXML/common/ZipCharStream.cpp:
    * ACE/ace/OS_NS_signal.h:
    * ACE/ace/OS_NS_stdio.cpp:
    * ACE/ace/OS_TLI.h:
    * ACE/ace/SStringfwd.h:
    * ACE/ace/Stack_Trace.cpp:
    * ACE/tests/Bug_3709_Regression_Test.cpp:
    * ACE/tests/Compiler_Features_12_Test.cpp:
    * TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp: