### PR TITLE
[TAO 2] Notify svc: Fixed include

### DIFF
--- a/TAO/orbsvcs/orbsvcs/Notify/Property_T.cpp
+++ b/TAO/orbsvcs/orbsvcs/Notify/Property_T.cpp
@@ -9,7 +9,7 @@
 
 #include "orbsvcs/Notify/PropertySeq.h"
 
-#include "orbsvcs/orbsvcs/NotifyExtC.h"
+#include "orbsvcs/NotifyExtC.h"
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 


### PR DESCRIPTION
The "make install" tree doesn't have two orbsvcs directories

(cherry picked from commit 026a87c8d9d1ce03c09d77e8c1fb99eb7d6af666)