### PR TITLE
Fix -Wformat-security issues in examples

### DIFF
--- a/ACE/examples/OS/Process/imore.cpp
+++ b/ACE/examples/OS/Process/imore.cpp
@@ -240,7 +240,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         ACE_ERROR_RETURN ((LM_ERROR, "Error, bailing out!\n"), -1);
     }
 
-  options.command_line (executable);
+  options.command_line (ACE_TEXT("%") ACE_TEXT_PRIs, executable);
   if (new_process.spawn (options) == -1)
     {
       int const error_number = ACE_OS::last_error ();
@@ -260,7 +260,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
   // if your child process don't need to interact with the terminal,
   // we can use the exact code for Unixes on NT.
   ACE_Process_Options options;
-  options.command_line (executable);
+  options.command_line (ACE_TEXT("%") ACE_TEXT_PRIs, executable);
   options.set_handles (infile);
   if (new_process.spawn (options) == -1)
     {

--- a/ACE/examples/OS/Process/process.cpp
+++ b/ACE/examples/OS/Process/process.cpp
@@ -124,7 +124,7 @@ test_more ()
 
   ACE_Process new_process;
   ACE_Process_Options options;
-  options.command_line (executable);
+  options.command_line (ACE_TEXT ("%") ACE_TEXT_PRIs, executable);
   options.set_handles (infile);
 
   if (new_process.spawn (options) == -1)
@@ -153,7 +153,7 @@ static void
 test_date ()
 {
   ACE_Process_Options options;
-  options.command_line (DATE_PATH);
+  options.command_line (ACE_TEXT ("%") ACE_TEXT_PRIs, DATE_PATH);
 
   // Try to create a new process running date.
   ACE_Process new_process;
@@ -457,7 +457,7 @@ test_setenv (const ACE_TCHAR *argv0)
   options.setenv (ACE_TEXT ("ACE_PROCESS_TEST= here's a large number %u"),
                   0 - 1);
   options.setenv (ACE_TEXT ("ACE_PROCESS_TEST2"), ACE_TEXT ("ophilli"));
-  options.command_line (ACE_TEXT ("%") ACE_TEXT_PRIs ACE_TEXT (" -g", argv0);
+  options.command_line (ACE_TEXT ("%") ACE_TEXT_PRIs ACE_TEXT (" -g"), argv0);
   ACE_Process process;
   if (process.spawn (options) == -1)
     {


### PR DESCRIPTION
This fixes some build issues in the ACE examples after the merge of #1907 