### PR TITLE
[ACE 6] Fixed warnings related to Handle_Set's copy constructor

### DIFF
--- a/ACE/ace/Handle_Set.h
+++ b/ACE/ace/Handle_Set.h
@@ -113,6 +113,8 @@ public:
   fd_set *fdset (void);
 
 #if defined (ACE_HAS_BIG_FD_SET)
+  ACE_Handle_Set (const ACE_Handle_Set &other);
+
   /// Assignment operator optimizes for cases where <size_> == 0.
   ACE_Handle_Set & operator= (const ACE_Handle_Set &);
 #endif /* ACE_HAS_BIG_FD_SET */

--- a/ACE/ace/Handle_Set.inl
+++ b/ACE/ace/Handle_Set.inl
@@ -27,6 +27,13 @@ ACE_Handle_Set::reset (void)
 }
 
 #if defined (ACE_HAS_BIG_FD_SET)
+ACE_INLINE ACE_Handle_Set::ACE_Handle_Set (const ACE_Handle_Set &other)
+  : size_ (other.size_)
+  , max_handle_ (other.max_handle_)
+  , min_handle_ (other.min_handle_)
+  , mask_ (other.mask_)
+{}
+
 ACE_INLINE ACE_Handle_Set &
 ACE_Handle_Set::operator = (const ACE_Handle_Set &rhs)
 {


### PR DESCRIPTION
GCC 11:
```
ace/Select_Reactor_T.cpp:1496:18: warning: implicitly-declared 'constexpr ACE_Handle_Set::ACE_Handle_Set(const ACE_Handle_Set&)' is deprecated [-Wdeprecated-copy]
ace/Handle_Set.inl:31:1: note: because 'ACE_Handle_Set' has user-provided 'ACE_Handle_Set& ACE_Handle_Set::operator=(const ACE_Handle_Set&)'
```
Not a problem for ACE 7