### PR TITLE
Fixed fallthrough warnings

### DIFF
--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.cpp
@@ -560,6 +560,7 @@ TAO_FT_Naming_Server::parse_args (int argc,
             }
         }
       case '?':
+        // fallthrough
       default:
         ORBSVCS_ERROR ((LM_ERROR,ACE_TEXT ("Unknown arg %c\n"), c ));
         ORBSVCS_ERROR_RETURN ((LM_ERROR,

--- a/TAO/orbsvcs/orbsvcs/Naming/Naming_Server.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/Naming_Server.cpp
@@ -260,6 +260,7 @@ TAO_Naming_Server::parse_args (int argc,
         this->round_trip_timeout_ = (int)1.0e7 * ACE_OS::atoi (get_opts.opt_arg ());
         break;
       case '?':
+        // fallthrough
       default:
 #if !defined (ACE_NLOGGING)
         const ACE_TCHAR *reqNonMinCorba=


### PR DESCRIPTION
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/Naming_Server.cpp: