### PR TITLE
When using native windows threads the thread function needs a special…

### DIFF
--- a/ACE/performance-tests/Misc/childbirth_time.cpp
+++ b/ACE/performance-tests/Misc/childbirth_time.cpp
@@ -1,4 +1,3 @@
-
 //=============================================================================
 /**
  *  @file    childbirth_time.cpp
@@ -46,16 +45,11 @@
  *            -e: Exec a program after fork ().  This option has no
  *                effect on NT.
  *
- * = CREATION DATE
- *    June 29, 1997
- *
  *  @author   Nanbor Wang
  */
 //=============================================================================
 
-
 // Process Creation profiling
-
 #include "ace/OS_NS_unistd.h"
 #include "ace/OS_main.h"
 #include "ace/Get_Opt.h"
@@ -74,13 +68,20 @@
 
 size_t MULTIPLY_FACTOR = 10;
 typedef double (*Profiler)(size_t);
-static int do_exec_after_fork = 0;
+static bool do_exec_after_fork = false;
 
 /// do nothing thread function
+#if defined (ACE_HAS_WTHREADS)
+DWORD WINAPI ace_empty (LPVOID)
+{
+  return 0;
+}
+#else
 extern "C" void *ace_empty (void*)
 {
   return 0;
 }
+#endif
 
 static double
 prof_ace_process (size_t iteration)
@@ -94,7 +95,7 @@ prof_ace_process (size_t iteration)
 
       iteration *= MULTIPLY_FACTOR;
 
-      if (do_exec_after_fork == 0)
+      if (!do_exec_after_fork)
         popt.creation_flags (ACE_Process_Options::NO_EXEC);
 
       ACE_Profile_Timer ptimer;
@@ -111,7 +112,7 @@ prof_ace_process (size_t iteration)
 
           if (result == -1)
             ACE_ERROR_RETURN ((LM_ERROR, "%p\n", "process.spawn"), -1);
-          else if (do_exec_after_fork == 0 && result == 0)
+          else if (!do_exec_after_fork && result == 0)
             ACE_OS::exit (0) ;
           else
             {
@@ -334,7 +335,7 @@ ACE_TMAIN (int argc, ACE_TCHAR* argv[])
   int c;
   size_t iteration = 10;
   Profiler profiler = 0;
-  const char *profile_name = 0 ;
+  const char *profile_name = 0;
 
   while ((c=get_opt ()) != -1)
     {
@@ -374,7 +375,7 @@ ACE_TMAIN (int argc, ACE_TCHAR* argv[])
           ACE_High_Res_Timer::get_env_global_scale_factor ();
           break;
         case 'e':
-          do_exec_after_fork = 1;
+          do_exec_after_fork = true;
           break;
         default:
           break;
@@ -388,7 +389,7 @@ ACE_TMAIN (int argc, ACE_TCHAR* argv[])
       double time = profiler (iteration);
       if (time > 0)
         ACE_DEBUG ((LM_DEBUG,
-                    "Average performance of %d iterations of %s: %.0f usec\n",
+                    "Average performance of %d iterations of %C: %.0f usec\n",
                     iteration * MULTIPLY_FACTOR, profile_name, time * 1e6));
     }
   return 0;


### PR DESCRIPTION
… signature else it could trigger some warnings

    * ACE/performance-tests/Misc/childbirth_time.cpp: