### PR TITLE
depgen for IDL: remove assumption about IDL files in subdirs

### DIFF
--- a/ACE/bin/DependencyGenerator/GNUIDLObjectGenerator.pm
+++ b/ACE/bin/DependencyGenerator/GNUIDLObjectGenerator.pm
@@ -11,10 +11,26 @@ package GNUIDLObjectGenerator;
 # ************************************************************
 
 use strict;
+use File::Spec;
 use ObjectGenerator;
 
 use vars qw(@ISA);
 @ISA = qw(ObjectGenerator);
+
+# ************************************************************
+# Constants
+# ************************************************************
+my $prefix = '$(IDL_GEN_FILES_DIR)/';
+my @suffixes = qw/
+    $(IDL_CLIENT_HDR_EXT)
+    $(IDL_CLIENT_INL_EXT)
+    $(IDL_CLIENT_SRC_EXT)
+    $(IDL_SERVER_HDR_EXT)
+    $(IDL_SERVER_SRC_EXT)
+    $(IDL_SERVER_THDR_EXT)
+    $(IDL_SERVER_TINL_EXT)
+    $(IDL_SERVER_TSRC_EXT)
+    /;
 
 # ************************************************************
 # Subroutine Section
@@ -24,15 +40,9 @@ sub process {
   my($noext) = $_[1];
   $noext =~ s/\.[^\.]+$//o;
   $noext =~ s/.+\/// if $noext =~ /\.\.\//;
-  return ["\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_CLIENT_HDR_EXT)",
-          "\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_CLIENT_INL_EXT)",
-          "\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_CLIENT_SRC_EXT)",
-          "\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_SERVER_HDR_EXT)",
-          "\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_SERVER_SRC_EXT)",
-          "\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_SERVER_THDR_EXT)",
-          "\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_SERVER_TINL_EXT)",
-          "\$(IDL_GEN_FILES_DIR)\/$noext\$(IDL_SERVER_TSRC_EXT)"
-         ];
+  my($vol, $dir, $file) = File::Spec->splitpath($noext);
+  my @list = map "$prefix$file$_", @suffixes;
+  return \@list;
 }
 
 1;


### PR DESCRIPTION
tao_idl dir/file.idl doesn't put its output in dir by default
The ObjectGenerator perl module doesn't know about the -o option to tao_idl
The base filename may work anyway due to VPATH