### PR TITLE
ACE 6 doesn't support Big Sur

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -5,15 +5,17 @@ on:
   pull_request:
   schedule:
     - cron: '0 1 * * SUN'
+  workflow_dispatch:
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         cxxstd: ["03", "11"]
+        os: [macos-10.15, macos-11.0]
         include:
-          - os: macos-10.15
-            platform_file: include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU
+          - platform_file: include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }}-C++${{ matrix.cxxstd }}"
     env:

--- a/ACE/include/makeinclude/platform_macosx.GNU
+++ b/ACE/include/makeinclude/platform_macosx.GNU
@@ -20,18 +20,27 @@ MACOS_CODENAME_VER_10_11  := elcapitan
 MACOS_CODENAME_VER_10_12  := sierra
 MACOS_CODENAME_VER_10_13  := highsierra
 MACOS_CODENAME_VER_10_14  := mojave
-MACOS_CODENAME_VER_latest := mojave
+MACOS_CODENAME_VER_10_15  := catalina
+MACOS_CODENAME_VER_10_latest  := catalina
+MACOS_CODENAME_VER_11_5   := bigsur
+MACOS_CODENAME_VER_11_latest := bigsur
 
 MACOS_CODENAME = $(MACOS_CODENAME_VER_$(MACOS_MAJOR_VERSION)_$(MACOS_MINOR_VERSION))
 
 ifeq ($(MACOS_MAJOR_VERSION),10)
-  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 14; echo $$?),0)
+  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 15; echo $$?),0)
     ## if the detected version is greater than the latest know version,
     ## just use the latest known version
-    MACOS_CODENAME = $(MACOS_CODENAME_VER_latest)
+    MACOS_CODENAME = $(MACOS_CODENAME_VER_10_latest)
   else ifeq ($(shell test $(MACOS_MINOR_VERSION) -lt 2; echo $$?),0)
     ## Unsupported minor version
     $(error Unsupported MacOS version $(MACOS_RELEASE_VERSION))
+  endif
+else ifeq ($(MACOS_MAJOR_VERSION),11)
+  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 2; echo $$?),0)
+    ## if the detected version is greater than the latest know version,
+    ## just use the latest known version
+    MACOS_CODENAME = $(MACOS_CODENAME_VER_11_latest)
   endif
 else
   ## Unsupported major version

--- a/ACE/include/makeinclude/platform_macosx_bigsur.GNU
+++ b/ACE/include/makeinclude/platform_macosx_bigsur.GNU
@@ -1,0 +1,1 @@
+include $(ACE_ROOT)/include/makeinclude/platform_macosx_catalina.GNU

--- a/ACE/include/makeinclude/platform_macosx_catalina.GNU
+++ b/ACE/include/makeinclude/platform_macosx_catalina.GNU
@@ -1,0 +1,1 @@
+include $(ACE_ROOT)/include/makeinclude/platform_macosx_mojave.GNU


### PR DESCRIPTION
Problem
-------

ACE 6 doesn't compile for macOS Big Sur.

Solution
--------

Update platform_macosx.GNU and related files to support Catalina and
Big Sur.