### PR TITLE
Make use of C++11 default and override

### DIFF
--- a/TAO/tao/Cleanup_Func_Registry.h
+++ b/TAO/tao/Cleanup_Func_Registry.h
@@ -40,7 +40,7 @@ class TAO_Export TAO_Cleanup_Func_Registry
 
 public:
   /// Constructor.
-  TAO_Cleanup_Func_Registry ();
+  TAO_Cleanup_Func_Registry () = default;
 
   /// Return the number of registered cleanup functions.
   size_t size () const;

--- a/TAO/tao/Cleanup_Func_Registry.inl
+++ b/TAO/tao/Cleanup_Func_Registry.inl
@@ -1,12 +1,6 @@
 // -*- C++ -*-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_INLINE
-TAO_Cleanup_Func_Registry::TAO_Cleanup_Func_Registry (void)
-  : cleanup_funcs_ ()
-{
-}
-
 ACE_INLINE size_t
 TAO_Cleanup_Func_Registry::size () const
 {

--- a/TAO/tao/Client_Strategy_Factory.h
+++ b/TAO/tao/Client_Strategy_Factory.h
@@ -56,7 +56,6 @@ namespace Messaging
 class TAO_Export TAO_Client_Strategy_Factory : public ACE_Service_Object
 {
 public:
-
   /// Destructor
   virtual ~TAO_Client_Strategy_Factory ();
 

--- a/TAO/tao/Codeset/Codeset.h
+++ b/TAO/tao/Codeset/Codeset.h
@@ -28,7 +28,7 @@ class TAO_Codeset_Export TAO_Codeset_Initializer
 {
 public:
   /// Used to force the initialization of the ORB code.
-  static int init (void);
+  static int init ();
 };
 
 static int

--- a/TAO/tao/Codeset/Codeset_Manager_i.cpp
+++ b/TAO/tao/Codeset/Codeset_Manager_i.cpp
@@ -57,7 +57,7 @@ TAO_Codeset_Manager_i::default_char_codeset = TAO_DEFAULT_CHAR_CODESET_ID;
 CONV_FRAME::CodeSetId
 TAO_Codeset_Manager_i::default_wchar_codeset = TAO_DEFAULT_WCHAR_CODESET_ID;
 
-TAO_Codeset_Manager_i::TAO_Codeset_Manager_i (void)
+TAO_Codeset_Manager_i::TAO_Codeset_Manager_i ()
   : codeset_info_ (),
     char_descriptor_ (),
     wchar_descriptor_ ()
@@ -70,18 +70,14 @@ TAO_Codeset_Manager_i::TAO_Codeset_Manager_i (void)
 
 }
 
-TAO_Codeset_Manager_i::~TAO_Codeset_Manager_i (void)
-{
-}
-
 TAO_Codeset_Descriptor_Base *
-TAO_Codeset_Manager_i::char_codeset_descriptor (void)
+TAO_Codeset_Manager_i::char_codeset_descriptor ()
 {
   return &this->char_descriptor_;
 }
 
 TAO_Codeset_Descriptor_Base *
-TAO_Codeset_Manager_i::wchar_codeset_descriptor (void)
+TAO_Codeset_Manager_i::wchar_codeset_descriptor ()
 {
   return &this->wchar_descriptor_;
 }

--- a/TAO/tao/Codeset/Codeset_Manager_i.h
+++ b/TAO/tao/Codeset/Codeset_Manager_i.h
@@ -56,7 +56,6 @@ class TAO_Codeset_Descriptor;
 class TAO_Codeset_Export TAO_Codeset_Manager_i :
   public TAO_Codeset_Manager
 {
-
 public:
   /// NCS for char is defaulted to ISO 8859-1:1987; Latin Alphabet
   /// No. 1
@@ -65,8 +64,8 @@ public:
   /// to provide a non-compliant default wchar codeset may do so.
   static CONV_FRAME::CodeSetId default_wchar_codeset;
 
-  TAO_Codeset_Manager_i (void);
-  ~TAO_Codeset_Manager_i (void);
+  TAO_Codeset_Manager_i ();
+  ~TAO_Codeset_Manager_i () = default;
 
   /// Called by an object of TAO_Acceptor to set NCS and CCS values
   /// for Char/Wchar in to the Object Reference.

--- a/TAO/tao/Codeset/Codeset_Service_Context_Handler.h
+++ b/TAO/tao/Codeset/Codeset_Service_Context_Handler.h
@@ -27,15 +27,15 @@ class TAO_Codeset_Service_Context_Handler :
   public TAO_Service_Context_Handler
 {
 public:
-  virtual int process_service_context (TAO_Transport& transport,
-                                       const IOP::ServiceContext& context,
-                                       TAO_ServerRequest *request);
-  virtual int generate_service_context (
+  int process_service_context (TAO_Transport& transport,
+                               const IOP::ServiceContext& context,
+                               TAO_ServerRequest *request) override;
+  int generate_service_context (
     TAO_Stub* stub,
     TAO_Transport &transport,
     TAO_Operation_Details &opdetails,
     TAO_Target_Specification &spec,
-    TAO_OutputCDR &msg);
+    TAO_OutputCDR &msg) override;
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/Codeset/Codeset_Translator_Factory.cpp
+++ b/TAO/tao/Codeset/Codeset_Translator_Factory.cpp
@@ -16,16 +16,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO_Codeset_Translator_Factory::TAO_Codeset_Translator_Factory ()
-{
-
-}
-
-TAO_Codeset_Translator_Factory::~TAO_Codeset_Translator_Factory ()
-{
-
-}
-
 int
 TAO_Codeset_Translator_Factory::init (int , ACE_TCHAR **)
 {

--- a/TAO/tao/Codeset/Codeset_Translator_Factory.h
+++ b/TAO/tao/Codeset/Codeset_Translator_Factory.h
@@ -54,8 +54,8 @@ class TAO_Codeset_Export TAO_Codeset_Translator_Factory :
   public ACE_Service_Object
 {
 public:
-  TAO_Codeset_Translator_Factory ();
-  virtual ~TAO_Codeset_Translator_Factory ();
+  TAO_Codeset_Translator_Factory () = default;
+  virtual ~TAO_Codeset_Translator_Factory () = default;
   virtual int init (int argc, ACE_TCHAR *argv[]);
 
 protected:

--- a/TAO/tao/Codeset/Codeset_Translator_Factory_T.cpp
+++ b/TAO/tao/Codeset/Codeset_Translator_Factory_T.cpp
@@ -20,12 +20,6 @@
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 template<class NCS_TO_TCS>
-TAO_Codeset_Translator_Factory_T<NCS_TO_TCS>::TAO_Codeset_Translator_Factory_T () :
-  translator_(0)
-{
-}
-
-template<class NCS_TO_TCS>
 TAO_Codeset_Translator_Factory_T<NCS_TO_TCS>::~TAO_Codeset_Translator_Factory_T ()
 {
   delete translator_;

--- a/TAO/tao/Codeset/Codeset_Translator_Factory_T.h
+++ b/TAO/tao/Codeset/Codeset_Translator_Factory_T.h
@@ -38,8 +38,7 @@ class TAO_Codeset_Translator_Factory_T
 : public TAO_Codeset_Translator_Factory
 {
 public:
-
-  TAO_Codeset_Translator_Factory_T ();
+  TAO_Codeset_Translator_Factory_T () = default;
   virtual ~TAO_Codeset_Translator_Factory_T ();
 
   /// initialize the factory service object. Instantiates the translator.
@@ -62,7 +61,7 @@ public:
   virtual void assign (TAO_OutputCDR *) const;
 
 private:
-  NCS_TO_TCS *translator_;
+  NCS_TO_TCS *translator_ {};
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/Codeset/UTF16_BOM_Factory.cpp
+++ b/TAO/tao/Codeset/UTF16_BOM_Factory.cpp
@@ -27,12 +27,6 @@ ACE_STATIC_SVC_DEFINE (TAO_UTF16_BOM_Factory,
                        0)
 ACE_FACTORY_DEFINE (TAO_Codeset, TAO_UTF16_BOM_Factory)
 
-TAO_UTF16_BOM_Factory::TAO_UTF16_BOM_Factory ()
-  : translator_ (0)
-  , forceBE_ (false)
-{
-}
-
 TAO_UTF16_BOM_Factory::~TAO_UTF16_BOM_Factory ()
 {
   delete this->translator_;

--- a/TAO/tao/Codeset/UTF16_BOM_Factory.h
+++ b/TAO/tao/Codeset/UTF16_BOM_Factory.h
@@ -27,7 +27,7 @@ class TAO_Codeset_Export TAO_UTF16_BOM_Factory
   : public  TAO_Codeset_Translator_Factory
 {
 public:
-  TAO_UTF16_BOM_Factory ();
+  TAO_UTF16_BOM_Factory () = default;
   virtual ~TAO_UTF16_BOM_Factory ();
   virtual int init (int argc, ACE_TCHAR *argv[]);
 
@@ -52,9 +52,9 @@ private:
   int parse_one_arg (int argc, ACE_TCHAR *argv[]);
 
 private:
-  TAO_UTF16_BOM_Translator *translator_;
+  TAO_UTF16_BOM_Translator *translator_ {};
   /// Force big endian wchar, warray, & wstring
-  bool forceBE_;
+  bool forceBE_ {false};
 };
 
 ACE_STATIC_SVC_DECLARE_EXPORT (TAO_Codeset, TAO_UTF16_BOM_Factory)

--- a/TAO/tao/Codeset/UTF16_BOM_Translator.cpp
+++ b/TAO/tao/Codeset/UTF16_BOM_Translator.cpp
@@ -39,10 +39,6 @@ TAO_UTF16_BOM_Translator::TAO_UTF16_BOM_Translator (bool forceBE)
                ACE_TEXT("forceBE %d\n"), this->forceBE_ ? 1:0 ));
 }
 
-TAO_UTF16_BOM_Translator::~TAO_UTF16_BOM_Translator (void)
-{
-}
-
 // = Documented in $ACE_ROOT/ace/CDR_Stream.h
 ACE_CDR::Boolean
 TAO_UTF16_BOM_Translator::read_wchar (ACE_InputCDR &cdr, ACE_CDR::WChar &x)

--- a/TAO/tao/Codeset/UTF16_BOM_Translator.h
+++ b/TAO/tao/Codeset/UTF16_BOM_Translator.h
@@ -21,10 +21,6 @@
 #include "tao/Codeset/codeset_export.h"
 #include "tao/Versioned_Namespace.h"
 #include "ace/CDR_Stream.h"
-
-
-// ****************************************************************
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /**
@@ -45,7 +41,7 @@ public:
   TAO_UTF16_BOM_Translator (bool forceBE);
 
   /// Virtual destruction
-  virtual ~TAO_UTF16_BOM_Translator (void);
+  virtual ~TAO_UTF16_BOM_Translator () = default;
 
   // = Documented in $ACE_ROOT/ace/CDR_Stream.h
   virtual ACE_CDR::Boolean read_wchar (ACE_InputCDR &,
@@ -92,7 +88,6 @@ private:
 private:
   /// if this flag is true, force wchar's to big endian order
   bool forceBE_;
-
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/Codeset/UTF8_Latin1_Factory.cpp
+++ b/TAO/tao/Codeset/UTF8_Latin1_Factory.cpp
@@ -15,11 +15,6 @@ ACE_STATIC_SVC_DEFINE (TAO_UTF8_Latin1_Factory,
 ACE_FACTORY_DEFINE (TAO_Codeset, TAO_UTF8_Latin1_Factory)
 
 
-TAO_UTF8_Latin1_Factory::TAO_UTF8_Latin1_Factory()
-  : translator_ (0)
-{
-}
-
 TAO_UTF8_Latin1_Factory::~TAO_UTF8_Latin1_Factory ()
 {
   delete this->translator_;

--- a/TAO/tao/Codeset/UTF8_Latin1_Factory.h
+++ b/TAO/tao/Codeset/UTF8_Latin1_Factory.h
@@ -15,7 +15,7 @@ class TAO_Codeset_Export TAO_UTF8_Latin1_Factory
   : public TAO_Codeset_Translator_Factory
 {
 public:
-  TAO_UTF8_Latin1_Factory ();
+  TAO_UTF8_Latin1_Factory () = default;
   virtual ~TAO_UTF8_Latin1_Factory ();
   virtual int init (int argc, ACE_TCHAR *argv[]);
 
@@ -39,7 +39,7 @@ private:
   void create_translator () const;
 
 private:
-  TAO_UTF8_Latin1_Translator *translator_;
+  TAO_UTF8_Latin1_Translator *translator_ {};
 };
 
 

--- a/TAO/tao/Codeset/UTF8_Latin1_Translator.cpp
+++ b/TAO/tao/Codeset/UTF8_Latin1_Translator.cpp
@@ -15,20 +15,7 @@
 #include "tao/debug.h"
 #include "ace/OS_Memory.h"
 
-// ****************************************************************
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
-
-/////////////////////////////
-// UTF8_Latin1_Translator implementation
-
-TAO_UTF8_Latin1_Translator::TAO_UTF8_Latin1_Translator ()
-{
-}
-
-TAO_UTF8_Latin1_Translator::~TAO_UTF8_Latin1_Translator (void)
-{
-}
 
 // = Documented in $ACE_ROOT/ace/CDR_Stream.h
 ACE_CDR::Boolean

--- a/TAO/tao/Codeset/UTF8_Latin1_Translator.h
+++ b/TAO/tao/Codeset/UTF8_Latin1_Translator.h
@@ -46,10 +46,10 @@ class TAO_Codeset_Export TAO_UTF8_Latin1_Translator
 {
 public:
   /// constructor
-  TAO_UTF8_Latin1_Translator ();
+  TAO_UTF8_Latin1_Translator () = default;
 
   /// Virtual destruction
-  virtual ~TAO_UTF8_Latin1_Translator (void);
+  virtual ~TAO_UTF8_Latin1_Translator () = default;
 
   // = Documented in $ACE_ROOT/ace/CDR_Stream.h
   virtual ACE_CDR::Boolean read_char (ACE_InputCDR &,
@@ -73,12 +73,9 @@ public:
   virtual ACE_CDR::ULong tcs () {return 0x05010001U;}
 
 private:
-  ACE_CDR::ULong read_char_i (ACE_InputCDR &,
-                                ACE_CDR::Char &);
+  ACE_CDR::ULong read_char_i (ACE_InputCDR &, ACE_CDR::Char &);
 
-  ACE_CDR::Boolean write_char_i (ACE_OutputCDR &,
-                                 ACE_CDR::Char);
-
+  ACE_CDR::Boolean write_char_i (ACE_OutputCDR &, ACE_CDR::Char);
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/Codeset_Manager.h
+++ b/TAO/tao/Codeset_Manager.h
@@ -58,11 +58,9 @@ class TAO_Codeset_Descriptor_Base;
  */
 class TAO_Export TAO_Codeset_Manager
 {
-
 public:
-
   /// Destructor.
-  virtual ~TAO_Codeset_Manager (void);
+  virtual ~TAO_Codeset_Manager ();
 
   /// Called by an object of TAO_Acceptor to set NCS and CCS values for
   /// Char/Wchar in to the Object Reference.

--- a/TAO/tao/Codeset_Manager_Factory_Base.cpp
+++ b/TAO/tao/Codeset_Manager_Factory_Base.cpp
@@ -5,10 +5,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO_Codeset_Manager_Factory_Base::~TAO_Codeset_Manager_Factory_Base ()
-{
-}
-
 bool
 TAO_Codeset_Manager_Factory_Base::is_default () const
 {

--- a/TAO/tao/Codeset_Manager_Factory_Base.h
+++ b/TAO/tao/Codeset_Manager_Factory_Base.h
@@ -43,12 +43,12 @@ class TAO_Codeset_Manager;
 class TAO_Export TAO_Codeset_Manager_Factory_Base : public ACE_Service_Object
 {
 public:
-  virtual ~TAO_Codeset_Manager_Factory_Base ();
+  virtual ~TAO_Codeset_Manager_Factory_Base () = default;
 
   /// Create makes a new instance of the codeset manager for every
   /// call. This allows multiple ORBs to have their own (or none).
   /// This default implementation returns a null pointer only.
-  virtual TAO_Codeset_Manager *create(void);
+  virtual TAO_Codeset_Manager *create();
 
   /// Is_default is called by the ORB Core to determine if it needs
   /// to reload the factory with a dynamically linked libTAO_Codeset.
@@ -57,7 +57,7 @@ public:
   virtual bool is_default () const;
 
   /// Static initializer ensures the factory is loaded
-  static int initialize (void);
+  static int initialize ();
 };
 
 static int


### PR DESCRIPTION
    * TAO/tao/Codeset/Codeset_Manager_i.cpp:
    * TAO/tao/Codeset/Codeset_Manager_i.h:
    * TAO/tao/Codeset/Codeset_Service_Context_Handler.h:
    * TAO/tao/Codeset/Codeset_Translator_Factory.cpp:
    * TAO/tao/Codeset/Codeset_Translator_Factory.h:
    * TAO/tao/Codeset/Codeset_Translator_Factory_T.cpp:
    * TAO/tao/Codeset/Codeset_Translator_Factory_T.h:
    * TAO/tao/Codeset/UTF16_BOM_Factory.cpp:
    * TAO/tao/Codeset/UTF16_BOM_Factory.h:
    * TAO/tao/Codeset/UTF16_BOM_Translator.cpp:
    * TAO/tao/Codeset/UTF16_BOM_Translator.h:
    * TAO/tao/Codeset/UTF8_Latin1_Factory.cpp:
    * TAO/tao/Codeset/UTF8_Latin1_Factory.h:
    * TAO/tao/Codeset/UTF8_Latin1_Translator.cpp:
    * TAO/tao/Codeset/UTF8_Latin1_Translator.h: