### PR TITLE
clang4 lacks adequate C++11 support so we don't support that anymore,…

### DIFF
--- a/ACE/tests/Compiler_Features_24_Test.cpp
+++ b/ACE/tests/Compiler_Features_24_Test.cpp
@@ -71,14 +71,6 @@ run_main (int, ACE_TCHAR *[])
 
   FOO::o_r<FOO::A> l = FOO::create();
 
-#if defined __clang__ && \
-    (defined __apple_build_version__ && __apple_build_version__ < 9100000 \
-     || __clang_major__ < 5)
-  ACE_ERROR ((LM_ERROR, ACE_TEXT ("ERROR: This version of clang doesn't")
-                        ACE_TEXT (" compile the C++11 code in this test.\n")));
-  ACE_END_TEST;
-  return 1;
-#else
   FOO::o_r<FOO::A> l2 = FOO::make_f<FOO::A>();
   // next line doesn't compile and shouldn't
   //FOO::o_r<FOO::B> l3 = FOO::make_f<FOO::B>();
@@ -88,5 +80,4 @@ run_main (int, ACE_TCHAR *[])
   ACE_END_TEST;
 
   return 0;
-#endif
 }


### PR DESCRIPTION
… we can now always compile this unit test

    * ACE/tests/Compiler_Features_24_Test.cpp: