### PR TITLE
Use override to fix Embarcadero C++ Builder 11.1 warnings

### DIFF
--- a/TAO/orbsvcs/tests/Security/Big_Request/TX_Object_i.h
+++ b/TAO/orbsvcs/tests/Security/Big_Request/TX_Object_i.h
@@ -20,7 +20,7 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-class  TX_Object_i : public virtual POA_TX_Object
+class TX_Object_i : public virtual POA_TX_Object
 {
 public:
   // Constructor
@@ -29,15 +29,14 @@ public:
   // Destructor
   ~TX_Object_i () override = default;
 
-  virtual void send (const DataSeq & data);
+  void send (const DataSeq & data) override;
 
-  virtual void recv (DataSeq_out data);
+  void recv (DataSeq_out data) override;
 
-  virtual void shutdown ();
+  void shutdown () override;
 
 private:
   CORBA::ORB_var orb_;
-
   DataSeq data_;
 };
 


### PR DESCRIPTION
    * TAO/orbsvcs/tests/Security/Big_Request/TX_Object_i.h: