### PR TITLE
Windows: Supporting Serial Port 

### DIFF
--- a/ACE/ace/README
+++ b/ACE/ace/README
@@ -100,6 +100,8 @@ ACE_TLI_TCP_DEVICE                      Device the platform uses for TCP on
                                         TLI.  Only needed if not /dev/tcp.
 ACE_USE_POLL                            The OS platform supports the
                                         poll() event demultiplexor
+ACE_USE_WIN32_WRITE_FILE                Uses WriteFile instead of WSASend. This works for 
+                                        serial Ports (COM1...)                  
 ACE_USES_ASM_SYMBOL_IN_DLSYM            Platform uses assembly symbols
                                         instead of C symbols in
                                         dlsym()

--- a/ACE/ace/WIN32_Asynch_IO.cpp
+++ b/ACE/ace/WIN32_Asynch_IO.cpp
@@ -853,7 +853,7 @@ ACE_WIN32_Asynch_Write_Stream::write (ACE_Message_Block &message_block,
   // Initiate the write; Winsock 2 is required for the higher-performing
   // WSASend() function. For Winsock 1, fall back to the slower WriteFile().
   int initiate_result = 0;
-#if (defined (ACE_HAS_WINSOCK2) && (ACE_HAS_WINSOCK2 != 0))
+#if (defined (ACE_HAS_WINSOCK2) && (ACE_HAS_WINSOCK2 != 0) && !(defined(ACE_USE_WIN32_WRITE_FILE))
   WSABUF iov;
   iov.buf = result->message_block ().rd_ptr ();
   iov.len = static_cast<DWORD> (bytes_to_write);


### PR DESCRIPTION
Motivation:
We use ace for communications using serial ports.  We do get an error code 10038. [10038 socket error](https://stackoverflow.com/questions/3948164/10038-socket-error)
To my understanding this is caused by ACE using WASend, which simply doesnt work with Serial Ports.
Implementation:
Add a macro to force usage of the WriteFile which does work with Serial Ports. There may be better ways to do this, I am not a windows c programmer... 