### PR TITLE
M1 iOS simulator compatibility

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,8 @@
 USER VISIBLE CHANGES BETWEEN ACE-7.0.6 and ACE-7.0.7
 ====================================================
 
+. Added support for iOS Simulator on M1 architecture MacOS systems
+
 USER VISIBLE CHANGES BETWEEN ACE-7.0.5 and ACE-7.0.6
 ====================================================
 

--- a/ACE/include/makeinclude/platform_macosx_iOS.GNU
+++ b/ACE/include/makeinclude/platform_macosx_iOS.GNU
@@ -10,7 +10,7 @@ else
 endif
 
 ifndef IPHONE_TARGET
-  $(error Please set IPHONE_TARGET to SIMULATOR or HARDWARE)
+  $(error Please set IPHONE_TARGET to SIMULATOR, M1_SIMULATOR, or HARDWARE)
 endif
 
 ifeq ($(IPHONE_TARGET), SIMULATOR)

--- a/ACE/include/makeinclude/platform_macosx_iOS.GNU
+++ b/ACE/include/makeinclude/platform_macosx_iOS.GNU
@@ -18,7 +18,16 @@ ifeq ($(IPHONE_TARGET), SIMULATOR)
   IPHONE_PLATFORM:=$(XCODE)/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer
   IPHONE_SDK:=$(IPHONE_PLATFORM)/SDKs/iPhoneSimulator${IPHONE_VERSION}.sdk
   IPHONE_HARDWARE_ARCHITECTURE=x86_64
+endif
 
+ifeq (($(IPHONE_TARGET), M1_SIMULATOR))
+  CROSS-COMPILE=1
+  IPHONE_PLATFORM:=$(XCODE)/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer
+  IPHONE_SDK:=$(IPHONE_PLATFORM)/SDKs/iPhoneSimulator${IPHONE_VERSION}.sdk
+  IPHONE_HARDWARE_ARCHITECTURE=arm64
+endif
+
+ifeq ($(IPHONE_TARGET), M1_SIMULATOR) or ifeq($(IPHONE_TARGET), SIMULATOR)
 # June 2017 release, iPhone 6s and later
   CFLAGS  += -miphoneos-version-min=12.0
   CCFLAGS += -miphoneos-version-min=12.0
@@ -56,8 +65,17 @@ ARFLAGS = rSv
 RANLIB:=$(XCODE)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib -no_warning_for_no_symbols
 DLD = $(CXX)
 LD  = $(CXX)
-CFLAGS  += -arch $(IPHONE_HARDWARE_ARCHITECTURE) -isysroot $(IPHONE_SDK)
-CCFLAGS += -arch $(IPHONE_HARDWARE_ARCHITECTURE) -isysroot $(IPHONE_SDK)
+
+ifeq ($(IPHONE_TARGET), M1_SIMULATOR)
+CFLAGS  += -target $(IPHONE_HARDWARE_ARCHITECTURE)-apple-ios${IPHONE_VERSION}-simulator
+CCFLAGS += -target $(IPHONE_HARDWARE_ARCHITECTURE)-apple-ios${IPHONE_VERSION}-simulator
+else
+CFLAGS  += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
+CCFLAGS += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
+endif
+
+CFLAGS  += -isysroot $(IPHONE_SDK)
+CCFLAGS += -isysroot $(IPHONE_SDK)
 
 ifneq (,$(HOST_ROOT))
   TAO_IDLFLAGS += -g $(HOST_ROOT)/bin/ace_gperf

--- a/ACE/include/makeinclude/platform_macosx_iOS.GNU
+++ b/ACE/include/makeinclude/platform_macosx_iOS.GNU
@@ -10,7 +10,7 @@ else
 endif
 
 ifndef IPHONE_TARGET
-  $(error Please set IPHONE_TARGET to SIMULATOR, M1_SIMULATOR, or HARDWARE)
+  $(error Please set IPHONE_TARGET to SIMULATOR or HARDWARE)
 endif
 
 ifeq ($(IPHONE_TARGET), SIMULATOR)
@@ -18,16 +18,7 @@ ifeq ($(IPHONE_TARGET), SIMULATOR)
   IPHONE_PLATFORM:=$(XCODE)/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer
   IPHONE_SDK:=$(IPHONE_PLATFORM)/SDKs/iPhoneSimulator${IPHONE_VERSION}.sdk
   IPHONE_HARDWARE_ARCHITECTURE=x86_64
-endif
 
-ifeq ($(IPHONE_TARGET), M1_SIMULATOR)
-  CROSS-COMPILE=1
-  IPHONE_PLATFORM:=$(XCODE)/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer
-  IPHONE_SDK:=$(IPHONE_PLATFORM)/SDKs/iPhoneSimulator${IPHONE_VERSION}.sdk
-  IPHONE_HARDWARE_ARCHITECTURE=arm64
-endif
-
-ifeq ($(IPHONE_TARGET), M1_SIMULATOR, SIMULATOR)
 # June 2017 release, iPhone 6s and later
   CFLAGS  += -miphoneos-version-min=12.0
   CCFLAGS += -miphoneos-version-min=12.0
@@ -66,12 +57,18 @@ RANLIB:=$(XCODE)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/
 DLD = $(CXX)
 LD  = $(CXX)
 
-ifeq ($(IPHONE_TARGET), M1_SIMULATOR)
-CFLAGS  += -target $(IPHONE_HARDWARE_ARCHITECTURE)-apple-ios${IPHONE_VERSION}-simulator
-CCFLAGS += -target $(IPHONE_HARDWARE_ARCHITECTURE)-apple-ios${IPHONE_VERSION}-simulator
+ifeq ($(shell uname -m), arm64)
+  ifeq ($(IPHONE_TARGET), SIMULATOR)
+    IPHONE_HARDWARE_ARCHITECTURE=arm64
+    CFLAGS  += -target $(IPHONE_HARDWARE_ARCHITECTURE)-apple-ios${IPHONE_VERSION}-simulator
+    CCFLAGS += -target $(IPHONE_HARDWARE_ARCHITECTURE)-apple-ios${IPHONE_VERSION}-simulator
+  else
+    CFLAGS  += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
+    CCFLAGS += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
+  endif
 else
-CFLAGS  += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
-CCFLAGS += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
+  CFLAGS  += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
+  CCFLAGS += -arch $(IPHONE_HARDWARE_ARCHITECTURE)
 endif
 
 CFLAGS  += -isysroot $(IPHONE_SDK)

--- a/ACE/include/makeinclude/platform_macosx_iOS.GNU
+++ b/ACE/include/makeinclude/platform_macosx_iOS.GNU
@@ -20,14 +20,14 @@ ifeq ($(IPHONE_TARGET), SIMULATOR)
   IPHONE_HARDWARE_ARCHITECTURE=x86_64
 endif
 
-ifeq (($(IPHONE_TARGET), M1_SIMULATOR))
+ifeq ($(IPHONE_TARGET), M1_SIMULATOR)
   CROSS-COMPILE=1
   IPHONE_PLATFORM:=$(XCODE)/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer
   IPHONE_SDK:=$(IPHONE_PLATFORM)/SDKs/iPhoneSimulator${IPHONE_VERSION}.sdk
   IPHONE_HARDWARE_ARCHITECTURE=arm64
 endif
 
-ifeq ($(IPHONE_TARGET), M1_SIMULATOR) or ifeq($(IPHONE_TARGET), SIMULATOR)
+ifeq ($(IPHONE_TARGET), M1_SIMULATOR, SIMULATOR)
 # June 2017 release, iPhone 6s and later
   CFLAGS  += -miphoneos-version-min=12.0
   CCFLAGS += -miphoneos-version-min=12.0


### PR DESCRIPTION
This PR adds iOS Simulator compatibility on M1 systems such as the 2021 by allowing the `IPHONE_TARGET` to be `M1_SIMULATOR`.  SImply changing the option passed to `-arch` to `arm64` was not sufficient for clang++ to operate properly, it needed the `-target` to be set instead.