### PR TITLE
[GitHub Actions] Disable fail-fast strategy for matrix builds

### DIFF
--- a/.github/workflows/face.yml
+++ b/.github/workflows/face.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     strategy:
-      fast-fail: false
+      fail-fast: false
       matrix:
         include:
           - CC: gcc-10

--- a/.github/workflows/face.yml
+++ b/.github/workflows/face.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fast-fail: false
       matrix:
         include:
           - CC: gcc-10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fast-fail: false
       matrix:
         include:
           - CC: gcc-4.8

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     strategy:
-      fast-fail: false
+      fail-fast: false
       matrix:
         include:
           - CC: gcc-4.8

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fast-fail: false
       matrix:
         os: [macos-10.15, macos-11.0]
         include:

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     strategy:
-      fast-fail: false
+      fail-fast: false
       matrix:
         os: [macos-10.15, macos-11.0]
         include:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   msvc:
     strategy:
+      fast-fail: false
       matrix:
         include:
           - name: VS2017WChar

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   msvc:
     strategy:
-      fast-fail: false
+      fail-fast: false
       matrix:
         include:
           - name: VS2017WChar
@@ -146,6 +146,7 @@ jobs:
   mingw:
     runs-on: windows-2019
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gcc]
         msystem: [MINGW64]


### PR DESCRIPTION
Problem:
When a single matrix build fails (say, for example, due to vcpkg errors), it cancels all other parallel matrix builds in the same job. This is unhelpful in most situations, as we'd still usually like to see the other test results.

Solution:
Disable the default 'fail fast' strategy for github actions to allow other matrix jobs to continue.