### PR TITLE
Fix auto_ptr and fallthrough warnings

### DIFF
--- a/TAO/orbsvcs/DevGuideExamples/NotifyService/EventSequence/Messenger_i.h
+++ b/TAO/orbsvcs/DevGuideExamples/NotifyService/EventSequence/Messenger_i.h
@@ -4,27 +4,26 @@
 #include "MessengerS.h"
 
 #include "orbsvcs/CosNotifyChannelAdminC.h"
-#include "ace/Auto_Ptr.h"
+#include <memory>
 
 class EventSequenceSupplier_i;
 
 class  Messenger_i : public POA_Messenger
 {
- public:
+public:
   Messenger_i (CORBA::ORB_ptr orb);
 
-  virtual ~Messenger_i (void);
+  virtual ~Messenger_i ();
 
   CORBA::Boolean send_message (
       const char * user_name,
       const char * subject,
-      char *& message
-    );
+      char *& message);
 
- private:
+private:
   CORBA::ORB_var orb_;
   CosNotifyChannelAdmin::SequenceProxyPushConsumer_var consumer_proxy_;
-  auto_ptr<EventSequenceSupplier_i> supplier_;
+  std::unique_ptr<EventSequenceSupplier_i> supplier_;
 };
 
 #endif

--- a/TAO/orbsvcs/DevGuideExamples/NotifyService/EventSequence/README
+++ b/TAO/orbsvcs/DevGuideExamples/NotifyService/EventSequence/README
@@ -1,7 +1,4 @@
-
-
 Event Notification Service
-
 
 File: examples/NotifyService/EventSequence/README
 

--- a/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/ReplicaController.cpp
+++ b/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/ReplicaController.cpp
@@ -107,7 +107,7 @@ ReplicaController (CORBA::ORB_ptr orb)
   ACE_DEBUG ((LM_DEBUG, "Becoming a member with id %s\n",
               uuid.to_string ()->c_str ()));
 
-  ACE_auto_ptr_reset (group_, new ACE_TMCast::Group (address, uuid.to_string ()->c_str ()));
+  group_.reset (new ACE_TMCast::Group (address, uuid.to_string ()->c_str ()));
 
   int r = ACE_Thread_Manager::instance ()->spawn (
     &ReplicaController::listener_thunk, this);

--- a/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/ReplicaController.h
+++ b/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/ReplicaController.h
@@ -11,10 +11,9 @@
 #include "tao/PortableServer/PortableServer.h"
 
 #include "Log.h"
+#include <memory>
 
 // State management
-//
-
 PortableInterceptor::SlotId
 state_slot_id ();
 
@@ -22,8 +21,6 @@ void
 state_slot_id (PortableInterceptor::SlotId slot_id);
 
 // ReplicaController
-//
-
 class ReplicaController
   : public virtual PortableInterceptor::ServerRequestInterceptor,
     public virtual ::CORBA::LocalObject
@@ -35,11 +32,9 @@ public:
   ReplicaController (CORBA::ORB_ptr orb);
 
 public:
-  virtual char *
-  name (void);
+  virtual char * name ();
 
-  virtual void
-  destroy (void);
+  virtual void destroy ();
 
 #if TAO_HAS_EXTENDED_FT_INTERCEPTORS == 1
   virtual void
@@ -109,7 +104,7 @@ private:
   Log_ log_;
   CORBA::ORB_var orb_;
   PortableServer::POA_var root_poa_;
-  auto_ptr<ACE_TMCast::Group> group_;
+  std::unique_ptr<ACE_TMCast::Group> group_;
 };
 
 #endif  /* REPLICA_CONTROLLER_H */

--- a/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/RolyPoly_i.cpp
+++ b/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/RolyPoly_i.cpp
@@ -10,10 +10,6 @@ RolyPoly_i::RolyPoly_i (CORBA::ORB_ptr orb)
 {
 }
 
-RolyPoly_i::~RolyPoly_i (void)
-{
-}
-
 CORBA::Any* RolyPoly_i::
 get_state ()
 {
@@ -59,7 +55,7 @@ RolyPoly_i::number (char *&str)
 }
 
 void
-RolyPoly_i::shutdown (void)
+RolyPoly_i::shutdown ()
 {
   ACE_DEBUG ((LM_DEBUG, "Server is shutting down.\n"));
 

--- a/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/RolyPoly_i.h
+++ b/TAO/orbsvcs/examples/FaultTolerance/RolyPoly/RolyPoly_i.h
@@ -12,24 +12,17 @@ class RolyPoly_i : public virtual POA_RolyPoly,
 public:
   RolyPoly_i (CORBA::ORB_ptr orb);
 
-  ~RolyPoly_i (void);
+  ~RolyPoly_i () = default;
 
   // Checkpointable
-  //
-  virtual CORBA::Any*
-  get_state ();
+  virtual CORBA::Any* get_state ();
 
-  virtual void
-  set_state (CORBA::Any const& state);
-
+  virtual void set_state (CORBA::Any const& state);
 
   // RolyPoly
-  //
-  virtual CORBA::Short
-  number (char *&s);
+  virtual CORBA::Short number (char *&s);
 
-  virtual void
-  shutdown (void);
+  virtual void shutdown ();
 
 private:
   CORBA::Short number_;

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.cpp
@@ -559,6 +559,7 @@ TAO_FT_Naming_Server::parse_args (int argc,
               break;
             }
         }
+        // fallthrough
       case '?':
         // fallthrough
       default:

--- a/TAO/orbsvcs/orbsvcs/Property/CosPropertyService_i.cpp
+++ b/TAO/orbsvcs/orbsvcs/Property/CosPropertyService_i.cpp
@@ -1181,6 +1181,7 @@ TAO_PropertySetDef::define_property_with_mode (const char *property_name,
         {
           break;
         }
+      // fallthrough
     default:
       // Error. ret is -1 or rebind returned other than 1.
       throw CORBA::UNKNOWN ();

--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/Low_Priority_Setup.h
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/Low_Priority_Setup.h
@@ -12,6 +12,7 @@
 #include "Send_Task_Stopper.h"
 #include "ace/Auto_Ptr.h"
 #include "ace/High_Res_Timer.h"
+#include <memory>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -59,7 +60,7 @@ public:
   typedef Auto_Disconnect<Client_Type> Client_Auto_Disconnect;
   typedef ACE_Auto_Basic_Array_Ptr<Client_Auto_Disconnect> Client_Auto_Disconnect_Array;
   typedef ACE_Auto_Basic_Array_Ptr<Send_Task> Send_Task_Array;
-  typedef auto_ptr<Send_Task_Stopper> Auto_Send_Task_Stopper;
+  typedef std::unique_ptr<Send_Task_Stopper> Auto_Send_Task_Stopper;
   typedef ACE_Auto_Basic_Array_Ptr<Auto_Send_Task_Stopper> Send_Task_Stopper_Array;
 
 private:


### PR DESCRIPTION
    * TAO/orbsvcs/DevGuideExamples/NotifyService/EventSequence/Messenger_i.h:
    * TAO/orbsvcs/DevGuideExamples/NotifyService/EventSequence/README:
    * TAO/orbsvcs/examples/FaultTolerance/RolyPoly/ReplicaController.cpp:
    * TAO/orbsvcs/examples/FaultTolerance/RolyPoly/ReplicaController.h:
    * TAO/orbsvcs/examples/FaultTolerance/RolyPoly/RolyPoly_i.cpp:
    * TAO/orbsvcs/examples/FaultTolerance/RolyPoly/RolyPoly_i.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.cpp:
    * TAO/orbsvcs/orbsvcs/Property/CosPropertyService_i.cpp:
    * TAO/orbsvcs/performance-tests/RTEvent/lib/Low_Priority_Setup.h: