### PR TITLE
Update ACE_Atomic_Op_GCC to use newer __atomic operations

### DIFF
--- a/ACE/ace/Atomic_Op_GCC_T.inl
+++ b/ACE/ace/Atomic_Op_GCC_T.inl
@@ -29,91 +29,91 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator++ ()
 {
-  return __sync_add_and_fetch (&this->value_, 1);
+  return __atomic_add_fetch (&value_, 1, __ATOMIC_ACQ_REL);
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator++ (int)
 {
-  return __sync_fetch_and_add (&this->value_, 1);
+  return __atomic_fetch_add (&value_, 1, __ATOMIC_ACQ_REL);
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-- ()
 {
-  return __sync_sub_and_fetch (&this->value_, 1);
+  return __atomic_sub_fetch (&value_, 1, __ATOMIC_ACQ_REL);
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-- (int)
 {
-  return __sync_fetch_and_sub (&this->value_, 1);
+  return __atomic_fetch_sub (&value_, 1, __ATOMIC_ACQ_REL);
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator+= (T rhs)
 {
-  return __sync_add_and_fetch (&this->value_, rhs);
+  return __atomic_add_fetch (&value_, rhs, __ATOMIC_ACQ_REL);
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::operator-= (T rhs)
 {
-  return __sync_sub_and_fetch (&this->value_, rhs);
+  return __atomic_sub_fetch (&value_, rhs, __ATOMIC_ACQ_REL);
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator== (T rhs) const
 {
-  return (this->value_ == rhs);
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) == rhs;
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator!= (T rhs) const
 {
-  return (this->value_ != rhs);
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) != rhs;
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator>= (T rhs) const
 {
-  return (this->value_ >= rhs);
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) >= rhs;
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator> (T rhs) const
 {
-  return (this->value_ > rhs);
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) > rhs;
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator<= (T rhs) const
 {
-  return (this->value_ <= rhs);
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) <= rhs;
 }
 
 template <typename T>
 ACE_INLINE bool
 ACE_Atomic_Op_GCC<T>::operator< (T rhs) const
 {
-  return (this->value_ < rhs);
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME) < rhs;
 }
 
 template <typename T>
 ACE_INLINE ACE_Atomic_Op_GCC<T> &
 ACE_Atomic_Op_GCC<T>::operator= (T rhs)
 {
-  (void) __sync_lock_test_and_set (&this->value_, rhs);
+  __atomic_store_n (&value_, rhs, __ATOMIC_RELEASE);
   return *this;
 }
 
@@ -122,7 +122,7 @@ ACE_INLINE ACE_Atomic_Op_GCC<T> &
 ACE_Atomic_Op_GCC<T>::operator= (
    const ACE_Atomic_Op_GCC<T> &rhs)
 {
-  (void) __sync_lock_test_and_set (&this->value_, rhs.value_);
+  __atomic_store_n (&value_, __atomic_load_n (&rhs.value_, __ATOMIC_CONSUME), __ATOMIC_RELEASE);
   return *this;
 }
 
@@ -130,21 +130,21 @@ template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::exchange (T newval)
 {
-  return __sync_val_compare_and_swap (&this->value_, this->value_, newval);
+  return __atomic_exchange_n (&value_, newval, __ATOMIC_ACQ_REL);
 }
 
 template <typename T>
 ACE_INLINE T
 ACE_Atomic_Op_GCC<T>::value () const
 {
-  return this->value_;
+  return __atomic_load_n (&value_, __ATOMIC_CONSUME);
 }
 
 template <typename T>
 ACE_INLINE volatile T &
 ACE_Atomic_Op_GCC<T>::value_i ()
 {
-  return this->value_;
+  return value_;
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
See PR #1664 . Same thing, but without CPP11 qualifications due to ACE7.