### PR TITLE
With VxWorks 7 the gethostbyname() API is not always reentrent

### DIFF
--- a/ACE/ace/OS_NS_arpa_inet.inl
+++ b/ACE/ace/OS_NS_arpa_inet.inl
@@ -69,7 +69,6 @@ ACE_OS::inet_pton (int family, const char *strptr, void *addrptr)
 #if defined ACE_HAS_IPV6 && !defined ACE_LACKS_INET_PTON
   return ::inet_pton (family, strptr, addrptr);
 #else
-
   if (family == AF_INET)
     {
       if (ACE_OS::inet_aton (strptr, static_cast<in_addr *> (addrptr)))

--- a/ACE/ace/OS_NS_netdb.inl
+++ b/ACE/ace/OS_NS_netdb.inl
@@ -238,10 +238,12 @@ ACE_OS::gethostbyname (const char *name)
   if (0 == name || '\0' == name[0])
       return 0;
 
-#   if defined (ACE_VXWORKS)
+#   if defined (ACE_VXWORKS_HAS_GETHOSTBYNAME_REENTRANT)
   // VxWorks 6.x has a gethostbyname() that is threadsafe and
   // returns an heap-allocated hostentry structure.
   // just call ACE_OS::gethostbyname_r () which knows how to handle this.
+  // With VxWorks 7 it depends on the GETHOSTBYNAME_REENTRANT
+  // define
   struct hostent hentry;
   ACE_HOSTENT_DATA buf;
   int h_error;  // Not the same as errno!
@@ -318,10 +320,11 @@ ACE_OS::gethostbyname_r (const char *name,
   //FUZZ: enable check_for_lack_ACE_OS
   else
     return (struct hostent *) 0;
-#   elif defined (ACE_VXWORKS)
+#   elif defined (ACE_VXWORKS_HAS_GETHOSTBYNAME_REENTRANT)
   ACE_UNUSED_ARG (h_errnop);
   // VxWorks 6.x has a threadsafe gethostbyname() which returns a heap-allocated
   // data structure which needs to be freed with hostentFree()
+  // With VxWorks 7 it depends on the GETHOSTBYNAME_REENTRANT macro
   //FUZZ: disable check_for_lack_ACE_OS
   struct hostent* hp = ::gethostbyname (name);
   //FUZZ: enable check_for_lack_ACE_OS

--- a/ACE/ace/os_include/os_unistd.h
+++ b/ACE/ace/os_include/os_unistd.h
@@ -49,6 +49,11 @@
 #  endif
 // for gethostname()
 #  include /**/ <hostLib.h>
+#  if (ACE_VXWORKS <= 0x700) || defined (GETHOSTBYNAME_REENTRANT)
+// With VxWorks 7 hostLib.h defines GETHOSTBYNAME_REENTRANT when gethostbyname()
+// is reentrant
+#    define ACE_VXWORKS_HAS_GETHOSTBYNAME_REENTRANT
+#  endif
 #endif /* ACE_VXWORKS */
 
 #ifdef ACE_MQX


### PR DESCRIPTION
    * ACE/ace/OS_NS_arpa_inet.inl:
    * ACE/ace/OS_NS_netdb.inl:
    * ACE/ace/os_include/os_unistd.h: