### PR TITLE
Embarcadero C++ Builder can now handle this IDL file

### DIFF
--- a/TAO/tests/Bug_3940_Regression/README
+++ b/TAO/tests/Bug_3940_Regression/README
@@ -1,5 +1,3 @@
-
-
 This is a compile only test. If it compiles, it's passed.
 
 tao_idl choked on the annotation syntax of IDL4 (and DDS-XTypes)
@@ -12,5 +10,4 @@ because that syntax was unknown to its IDL grammar:
 
 The first patch for this bug adds a rule in the lexer to ignore the annotations
 by consuming them without action.
-Actual processing of annotations is still to be done.
-
+Actual processing of annotations still has to be done.

--- a/TAO/tests/Bug_3940_Regression/test.idl
+++ b/TAO/tests/Bug_3940_Regression/test.idl
@@ -1,5 +1,3 @@
-#if !defined (__BORLANDC__)
-
 @annotation unit {
   string value;
 };
@@ -35,5 +33,3 @@ module test {
    };
 
 };
-
-#endif


### PR DESCRIPTION
    * TAO/tests/Bug_3940_Regression/README:
    * TAO/tests/Bug_3940_Regression/test.idl: