### PR TITLE
Fix syntax error when compiling without threads.

### DIFF
--- a/ACE/ace/Select_Reactor.h
+++ b/ACE/ace/Select_Reactor.h
@@ -45,7 +45,7 @@ class ACE_Export ACE_Guard< ACE_Reactor_Token_T<ACE_Noop_Token> >
 public:
   ACE_Guard (ACE_Reactor_Token_T<ACE_Noop_Token> &) {}
   ACE_Guard (ACE_Reactor_Token_T<ACE_Noop_Token> &, int) {}
-  ~ACE_Guard () = default
+  ~ACE_Guard () = default;
 
   int acquire (void) { return 0; }
   int tryacquire (void) { return 0; }


### PR DESCRIPTION
This addresses issue in [ACE-TAO Issue #1889](https://github.com/DOCGroup/ACE_TAO/issues/1889)
