### PR TITLE
Removed old workarounds for bcc32

### DIFF
--- a/ACE/ace/Refcounted_Auto_Ptr.h
+++ b/ACE/ace/Refcounted_Auto_Ptr.h
@@ -146,8 +146,6 @@ private:
   ACE_ALLOC_HOOK_DECLARE;
 
   // = Encapsulate reference count and object lifetime of instances.
-  // These methods must go after the others to work around a bug with
-  // Borland's C++ Builder...
 
   /// Allocate a new ACE_Refcounted_Auto_Ptr_Rep<X, ACE_LOCK> instance,
   /// returning NULL if it cannot be created.

--- a/ACE/ace/XML_Utils/XercesString.h
+++ b/ACE/ace/XML_Utils/XercesString.h
@@ -64,7 +64,6 @@ namespace XML
   private:
 
     XMLCh* _wstr; // Internal representation
-
   };
 
   XML_Utils_Export bool operator== (const XStr& lhs, const XStr& rhs);
@@ -72,7 +71,6 @@ namespace XML
 
   XML_Utils_Export std::ostream&
   operator<< (std::ostream& o, XStr const& str);
-
 }
 
 #include /**/ "ace/post.h"

--- a/TAO/orbsvcs/orbsvcs/AV/RTCP_Channel.cpp
+++ b/TAO/orbsvcs/orbsvcs/AV/RTCP_Channel.cpp
@@ -188,9 +188,7 @@ RTCP_Channel_In::update_seq(ACE_UINT16 seq)
   else if (udelta <= RTP_SEQ_MOD - MAX_MISORDER)
     {
       // the sequence number made a large jump
-      ACE_UINT32 temp = seq; // Borland reports a warning on the next line
-                             // without this line.
-      if (temp == this->bad_seq_)
+      if (seq == this->bad_seq_)
         {
           // two sequential packets, assume the other side restarted without
           // telling us so just re-sync

--- a/TAO/orbsvcs/orbsvcs/AV/RTCP_Packet.cpp
+++ b/TAO/orbsvcs/orbsvcs/AV/RTCP_Packet.cpp
@@ -136,10 +136,8 @@ RTCP_BYE_Packet::RTCP_BYE_Packet(char* buffer, int *len)
     }
 
   // Optional - store the reason for leaving
-  unsigned int temp = this->chd_.length_; // Borland reports a warning on the
-                                          // following line with out this.
   ACE_OS::memset(this->reason_, 0, sizeof(this->reason_));
-  if (temp > this->chd_.count_)
+  if (this->chd_.length_ > this->chd_.count_)
     {
       this->reason_length_ = buffer[index];
       index++;

--- a/TAO/utils/nslist/nslist.cpp
+++ b/TAO/utils/nslist/nslist.cpp
@@ -64,8 +64,7 @@ namespace
 
     static void remove ()
     {
-      const NestedNamingContexts *const pThisOne= pBottom;
-      delete pThisOne; // i.e. delete pBottom; Attempt to stop over-optimisation by BORLAND
+      delete pBottom;
     }
 
     static size_t hasBeenSeen (const CosNaming::NamingContext_ptr nc)

--- a/TAO/utils/wxNamingViewer/wxNamingViewer.cpp
+++ b/TAO/utils/wxNamingViewer/wxNamingViewer.cpp
@@ -39,14 +39,12 @@ public:
   virtual int OnExit();
 };
 
-
 IMPLEMENT_APP(WxNamingViewer)
 
 // Need this to keep C++Builder 4 happy
 #ifdef __BORLANDC__
 extern WINAPI WinMain( HINSTANCE, HINSTANCE, LPSTR, int);
 #endif
-
 
 int WxNamingViewer::OnExit()
 {


### PR DESCRIPTION
    * ACE/ace/Refcounted_Auto_Ptr.h:
    * ACE/ace/XML_Utils/XercesString.h:
    * TAO/orbsvcs/orbsvcs/AV/RTCP_Channel.cpp:
    * TAO/orbsvcs/orbsvcs/AV/RTCP_Packet.cpp:
    * TAO/utils/nslist/nslist.cpp:
    * TAO/utils/wxNamingViewer/wxNamingViewer.cpp: