### PR TITLE
Fix ACE_FALLTHROUGH definition for old GCC compilers.

### DIFF
--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -16,22 +16,23 @@
 
 #define ACE_TEMPLATES_REQUIRE_SOURCE
 
-#if __cplusplus >= 201103L
-# define ACE_HAS_CPP11
-#if __GNUC__ >= 7
-# define ACE_FALLTHROUGH [[gnu::fallthrough]]
-#else
-# define ACE_FALLTHROUGH
+#if __cplusplus >= 202002L
+# define ACE_HAS_CPP20
 #endif
+#if __cplusplus >= 201703L
+# define ACE_HAS_CPP17
+# define ACE_FALLTHROUGH [[fallthrough]]
 #endif
 #if __cplusplus >= 201402L
 # define ACE_HAS_CPP14
 #endif
-#if __cplusplus >= 201703L
-# define ACE_HAS_CPP17
-#endif
-#if __cplusplus >= 202002L
-# define ACE_HAS_CPP20
+#if __cplusplus >= 201103L
+# define ACE_HAS_CPP11
+# if !defined (ACE_FALLTHROUGH) && (__GNUC__ >= 7)
+#  define ACE_FALLTHROUGH [[gnu::fallthrough]]
+# else
+#  define ACE_FALLTHROUGH
+# endif
 #endif
 
 #if (defined (i386) || defined (__i386__)) && !defined (ACE_SIZEOF_LONG_DOUBLE)

--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -26,11 +26,6 @@
 #endif
 #if __cplusplus >= 201402L
 # define ACE_HAS_CPP14
-#if __GNUC__ >= 7
-# define ACE_FALLTHROUGH [[gnu::fallthrough]]
-#else
-# define ACE_FALLTHROUGH
-#endif
 #endif
 #if __cplusplus >= 201703L
 # define ACE_HAS_CPP17

--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -18,11 +18,19 @@
 
 #if __cplusplus >= 201103L
 # define ACE_HAS_CPP11
+#if __GNUC__ >= 7
 # define ACE_FALLTHROUGH [[gnu::fallthrough]]
+#else
+# define ACE_FALLTHROUGH
+#endif
 #endif
 #if __cplusplus >= 201402L
 # define ACE_HAS_CPP14
+#if __GNUC__ >= 7
 # define ACE_FALLTHROUGH [[gnu::fallthrough]]
+#else
+# define ACE_FALLTHROUGH
+#endif
 #endif
 #if __cplusplus >= 201703L
 # define ACE_HAS_CPP17


### PR DESCRIPTION
GCC compiler prior to GCC7 don't understand `[[gnu::fallthrough]]` statement.