### PR TITLE
C++17 or greater implies lack of std::auto_ptr

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cxxstd: ["03", "11"]
-        os: [macos-10.15, macos-11.0]
+        cxxstd: ["03", "11", "17"]
+        os: [macos-10.15, macos-11, macos-12]
         include:
           - platform_file: include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         cxxstd: ["03", "11", "17"]
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
         include:
           - platform_file: include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU
     runs-on: ${{ matrix.os }}

--- a/ACE/ace/config-macosx-leopard.h
+++ b/ACE/ace/config-macosx-leopard.h
@@ -211,6 +211,10 @@
 #endif
 #endif
 
+#if __cplusplus >= 201703L && !defined (_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR)
+# define ACE_LACKS_AUTO_PTR
+#endif
+
 // dlcompat package (not part of base Darwin) is needed for dlopen().
 // You may download directly from sourceforge and install or use fink
 // Fink installer puts libraries in /sw/lib and headers in /sw/include


### PR DESCRIPTION
Problem: Build issues on macOS for setting standard to C++17 (and presumably c++20) due to lack of `std::auto_ptr`.

Solution: Be sure to set ACE_LACKS_AUTO_PTR when C++ standard 17 or greater is detected.