### PR TITLE
Fixed redefined ACE_FALLTHROUGH warnings

### DIFF
--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -28,10 +28,12 @@
 #endif
 #if __cplusplus >= 201103L
 # define ACE_HAS_CPP11
-# if !defined (ACE_FALLTHROUGH) && (__GNUC__ >= 7)
-#  define ACE_FALLTHROUGH [[gnu::fallthrough]]
-# else
-#  define ACE_FALLTHROUGH
+# if !defined (ACE_FALLTHROUGH)
+#  if __GNUC__ >= 7
+#   define ACE_FALLTHROUGH [[gnu::fallthrough]]
+#  else
+#   define ACE_FALLTHROUGH
+# endif
 # endif
 #endif
 


### PR DESCRIPTION
    * ACE/ace/config-g++-common.h: