### PR TITLE
[ACE6] Update ACE_Atomic_Op_GCC to support newer __atomic operations when available

### DIFF
--- a/ACE/ace/Atomic_Op_GCC_T.inl
+++ b/ACE/ace/Atomic_Op_GCC_T.inl
@@ -29,91 +29,149 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator++ (void)
 {
-  return __sync_add_and_fetch (&this->value_, 1);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_add_fetch (&value_, 1, __ATOMIC_ACQ_REL);
+#else
+  return __sync_add_and_fetch (&value_, 1);
+#endif
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator++ (int)
 {
-  return __sync_fetch_and_add (&this->value_, 1);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_fetch_add (&value_, 1, __ATOMIC_ACQ_REL);
+#else
+  return __sync_fetch_and_add (&value_, 1);
+#endif
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-- (void)
 {
-  return __sync_sub_and_fetch (&this->value_, 1);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_sub_fetch (&value_, 1, __ATOMIC_ACQ_REL);
+#else
+  return __sync_sub_and_fetch (&value_, 1);
+#endif
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-- (int)
 {
-  return __sync_fetch_and_sub (&this->value_, 1);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_fetch_sub (&value_, 1, __ATOMIC_ACQ_REL);
+#else
+  return __sync_fetch_and_sub (&value_, 1);
+#endif
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator+= (T rhs)
 {
-  return __sync_add_and_fetch (&this->value_, rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_add_fetch (&value_, rhs, __ATOMIC_ACQ_REL);
+#else
+  return __sync_add_and_fetch (&value_, rhs);
+#endif
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-= (T rhs)
 {
-  return __sync_sub_and_fetch (&this->value_, rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_sub_fetch (&value_, rhs, __ATOMIC_ACQ_REL);
+#else
+  return __sync_sub_and_fetch (&value_, rhs);
+#endif
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator== (T rhs) const
 {
-  return (this->value_ == rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) == rhs;
+#else
+  __sync_synchronize();
+  return value_ == rhs;
+#endif
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator!= (T rhs) const
 {
-  return (this->value_ != rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) != rhs;
+#else
+  __sync_synchronize();
+  return value_ != rhs;
+#endif
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator>= (T rhs) const
 {
-  return (this->value_ >= rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) >= rhs;
+#else
+  __sync_synchronize();
+  return value_ >= rhs;
+#endif
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator> (T rhs) const
 {
-  return (this->value_ > rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) > rhs;
+#else
+  __sync_synchronize();
+  return value_ > rhs;
+#endif
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator<= (T rhs) const
 {
-  return (this->value_ <= rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) <= rhs;
+#else
+  __sync_synchronize();
+  return value_ <= rhs;
+#endif
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator< (T rhs) const
 {
-  return (this->value_ < rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) < rhs;
+#else
+  __sync_synchronize();
+  return value_ < rhs;
+#endif
 }
 
 template <typename T>
 ACE_INLINE ACE_Atomic_Op_GCC<T> &
 ACE_Atomic_Op_GCC<T>::operator= (T rhs)
 {
-  (void) __sync_lock_test_and_set (&this->value_, rhs);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  __atomic_store_n (&value_, rhs, __ATOMIC_RELEASE);
+#else
+  (void) __sync_lock_test_and_set (&value_, rhs);
+#endif
   return *this;
 }
 
@@ -122,7 +180,11 @@ ACE_INLINE ACE_Atomic_Op_GCC<T> &
 ACE_Atomic_Op_GCC<T>::operator= (
    const ACE_Atomic_Op_GCC<T> &rhs)
 {
-  (void) __sync_lock_test_and_set (&this->value_, rhs.value_);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  __atomic_store_n (&value_, __atomic_load_n (&rhs.value_, __ATOMIC_CONSUME), __ATOMIC_RELEASE);
+#else
+  (void) __sync_lock_test_and_set (&value_, rhs.value_);
+#endif
   return *this;
 }
 
@@ -130,21 +192,30 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::exchange (T newval)
 {
-  return __sync_val_compare_and_swap (&this->value_, this->value_, newval);
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_exchange_n (&value_, newval, __ATOMIC_ACQ_REL);
+#else
+  return __sync_val_compare_and_swap (&value_, value_, newval);
+#endif
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::value (void) const
 {
-  return this->value_;
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME);
+#else
+  __sync_synchronize();
+  return value_;
+#endif
 }
 
 template <typename T>
 ACE_INLINE volatile T &
 ACE_Atomic_Op_GCC<T>::value_i (void)
 {
-  return this->value_;
+  return value_;
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Atomic_Op_GCC_T.inl
+++ b/ACE/ace/Atomic_Op_GCC_T.inl
@@ -1,6 +1,11 @@
 // -*- C++ -*-
 #if defined (ACE_HAS_GCC_ATOMIC_BUILTINS) && (ACE_HAS_GCC_ATOMIC_BUILTINS == 1)
 
+#if (defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))) \
+ || (defined (__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 3)))
+#  define USE_GCC_CPP11_ATOMICS
+#endif
+
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 template <typename T>
@@ -29,7 +34,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator++ (void)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_add_fetch (&value_, 1, __ATOMIC_ACQ_REL);
 #else
   return __sync_add_and_fetch (&value_, 1);
@@ -40,7 +45,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator++ (int)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_fetch_add (&value_, 1, __ATOMIC_ACQ_REL);
 #else
   return __sync_fetch_and_add (&value_, 1);
@@ -51,7 +56,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-- (void)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_sub_fetch (&value_, 1, __ATOMIC_ACQ_REL);
 #else
   return __sync_sub_and_fetch (&value_, 1);
@@ -62,7 +67,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-- (int)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_fetch_sub (&value_, 1, __ATOMIC_ACQ_REL);
 #else
   return __sync_fetch_and_sub (&value_, 1);
@@ -73,7 +78,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator+= (T rhs)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_add_fetch (&value_, rhs, __ATOMIC_ACQ_REL);
 #else
   return __sync_add_and_fetch (&value_, rhs);
@@ -84,7 +89,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-= (T rhs)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_sub_fetch (&value_, rhs, __ATOMIC_ACQ_REL);
 #else
   return __sync_sub_and_fetch (&value_, rhs);
@@ -95,7 +100,7 @@ template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator== (T rhs) const
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_load_n (&value_, __ATOMIC_CONSUME) == rhs;
 #else
   __sync_synchronize();
@@ -107,7 +112,7 @@ template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator!= (T rhs) const
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_load_n (&value_, __ATOMIC_CONSUME) != rhs;
 #else
   __sync_synchronize();
@@ -119,7 +124,7 @@ template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator>= (T rhs) const
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_load_n (&value_, __ATOMIC_CONSUME) >= rhs;
 #else
   __sync_synchronize();
@@ -131,7 +136,7 @@ template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator> (T rhs) const
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_load_n (&value_, __ATOMIC_CONSUME) > rhs;
 #else
   __sync_synchronize();
@@ -143,7 +148,7 @@ template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator<= (T rhs) const
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_load_n (&value_, __ATOMIC_CONSUME) <= rhs;
 #else
   __sync_synchronize();
@@ -155,7 +160,7 @@ template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator< (T rhs) const
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_load_n (&value_, __ATOMIC_CONSUME) < rhs;
 #else
   __sync_synchronize();
@@ -167,7 +172,7 @@ template <typename T>
 ACE_INLINE ACE_Atomic_Op_GCC<T> &
 ACE_Atomic_Op_GCC<T>::operator= (T rhs)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   __atomic_store_n (&value_, rhs, __ATOMIC_RELEASE);
 #else
   (void) __sync_lock_test_and_set (&value_, rhs);
@@ -180,7 +185,7 @@ ACE_INLINE ACE_Atomic_Op_GCC<T> &
 ACE_Atomic_Op_GCC<T>::operator= (
    const ACE_Atomic_Op_GCC<T> &rhs)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   __atomic_store_n (&value_, __atomic_load_n (&rhs.value_, __ATOMIC_CONSUME), __ATOMIC_RELEASE);
 #else
   (void) __sync_lock_test_and_set (&value_, rhs.value_);
@@ -192,7 +197,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::exchange (T newval)
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_exchange_n (&value_, newval, __ATOMIC_ACQ_REL);
 #else
   return __sync_val_compare_and_swap (&value_, value_, newval);
@@ -203,7 +208,7 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::value (void) const
 {
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+#if  defined (USE_GCC_CPP11_ATOMICS)
   return __atomic_load_n (&value_, __ATOMIC_CONSUME);
 #else
   __sync_synchronize();
@@ -217,6 +222,8 @@ ACE_Atomic_Op_GCC<T>::value_i (void)
 {
   return value_;
 }
+
+#undef USE_GCC_CPP11_ATOMICS
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 


### PR DESCRIPTION
Problem: ACE_Atomic_Op_GCC_T currently only uses the older __sync style atomic operations, which don't allow for memory ordering, meaning that they often enforce stricter-than-necessary memory barriers in order to achieve synchronization. The `__sync_synchronize()` builtin also isn't supported by clang and GCC's ThreadSanitizer feature, meaning that newer compilers will get false-positive reports of data races when using -fsanitize. ACE_Atomic_Op_GCC_T also appears to be missing load-side synchronization (via `__sync_synchronize()`).

Solution: Update ACE_Atomic_Op_GCC_T's load-side synchronization to use `__sync_synchronize()` and add support for __atomic builtins for GCC versions new enough to support them.