### PR TITLE
[ACE 6] make_multicast_ifaddr: prevent buffer overrun from net_if

### DIFF
--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -673,7 +673,6 @@ ACE_SOCK_Dgram::make_multicast_ifaddr (ip_mreq *ret_mreq,
       ACE_INET_Addr interface_addr;
       if (interface_addr.set (mcast_addr.get_port_number (), net_if) == -1)
         {
-#if defined (ACE_WIN32)
           IP_ADAPTER_ADDRESSES tmp_addrs;
           // Initial call to determine actual memory size needed
           ULONG bufLen = 0;
@@ -717,15 +716,12 @@ ACE_SOCK_Dgram::make_multicast_ifaddr (ip_mreq *ret_mreq,
               errno = EINVAL;
               return -1;
             }
-#else
-          ACE_NOTSUP_RETURN (-1);
-#endif /* ACE_WIN32 */
         }
       lmreq.imr_interface.s_addr =
         ACE_HTONL (interface_addr.get_ip_address ());
 #else
       ifreq if_address;
-      ACE_OS::strcpy (if_address.ifr_name, ACE_TEXT_ALWAYS_CHAR (net_if));
+      ACE_OS::strncpy (if_address.ifr_name, ACE_TEXT_ALWAYS_CHAR (net_if), sizeof if_address.ifr_name);
       if (ACE_OS::ioctl (this->get_handle (),
                          SIOCGIFADDR,
                          &if_address) == -1)


### PR DESCRIPTION
fixes #1637
also removed a preprocessor conditional that was redundant

(cherry picked from commit 06e2a14d2d98b2a18b50615f4c048cffd49b3bfd)