### PR TITLE
Fix tao_idl File Error Messages

### DIFF
--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -2,6 +2,7 @@ USER VISIBLE CHANGES BETWEEN TAO-3.0.6 and TAO-3.0.7
 ====================================================
 
 . Fixed an issue with handling spaces in paths for TAO_IDL
+
 . TAO_IDL: Fix open file error not mentioning the filename and not checking if
   the file is actually a directory.
 

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,6 +1,9 @@
 USER VISIBLE CHANGES BETWEEN TAO-3.0.6 and TAO-3.0.7
 ====================================================
 
+. TAO_IDL: Fix open file error not mentioning the filename and not checking if
+  the file is actually a directory.
+
 USER VISIBLE CHANGES BETWEEN TAO-3.0.5 and TAO-3.0.6
 ====================================================
 

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -1200,7 +1200,7 @@ DRV_pre_proc (const char *myfile)
       // is a directory, then the copy would be blank and any error message
       // later wouldn't be accurate.
       const ACE_HANDLE file_desc = ACE_OS::fileno (file);
-      if (file_desc == -1)
+      if (file_desc == ACE_INVALID_HANDLE)
         call_failed = "(fileno) ";
       else
         {

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -1134,7 +1134,7 @@ DRV_pre_proc (const char *myfile)
   else if ((file_stat.st_mode & S_IFREG) != S_IFREG)
     {
       ACE_ERROR ((LM_ERROR,
-                  "%C: ERROR: This is not a normal file: \"%C\"\n",
+                  "%C: ERROR: This is not a regular file: \"%C\"\n",
                   idl_global->prog_name (),
                   myfile));
       throw Bailout ();


### PR DESCRIPTION
1. The error message for failing to open an IDL file didn't have the filename in it. This was because the `ACE_ERROR` for it was using a `%m` when it looks like it used to use a `%p`. It looks like https://github.com/DOCGroup/ACE_TAO/pull/1420/commits/faab6830cf4ecf67b452183dba712caae7996be4 went one change too far.

2. First brought up here: https://github.com/objectcomputing/OpenDDS/issues/3308. Inputting a directory to tao_idl results in an empty file that causes a weird error latter. Changed it to ensure the file is a regular file using `fstat`.