### PR TITLE
All platforms that define ACE_LACKS_IOVEC has an unsigned iov_len, no…

### DIFF
--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -406,7 +406,6 @@ ACE_SOCK_Dgram::recv (iovec iov[],
 
 // Send an iovec of size N to ADDR as a datagram (connectionless
 // version).
-
 ssize_t
 ACE_SOCK_Dgram::send (const iovec iov[],
                       int n,
@@ -420,8 +419,8 @@ ACE_SOCK_Dgram::send (const iovec iov[],
 
   // Determine the total length of all the buffers in <iov>.
   for (i = 0; i < n; i++)
-#if ! (defined(__BORLANDC__) || defined(ACE_LINUX) || defined(ACE_HAS_RTEMS))
-    // The iov_len is unsigned on Linux, RTEMS and with Borland. If we go
+#if ! (defined(ACE_LACKS_IOVEC) || defined(ACE_LINUX) || defined(ACE_HAS_RTEMS))
+    // The iov_len is unsigned on Linux, RTEMS and when using the ACE iovec struct. If we go
     // ahead and try the if, it will emit a warning.
     if (iov[i].iov_len < 0)
       return -1;
@@ -481,8 +480,8 @@ ACE_SOCK_Dgram::recv (iovec iov[],
   ACE_UNUSED_ARG (to_addr);
 
   for (i = 0; i < n; i++)
-#if ! (defined(__BORLANDC__) || defined(ACE_LINUX) || defined(ACE_HAS_RTEMS))
-    // The iov_len is unsigned on Linux, RTEMS and with Borland. If we go
+#if ! (defined(ACE_LACKS_IOVEC) || defined(ACE_LINUX) || defined(ACE_HAS_RTEMS))
+    // The iov_len is unsigned on Linux, RTEMS and when using the ACE iovec struct. If we go
     // ahead and try the if, it will emit a warning.
     if (iov[i].iov_len < 0)
       return -1;


### PR DESCRIPTION
…t only Embarcadero C++ Builder/Linux/RTEMS

    * ACE/ace/SOCK_Dgram.cpp: