### PR TITLE
VxWorks 7 inet_aton returns 0 on failure, so we don't need the specia…

### DIFF
--- a/ACE/ace/OS_NS_arpa_inet.cpp
+++ b/ACE/ace/OS_NS_arpa_inet.cpp
@@ -85,7 +85,7 @@ ACE_OS::inet_aton (const char *host_name, struct in_addr *addr)
       return 1;
     }
 #  endif // ACE_LACKS_INET_ADDR
-#elif defined (ACE_VXWORKS)
+#elif defined (ACE_VXWORKS) && (ACE_VXWORKS < 0x700)
   // inet_aton() returns OK (0) on success and ERROR (-1) on failure.
   // Must reset errno first. Refer to WindRiver SPR# 34949, SPR# 36026
   ::errnoSet(0);


### PR DESCRIPTION
…l VxWorks code anymore

    * ACE/ace/OS_NS_arpa_inet.cpp: