### PR TITLE
Include tao/StringSeq.pidl to fix duplicate symbols with msvc

### DIFF
--- a/TAO/tests/Bug_1676_Regression/Test.idl
+++ b/TAO/tests/Bug_1676_Regression/Test.idl
@@ -1,5 +1,3 @@
-// -*- IDL -*-
-
 //=============================================================================
 /**
  * @file Test.idl
@@ -7,10 +5,11 @@
  * "test" IDL interface for the Uninitialized "out" param for sequence<string>
  * can cause server to core test.
  *
- * @author Kees van Marle <kvmarle@ermedy.nl>
+ * @author Kees van Marle <kvmarle@remedy.nl>
  */
 //=============================================================================
 
+#include "tao/StringSeq.pidl"
 
 module Test
 {

--- a/TAO/tests/Bug_3524_Regression/README
+++ b/TAO/tests/Bug_3524_Regression/README
@@ -1,8 +1,5 @@
-
-
-According to corba C++ mapping if bounds for IDL-bounded strings are violated
+According to CORBA C++ mapping if bounds for IDL-bounded strings are violated
 then BAD_PARAM has to be thrown. Currently MARSHAL is thrown.
-
 
 _Expected successful result_:
 

--- a/TAO/tests/Bug_3524_Regression/test.idl
+++ b/TAO/tests/Bug_3524_Regression/test.idl
@@ -1,3 +1,5 @@
+#include "tao/StringSeq.pidl"
+
 module Test
 {
   const short BOUND = 10;


### PR DESCRIPTION
    * TAO/tests/Bug_1676_Regression/Test.idl:
    * TAO/tests/Bug_3524_Regression/README:
    * TAO/tests/Bug_3524_Regression/test.idl: