### PR TITLE
Use override, remove redundant whitespacing, fixed typo

### DIFF
--- a/ACE/tests/Enum_Interfaces_Test.cpp
+++ b/ACE/tests/Enum_Interfaces_Test.cpp
@@ -20,12 +20,9 @@
  */
 //=============================================================================
 
-
 #include "test_config.h"
 #include "ace/OS_NS_sys_utsname.h"
 #include "ace/INET_Addr.h"
-
-
 
 int
 run_main (int, ACE_TCHAR *[])

--- a/TAO/orbsvcs/DevGuideExamples/Security/SecurityUnawareApp/README
+++ b/TAO/orbsvcs/DevGuideExamples/Security/SecurityUnawareApp/README
@@ -44,7 +44,7 @@ server and therefore does not need a value for SSL_CERT_FILE.
 Example 1: Secured server and unsecured client
 ----------------------------------------------
 The server is configured to accept requests only via secured
-connections.  No specific configurationi is provided for the
+connections.  No specific configuration is provided for the
 client so it has the default configuration.
 
 The server's configuration is:

--- a/TAO/orbsvcs/tests/Security/ssliop_corbaloc/client.cpp
+++ b/TAO/orbsvcs/tests/Security/ssliop_corbaloc/client.cpp
@@ -29,15 +29,15 @@ public:
   My_Test_Object (CORBA::Short id = 0);
 
   /// Destructor.
-  ~My_Test_Object (void);
+  ~My_Test_Object () = default;
 
   // = Interface implementation accessor methods.
 
   /// Sets id.
-  void id (CORBA::Short id);
+  void id (CORBA::Short id) override;
 
   /// Gets id.
-  CORBA::Short id (void);
+  CORBA::Short id () override;
 
 private:
   short id_;
@@ -48,12 +48,8 @@ My_Test_Object::My_Test_Object (CORBA::Short id)
 {
 }
 
-My_Test_Object::~My_Test_Object (void)
-{
-}
-
 CORBA::Short
-My_Test_Object::id (void)
+My_Test_Object::id ()
 {
   return id_;
 }
@@ -65,8 +61,7 @@ My_Test_Object::id (CORBA::Short id)
 }
 
 // Constructor.
-
-CosNaming_Client::CosNaming_Client (void)
+CosNaming_Client::CosNaming_Client ()
   : argc_ (0),
     argv_ (0),
     test_ (0)
@@ -74,7 +69,6 @@ CosNaming_Client::CosNaming_Client (void)
 }
 
 // Parses the command line arguments and returns an error status.
-
 int
 CosNaming_Client::parse_args (void)
 {

--- a/TAO/orbsvcs/tests/Security/ssliop_corbaloc/test_object.idl
+++ b/TAO/orbsvcs/tests/Security/ssliop_corbaloc/test_object.idl
@@ -1,9 +1,7 @@
+/// This is a simple interface that tests the Naming Service.
 interface Test_Object
 {
-  // = TITLE
-  //   This is a simple interface that tests the Naming Service.
-
+  /// This provides an easy way to differentiate objects if each
+  /// objects is served by a separate servant.
   attribute short id;
-  // This provides an easy way to differentiate objects if each
-  // objects is served by a separate servant.
 };


### PR DESCRIPTION
    * ACE/tests/Enum_Interfaces_Test.cpp:
    * TAO/orbsvcs/DevGuideExamples/Security/SecurityUnawareApp/README:
    * TAO/orbsvcs/tests/Security/ssliop_corbaloc/client.cpp:
    * TAO/orbsvcs/tests/Security/ssliop_corbaloc/test_object.idl: