### PR TITLE
[TAO 2] Fix tao_idl File Error Messages

### DIFF
--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,3 +1,9 @@
+USER VISIBLE CHANGES BETWEEN TAO-2.5.16 and TAO-2.5.17
+======================================================
+
+. TAO_IDL: Fix open file error not mentioning the filename and not checking if
+  the file is actually a directory.
+
 USER VISIBLE CHANGES BETWEEN TAO-2.5.15 and TAO-2.5.16
 ======================================================
 


### PR DESCRIPTION
Backport of https://github.com/DOCGroup/ACE_TAO/pull/1783

1. The error message for failing to open an IDL file didn't have the filename in it. This was because the `ACE_ERROR` for it was using a `%m` when it should have been using a `%p`. It looks like https://github.com/DOCGroup/ACE_TAO/commit/faab6830cf4ecf67b452183dba712caae7996be4 went one change too far.

2. First brought up here: https://github.com/objectcomputing/OpenDDS/issues/3308 Inputting a directory to tao_idl results in an empty file that causes a weird error latter. Changed it to ensure the file is a regular file using `stat`.