### PR TITLE
Fixed g++ warning, use override/default

### DIFF
--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Manager.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Manager.h
@@ -33,7 +33,6 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace TAO
@@ -59,9 +58,8 @@ class TAO_FtNaming_Export TAO_FT_Naming_Manager
     public ACE_Task_Base
 {
 public:
-
   /// Constructor.
-  TAO_FT_Naming_Manager (void);
+  TAO_FT_Naming_Manager ();
 
   void set_replicator (TAO_FT_Naming_Replication_Manager *repl);
 
@@ -340,9 +338,7 @@ private:
   PortableGroup::Name built_in_balancing_strategy_name_;
 
   PortableGroup::Name object_group_property_name_;
-
 };
-
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.h
@@ -34,7 +34,7 @@ class TAO_FTNS_Notifier : public ACE_Event_Handler
 public:
   TAO_FTNS_Notifier (TAO_FT_Naming_Server &owner, bool iors);
 
-  virtual int handle_exception (ACE_HANDLE );
+  int handle_exception (ACE_HANDLE) override;
 
   TAO_FT_Naming_Server &owner_;
   bool iors_;
@@ -57,7 +57,7 @@ class TAO_FtNaming_Export TAO_FT_Naming_Server : public TAO_Naming_Server
 public:
   friend class TAO_FTNS_Notifier;
 
-  TAO_FT_Naming_Server (void);
+  TAO_FT_Naming_Server ();
 
   /// Initialize the Naming Service and Object Group Manager with the command line
   /// arguments and the ORB. Overrridden from TAO_Naming_Server
@@ -138,7 +138,6 @@ public:
   void update_iors_i ();
 
 protected:
-
   enum FT_IOR_Indexes {
     PEER_ROOT = 1,
     FT_ROOT,
@@ -199,9 +198,7 @@ protected:
   ACE_Unbounded_Queue<FT_Naming::UpdateInfoSeq*> u_infos_;
   TAO_SYNCH_MUTEX ior_lock_;
   TAO_SYNCH_MUTEX info_lock_;
-
-
- };
+};
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Group_Factory.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Group_Factory.cpp
@@ -18,15 +18,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO::FT_PG_Group_Factory::FT_PG_Group_Factory()
-  : replicator_ (0)
-{
-}
-
-TAO::FT_PG_Group_Factory::~FT_PG_Group_Factory()
-{
-}
-
 void
 TAO::FT_PG_Group_Factory::set_replicator (TAO_FT_Naming_Replication_Manager *repl)
 {
@@ -49,14 +40,15 @@ TAO::FT_PG_Group_Factory::set_object_group_stale (
             {
               ACE_CString change_type_str ("created");
               if (group_info.change_type == FT_Naming::DELETED)
-                change_type_str = "deleted";
-                ORBSVCS_DEBUG ((LM_DEBUG,
+                {
+                  change_type_str = "deleted";
+                }
+              ORBSVCS_DEBUG ((LM_DEBUG,
                             ACE_TEXT ("TAO (%P|%t) - FT_PG_Group_Factory: ")
                             ACE_TEXT ("Setting list store as stale "),
                             ACE_TEXT ("because of group with ID %lld "),
                             ACE_TEXT ("was %C\n"),
-                            group_id, change_type_str.c_str ()
-                            ));
+                            group_id, change_type_str.c_str ()));
             }
           this->list_store_->stale(true);
         }

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Group_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Group_Factory.h
@@ -33,19 +33,17 @@ class TAO_FT_Naming_Replication_Manager;
 
 namespace TAO
 {
-
   /**
    * class FT_PG_Group_Factory
    */
   class TAO_FtNaming_Export FT_PG_Group_Factory : public PG_Group_Factory
   {
   public:
-
     /// Constructor.
-    FT_PG_Group_Factory ();
+    FT_PG_Group_Factory () = default;
 
     /// Destructor.
-    ~FT_PG_Group_Factory ();
+    ~FT_PG_Group_Factory () override = default;
 
     /**
      * indicate the object group state is stale.
@@ -56,8 +54,7 @@ namespace TAO
     void set_replicator (TAO_FT_Naming_Replication_Manager *repl);
 
   protected:
-
-    virtual PG_Object_Group_Storable * create_persistent_group (
+    PG_Object_Group_Storable * create_persistent_group (
       CORBA::ORB_ptr orb,
       PortableGroup::FactoryRegistry_ptr factory_registry,
       TAO::PG_Object_Group_Manipulator & manipulator,
@@ -66,16 +63,16 @@ namespace TAO
       const char * type_id,
       const PortableGroup::Criteria & the_criteria,
       const TAO::PG_Property_Set_var & type_properties,
-      TAO::Storable_Factory & storable_factory);
+      TAO::Storable_Factory & storable_factory) override;
 
-    virtual PG_Object_Group_Storable * restore_persistent_group (
+    PG_Object_Group_Storable * restore_persistent_group (
       PortableGroup::ObjectGroupId group_id,
       CORBA::ORB_ptr orb,
       PortableGroup::FactoryRegistry_ptr factory_registry,
       TAO::PG_Object_Group_Manipulator & manipulator,
-      TAO::Storable_Factory & storable_factory);
+      TAO::Storable_Factory & storable_factory) override;
 
-    TAO_FT_Naming_Replication_Manager *replicator_;
+    TAO_FT_Naming_Replication_Manager *replicator_ {};
   };
 } // namespace TAO
 

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Object_Group_Storable.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Object_Group_Storable.cpp
@@ -52,10 +52,6 @@ TAO::FT_PG_Object_Group_Storable::FT_PG_Object_Group_Storable
 {
 }
 
-TAO::FT_PG_Object_Group_Storable::~FT_PG_Object_Group_Storable ()
-{
-}
-
 void
 TAO::FT_PG_Object_Group_Storable::stale (bool is_stale)
 {

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Object_Group_Storable.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Object_Group_Storable.h
@@ -41,11 +41,7 @@ namespace TAO
   class TAO_FtNaming_Export FT_PG_Object_Group_Storable
     : public PG_Object_Group_Storable
   {
-
-    /////////////////////
-    // Construct/Destruct
   public:
-
     /**
      * This constructor is suitable for creating an object group from
      * scratch.
@@ -75,18 +71,13 @@ namespace TAO
       TAO_FT_Naming_Replication_Manager *replicator);
 
     /// Destructor
-    virtual ~FT_PG_Object_Group_Storable ();
-
-    /////////////////
-    // public methods
+    virtual ~FT_PG_Object_Group_Storable () = default;
 
   public:
-
     virtual void stale (bool is_stale);
     virtual bool stale ();
 
   protected:
-
     virtual void state_written ();
 
     virtual bool is_obsolete (time_t stored_time);
@@ -97,16 +88,11 @@ namespace TAO
       CORBA::Object_ptr member);
 
   private:
-
-    /////////////////////////
-    // Forbidden methods
-    FT_PG_Object_Group_Storable ();
-    FT_PG_Object_Group_Storable (const FT_PG_Object_Group_Storable & rhs);
-    FT_PG_Object_Group_Storable & operator = (
-      const FT_PG_Object_Group_Storable & rhs);
+    FT_PG_Object_Group_Storable () = delete;
+    FT_PG_Object_Group_Storable (const FT_PG_Object_Group_Storable &) = delete;
+    FT_PG_Object_Group_Storable & operator = (const FT_PG_Object_Group_Storable &) = delete;
 
     /// Replication persistence support
-
     bool stale_;
 
     /// Track if the persistent file used for storage has been created yet
@@ -124,7 +110,6 @@ namespace TAO
      * resolution.
      */
     int propagate_update_notification (FT_Naming::ChangeType change_type);
-
   };
 } // namespace TAO
 

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context.cpp
@@ -27,13 +27,6 @@ TAO_FT_Persistent_Naming_Context::TAO_FT_Persistent_Naming_Context (
                                    map,
                                    counter)
 {
-
-}
-
-
-TAO_FT_Persistent_Naming_Context::~TAO_FT_Persistent_Naming_Context ()
-{
-  // Perform appropriate cleanup based on the destruction level specified.
 }
 
 

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context.h
@@ -46,7 +46,7 @@ public:
                                     ACE_UINT32 *counter = 0);
 
   /// Destructor.
-  virtual ~TAO_FT_Persistent_Naming_Context (void);
+  virtual ~TAO_FT_Persistent_Naming_Context () = default;
 
   /**
    * Override the resolve operation to support load balancing using

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context_Factory.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context_Factory.cpp
@@ -3,20 +3,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-/// Constructor.
-TAO_FT_Persistent_Naming_Context_Factory::TAO_FT_Persistent_Naming_Context_Factory ()
-: TAO_Persistent_Naming_Context_Factory ()
-{
-
-}
-
-/// Destructor.  Does not deallocate the hash map: if an instance of
-/// this class goes out of scope, its hash_map remains in persistent storage.
-TAO_FT_Persistent_Naming_Context_Factory::~TAO_FT_Persistent_Naming_Context_Factory ()
-{
-}
-
-
 /// Factory method for creating an implementation object for naming contexts
 TAO_Persistent_Naming_Context*
 TAO_FT_Persistent_Naming_Context_Factory::create_naming_context_impl (

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context_Factory.h
@@ -30,19 +30,19 @@ class TAO_FtNaming_Export TAO_FT_Persistent_Naming_Context_Factory
 {
 public:
   /// Constructor.
-  TAO_FT_Persistent_Naming_Context_Factory (void);
+  TAO_FT_Persistent_Naming_Context_Factory () = default;
 
   /// Destructor.  Does not deallocate the hash map: if an instance of
   /// this class goes out of scope, its hash_map remains in persistent storage.
-  virtual ~TAO_FT_Persistent_Naming_Context_Factory (void);
+  ~TAO_FT_Persistent_Naming_Context_Factory () override = default;
 
   /// Factory method for creating an implementation object for naming contexts
-  virtual TAO_Persistent_Naming_Context* create_naming_context_impl (
+  TAO_Persistent_Naming_Context* create_naming_context_impl (
     PortableServer::POA_ptr poa,
     const char *poa_id,
     TAO_Persistent_Context_Index *context_index,
     HASH_MAP * map = 0,
-    ACE_UINT32 *counter = 0);
+    ACE_UINT32 *counter = 0) override;
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Random.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Random.cpp
@@ -9,14 +9,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO_FT_Random::TAO_FT_Random ()
-{
-}
-
-TAO_FT_Random::~TAO_FT_Random ()
-{
-}
-
 bool
 TAO_FT_Random::next_location (
       PortableGroup::ObjectGroup_ptr object_group,

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Random.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Random.h
@@ -45,12 +45,11 @@ class TAO_FT_Naming_Manager;
 class TAO_FtNaming_Export TAO_FT_Random
 {
 public:
-
   /// Constructor.
-  TAO_FT_Random (void);
+  TAO_FT_Random () = default;
 
   /// Destructor
-  virtual ~TAO_FT_Random (void);
+  virtual ~TAO_FT_Random () = default;
 
   /// This function obtains the next object's location as it is bound
   /// within the object group.
@@ -65,7 +64,6 @@ public:
       PortableGroup::ObjectGroup_ptr object_group,
       TAO_FT_Naming_Manager *naming_manager,
       PortableGroup::Location& location);
-
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.cpp
@@ -15,11 +15,6 @@ TAO_FT_Round_Robin::TAO_FT_Round_Robin ()
 {
 }
 
-TAO_FT_Round_Robin::~TAO_FT_Round_Robin ()
-{
-}
-
-
 bool
 TAO_FT_Round_Robin::next_location (
       PortableGroup::ObjectGroup_ptr object_group,

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.h
@@ -22,7 +22,6 @@
 
 #include "orbsvcs/Naming/FaultTolerant/FT_Location_Index_Map.h"
 
-
 #include "orbsvcs/CosLoadBalancingS.h"
 #include "ace/Vector_T.h"
 #include "orbsvcs/Naming/FaultTolerant/ftnaming_export.h"
@@ -45,9 +44,8 @@ class TAO_FT_Naming_Manager;
 class TAO_FtNaming_Export TAO_FT_Round_Robin
 {
 public:
-
   /// Constructor.
-  TAO_FT_Round_Robin (void);
+  TAO_FT_Round_Robin ();
 
   /// This function obtains the next object's location as it is bound
   /// within the object group.
@@ -64,10 +62,9 @@ public:
       PortableGroup::Location& location);
 
   /// Destructor
-  virtual ~TAO_FT_Round_Robin (void);
+  virtual ~TAO_FT_Round_Robin () = default;
 
 private:
-
   /// Lock used to ensure atomic access to state retained by this
   /// class.
   TAO_SYNCH_MUTEX lock_;
@@ -83,7 +80,6 @@ private:
    * to be returned from the Strategy::next_member() method.
    */
   TAO_FT_Location_Index_Map location_index_map_;
-
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context.cpp
@@ -31,15 +31,7 @@ TAO_FT_Storable_Naming_Context::TAO_FT_Storable_Naming_Context (CORBA::ORB_ptr o
     stale_ (false),
     replicator_ (((TAO_FT_Storable_Naming_Context_Factory *)cxt_factory)->replicator())
 {
-
 }
-
-
-TAO_FT_Storable_Naming_Context::~TAO_FT_Storable_Naming_Context ()
-{
-  // Perform appropriate cleanup based on the destruction level specified.
-}
-
 
 CORBA::Boolean
 TAO_FT_Storable_Naming_Context::is_object_group (CORBA::Object_ptr obj) const
@@ -128,7 +120,6 @@ TAO_FT_Storable_Naming_Context::stale ()
 {
   return stale_;
 }
-
 
 void
 TAO_FT_Storable_Naming_Context::context_written ()

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context.h
@@ -48,7 +48,7 @@ public:
                                   TAO::Storable_Factory *factory);
 
   /// Destructor.
-  virtual ~TAO_FT_Storable_Naming_Context (void);
+  virtual ~TAO_FT_Storable_Naming_Context () = default;
 
   /**
    * Override the resolve operation to support load balancing using

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context_Factory.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context_Factory.cpp
@@ -22,13 +22,6 @@ TAO_FT_Storable_Naming_Context_Factory (size_t hash_table_size,
 {
 }
 
-  /// Destructor.  Does not deallocate the hash map: if an instance of
-  /// this class goes out of scope, its hash_map remains in persistent storage.
-TAO_FT_Storable_Naming_Context_Factory::~TAO_FT_Storable_Naming_Context_Factory ()
-{
-}
-
-
 TAO_FT_Naming_Replication_Manager *
 TAO_FT_Storable_Naming_Context_Factory::replicator ()
 {

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context_Factory.h
@@ -45,7 +45,7 @@ public:
 
   /// Destructor.  Does not deallocate the hash map: if an instance of
   /// this class goes out of scope, its hash_map remains in persistent storage.
-  virtual ~TAO_FT_Storable_Naming_Context_Factory (void);
+  virtual ~TAO_FT_Storable_Naming_Context_Factory () = default;
 
   TAO_FT_Naming_Replication_Manager * replicator (void);
 

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/nsgroup_svc.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/nsgroup_svc.cpp
@@ -12,8 +12,7 @@
 #include "orbsvcs/Naming/FaultTolerant/nsgroup_svc.h"
 #include "ace/OS_NS_strings.h"
 
-
-NS_group_svc::NS_group_svc (bool quiet )
+NS_group_svc::NS_group_svc (bool quiet)
   : quiet_ (quiet)
 {
 }

--- a/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/nsgroup_svc.h
+++ b/TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/nsgroup_svc.h
@@ -25,7 +25,6 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 class  TAO_FtNaming_Intf_Export NS_group_svc
 {
 public:
-
   /**
    *  Constructor
    */
@@ -159,9 +158,8 @@ public:
   int set_name_context( CosNaming::NamingContextExt_ptr value);
 
 private:
-
   /**
-   *  determine stategy based on policy string
+   *  determine strategy based on policy string
    *
    *  @param const ACE_TCHAR *policy ["round"]
    *  @param FT_Naming::LoadBalancingStrategyValue& value
@@ -179,14 +177,12 @@ private:
     const ACE_TCHAR *display_label);
 
 private:
-
   FT_Naming::NamingManager_var naming_manager_;
 
   CosNaming::NamingContextExt_var name_service_;
 
   CORBA::ORB_var orb_;
   bool quiet_;
-
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Manager.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Naming_Server.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Group_Factory.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Group_Factory.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Object_Group_Storable.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_PG_Object_Group_Storable.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context_Factory.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Persistent_Naming_Context_Factory.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Random.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Random.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Round_Robin.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context_Factory.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/FT_Storable_Naming_Context_Factory.h:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/nsgroup_svc.cpp:
    * TAO/orbsvcs/orbsvcs/Naming/FaultTolerant/nsgroup_svc.h: