### PR TITLE
UBSan fixes for *_Addr member method access during construction

### DIFF
--- a/ACE/ace/INET_Addr.h
+++ b/ACE/ace/INET_Addr.h
@@ -398,7 +398,7 @@ private:
   // the underlying internet address structure.
   void *ip_addr_pointer (void) const;
   int ip_addr_size (void) const;
-  int determine_type (void) const;
+  static int determine_type (void);
 
   /// Initialize underlying inet_addr_ to default values
   void reset_i (void);

--- a/ACE/ace/INET_Addr.inl
+++ b/ACE/ace/INET_Addr.inl
@@ -32,7 +32,7 @@ ACE_INET_Addr::reset_i (void)
 }
 
 ACE_INLINE int
-ACE_INET_Addr::determine_type (void) const
+ACE_INET_Addr::determine_type (void)
 {
 #if defined (ACE_HAS_IPV6)
 #  if defined (ACE_USES_IPV4_IPV6_MIGRATION)

--- a/ACE/ace/Netlink_Addr.h
+++ b/ACE/ace/Netlink_Addr.h
@@ -89,7 +89,7 @@ private:
    * @return family type  AF_NETLINK
    *
    * */
-  int determine_type (void) const;
+  static int determine_type (void);
   /**
    * set nl_  @see nl_ to zero and sets address family to default value
    */

--- a/ACE/ace/Netlink_Addr.inl
+++ b/ACE/ace/Netlink_Addr.inl
@@ -6,7 +6,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 ACE_INLINE ACE_Netlink_Addr::~ACE_Netlink_Addr (void){}
 
 ACE_INLINE ACE_Netlink_Addr::ACE_Netlink_Addr (void):
-ACE_Addr (this->determine_type(), sizeof (sockaddr_nl))
+ACE_Addr (determine_type(), sizeof (sockaddr_nl))
 {
   this->nl_.nl_family = AF_NETLINK;
 }
@@ -23,7 +23,7 @@ ACE_INLINE void ACE_Netlink_Addr::reset (void)
   this->nl_.nl_family = AF_NETLINK;
 }
 
-ACE_INLINE int ACE_Netlink_Addr::determine_type (void) const
+ACE_INLINE int ACE_Netlink_Addr::determine_type (void)
 {
   return AF_NETLINK;
 }


### PR DESCRIPTION
Problem: Undefined Behavior Sanitizer (ubsan) complains about constructor use of member methods due to virtual table construction.

Solution: Make these methods static.