### PR TITLE
ACE/ace/SSL/SSL_Asynch_BIO.cpp: fix build with libressl

### DIFF
--- a/ACE/ace/SSL/SSL_Asynch_BIO.cpp
+++ b/ACE/ace/SSL/SSL_Asynch_BIO.cpp
@@ -41,7 +41,7 @@ extern "C"
 
 #define BIO_TYPE_ACE  ( 21 | BIO_TYPE_SOURCE_SINK )
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 static BIO_METHOD methods_ACE =
   {
     BIO_TYPE_ACE, // BIO_TYPE_PROXY_SERVER,
@@ -68,14 +68,14 @@ static BIO_METHOD methods_ACE =
 #else
 static BIO_METHOD* methods_ACE;
 # define BIO_set_num(b, val)
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER) */
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 BIO *
 ACE_SSL_make_BIO (void * ssl_asynch_stream)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
   BIO * const pBIO = BIO_new (&methods_ACE);
 #else
   if (!methods_ACE)


### PR DESCRIPTION
Fix the following build failure with libressl:

```
/home/autobuild/autobuild/instance-10/output-1/build/ace-7.0.6/ace/SSL/SSL_Asynch_BIO.cpp:174:7: error: 'BIO_get_init' was not declared in this scope; did you mean 'BIO_set_init'?
  174 |   if (BIO_get_init(pBIO) == 0 || p_stream == 0 || buf == 0 || len <= 0)
      |       ^~~~~~~~~~~~
      |       BIO_set_init
```

Fixes:
 - http://autobuild.buildroot.org/results/386afa88ac9e5e3bb65dddeabf610bb1e9bc4285

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>