### PR TITLE
TAO_IDL: Fix Space In Path Handling: Unused Variable Followup

### DIFF
--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -143,10 +143,10 @@ DRV_cpp_putarg (const char *str)
   char *replace = nullptr;
   if (str)
     {
-      const char *const first_quote = ACE_OS::strchr (str, '"');
       bool allocate_error = false;
 
 #ifdef ACE_WIN32
+      const char *const first_quote = ACE_OS::strchr (str, '"');
       if (first_quote)
         {
           // Escape Doublequotes on Windows


### PR DESCRIPTION
This is a followup to the PR #1772 . 

The `first_quote` variable was unused outside of the `#ifdef ACE_WIN32`, so it was giving a warning on other systems. This PR resolves that by moving its declaration into the ifdef.