### PR TITLE
Don't check for ACE_LACKS_STRTOD, not set by any config file

### DIFF
--- a/ACE/ace/OS_NS_stdlib.h
+++ b/ACE/ace/OS_NS_stdlib.h
@@ -310,11 +310,9 @@ namespace ACE_OS {
   extern ACE_Export
   ACE_TCHAR *strenvdup (const ACE_TCHAR *str);
 
-#if !defined (ACE_LACKS_STRTOD)
   /// Converts a string to a double value (char version).
   ACE_NAMESPACE_INLINE_FUNCTION
   double strtod (const char *s, char **endptr);
-#endif /* !ACE_LACKS_STRTOD */
 
 #if defined (ACE_HAS_WCHAR) && !defined (ACE_LACKS_WCSTOD)
   /// Converts a string to a double value (wchar_t version).

--- a/ACE/ace/OS_NS_stdlib.inl
+++ b/ACE/ace/OS_NS_stdlib.inl
@@ -483,13 +483,11 @@ ACE_OS::srand (u_int seed)
 #endif
 }
 
-#if !defined (ACE_LACKS_STRTOD)
 ACE_INLINE double
 ACE_OS::strtod (const char *s, char **endptr)
 {
   return ::strtod (s, endptr);
 }
-#endif /* !ACE_LACKS_STRTOD */
 
 #if defined (ACE_HAS_WCHAR) && !defined (ACE_LACKS_WCSTOD)
 ACE_INLINE double

--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -145,7 +145,7 @@
 #define ACE_STRNCASECMP_EQUIVALENT ::strnicmp
 #define ACE_WTOF_EQUIVALENT ::_wtof
 #define ACE_FILENO_EQUIVALENT(X) (_get_osfhandle (::_fileno (X)))
-#define ACE_HAS_ITOA 1
+#define ACE_HAS_ITOA
 
 #if defined (ACE_HAS_BCC64)
 # if (__BORLANDC__ <= 0x730)


### PR DESCRIPTION
    * ACE/ace/OS_NS_stdlib.h:
    * ACE/ace/OS_NS_stdlib.inl:
    * ACE/ace/config-win32-borland.h: