### PR TITLE
Sync debian/* files for ACE

### DIFF
--- a/ACE/debian/changelog
+++ b/ACE/debian/changelog
@@ -1,3 +1,54 @@
+ace (7.0.6+dfsg-2) unstable; urgency=medium
+
+  * Team upload.
+  * Upload to unstable.
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Mon, 14 Feb 2022 19:22:20 +0000
+
+ace (7.0.6+dfsg-1) experimental; urgency=medium
+
+  * Team upload.
+  * Update to upstream v7.0.6
+    - Sync debian/* with upstream.
+    - Install ACE_Monitor_Control.pc
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Fri, 28 Jan 2022 19:42:31 +0000
+
+ace (7.0.5+dfsg-1) experimental; urgency=medium
+
+  * Team upload.
+  * Update to upstream v7.0.5
+    - Sync debian/* with upstream.
+    - Remove upstream applied patch.
+  * Update Standards-Version to 4.6.0.1
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Thu, 30 Dec 2021 00:08:17 +0000
+
+ace (7.0.3+dfsg-2) unstable; urgency=medium
+
+  * Team upload.
+  * Upload to unstable.
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Mon, 23 Aug 2021 22:27:59 +0100
+
+ace (7.0.3+dfsg-1) experimental; urgency=medium
+
+  * Team upload.
+  * Update to upstream v7.0.3
+    - Sync debian/* with upstream.
+    - Remove upstream applied patch.
+    - Add upstream patch to fix doxygen generation.
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Thu, 19 Aug 2021 21:37:21 +0100
+
+ace (7.0.2+dfsg-2) experimental; urgency=medium
+
+  * Team upload.
+  * Add upstream patch to fix FTBFS on arm.
+  * Update copyright to use SPDX identifier.
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Sun, 13 Jun 2021 14:20:33 +0100
+
 ace (7.0.2+dfsg-1) experimental; urgency=medium
 
   * Team upload.

--- a/ACE/debian/control
+++ b/ACE/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian ACE maintainers <team+ace@tracker.debian.org>
 Uploaders: Thomas Girard <thomas.g.girard@free.fr>, Johnny Willemsen <jwillemsen@remedy.nl>
 Build-Depends: debhelper-compat (=13), libssl-dev, libxt-dev (>= 4.3.0), libfltk1.3-dev, tk-dev (>= 8.5), libfox-1.6-dev, docbook-to-man, libxerces-c-dev
 Build-Depends-Indep: doxygen, graphviz
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0.1
 Vcs-Git: https://salsa.debian.org/debian/ace.git
 Vcs-Browser: https://salsa.debian.org/debian/ace
 Homepage: https://www.dre.vanderbilt.edu/~schmidt/ACE.html

--- a/ACE/debian/copyright
+++ b/ACE/debian/copyright
@@ -21,14 +21,14 @@ Files:     *
 Copyright: 1993-2019 Douglas C. Schmidt and his research group at
            Washington University, University of California, Irvine,
            and Vanderbilt University
-License:   other-BSD
+License:   DOC
 
 Files:     debian/*
 Copyright: 1998, Ossama Othman <ossama@debian.org>
            Brian Nelson <pyro@debian.org>
            Konstantinos Margaritis <markos@debian.org>
            Thomas Girard <thomas.g.girard@free.fr>
-License:   other-BSD
+License:   DOC
 
 Files:     apps/gperf/*
 Copyright: 1989 Free Software Foundation, Inc.
@@ -131,7 +131,7 @@ License: BSD-4.2
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-License: other-BSD
+License: DOC
  Copyright and Licensing Information for ACE(TM), TAO(TM), CIAO(TM),
  DAnCE(TM), and CoSMIC(TM)
  .

--- a/ACE/debian/libace-dev.install.in
+++ b/ACE/debian/libace-dev.install.in
@@ -23,3 +23,4 @@ usr/lib/libACE_RLECompression.so usr/lib/@DEB_HOST_MULTIARCH@/
 usr/lib/pkgconfig/ACE.pc usr/lib/@DEB_HOST_MULTIARCH@/pkgconfig/
 usr/lib/pkgconfig/ACE_ETCL.pc usr/lib/@DEB_HOST_MULTIARCH@/pkgconfig/
 usr/lib/pkgconfig/ACE_ETCL_Parser.pc usr/lib/@DEB_HOST_MULTIARCH@/pkgconfig/
+usr/lib/pkgconfig/ACE_Monitor_Control.pc usr/lib/@DEB_HOST_MULTIARCH@/pkgconfig/


### PR DESCRIPTION
Sync debian/* files for ACE as of Debian package 7.0.6+dfsg-2.