### PR TITLE
Use strsncpy as that will return a zero terminated string, fixes gcc …

### DIFF
--- a/ACE/ace/OS_NS_string.cpp
+++ b/ACE/ace/OS_NS_string.cpp
@@ -83,9 +83,9 @@ ACE_OS::strerror (int errnum)
   if (ACE::is_sock_error (errnum))
     {
       const ACE_TCHAR *errortext = ACE::sock_error (errnum);
-      ACE_OS::strncpy (ret_errortext,
-                       ACE_TEXT_ALWAYS_CHAR (errortext),
-                       sizeof (ret_errortext));
+      ACE_OS::strsncpy (ret_errortext,
+                        ACE_TEXT_ALWAYS_CHAR (errortext),
+                        sizeof (ret_errortext));
       return ret_errortext;
     }
 #if defined (ACE_LACKS_STRERROR)

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -720,8 +720,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr (ip_mreq *ret_mreq,
         ACE_HTONL (interface_addr.get_ip_address ());
 #else
       ifreq if_address;
-      ACE_OS::strncpy (if_address.ifr_name, ACE_TEXT_ALWAYS_CHAR (net_if), (sizeof if_address.ifr_name) - 1);
-      if_address.ifr_name[(sizeof if_address.ifr_name) - 1] = '\0';
+      ACE_OS::strsncpy (if_address.ifr_name, ACE_TEXT_ALWAYS_CHAR (net_if), (sizeof if_address.ifr_name));
       if (ACE_OS::ioctl (this->get_handle (),
                          SIOCGIFADDR,
                          &if_address) == -1)


### PR DESCRIPTION
…warnings

:
    * ACE/ace/OS_NS_string.cpp:
    * ACE/ace/SOCK_Dgram.cpp: