### PR TITLE
GCC 12

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,6 +61,12 @@ jobs:
             optional_macros: CCFLAGS+=-std=c++20
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU
             os: ubuntu-22.04
+          - CC: gcc-12
+            CXX: g++-12
+            PackageDeps: g++-12
+            optional_macros: CCFLAGS+=-std=c++20
+            platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU
+            os: ubuntu-22.04
           - CC: clang-5.0
             CXX: clang++-5.0
             PackageDeps: clang-5.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,7 +63,6 @@ jobs:
             os: ubuntu-22.04
           - CC: gcc-12
             CXX: g++-12
-            Repo: ppa:ubuntu-toolchain-r/ppa
             PackageDeps: g++-12
             optional_macros: CCFLAGS+=-std=c++20
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,6 +63,7 @@ jobs:
             os: ubuntu-22.04
           - CC: gcc-12
             CXX: g++-12
+            Repo: ppa:ubuntu-toolchain-r/ppa
             PackageDeps: g++-12
             optional_macros: CCFLAGS+=-std=c++20
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU
@@ -177,11 +178,15 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: ${{ env.MPC_ROOT }}
-    - name: Add apt repo ${{ matrix.Repo }}
+    - name: Add LLVM apt repo ${{ matrix.Repo }}
       run: |
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ ${{ matrix.Repo }} main"
       if: startsWith (matrix.Repo, 'llvm-toolchain')
+    - name: Add PPA apt repo ${{ matrix.Repo }}
+      run: |
+        sudo apt-add-repository ${{ matrix.Repo }}
+      if: startsWith (matrix.Repo, 'ppa:')
     - name: Add apt packages ${{ matrix.PackageDeps }}
       run: |
         sudo apt-get --yes update

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -69,8 +69,7 @@ jobs:
       run: |
         make -j 6 -C ${env:ACE_ROOT}/tests
       shell: pwsh
-# Requires fixing of https://github.com/DOCGroup/ACE_TAO/issues/1525
-#    - name: Build TAO/tests/IDL_Test project
-#      run: |
-#        make -j 6 -C ${env:TAO_ROOT}/tests/IDL_Test
-#      shell: pwsh
+    - name: Build TAO/tests/IDL_Test project
+      run: |
+        make -j 6 -C ${env:TAO_ROOT}/tests/IDL_Test
+      shell: pwsh

--- a/ACE/ace/config-macosx-lion.h
+++ b/ACE/ace/config-macosx-lion.h
@@ -3,10 +3,6 @@
 
 #include "ace/config-macosx-leopard.h"
 
-#ifdef __clang__
-# define ACE_ANY_OPS_USE_NAMESPACE
-#endif /* __clang__ */
-
 #if  defined (__x86_64__)
 # define ACE_SSIZE_T_FORMAT_SPECIFIER_ASCII "%ld"
 # define ACE_SIZE_T_FORMAT_SPECIFIER_ASCII "%lu"

--- a/ACE/ace/config-macosx-snowleopard.h
+++ b/ACE/ace/config-macosx-snowleopard.h
@@ -3,10 +3,6 @@
 
 #include "ace/config-macosx-leopard.h"
 
-#ifdef __clang__
-#define ACE_ANY_OPS_USE_NAMESPACE
-#endif
-
 #define ACE_LACKS_UCONTEXT_H
 
 #endif // ACE_CONFIG_MACOSX_SNOWLEOPARD_H

--- a/ACE/include/makeinclude/platform_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_clang_common.GNU
@@ -1,8 +1,5 @@
 # -*- Makefile -*-
 
-# Compiling TAO requires relaxing strict 2-phase name lookup rules:
-CCFLAGS += -fdelayed-template-parsing
-
 ifneq ($(CROSS_COMPILE),)
   CROSS-COMPILE = 1
   # Build using the cross-tools

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -68,9 +68,6 @@ ifeq ($(shared_libs), 1)
   endif
 endif
 
-# Compiling TAO requires relaxing strict 2-phase name lookup rules:
-CCFLAGS += -fdelayed-template-parsing
-
 # Added line below to support "Executable Shared Object" files (as
 # needed by the service configurator).
 # Marius Kjeldahl <mariusk@sn.no, marius@funcom.com>

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,6 +1,11 @@
 USER VISIBLE CHANGES BETWEEN TAO-3.0.7 and TAO-3.0.8
 ====================================================
 
+. Moved operators<<= and >>= for CORBA::Any to the CORBA namespace.
+  This makes the code compatible with GCC 12 and removes the need for
+  both the -fdelayed-template-parsing workaround (for clang) and defining
+  ACE_ANY_OPS_USE_NAMESPACE in config-macos*.h.
+
 USER VISIBLE CHANGES BETWEEN TAO-3.0.6 and TAO-3.0.7
 ====================================================
 

--- a/TAO/TAO_IDL/be/be_global.cpp
+++ b/TAO/TAO_IDL/be/be_global.cpp
@@ -62,6 +62,8 @@ BE_GlobalData::BE_GlobalData ()
     stripped_filename_ (nullptr),
     core_versioning_begin_ (core_versioned_ns_begin),
     core_versioning_end_ (core_versioned_ns_end),
+    anyops_versioning_begin_ (core_versioning_begin_ + "namespace CORBA {\n"),
+    anyops_versioning_end_ ("\n}" + core_versioning_end_),
     versioning_begin_ (),
     versioning_end_ (),
     versioning_include_ (),
@@ -1150,6 +1152,9 @@ BE_GlobalData::versioning_end (const char * s)
   this->core_versioning_begin_ =
     this->versioning_end_ + // Yes, "end".
     core_versioned_ns_begin;
+
+  this->anyops_versioning_begin_ =
+    this->core_versioning_begin_ + "namespace CORBA {\n";
 }
 
 void
@@ -1164,7 +1169,8 @@ BE_GlobalData::versioning_begin (const char * s)
     core_versioned_ns_end
     + this->versioning_begin_;  // Yes, "begin".
 
-  // Yes, "begin".
+  this->anyops_versioning_end_ =
+    "\n}" + this->core_versioning_end_;
 }
 
 const char *
@@ -1177,6 +1183,18 @@ const char *
 BE_GlobalData::core_versioning_end () const
 {
   return this->core_versioning_end_.c_str ();
+}
+
+const char *
+BE_GlobalData::anyops_versioning_begin () const
+{
+  return this->anyops_versioning_begin_.c_str ();
+}
+
+const char *
+BE_GlobalData::anyops_versioning_end () const
+{
+  return this->anyops_versioning_end_.c_str ();
 }
 
 // Set the client_hdr_ending.
@@ -3743,4 +3761,3 @@ BE_GlobalData::parse_args (long &i, char **av)
         idl_global->parse_args_exit (1);
     }
 }
-

--- a/TAO/TAO_IDL/be/be_visitor_array/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_array/any_op_ch.cpp
@@ -31,14 +31,14 @@ be_visitor_array_any_op_ch::visit_array (be_array *node)
 
   TAO_INSERT_COMMENT (os);
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void operator<<= (::CORBA::Any &, const " << node->name ()
       << "_forany &);" << be_nl;
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
       << node->name () << "_forany &);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   node->cli_hdr_any_op_gen (true);
   return 0;

--- a/TAO/TAO_IDL/be/be_visitor_array/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_array/any_op_cs.cpp
@@ -30,8 +30,6 @@ be_visitor_array_any_op_cs::visit_array (be_array *node)
 
   TAO_INSERT_COMMENT (os);
 
-  *os << be_global->core_versioning_begin () << be_nl;
-
   // Since we don't generate CDR stream operators for types that
   // explicitly contain a local interface (at some level), we
   // must override these Any template class methods to avoid
@@ -40,6 +38,8 @@ be_visitor_array_any_op_cs::visit_array (be_array *node)
   // type is inserted into an Any and then marshaled.
   if (node->is_local ())
     {
+      *os << be_global->core_versioning_begin () << be_nl;
+
       *os << be_nl_2
           << "namespace TAO" << be_nl
           << "{" << be_idt_nl
@@ -64,7 +64,11 @@ be_visitor_array_any_op_cs::visit_array (be_array *node)
           << "return false;" << be_uidt_nl
           << "}" << be_uidt_nl
           << "}";
+
+      *os << be_global->core_versioning_end () << be_nl;
     }
+
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // If this is non-zero, we want to call its tc_name()
   // for the TypeCode to pass to the Any operator impls.
@@ -107,7 +111,7 @@ be_visitor_array_any_op_cs::visit_array (be_array *node)
       << ");" << be_uidt << be_uidt << be_uidt << be_uidt_nl
       << "}";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   node->cli_stub_any_op_gen (true);
   return 0;

--- a/TAO/TAO_IDL/be/be_visitor_enum/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_enum/any_op_ch.cpp
@@ -74,7 +74,7 @@ be_visitor_enum_any_op_ch::visit_enum (be_enum *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // Generate the Any <<= and >>= operators.
   *os << be_nl_2
@@ -83,7 +83,7 @@ be_visitor_enum_any_op_ch::visit_enum (be_enum *node)
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
       << node->name () << " &);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_enum/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_enum/any_op_cs.cpp
@@ -132,7 +132,7 @@ be_visitor_enum_any_op_cs::visit_enum (be_enum *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // Generate the Any <<= and >>= operator declarations
   // Any <<= and >>= operators.
@@ -163,7 +163,7 @@ be_visitor_enum_any_op_cs::visit_enum (be_enum *node)
       << be_uidt << be_uidt << be_uidt_nl
       << "}";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_exception/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_exception/any_op_ch.cpp
@@ -79,7 +79,7 @@ be_visitor_exception_any_op_ch::visit_exception (be_exception *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << be_nl_2
       << macro << " void operator<<= (::CORBA::Any &, const " << node->name ()
@@ -89,7 +89,7 @@ be_visitor_exception_any_op_ch::visit_exception (be_exception *node)
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const "
       << node->name () << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {
@@ -204,4 +204,3 @@ be_visitor_exception_any_op_ch::visit_union (be_union *node)
 
   return 0;
 }
-

--- a/TAO/TAO_IDL/be/be_visitor_exception/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_exception/any_op_cs.cpp
@@ -188,7 +188,7 @@ be_visitor_exception_any_op_cs::visit_exception (be_exception *node)
     }
 
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // Copying insertion operator.
 
@@ -240,7 +240,7 @@ be_visitor_exception_any_op_cs::visit_exception (be_exception *node)
       << be_uidt_nl
       << "}";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_interface/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface/any_op_ch.cpp
@@ -89,7 +89,7 @@ be_visitor_interface_any_op_ch::visit_interface (be_interface *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void operator<<= (::CORBA::Any &, " << node->name ()
       << "_ptr); // copying" << be_nl;
@@ -98,7 +98,7 @@ be_visitor_interface_any_op_ch::visit_interface (be_interface *node)
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
       << node->name () << "_ptr &);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {
@@ -133,4 +133,3 @@ be_visitor_interface_any_op_ch::visit_connector (
 {
   return this->visit_interface (node);
 }
-

--- a/TAO/TAO_IDL/be/be_visitor_interface/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface/any_op_cs.cpp
@@ -191,7 +191,7 @@ be_visitor_interface_any_op_cs::visit_interface (be_interface *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << be_nl_2
       << "/// Copying insertion." << be_nl
@@ -235,7 +235,7 @@ be_visitor_interface_any_op_cs::visit_interface (be_interface *node)
       << be_uidt << be_uidt << be_uidt_nl
       << "}" << be_nl;
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {
@@ -267,4 +267,3 @@ be_visitor_interface_any_op_cs::visit_connector (
 {
   return this->visit_interface (node);
 }
-

--- a/TAO/TAO_IDL/be/be_visitor_interface_fwd/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface_fwd/any_op_ch.cpp
@@ -86,7 +86,7 @@ be_visitor_interface_fwd_any_op_ch::visit_interface_fwd (
           << "#else\n\n";
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void"
       << " operator<<= (::CORBA::Any &, " << node->name ()
@@ -98,7 +98,7 @@ be_visitor_interface_fwd_any_op_ch::visit_interface_fwd (
       << " operator>>= (const ::CORBA::Any &, "
       << node->name () << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_sequence/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_sequence/any_op_ch.cpp
@@ -123,7 +123,7 @@ be_visitor_sequence_any_op_ch::visit_sequence (be_sequence *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // Generate the Any <<= and >>= operators.
   *os << macro
@@ -147,7 +147,7 @@ be_visitor_sequence_any_op_ch::visit_sequence (be_sequence *node)
       << name.c_str ()
       << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_sequence/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_sequence/any_op_cs.cpp
@@ -267,7 +267,7 @@ be_visitor_sequence_any_op_cs::visit_sequence (be_sequence *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // Copying insertion.
   *os << be_nl
@@ -318,7 +318,7 @@ be_visitor_sequence_any_op_cs::visit_sequence (be_sequence *node)
       << be_uidt_nl
       << "}";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_structure/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_structure/any_op_ch.cpp
@@ -81,11 +81,11 @@ be_visitor_structure_any_op_ch::visit_structure (be_structure *node)
 
   *os << be_global->anyops_versioning_begin () << be_nl;
 
-  *os << macro << " void operator<<= (::CORBA::Any &, const " << node->name ()
+  *os << macro << " void operator<<= (::CORBA::Any &, const ::" << node->name ()
       << " &); // copying version" << be_nl;
-  *os << macro << " void operator<<= (::CORBA::Any &, " << node->name ()
+  *os << macro << " void operator<<= (::CORBA::Any &, ::" << node->name ()
       << "*); // noncopying version" << be_nl;
-  *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const "
+  *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const ::"
       << node->name () << " *&);";
 
   *os << be_global->anyops_versioning_end () << be_nl;

--- a/TAO/TAO_IDL/be/be_visitor_structure/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_structure/any_op_ch.cpp
@@ -79,7 +79,7 @@ be_visitor_structure_any_op_ch::visit_structure (be_structure *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void operator<<= (::CORBA::Any &, const " << node->name ()
       << " &); // copying version" << be_nl;
@@ -88,7 +88,7 @@ be_visitor_structure_any_op_ch::visit_structure (be_structure *node)
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const "
       << node->name () << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {
@@ -183,4 +183,3 @@ be_visitor_structure_any_op_ch::visit_enum (be_enum *node)
 
   return 0;
 }
-

--- a/TAO/TAO_IDL/be/be_visitor_structure/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_structure/any_op_cs.cpp
@@ -161,13 +161,13 @@ be_visitor_structure_any_op_cs::visit_structure (be_structure *node)
   *os << "/// Copying insertion." << be_nl
       << "void operator<<= (" << be_idt_nl
       << "::CORBA::Any &_tao_any," << be_nl
-      << "const " << node->name () << " &_tao_elem)"
+      << "const ::" << node->name () << " &_tao_elem)"
       << be_uidt_nl
       << "{" << be_idt_nl
-      << "TAO::Any_Dual_Impl_T<" << node->name () << ">::insert_copy ("
+      << "TAO::Any_Dual_Impl_T< ::" << node->name () << ">::insert_copy ("
       << be_idt_nl
       << "_tao_any," << be_nl
-      << node->name () << "::_tao_any_destructor," << be_nl
+      << "::" << node->name () << "::_tao_any_destructor," << be_nl
       << node->tc_name () << "," << be_nl
       << "_tao_elem);"
       << be_uidt << be_uidt_nl
@@ -177,13 +177,13 @@ be_visitor_structure_any_op_cs::visit_structure (be_structure *node)
   *os << "/// Non-copying insertion." << be_nl
       << "void operator<<= (" << be_idt_nl
       << "::CORBA::Any &_tao_any," << be_nl
-      << node->name () << " *_tao_elem)"
+      << "::" << node->name () << " *_tao_elem)"
       << be_uidt_nl
       << "{" << be_idt_nl
-      << "TAO::Any_Dual_Impl_T<" << node->name () << ">::insert ("
+      << "TAO::Any_Dual_Impl_T< ::" << node->name () << ">::insert ("
       << be_idt_nl
       << "_tao_any," << be_nl
-      << node->name () << "::_tao_any_destructor," << be_nl
+      << "::" << node->name () << "::_tao_any_destructor," << be_nl
       << node->tc_name () << "," << be_nl
       << "_tao_elem);"
       << be_uidt << be_uidt_nl
@@ -193,13 +193,13 @@ be_visitor_structure_any_op_cs::visit_structure (be_structure *node)
   *os << "/// Extraction to const pointer." << be_nl
       << "::CORBA::Boolean operator>>= (" << be_idt_nl
       << "const ::CORBA::Any &_tao_any," << be_nl
-      << "const " << node->name () << " *&_tao_elem)"
+      << "const ::" << node->name () << " *&_tao_elem)"
       << be_uidt_nl
       << "{" << be_idt_nl
-      << "return TAO::Any_Dual_Impl_T<" << node->name () << ">::extract ("
+      << "return TAO::Any_Dual_Impl_T< ::" << node->name () << ">::extract ("
       << be_idt_nl
       << "_tao_any," << be_nl
-      << node->name () << "::_tao_any_destructor," << be_nl
+      << "::" << node->name () << "::_tao_any_destructor," << be_nl
       << node->tc_name () << "," << be_nl
       << "_tao_elem);"
       << be_uidt << be_uidt_nl

--- a/TAO/TAO_IDL/be/be_visitor_structure/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_structure/any_op_cs.cpp
@@ -155,7 +155,7 @@ be_visitor_structure_any_op_cs::visit_structure (be_structure *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // Copying insertion.
   *os << "/// Copying insertion." << be_nl
@@ -205,7 +205,7 @@ be_visitor_structure_any_op_cs::visit_structure (be_structure *node)
       << be_uidt << be_uidt_nl
       << "}";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_union/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_union/any_op_ch.cpp
@@ -82,7 +82,7 @@ be_visitor_union_any_op_ch::visit_union (be_union *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void operator<<= (::CORBA::Any &, const " << node->name ()
       << " &); // copying version" << be_nl;
@@ -91,7 +91,7 @@ be_visitor_union_any_op_ch::visit_union (be_union *node)
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const "
       << node->name () << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {
@@ -206,4 +206,3 @@ be_visitor_union_any_op_ch::visit_structure (be_structure *node)
 
   return 0;
 }
-

--- a/TAO/TAO_IDL/be/be_visitor_union/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_union/any_op_cs.cpp
@@ -155,7 +155,7 @@ be_visitor_union_any_op_cs::visit_union (be_union *node)
         }
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   // Copying insertion.
   *os << "/// Copying insertion." << be_nl
@@ -205,7 +205,7 @@ be_visitor_union_any_op_cs::visit_union (be_union *node)
       << be_uidt_nl
       << "}";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_valuebox/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuebox/any_op_ch.cpp
@@ -83,7 +83,7 @@ be_visitor_valuebox_any_op_ch::visit_valuebox (be_valuebox *node)
           << "#else\n\n";
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void operator<<= (::CORBA::Any &, " << node->name ()
       << " *); // copying" << be_nl;
@@ -94,7 +94,7 @@ be_visitor_valuebox_any_op_ch::visit_valuebox (be_valuebox *node)
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
       << node->name () << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_valuebox/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuebox/any_op_cs.cpp
@@ -136,7 +136,7 @@ be_visitor_valuebox_any_op_cs::visit_valuebox (be_valuebox *node)
           << "#else\n\n";
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << "/// Copying insertion." << be_nl
       << "void" << be_nl
@@ -181,7 +181,7 @@ be_visitor_valuebox_any_op_cs::visit_valuebox (be_valuebox *node)
       << ");" << be_uidt << be_uidt << be_uidt_nl
       << "}" << be_nl_2;
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_valuetype/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuetype/any_op_ch.cpp
@@ -83,7 +83,7 @@ be_visitor_valuetype_any_op_ch::visit_valuetype (be_valuetype *node)
           << "#else\n\n";
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void operator<<= (::CORBA::Any &, " << node->name ()
       << " *); // copying" << be_nl;
@@ -94,7 +94,7 @@ be_visitor_valuetype_any_op_ch::visit_valuetype (be_valuetype *node)
   *os << macro << " ::CORBA::Boolean operator>>= (const ::CORBA::Any &, "
       << node->name () << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {
@@ -110,4 +110,3 @@ be_visitor_valuetype_any_op_ch::visit_eventtype (be_eventtype *node)
 {
   return this->visit_valuetype (node);
 }
-

--- a/TAO/TAO_IDL/be/be_visitor_valuetype/any_op_cs.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuetype/any_op_cs.cpp
@@ -146,7 +146,7 @@ be_visitor_valuetype_any_op_cs::visit_valuetype (be_valuetype *node)
           << "#else\n\n";
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << "/// Copying insertion." << be_nl
       << "void" << be_nl
@@ -199,7 +199,7 @@ be_visitor_valuetype_any_op_cs::visit_valuetype (be_valuetype *node)
       << ");" << be_uidt << be_uidt << be_uidt_nl
       << "}" << be_nl_2;
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
 
   if (module != nullptr)
     {

--- a/TAO/TAO_IDL/be/be_visitor_valuetype_fwd/any_op_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuetype_fwd/any_op_ch.cpp
@@ -96,7 +96,7 @@ be_visitor_valuetype_fwd_any_op_ch::visit_valuetype_fwd (
       *os << "#else\n\n";
     }
 
-  *os << be_global->core_versioning_begin () << be_nl;
+  *os << be_global->anyops_versioning_begin () << be_nl;
 
   *os << macro << " void"
       << " operator<<= ( ::CORBA::Any &, " << node->name ()
@@ -108,7 +108,7 @@ be_visitor_valuetype_fwd_any_op_ch::visit_valuetype_fwd (
       << " operator>>= (const ::CORBA::Any &, "
       << node->name () << " *&);";
 
-  *os << be_global->core_versioning_end () << be_nl;
+  *os << be_global->anyops_versioning_end () << be_nl;
   if (module != nullptr)
     {
       *os << "\n\n#endif";
@@ -123,4 +123,3 @@ be_visitor_valuetype_fwd_any_op_ch::visit_eventtype_fwd (be_eventtype_fwd *node)
 {
   return this->visit_valuetype_fwd (node);
 }
-

--- a/TAO/TAO_IDL/be_include/be_global.h
+++ b/TAO/TAO_IDL/be_include/be_global.h
@@ -437,6 +437,12 @@ public:
   /// related code.
   const char * core_versioning_end () const;
 
+  /// Get text that opens a "versioned" namespace for CORBA::Any operators
+  const char *anyops_versioning_begin () const;
+
+  /// Get text that closes a "versioned" namespace for CORBA::Any operators
+  const char *anyops_versioning_end () const;
+
   // = Set and get methods for different file name endings.
 
   /// Set the client_hdr_ending.
@@ -980,6 +986,12 @@ private:
   /// Text that closes a "versioned" namespace for core TAO and
   /// orbsvcs related code.
   ACE_CString core_versioning_end_;
+
+  /// Text that opens a "versioned" namespace for CORBA::Any operators
+  ACE_CString anyops_versioning_begin_;
+
+  /// Text that closes a "versioned" namespace for CORBA::Any operators
+  ACE_CString anyops_versioning_end_;
 
   /// Text that opens a "versioned" namespace.
   ACE_CString versioning_begin_;

--- a/TAO/tao/AnyTypeCode/Any.cpp
+++ b/TAO/tao/AnyTypeCode/Any.cpp
@@ -363,10 +363,8 @@ CORBA::Any::operator<<= (CORBA::Any::from_wstring ws)
 
 // Insertion of the other basic types.
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 namespace CORBA
 {
-#endif
 
 void
 operator<<= (CORBA::Any &any, CORBA::Short s)
@@ -770,9 +768,7 @@ operator >>= (const CORBA::Any &any, std::wstring &str)
 }
 #endif
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 
 // ================================================================
 // Any_Impl_T template specializations.

--- a/TAO/tao/AnyTypeCode/Any.h
+++ b/TAO/tao/AnyTypeCode/Any.h
@@ -280,10 +280,8 @@ operator<< (std::ostream &, const CORBA::Any &);
 
 #endif /* GEN_OSTREAM_OPS */
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 namespace CORBA
 {
-#endif
 
 /// Typesafe insertion.
 
@@ -346,9 +344,7 @@ TAO_AnyTypeCode_Export CORBA::Boolean operator>>= (const CORBA::Any &,
                                        std::wstring &);
 #endif
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 
@@ -358,10 +354,8 @@ TAO_END_VERSIONED_NAMESPACE_DECL
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 namespace CORBA
 {
-#endif
 
 /// Copying versions of insertion operators for basic types
 /// must also be defined for CORBA::Any_var.
@@ -426,10 +420,7 @@ TAO_AnyTypeCode_Export CORBA::Boolean operator>>= (const CORBA::Any_var &,
                                        CORBA::Any::to_wstring);
 TAO_AnyTypeCode_Export CORBA::Boolean operator>>= (const CORBA::Any_var &,
                                        CORBA::Any::to_object);
-
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 

--- a/TAO/tao/AnyTypeCode/Any.inl
+++ b/TAO/tao/AnyTypeCode/Any.inl
@@ -85,10 +85,8 @@ CORBA::Any_var::ptr () const
 // CORBA::Any_var insertion operators
 // *************************************************************
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 namespace CORBA
 {
-#endif
 
 ACE_INLINE void
 operator <<= (CORBA::Any_var &lhs, CORBA::Short rhs)
@@ -316,9 +314,7 @@ operator >>= (const CORBA::Any_var &lhs, CORBA::Any::to_object rhs)
   return lhs.in () >>= rhs;
 }
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 
 // *************************************************************
 // Inline operations for class CORBA::Any_out

--- a/TAO/tao/AnyTypeCode/ExceptionA.cpp
+++ b/TAO/tao/AnyTypeCode/ExceptionA.cpp
@@ -77,11 +77,8 @@ namespace TAO
 
 // =======================================================================
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 namespace CORBA
 {
-#endif
-
 
 // Insertion of CORBA::Exception - copying.
 void
@@ -105,9 +102,7 @@ operator<<= (CORBA::Any &any, CORBA::Exception *exception)
       exception);
 }
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/AnyTypeCode/ExceptionA.h
+++ b/TAO/tao/AnyTypeCode/ExceptionA.h
@@ -32,19 +32,11 @@ namespace CORBA
 {
   class Any;
   typedef Any *Any_ptr;
-}
-
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
-namespace CORBA
-{
-#endif
 
 TAO_AnyTypeCode_Export void operator<<= (CORBA::Any &, const CORBA::Exception &);
 TAO_AnyTypeCode_Export void operator<<= (CORBA::Any &, CORBA::Exception *);
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 

--- a/TAO/tao/AnyTypeCode/WrongTransactionA.cpp
+++ b/TAO/tao/AnyTypeCode/WrongTransactionA.cpp
@@ -87,10 +87,8 @@ namespace TAO
   }
 }
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 namespace CORBA
 {
-#endif
 
 // Copying insertion.
 void operator<<= (
@@ -141,8 +139,6 @@ CORBA::Boolean operator>>= (
         _tao_elem);
 }
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/AnyTypeCode/WrongTransactionA.h
+++ b/TAO/tao/AnyTypeCode/WrongTransactionA.h
@@ -75,19 +75,15 @@ namespace TAO
 // TAO_IDL - Generated from
 // be\be_visitor_exception/any_op_ch.cpp:52
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 namespace CORBA
 {
-#endif
 
 TAO_AnyTypeCode_Export void operator<<= (CORBA::Any &, const CORBA::WrongTransaction &); // copying version
 TAO_AnyTypeCode_Export void operator<<= (CORBA::Any &, CORBA::WrongTransaction*); // noncopying version
 TAO_AnyTypeCode_Export CORBA::Boolean operator>>= (const CORBA::Any &, CORBA::WrongTransaction *&); // deprecated
 TAO_AnyTypeCode_Export CORBA::Boolean operator>>= (const CORBA::Any &, const CORBA::WrongTransaction *&);
 
-#ifdef ACE_ANY_OPS_USE_NAMESPACE
 }
-#endif
 // TAO_IDL - Generated from
 // be\be_codegen.cpp:955
 
@@ -100,5 +96,3 @@ TAO_END_VERSIONED_NAMESPACE_DECL
 #include /**/ "ace/post.h"
 
 #endif /* ifndef */
-
-

--- a/TAO/tao/RTCORBA/RT_ProtocolPropertiesA.cpp
+++ b/TAO/tao/RTCORBA/RT_ProtocolPropertiesA.cpp
@@ -145,13 +145,7 @@ namespace RTCORBA
 
 #else
 
-
-TAO_END_VERSIONED_NAMESPACE_DECL
-
-
-TAO_BEGIN_VERSIONED_NAMESPACE_DECL
-
-
+namespace CORBA {
 
 /// Copying insertion.
 void
@@ -190,16 +184,9 @@ operator>>= (
         _tao_elem);
 }
 
-TAO_END_VERSIONED_NAMESPACE_DECL
-
-
-TAO_BEGIN_VERSIONED_NAMESPACE_DECL
-
-
+}
 
 
 #endif
 
 TAO_END_VERSIONED_NAMESPACE_DECL
-
-

--- a/TAO/tao/RTCORBA/RT_ProtocolPropertiesA.h
+++ b/TAO/tao/RTCORBA/RT_ProtocolPropertiesA.h
@@ -79,10 +79,11 @@ TAO_END_VERSIONED_NAMESPACE_DECL
 
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
-
+namespace CORBA {
 TAO_RTCORBA_Export void operator<<= (::CORBA::Any &, RTCORBA::ProtocolProperties_ptr); // copying
 TAO_RTCORBA_Export void operator<<= (::CORBA::Any &, RTCORBA::ProtocolProperties_ptr *); // non-copying
 TAO_RTCORBA_Export ::CORBA::Boolean operator>>= (const ::CORBA::Any &, RTCORBA::ProtocolProperties_ptr &);
+}
 TAO_END_VERSIONED_NAMESPACE_DECL
 
 


### PR DESCRIPTION
Fixes #1832 

- Use CORBA namespace for operator<<= and >>= with CORBA::Any
- Clang can now compile TAO without `-fdelayed-template-parsing`