### PR TITLE
TAO_IDL: Fix Space In Path Handling

### DIFF
--- a/TAO/TAO_IDL/driver/drv_args.cpp
+++ b/TAO/TAO_IDL/driver/drv_args.cpp
@@ -186,7 +186,6 @@ DRV_parse_args (long ac, char **av)
   ACE_CString buffer;
   char *s = nullptr;
   long i;
-  bool has_space = false;
 
   // After -- process all arguments as files
   bool just_files = false;
@@ -285,10 +284,7 @@ DRV_parse_args (long ac, char **av)
                   if (i < ac - 1)
                     {
                       idl_global->append_idl_flag (av[i + 1]);
-                      has_space = FE_Utils::hasspace (av[i + 1]);
 
-                      // If the include path has a space, we need to
-                      // add literal "s.
                       ACE_CString arg = av[i];
                       arg += av[i + 1];
 
@@ -303,10 +299,6 @@ DRV_parse_args (long ac, char **av)
                 }
               else
                 {
-                  has_space = FE_Utils::hasspace (av[i]);
-
-                  // If the include path has a space, we need to
-                  // add literal "s.
                   ACE_CString arg (av[i], 2);
                   arg += av[i] + 2;
 

--- a/TAO/TAO_IDL/driver/drv_args.cpp
+++ b/TAO/TAO_IDL/driver/drv_args.cpp
@@ -290,9 +290,7 @@ DRV_parse_args (long ac, char **av)
                       // If the include path has a space, we need to
                       // add literal "s.
                       ACE_CString arg = av[i];
-                      arg += (has_space ? "\"" : "");
                       arg += av[i + 1];
-                      arg += (has_space ? "\"" : "");
 
                       DRV_cpp_putarg (arg.c_str ());
                       idl_global->add_include_path (arg.substr (2).c_str (), false);
@@ -310,9 +308,7 @@ DRV_parse_args (long ac, char **av)
                   // If the include path has a space, we need to
                   // add literal "s.
                   ACE_CString arg (av[i], 2);
-                  arg += (has_space ? "\"" : "");
                   arg += av[i] + 2;
-                  arg += (has_space? "\"" : "");
 
                   idl_global->add_include_path (arg.substr (2).c_str (), false);
                   DRV_cpp_putarg (arg.c_str ());

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -177,7 +177,7 @@ DRV_cpp_putarg (const char *str)
             }
         }
 #endif
-      if (ACE_OS::strchr (str, ' ') && !first_quote)
+      if (ACE_OS::strchr (str, ' '))
         {
           ACE_NEW_NORETURN (replace, char[ACE_OS::strlen (str) + 3]);
           allocate_error = !replace;

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -485,10 +485,7 @@ DRV_sweep_dirs (const char *rel_path,
             {
               if (!include_added)
                 {
-                  /// Surround the path name with quotes, in
-                  /// case the original path argument included
-                  /// spaces. If it didn't, no harm done.
-                  ACE_CString incl_arg ("-I ");
+                  ACE_CString incl_arg ("-I");
                   incl_arg += bname;
                   DRV_cpp_putarg (incl_arg.c_str ());
                   idl_global->add_rel_include_path (bname.c_str ());

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -146,19 +146,8 @@ DRV_cpp_putarg (const char *str)
       const char *const first_quote = ACE_OS::strchr (str, '"');
       bool allocate_error = false;
 
-      if (ACE_OS::strchr (str, ' ') && !first_quote)
-        {
-          ACE_NEW_NORETURN (replace, char[ACE_OS::strlen (str) + 3]);
-          allocate_error = !replace;
-          if (replace)
-            {
-              replace[0] = '"';
-              ACE_OS::strcpy (replace + 1, str);
-              ACE_OS::strcat (replace, "\"");
-            }
-        }
 #ifdef ACE_WIN32
-      else if (first_quote)
+      if (first_quote)
         {
           // Escape Doublequotes on Windows
 
@@ -188,6 +177,17 @@ DRV_cpp_putarg (const char *str)
             }
         }
 #endif
+      if (ACE_OS::strchr (str, ' ') && !first_quote)
+        {
+          ACE_NEW_NORETURN (replace, char[ACE_OS::strlen (str) + 3]);
+          allocate_error = !replace;
+          if (replace)
+            {
+              replace[0] = '"';
+              ACE_OS::strcpy (replace + 1, str);
+              ACE_OS::strcat (replace, "\"");
+            }
+        }
 
       if (allocate_error)
         {
@@ -489,9 +489,7 @@ DRV_sweep_dirs (const char *rel_path,
                   /// case the original path argument included
                   /// spaces. If it didn't, no harm done.
                   ACE_CString incl_arg ("-I ");
-                  incl_arg += '\"';
                   incl_arg += bname;
-                  incl_arg += '\"';
                   DRV_cpp_putarg (incl_arg.c_str ());
                   idl_global->add_rel_include_path (bname.c_str ());
                   full_path = ACE_OS::realpath ("", abspath);


### PR DESCRIPTION
There is a problem with handling spaces in paths for TAO_IDL on Win32 systems.  This is due to the places where quotes are added leading to the elseif  in `DRV_cpp_putarg` which incorrectly escapes the quotes. This causes any spaces to not be properly handled. 