### PR TITLE
SystemExceptions shouldn't use a different export

### DIFF
--- a/TAO/tao/SystemException.h
+++ b/TAO/tao/SystemException.h
@@ -26,12 +26,6 @@
 
 #include "tao/Exception.h"
 
-#ifndef TAO_Exception_Export
-#  define TAO_Exception_Export ACE_Proper_Export_Flag
-# else
-#  define TAO_Exception_Export TAO_Export
-#endif  /* !TAO_Exception_Export */
-
 #ifdef THREAD_CANCELLED
 # undef THREAD_CANCELLED
 #endif /* THREAD_CANCELLED */
@@ -181,7 +175,7 @@ namespace CORBA
   // inside the ORB.  All minor codes should be symbolically catalogued.
 
 #define TAO_SYSTEM_EXCEPTION(name) \
-    class TAO_Exception_Export name : public SystemException \
+    class TAO_Export name : public SystemException \
     { \
     public: \
       name (void); \


### PR DESCRIPTION
All classes defined in libTAO should use the same export macro.
This avoids MSVC creating import libs for all executables that use
libTAO -- see https://github.com/DOCGroup/MPC/issues/130 and
https://github.com/microsoft/vcpkg/issues/16551