### PR TITLE
Cleanup old Embarcadero compiler checks

### DIFF
--- a/ACE/ace/Compression/rle/RLECompressor.cpp
+++ b/ACE/ace/Compression/rle/RLECompressor.cpp
@@ -1,10 +1,6 @@
 #include "RLECompressor.h"
 #include "ace/OS_NS_string.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-#  pragma option push -w-8072
-#endif
-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_RLECompressor::ACE_RLECompressor()
@@ -136,6 +132,3 @@ ACE_SINGLETON_TEMPLATE_INSTANTIATE(ACE_Singleton, ACE_RLECompressor, ACE_SYNCH_M
 // Close versioned namespace, if enabled by the user.
 ACE_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-# pragma option pop
-#endif

--- a/ACE/ace/post.h
+++ b/ACE/ace/post.h
@@ -15,9 +15,6 @@
 # pragma pack (pop)
 #elif defined (__BORLANDC__)
 # pragma option pop
-# if (__BORLANDC__ <= 0x750)
-#  pragma option pop
-# endif
 # pragma nopushoptwarn
 # pragma nopackwarning
 #endif

--- a/ACE/ace/pre.h
+++ b/ACE/ace/pre.h
@@ -17,11 +17,6 @@
 # pragma pack (push, 8)
 #elif defined (__BORLANDC__)
 # pragma option push -a8 -b -Ve- -Vx- -w-rvl -w-rch -w-ccc -w-obs -w-aus -w-pia -w-inl -w-sig
-# if (__BORLANDC__ <= 0x750)
-// False warning: Function defined with different linkage, reported to
-// Embarcadero as QC 117740
-#  pragma option push -w-8127
-# endif
 # pragma nopushoptwarn
 # pragma nopackwarning
 #endif

--- a/TAO/orbsvcs/orbsvcs/Notify/MonitorControlExt/MC_Default_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/MonitorControlExt/MC_Default_Factory.h
@@ -21,10 +21,6 @@
 
 #if defined (TAO_HAS_MONITOR_FRAMEWORK) && (TAO_HAS_MONITOR_FRAMEWORK == 1)
 
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-#  pragma option push -w-8022
-#endif
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /**
@@ -65,10 +61,6 @@ public:
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL
-
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-# pragma option pop
-#endif
 
 #endif /* TAO_HAS_MONITOR_FRAMEWORK==1 */
 

--- a/TAO/orbsvcs/orbsvcs/Notify/RT_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/RT_Factory.h
@@ -18,10 +18,6 @@
 
 #include "orbsvcs/Notify/Default_Factory.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-#  pragma option push -w-8022
-#endif
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /**
@@ -33,7 +29,7 @@ class TAO_RT_Notify_Export TAO_Notify_RT_Factory : public TAO_Notify_Default_Fac
 {
 public:
   /// Constructor
-  TAO_Notify_RT_Factory (void);
+  TAO_Notify_RT_Factory ();
 
   /// Destructor
   virtual ~TAO_Notify_RT_Factory ();
@@ -47,10 +43,6 @@ public:
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL
-
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-# pragma option pop
-#endif
 
 ACE_FACTORY_DECLARE (TAO_RT_Notify, TAO_Notify_RT_Factory)
 

--- a/TAO/orbsvcs/tests/Notify/Bug_3252_Regression/server.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_3252_Regression/server.cpp
@@ -10,10 +10,6 @@
 
 #include "DllOrb.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-#  pragma option push -w-8057
-#endif
-
 ACE_TCHAR const * const scpc_loadOrb = ACE_DYNAMIC_VERSIONED_SERVICE_DIRECTIVE(
   "testDllOrb",
   "Bug_3252",
@@ -230,7 +226,3 @@ ACE_TMAIN(int, ACE_TCHAR **argv)
 
   return 0;
 }
-
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-# pragma option pop
-#endif

--- a/TAO/tests/Bug_3574_Regression/test.cpp
+++ b/TAO/tests/Bug_3574_Regression/test.cpp
@@ -1,9 +1,5 @@
 #include "tao/StringSeqC.h"
 
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-#  pragma option push -w-8011
-#endif
-
 int
 ACE_TMAIN (int, ACE_TCHAR *[])
 {
@@ -51,7 +47,3 @@ ACE_TMAIN (int, ACE_TCHAR *[])
 
   return 0;
 }
-
-#if defined (__BORLANDC__) && (__BORLANDC__ <= 0x750)
-# pragma option pop
-#endif


### PR DESCRIPTION
    * ACE/ace/Compression/rle/RLECompressor.cpp:
    * ACE/ace/post.h:
    * ACE/ace/pre.h:
    * TAO/orbsvcs/orbsvcs/Notify/MonitorControlExt/MC_Default_Factory.h:
    * TAO/orbsvcs/orbsvcs/Notify/RT_Factory.h:
    * TAO/orbsvcs/tests/Notify/Bug_3252_Regression/server.cpp:
    * TAO/tests/Bug_3574_Regression/test.cpp: