### PR TITLE
gnuace: Mark `__postbuild__` Target as PHONY

### DIFF
--- a/ACE/bin/MakeProjectCreator/templates/gnu.mpd
+++ b/ACE/bin/MakeProjectCreator/templates/gnu.mpd
@@ -731,6 +731,7 @@ endif
 <%if(postbuild)%>
 all: __postbuild__
 
+.PHONY: __postbuild__
 <%if(exename)%>
 __postbuild__: $(VBIN) $(INSTALL)
 <%else%>


### PR DESCRIPTION
To prevent it from being created as a file when `make --touch` is used.