### PR TITLE
Restore getpid() result cast to int.

### DIFF
--- a/ACE/ace/Atomic_Op.h
+++ b/ACE/ace/Atomic_Op.h
@@ -269,6 +269,7 @@ public:
   ACE_Atomic_Op (int c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, int> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, int> &operator= (int rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, int> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, int> &rhs);
 };
 
 template<>
@@ -280,6 +281,7 @@ public:
   ACE_Atomic_Op (unsigned int c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> &operator= (unsigned int rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> &rhs);
 };
 
 // If we have built in atomic op, use that, the assignment operator
@@ -293,6 +295,7 @@ public:
   ACE_Atomic_Op (long c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, long> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, long> &operator= (long rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, long> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, long> &rhs);
 };
 
 template<>
@@ -318,6 +321,7 @@ public:
   ACE_Atomic_Op (long long c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, long long> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, long long> &operator= (long long rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, long long> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, long long> &c);
 };
 
 template<>
@@ -329,6 +333,7 @@ public:
   ACE_Atomic_Op (unsigned long long c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long> &operator= (unsigned long long rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long> &c);
 };
 #endif /* !__powerpc__ */
 
@@ -342,6 +347,7 @@ public:
   ACE_Atomic_Op (short c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, short> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, short> &operator= (short rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, short> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, short> &c);
 };
 
 template<>
@@ -353,6 +359,7 @@ public:
   ACE_Atomic_Op (unsigned short c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short> &operator= (unsigned short rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short> &c);
 };
 #endif
 
@@ -366,6 +373,7 @@ public:
   ACE_Atomic_Op (bool c);
   ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Thread_Mutex, bool> &c);
   ACE_Atomic_Op<ACE_Thread_Mutex, bool> &operator= (bool rhs);
+  ACE_Atomic_Op<ACE_Thread_Mutex, bool> &operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, bool> &c);
 };
 #endif
 

--- a/ACE/ace/Atomic_Op.inl
+++ b/ACE/ace/Atomic_Op.inl
@@ -444,6 +444,14 @@ ACE_Atomic_Op<ACE_Thread_Mutex, int>::operator= (int rhs)
   return *this;
 }
 
+ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, int>&
+ACE_Atomic_Op<ACE_Thread_Mutex, int>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, int> &rhs)
+{
+  ACE_Atomic_Op_GCC<int>::operator= (rhs);
+  return *this;
+}
+
 
 ACE_INLINE
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int>::ACE_Atomic_Op () :
@@ -472,6 +480,14 @@ ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int>::operator= (unsigned int rhs)
 }
 
 ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int>&
+ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> &rhs)
+{
+  ACE_Atomic_Op_GCC<unsigned int>::operator= (rhs);
+  return *this;
+}
+
+ACE_INLINE
 ACE_Atomic_Op<ACE_Thread_Mutex, long>::ACE_Atomic_Op () :
   ACE_Atomic_Op_GCC<long>()
 {
@@ -492,6 +508,14 @@ ACE_Atomic_Op<ACE_Thread_Mutex, long>::ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Th
 ACE_INLINE
 ACE_Atomic_Op<ACE_Thread_Mutex, long>&
 ACE_Atomic_Op<ACE_Thread_Mutex, long>::operator= (long rhs)
+{
+  ACE_Atomic_Op_GCC<long>::operator= (rhs);
+  return *this;
+}
+
+ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, long>&
+ACE_Atomic_Op<ACE_Thread_Mutex, long>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, long> &rhs)
 {
   ACE_Atomic_Op_GCC<long>::operator= (rhs);
   return *this;
@@ -561,6 +585,14 @@ ACE_Atomic_Op<ACE_Thread_Mutex, long long>::operator= (long long rhs)
 }
 
 ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, long long>&
+ACE_Atomic_Op<ACE_Thread_Mutex, long long>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, long long> &rhs)
+{
+  ACE_Atomic_Op_GCC<long long>::operator= (rhs);
+  return *this;
+}
+
+ACE_INLINE
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long>::ACE_Atomic_Op () :
   ACE_Atomic_Op_GCC<unsigned long  long> ()
 {
@@ -585,6 +617,15 @@ ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long>::operator= (unsigned long lo
   ACE_Atomic_Op_GCC<unsigned long long>::operator= (rhs);
   return *this;
 }
+
+ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long>&
+ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long long> &rhs)
+{
+  ACE_Atomic_Op_GCC<unsigned long long>::operator= (rhs);
+  return *this;
+}
+
 #endif /* !__powerpc__ */
 
 #if !defined (ACE_LACKS_GCC_ATOMIC_BUILTINS_2)
@@ -615,6 +656,14 @@ ACE_Atomic_Op<ACE_Thread_Mutex, short>::operator= (short rhs)
 }
 
 ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, short>&
+ACE_Atomic_Op<ACE_Thread_Mutex, short>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, short> &rhs)
+{
+  ACE_Atomic_Op_GCC<short>::operator= (rhs);
+  return *this;
+}
+
+ACE_INLINE
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short>::ACE_Atomic_Op () :
   ACE_Atomic_Op_GCC<unsigned short> ()
 {
@@ -635,6 +684,14 @@ ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short>::ACE_Atomic_Op (const ACE_Atomic
 ACE_INLINE
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short>&
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short>::operator= (unsigned short rhs)
+{
+  ACE_Atomic_Op_GCC<unsigned short>::operator= (rhs);
+  return *this;
+}
+
+ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short>&
+ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, unsigned short> &rhs)
 {
   ACE_Atomic_Op_GCC<unsigned short>::operator= (rhs);
   return *this;
@@ -663,6 +720,14 @@ ACE_Atomic_Op<ACE_Thread_Mutex, bool>::ACE_Atomic_Op (const ACE_Atomic_Op<ACE_Th
 ACE_INLINE
 ACE_Atomic_Op<ACE_Thread_Mutex, bool>&
 ACE_Atomic_Op<ACE_Thread_Mutex, bool>::operator= (bool rhs)
+{
+  ACE_Atomic_Op_GCC<bool>::operator= (rhs);
+  return *this;
+}
+
+ACE_INLINE
+ACE_Atomic_Op<ACE_Thread_Mutex, bool>&
+ACE_Atomic_Op<ACE_Thread_Mutex, bool>::operator= (const ACE_Atomic_Op<ACE_Thread_Mutex, bool> &rhs)
 {
   ACE_Atomic_Op_GCC<bool>::operator= (rhs);
   return *this;

--- a/ACE/tests/Naming_Test.cpp
+++ b/ACE/tests/Naming_Test.cpp
@@ -263,7 +263,7 @@ run_main (int argc, ACE_TCHAR *argv[])
                        ACE_TEXT ("%s%d"),
 #endif
                        pname,
-                       ACE_OS::getpid ());
+                       (int)ACE_OS::getpid ());
 
       name_options->database (temp_file);
     }


### PR DESCRIPTION
Resolves compile warning resulting from PR #1812 