### PR TITLE
Header File for TAO_IDL Supported IDL Features

### DIFF
--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -6,6 +6,9 @@ USER VISIBLE CHANGES BETWEEN TAO-3.0.2 and TAO-3.0.3
   these are new distinct types that are not aliases of existing types covered
   by the CORBA specification.
 
+. Added the `tao/idl_features.h` header file for getting the IDL features
+  supported by IDL. See the file for example usage.
+
 USER VISIBLE CHANGES BETWEEN TAO-3.0.1 and TAO-3.0.2
 ====================================================
 

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -7,7 +7,7 @@ USER VISIBLE CHANGES BETWEEN TAO-3.0.2 and TAO-3.0.3
   by the CORBA specification.
 
 . Added the `tao/idl_features.h` header file for getting the IDL features
-  supported by IDL. See the file for example usage.
+  supported by TAO_IDL. See the file for example usage.
 
 USER VISIBLE CHANGES BETWEEN TAO-3.0.1 and TAO-3.0.2
 ====================================================

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -582,6 +582,13 @@ DRV_add_include_path (ACE_CString& include_path,
 void
 DRV_cpp_post_init ()
 {
+  char idl_version_arg[128];
+  ACE_OS::sprintf (idl_version_arg, "-D__TAO_IDL_IDL_VERSION=%s",
+    idl_global->idl_version_.to_macro ());
+  DRV_cpp_putarg (idl_version_arg);
+
+  DRV_cpp_putarg ("-D__TAO_IDL_FEATURES=\"tao/idl_features.h\"");
+
   // Add include path for TAO_ROOT/orbsvcs.
   char* TAO_ROOT = ACE_OS::getenv ("TAO_ROOT");
 

--- a/TAO/TAO_IDL/include/idl_defines.h
+++ b/TAO/TAO_IDL/include/idl_defines.h
@@ -65,6 +65,8 @@ trademarks or registered trademarks of Sun Microsystems, Inc.
 #ifndef _IDL_DEFINES_IDL_DEFINES_HH
 #define _IDL_DEFINES_IDL_DEFINES_HH
 
+#include "tao/idl_features.h"
+
 #include "ace/os_include/os_limits.h"
 
 /*
@@ -110,11 +112,6 @@ trademarks or registered trademarks of Sun Microsystems, Inc.
  *   #endif
  */
 #define TAO_IDL_HAS_PARSE_ARGS_EXIT
-
-/**
- * Defined if TAO_IDL has support for annotations
- */
-#define TAO_IDL_HAS_ANNOTATIONS
 
 #define NAMEBUFSIZE 1024
 // Maximum length of static buffers used to store names.

--- a/TAO/TAO_IDL/include/idl_version.h
+++ b/TAO/TAO_IDL/include/idl_version.h
@@ -95,6 +95,11 @@ public:
   void from_string (const char * version);
 
   /**
+   * Get the value for the __TAO_IDL_IDL_VERSION preprocessor macro.
+   */
+  const char * to_macro () const;
+
+  /**
    * Compare a IdlVersion to a SpecificIdlVersion or another IdlVersion
    */
   ///{

--- a/TAO/TAO_IDL/util/idl_version.cpp
+++ b/TAO/TAO_IDL/util/idl_version.cpp
@@ -7,11 +7,22 @@
 #include "ace/OS_NS_string.h"
 #include "idl_version.h"
 
-static const char * idlVersionNames[IDL_VERSION_COUNT] = {
-  "Invalid",
-  "3",
-  "4"
-};
+namespace {
+  const char * idlVersionNames[IDL_VERSION_COUNT] = {
+    "Invalid",
+    "3",
+    "4"
+  };
+
+  /**
+   * Values for __TAO_IDL_IDL_VERSION. Should work like __TAO_IDL does.
+   */
+  const char * idl_version_macros[IDL_VERSION_COUNT] = {
+    "0x0",
+    "0x030000",
+    "0x040000"
+  };
+}
 
 IdlVersion::IdlVersion () : version_(DEFAULT_DEFAULT_IDL_VERSION)
 {
@@ -56,6 +67,11 @@ void IdlVersion::from_string (const char * version)
         }
     }
   version_ = IDL_VERSION_INVALID;
+}
+
+const char * IdlVersion::to_macro () const
+{
+  return idl_version_macros[version_];
 }
 
 IdlVersion::operator SpecificIdlVersion () const

--- a/TAO/tao/idl_features.h
+++ b/TAO/tao/idl_features.h
@@ -1,0 +1,75 @@
+/**
+ * @file idl_features.h
+ *
+ * Get information about what IDL features the IDL compiler has, similarly to
+ * the "version" standard header in C++.
+ *
+ * In C++ it can be used like this if you want to be compatible with older
+ * versions of TAO:
+ *
+ * #include "tao/orbconf.h"
+ * #if defined TAO_HAS_IDL_FEATURES && TAO_HAS_IDL_FEATURES
+ * // Use this macro if you are using something that's not the max possible
+ * // version.
+ * #  define TAO_IDL_IDL_VERSION 0x30000
+ * #  include "tao/idl_features.h"
+ * #  define USE_FEATURE defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
+ * #else
+ * #  define USE_FEATURE 0
+ * #endif
+ *
+ * In IDL it can be used like this if you want to be compatible with older
+ * versions of TAO:
+ *
+ * #if defined __TAO_IDL_FEATURES
+ * #  include __TAO_IDL_FEATURES
+ * #  define USE_FEATURE defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
+ * #else
+ * #  define USE_FEATURE 0
+ * #endif
+ */
+
+#ifndef TAO_IDL_FEATURES_H
+#define TAO_IDL_FEATURES_H
+
+#ifndef TAO_IDL_IDL_VERSION
+#  ifdef __TAO_IDL_IDL_VERSION
+#    define TAO_IDL_IDL_VERSION __TAO_IDL_IDL_VERSION
+#  else
+#    define TAO_IDL_IDL_VERSION 0xffffffff
+#  endif
+#endif
+
+#ifndef TAO_IDL_HAS_ANNOTATIONS
+#  define TAO_IDL_HAS_ANNOTATIONS TAO_IDL_IDL_VERSION >= 0x40000
+#endif
+
+#ifndef TAO_IDL_HAS_ANONYMOUS_TYPES
+#  define TAO_IDL_HAS_ANONYMOUS_TYPES TAO_IDL_IDL_VERSION >= 0x40000
+#endif
+
+#ifndef TAO_IDL_HAS_EXPLICIT_INTS
+#  define TAO_IDL_HAS_EXPLICIT_INTS TAO_IDL_IDL_VERSION >= 0x40000
+#endif
+
+#ifndef TAO_IDL_HAS_OCTET_AND_WCHAR_UNION_DISCS
+#  define TAO_IDL_HAS_OCTET_AND_WCHAR_UNION_DISCS 0
+#endif
+
+#ifndef TAO_IDL_HAS_STRUCT_INHERITANCE
+#  define TAO_IDL_HAS_STRUCT_INHERITANCE 0
+#endif
+
+#ifndef TAO_IDL_HAS_MAP
+#  define TAO_IDL_HAS_MAP 0
+#endif
+
+#ifndef TAO_IDL_HAS_BITSET
+#  define TAO_IDL_HAS_BITSET 0
+#endif
+
+#ifndef TAO_IDL_HAS_BITMASK
+#  define TAO_IDL_HAS_BITMASK 0
+#endif
+
+#endif

--- a/TAO/tao/idl_features.h
+++ b/TAO/tao/idl_features.h
@@ -13,9 +13,9 @@
  * // version.
  * #  define TAO_IDL_IDL_VERSION 0x30000
  * #  include "tao/idl_features.h"
- * #  define USE_FEATURE defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
- * #else
- * #  define USE_FEATURE 0
+ * #  if defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
+ * #    define USE_FEATURE
+ * #  endif
  * #endif
  *
  * In IDL it can be used like this if you want to be compatible with older
@@ -23,10 +23,14 @@
  *
  * #if defined __TAO_IDL_FEATURES
  * #  include __TAO_IDL_FEATURES
- * #  define USE_FEATURE defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
- * #else
- * #  define USE_FEATURE 0
+ * #  if defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
+ * #    define USE_FEATURE
+ * #  endif
  * #endif
+ *
+ * Note that support for annotations and anonymous types in IDL4 predate this
+ * file, so they are a potential special case depending on what ACE/TAO is
+ * being used.
  */
 
 #ifndef TAO_IDL_FEATURES_H

--- a/TAO/tao/orbconf.h
+++ b/TAO/tao/orbconf.h
@@ -857,6 +857,10 @@ enum TAO_Policy_Scope
 # define TAO_DEFAULT_COLLOCATION_STRATEGY TAO_COLLOCATION_THRU_POA
 #endif
 
+#ifndef TAO_HAS_IDL_FEATURES
+#  define TAO_HAS_IDL_FEATURES 1
+#endif
+
 TAO_END_VERSIONED_NAMESPACE_DECL
 
 #include /**/ "ace/post.h"

--- a/TAO/tao/tao.mpc
+++ b/TAO/tao/tao.mpc
@@ -448,6 +448,7 @@ project(TAO) : acelib, install, tao_output, taodefaults, pidl, extra_core, taoid
     HTTP_Client.h
     HTTP_Handler.h
     HTTP_Parser.h
+    idl_features.h
     IFR_Client_Adapter.h
     IIOP_Acceptor.h
     IIOPC.h

--- a/TAO/tests/IDLv4/anonymous_types/test.idl
+++ b/TAO/tests/IDLv4/anonymous_types/test.idl
@@ -3,6 +3,15 @@
  * there is already a test file at tests/IDL_Test/anonymous.idl.
  */
 
+#include __TAO_IDL_FEATURES
+#ifdef TAO_IDL_HAS_ANONYMOUS_TYPES
+#  if !TAO_IDL_HAS_ANONYMOUS_TYPES
+#    error "Expecting macro to be true"
+#  endif
+#else
+#  error "Expecting macro to be defined"
+#endif
+
 struct TestStruct {
   short short_array[10];
   short another_short_array[10];

--- a/TAO/tests/IDLv4/explicit_ints/main.cpp
+++ b/TAO/tests/IDLv4/explicit_ints/main.cpp
@@ -1,5 +1,14 @@
 #include "testC.h"
 
+#include "tao/idl_features.h"
+#ifdef TAO_IDL_HAS_EXPLICIT_INTS
+#  if !TAO_IDL_HAS_EXPLICIT_INTS
+#    error "Expecting macro to be true"
+#  endif
+#else
+#  error "Expecting macro to be defined"
+#endif
+
 #include "ace/OS_NS_stdlib.h"
 #include "ace/OS_main.h"
 #include "ace/streams.h"

--- a/TAO/tests/IDLv4/explicit_ints/test.idl
+++ b/TAO/tests/IDLv4/explicit_ints/test.idl
@@ -1,3 +1,12 @@
+#include __TAO_IDL_FEATURES
+#ifdef TAO_IDL_HAS_EXPLICIT_INTS
+#  if !TAO_IDL_HAS_EXPLICIT_INTS
+#    error "Expecting macro to be true"
+#  endif
+#else
+#  error "Expecting macro to be defined"
+#endif
+
 #include "tao/Int8Seq.pidl"
 #include "tao/UInt8Seq.pidl"
 #include "tao/OctetSeq.pidl"


### PR DESCRIPTION
Get information about what the IDL compiler is capable of, similarly to the "version" standard header in C++.

In C++ it can be used like this if you want to be compatible with older versions of TAO:

```c++
#include "tao/orbconf.h"
#if defined TAO_HAS_IDL_FEATURES && TAO_HAS_IDL_FEATURES
// Use this macro if you are using something that's not the max possible
// version.
#  define TAO_IDL_IDL_VERSION 0x30000
#  include "tao/idl_features.h"
#  if defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
#    define USE_FEATURE
#  endif
#endif
```

In IDL it can be used like this if you want to be compatible with older versions of TAO:

```c++
#if defined __TAO_IDL_FEATURES
#  include __TAO_IDL_FEATURES
#  if defined TAO_IDL_HAS_FEATURE && TAO_IDL_HAS_FEATURE
#    define USE_FEATURE
#  endif
#endif
```