### PR TITLE
Fix a small part of commit e401f02ed7c5 which broke compilation

### DIFF
--- a/ACE/bin/PerlACE/Process_Unix.pm
+++ b/ACE/bin/PerlACE/Process_Unix.pm
@@ -874,7 +874,11 @@ sub check_return_value ($)
 {
     my $self = shift;
     my $rc = shift;
-    my $opts = shift // {};
+    my $opts = shift;
+
+    if (! defined $opts) {
+        $opts = {};
+    }
 
     # NSK OSS has a 32-bit waitpid() status
     my $is_NSK = ($^O eq "nonstop_kernel");


### PR DESCRIPTION
Commit e401f02ed7c5 broke compilation with Perl 5.8.8. This pull request fixes that to allow tests to run on scoreboard builds e.g.: https://tao.microfocus.com/scoreboard/rhel5_x86_noinline/index.html