### PR TITLE
Correction for wide-char builds

### DIFF
--- a/ACE/ace/Configuration.cpp
+++ b/ACE/ace/Configuration.cpp
@@ -1506,10 +1506,10 @@ ACE_Configuration_Heap::open_section (const ACE_Configuration_Section_Key& base,
        )
     {
       // Create a substring from the current location until the new found separator
-      // Because ACE_TString works with the character length we need to keep in mind
-      // the size of a single character
+      // Because both separator and sub_section are ACE_TCHAR*, the character size is
+      // already taken into account.
       ACE_TString tsub_section (sub_section);
-      ACE_TString const simple_section = tsub_section.substring(0, (separator - sub_section) / sizeof (ACE_TCHAR));
+      ACE_TString const simple_section = tsub_section.substring(0, separator - sub_section);
       int const ret_val = open_simple_section (result, simple_section.c_str(), create, result);
       if (ret_val)
         return ret_val;


### PR DESCRIPTION
After pulling 0c2228f586a6c8fda87b707fcdaf2e861e118eff into ACE 6, the wide-character builds of OpenDDS built against ACE 6 began failing tests due to configuration errors.

After debugging, I found that the division by sizeof(ACE_TCHAR) was causing the substring calculation to be incorrect due to the fact that pointer arithmetic already accounts for the size of the indivdiual elements.  I have made the same change for ACE 6.

https://github.com/DOCGroup/ACE_TAO/pull/1991