### PR TITLE
Fix HP-UX g++ DCCFLAGS.

### DIFF
--- a/ACE/include/makeinclude/platform_hpux_gcc.GNU
+++ b/ACE/include/makeinclude/platform_hpux_gcc.GNU
@@ -44,6 +44,7 @@ endif
 #CCFLAGS		+= -fstrict-prototype
 #endif
 DCFLAGS		+= -g
+DCCFLAGS	+= -g
 DLD		= $(CXX)
 LD		= $(CXX)
 OCFLAGS		+= -O2


### PR DESCRIPTION
Build ACE by GCC on HP-UX 11.31 IA64 :

```bash
make optimize=0 inline=0 debug=1
```

**No debug info** is produced because `DCCFLAGS` is not set to `-g`