### PR TITLE
make ssl_connect() virtual

### DIFF
--- a/ACE/ace/SSL/SSL_SOCK_Connector.h
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.h
@@ -291,8 +291,8 @@ public:
 
 protected:
   /// Complete non-blocking SSL active connection.
-  int ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
-                   const ACE_Time_Value *timeout);
+  virtual int ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
+                           const ACE_Time_Value *timeout);
 
 protected:
   /// The class that does all of the non-secure socket connection.


### PR DESCRIPTION
support modifying the SSL connection context before ssl_connect() is called with it. Allows implementing support for e.g. TLS SNI.