### PR TITLE
Support for MacOS 10.12 Monterey - Intel build.

### DIFF
--- a/ACE/include/makeinclude/platform_macosx.GNU
+++ b/ACE/include/makeinclude/platform_macosx.GNU
@@ -45,13 +45,13 @@ else ifeq ($(MACOS_MAJOR_VERSION),11)
     MACOS_CODENAME = $(MACOS_CODENAME_VER_11_latest)
   endif
 else ifeq ($(MACOS_MAJOR_VERSION),12)
-  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 2; echo $$?),0)
+  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 0; echo $$?),0)
     ## if the detected version is greater than the latest know version,
     ## just use the latest known version
     MACOS_CODENAME = $(MACOS_CODENAME_VER_12_latest)
   endif
 else
-  ## Unsupported major version
+  ## Unsupported major version -- will fallback to the last known version.
   MACOS_CODENAME = $(MACOS_CODENAME_VER_12_latest)
 endif
 

--- a/ACE/include/makeinclude/platform_macosx.GNU
+++ b/ACE/include/makeinclude/platform_macosx.GNU
@@ -24,6 +24,8 @@ MACOS_CODENAME_VER_11_0   := bigsur
 MACOS_CODENAME_VER_11_1   := bigsur
 MACOS_CODENAME_VER_11_2   := bigsur
 MACOS_CODENAME_VER_11_latest := bigsur
+MACOS_CODENAME_VER_12_0   := monterey
+MACOS_CODENAME_VER_12_latest := monterey
 
 MACOS_CODENAME = $(MACOS_CODENAME_VER_$(MACOS_MAJOR_VERSION)_$(MACOS_MINOR_VERSION))
 
@@ -42,10 +44,15 @@ else ifeq ($(MACOS_MAJOR_VERSION),11)
     ## just use the latest known version
     MACOS_CODENAME = $(MACOS_CODENAME_VER_11_latest)
   endif
+else ifeq ($(MACOS_MAJOR_VERSION),12)
+  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 2; echo $$?),0)
+    ## if the detected version is greater than the latest know version,
+    ## just use the latest known version
+    MACOS_CODENAME = $(MACOS_CODENAME_VER_12_latest)
+  endif
 else
-  ## if the detected version is greater than the latest know version,
-  ## just use the latest known version
-  MACOS_CODENAME = $(MACOS_CODENAME_VER_11_latest)
+  ## Unsupported major version
+  $(error Unsupported MacOS version $(MACOS_RELEASE_VERSION))
 endif
 
 include $(ACE_ROOT)/include/makeinclude/platform_macosx_$(MACOS_CODENAME).GNU

--- a/ACE/include/makeinclude/platform_macosx.GNU
+++ b/ACE/include/makeinclude/platform_macosx.GNU
@@ -52,7 +52,7 @@ else ifeq ($(MACOS_MAJOR_VERSION),12)
   endif
 else
   ## Unsupported major version
-  $(error Unsupported MacOS version $(MACOS_RELEASE_VERSION))
+  MACOS_CODENAME = $(MACOS_CODENAME_VER_12_latest)
 endif
 
 include $(ACE_ROOT)/include/makeinclude/platform_macosx_$(MACOS_CODENAME).GNU

--- a/ACE/include/makeinclude/platform_macosx_monterey.GNU
+++ b/ACE/include/makeinclude/platform_macosx_monterey.GNU
@@ -1,0 +1,2 @@
+include $(ACE_ROOT)/include/makeinclude/platform_macosx_bigsur.GNU
+


### PR DESCRIPTION
Added support for compiling on MacOS Monterey, Intel architecture using clang.