### PR TITLE
Make use of noexcept instead of throw()

### DIFF
--- a/ACE/ace/Auto_Functor.h
+++ b/ACE/ace/Auto_Functor.h
@@ -46,10 +46,10 @@ struct Auto_Functor_Ref
  *
  * The functor is called in the destructor, and it must implement:
  *
- * Functor() throw();<BR>
- * Functor(Functor const &) throw();<BR>
- * Functor & operator=(Functor const &) throw();<BR>
- * void operator()(X * p) throw();<BR>
+ * Functor() noexcept;<BR>
+ * Functor(Functor const &) noexcept;<BR>
+ * Functor & operator=(Functor const &) noexcept;<BR>
+ * void operator()(X * p) noexcept;<BR>
  */
 template<typename X, typename Functor>
 class Auto_Functor
@@ -60,41 +60,41 @@ public:
 
   /// Constructor
   explicit Auto_Functor (X * p = 0,
-      Functor functor = Functor()); // throw()
+      Functor functor = Functor()); // noexcept
 
-  Auto_Functor (Auto_Functor & rhs); // throw()
+  Auto_Functor (Auto_Functor & rhs); // noexcept
 
-  Auto_Functor<X,Functor>& operator= (Auto_Functor & rhs); // throw()
-
-  template<typename Y>
-  Auto_Functor(Auto_Functor<Y,Functor>& rhs); // throw()
+  Auto_Functor<X,Functor>& operator= (Auto_Functor & rhs); // noexcept
 
   template<typename Y>
-  Auto_Functor<X,Functor>& operator= (Auto_Functor<Y,Functor>& rhs); // throw()
+  Auto_Functor(Auto_Functor<Y,Functor>& rhs); // noexcept
 
-  ~Auto_Functor(); // throw()
+  template<typename Y>
+  Auto_Functor<X,Functor>& operator= (Auto_Functor<Y,Functor>& rhs); // noexcept
 
-  X & operator*() const; // throw()
+  ~Auto_Functor(); // noexcept
 
-  X * operator->() const; // throw()
+  X & operator*() const; // noexcept
 
-  X * get(); // throw()
+  X * operator->() const; // noexcept
 
-  X * release(); // throw()
+  X * get(); // noexcept
 
-  void reset (X * p = 0); // throw()
+  X * release(); // noexcept
 
-  void reset (X * p, Functor f); // throw()
+  void reset (X * p = 0); // noexcept
 
-  Functor const & functor() const; // throw()
+  void reset (X * p, Functor f); // noexcept
 
-  Auto_Functor(Auto_Functor_Ref<X,Functor> rhs); // throw()
+  Functor const & functor() const; // noexcept
 
-  Auto_Functor<X,Functor> & operator=(Auto_Functor_Ref<X,Functor> rhs); // throw()
+  Auto_Functor(Auto_Functor_Ref<X,Functor> rhs); // noexcept
 
-  template<typename Y> operator Auto_Functor_Ref<Y,Functor>(); // throw()
+  Auto_Functor<X,Functor> & operator=(Auto_Functor_Ref<X,Functor> rhs); // noexcept
 
-  template<typename Y> operator Auto_Functor<Y,Functor>(); // throw()
+  template<typename Y> operator Auto_Functor_Ref<Y,Functor>(); // noexcept
+
+  template<typename Y> operator Auto_Functor<Y,Functor>(); // noexcept
 
 private:
   X * p_;

--- a/ACE/ace/Local_Name_Space_T.cpp
+++ b/ACE/ace/Local_Name_Space_T.cpp
@@ -439,8 +439,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::create_manager_i ()
   ACE_TCHAR lock_name_for_backing_store [MAXPATHLEN + MAXNAMELEN];
   const ACE_TCHAR *postfix = database;
 
-  size_t length = 0;
-  length = sizeof lock_name_for_local_name_space / sizeof (ACE_TCHAR);
+  size_t length = sizeof lock_name_for_local_name_space / sizeof (ACE_TCHAR);
   ACE_OS::strsncpy (lock_name_for_local_name_space,
                     dir,
                     length);

--- a/ACE/ace/Svc_Handler.cpp
+++ b/ACE/ace/Svc_Handler.cpp
@@ -56,7 +56,7 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t n)
 
 template <typename PEER_STREAM, typename SYNCH_TRAITS> void *
 ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t n,
-                                                          const std::nothrow_t&) throw()
+                                                          const std::nothrow_t&) noexcept
 {
   ACE_TRACE ("ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new(nothrow)");
 
@@ -83,7 +83,7 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t n,
 
 template <typename PEER_STREAM, typename SYNCH_TRAITS> void
 ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator delete (void *p,
-                                         const std::nothrow_t&) throw()
+                                         const std::nothrow_t&) noexcept
 {
   ACE_TRACE("ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator delete(nothrow)");
   ::delete [] static_cast <char *> (p);

--- a/ACE/ace/Svc_Handler.h
+++ b/ACE/ace/Svc_Handler.h
@@ -174,8 +174,8 @@ public:
   /// <Svc_Handler> is allocated dynamically, which allows it to clean
   /// itself up correctly whether or not it's allocated statically or
   /// dynamically.
-  void *operator new (size_t n, const std::nothrow_t&) throw();
-  void operator delete (void *p, const std::nothrow_t&) throw ();
+  void *operator new (size_t n, const std::nothrow_t&) noexcept;
+  void operator delete (void *p, const std::nothrow_t&) noexcept;
 
   /// This operator permits "placement new" on a per-object basis.
   void * operator new (size_t n, void *p);

--- a/ACE/ace/config-lite.h
+++ b/ACE/ace/config-lite.h
@@ -54,7 +54,7 @@ extern "C"
 # if defined (ACE_HAS_SIG_C_FUNC)
 extern "C" {
 # endif /* ACE_HAS_SIG_C_FUNC */
-typedef void (*ACE_CLEANUP_FUNC)(void *object, void *param) /* throw () */;
+typedef void (*ACE_CLEANUP_FUNC)(void *object, void *param) /* noexcept */;
 # if defined (ACE_HAS_SIG_C_FUNC)
 }
 # endif /* ACE_HAS_SIG_C_FUNC */

--- a/ACE/ace/config-macros.h
+++ b/ACE/ace/config-macros.h
@@ -293,12 +293,12 @@
 #  define ACE_ALLOC_HOOK_DECLARE \
   void *operator new (size_t bytes); \
   void *operator new (size_t bytes, void *ptr); \
-  void *operator new (size_t bytes, const std::nothrow_t &) throw (); \
+  void *operator new (size_t bytes, const std::nothrow_t &) noexcept; \
   void operator delete (void *ptr); \
   void operator delete (void *ptr, const std::nothrow_t &); \
   void *operator new[] (size_t size); \
   void operator delete[] (void *ptr); \
-  void *operator new[] (size_t size, const std::nothrow_t &) throw (); \
+  void *operator new[] (size_t size, const std::nothrow_t &) noexcept; \
   void operator delete[] (void *ptr, const std::nothrow_t &)
 
 #  define ACE_GENERIC_ALLOCS(MAKE_PREFIX, CLASS) \
@@ -311,7 +311,7 @@
   }                                                               \
   MAKE_PREFIX (void *, CLASS)::operator new (size_t, void *ptr) { return ptr; }\
   MAKE_PREFIX (void *, CLASS)::operator new (size_t bytes, \
-                                             const std::nothrow_t &) throw () \
+                                             const std::nothrow_t &) noexcept \
   { return ACE_Allocator::instance ()->malloc (bytes); } \
   MAKE_PREFIX (void, CLASS)::operator delete (void *ptr) \
   { if (ptr) ACE_Allocator::instance ()->free (ptr); } \
@@ -328,7 +328,7 @@
   MAKE_PREFIX (void, CLASS)::operator delete[] (void *ptr) \
   { if (ptr) ACE_Allocator::instance ()->free (ptr); } \
   MAKE_PREFIX (void *, CLASS)::operator new[] (size_t size, \
-                                               const std::nothrow_t &) throw ()\
+                                               const std::nothrow_t &) noexcept\
   { return ACE_Allocator::instance ()->malloc (size); } \
   MAKE_PREFIX (void, CLASS)::operator delete[] (void *ptr, \
                                                 const std::nothrow_t &) \

--- a/ACE/examples/DLL/Newsweek.cpp
+++ b/ACE/examples/DLL/Newsweek.cpp
@@ -24,7 +24,7 @@ Newsweek::operator new (size_t bytes, const std::nothrow_t&)
   return ::new (std::nothrow) char[bytes];
 }
 void
-Newsweek::operator delete (void *p, const std::nothrow_t&) throw ()
+Newsweek::operator delete (void *p, const std::nothrow_t&) noexcept
 {
   delete [] static_cast <char *> (p);
 }

--- a/ACE/examples/DLL/Newsweek.h
+++ b/ACE/examples/DLL/Newsweek.h
@@ -43,7 +43,7 @@ public:
   void *operator new (size_t bytes);
   // Overloaded new operator, nothrow_t variant.
   void *operator new (size_t bytes, const std::nothrow_t&);
-  void operator delete (void *p, const std::nothrow_t&) throw ();
+  void operator delete (void *p, const std::nothrow_t&) noexcept;
   void operator delete (void *ptr);
 };
 

--- a/ACE/examples/DLL/Today.cpp
+++ b/ACE/examples/DLL/Today.cpp
@@ -25,7 +25,7 @@ Today::operator new (size_t bytes, const std::nothrow_t&)
   return ::new (std::nothrow) char[bytes];
 }
 void
-Today::operator delete (void *p, const std::nothrow_t&) throw ()
+Today::operator delete (void *p, const std::nothrow_t&) noexcept
 {
   delete [] static_cast <char *> (p);
 }

--- a/ACE/examples/DLL/Today.h
+++ b/ACE/examples/DLL/Today.h
@@ -44,7 +44,7 @@ public:
   void *operator new (size_t bytes);
   // Overloaded new operator, nothrow_t variant.
   void *operator new (size_t bytes, const std::nothrow_t&);
-  void operator delete (void *p, const std::nothrow_t&) throw ();
+  void operator delete (void *p, const std::nothrow_t&) noexcept;
   void operator delete (void *ptr);
 };
 

--- a/ACE/examples/Shared_Malloc/test_persistence.cpp
+++ b/ACE/examples/Shared_Malloc/test_persistence.cpp
@@ -63,7 +63,7 @@ public:
   {
     return shmem_allocator->malloc (sizeof (Employee));
   }
-  void operator delete (void *p, const std::nothrow_t&) throw ()
+  void operator delete (void *p, const std::nothrow_t&) noexcept
   {
     shmem_allocator->free (p);
   }

--- a/ACE/tests/DLL_Test_Impl.cpp
+++ b/ACE/tests/DLL_Test_Impl.cpp
@@ -62,7 +62,7 @@ Hello_Impl::operator new (size_t bytes, const std::nothrow_t &nt)
 }
 
 void
-Hello_Impl::operator delete (void *ptr, const std::nothrow_t&) throw ()
+Hello_Impl::operator delete (void *ptr, const std::nothrow_t&) noexcept
 {
   ACE_DEBUG ((LM_INFO, "Hello_Impl::delete\n"));
   ::delete [] static_cast<char *> (ptr);

--- a/ACE/tests/DLL_Test_Impl.h
+++ b/ACE/tests/DLL_Test_Impl.h
@@ -52,7 +52,7 @@ public:
 
   /// Overloaded new operator, nothrow_t variant.
   void *operator new (size_t bytes, const std::nothrow_t &nt);
-  void operator delete (void *p, const std::nothrow_t&) throw ();
+  void operator delete (void *p, const std::nothrow_t&) noexcept;
 
   void operator delete (void *ptr);
 };

--- a/ACE/tests/Dynamic_Test.cpp
+++ b/ACE/tests/Dynamic_Test.cpp
@@ -23,8 +23,8 @@ public:
 
   void *operator new (size_t n);
 
-  void *operator new (size_t n, const std::nothrow_t&) throw();
-  void operator delete (void *p, const std::nothrow_t&) throw ();
+  void *operator new (size_t n, const std::nothrow_t&) noexcept;
+  void operator delete (void *p, const std::nothrow_t&) noexcept;
   void * operator new (size_t n, void *p);
 
   void operator delete (void *);
@@ -60,7 +60,7 @@ A::operator new (size_t n)
 }
 
 void*
-A::operator new (size_t n, const std::nothrow_t&) throw()
+A::operator new (size_t n, const std::nothrow_t&) noexcept
 {
   ACE_Dynamic *const dynamic_instance = ACE_Dynamic::instance ();
 
@@ -84,7 +84,7 @@ A::operator new (size_t n, const std::nothrow_t&) throw()
 }
 
 void
-A::operator delete (void *p, const std::nothrow_t&) throw()
+A::operator delete (void *p, const std::nothrow_t&) noexcept
 {
   ::delete [] static_cast <char *> (p);
 }

--- a/TAO/orbsvcs/orbsvcs/ESF/ESF_Peer_Admin.h
+++ b/TAO/orbsvcs/orbsvcs/ESF/ESF_Peer_Admin.h
@@ -39,17 +39,17 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
  * the PROXY interface must implement:
  *
  * @verbatim
- * void connected (PEER *peer) throw ();
- * void reconnected (PEER *peer) throw ();
- * void disconnected (PEER *peer) throw ();
+ * void connected (PEER *peer) noexcept;
+ * void reconnected (PEER *peer) noexcept;
+ * void disconnected (PEER *peer) noexcept;
  * @endverbatim
  *
  * Similarly, the PEER interface must implement:
  *
  * @verbatim
- * void connected (PROXY *proxy) throw ();
- * void reconnected (PROXY *proxy) throw ();
- * void disconnected (PROXY *proxy) throw ();
+ * void connected (PROXY *proxy) noexcept;
+ * void reconnected (PROXY *proxy) noexcept;
+ * void disconnected (PROXY *proxy) noexcept;
  * @endverbatim
  */
 template<class EVENT_CHANNEL, class PROXY, class INTERFACE, class PEER>

--- a/TAO/orbsvcs/orbsvcs/ESF/ESF_Proxy_Admin.h
+++ b/TAO/orbsvcs/orbsvcs/ESF/ESF_Proxy_Admin.h
@@ -55,7 +55,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
  *
  * /// activate the proxy and return the object reference
  * PROXY::_ptr_type
- * PROXY::activate () throw ();
+ * PROXY::activate () noexcept;
  * @endverbatim
  */
 template<class EVENT_CHANNEL, class PROXY, class INTERFACE>

--- a/TAO/orbsvcs/orbsvcs/Event/EC_Channel_Destroyer.cpp
+++ b/TAO/orbsvcs/orbsvcs/Event/EC_Channel_Destroyer.cpp
@@ -10,7 +10,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 void
 TAO_EC_Channel_Destroyer_Functor::operator() (
-                           TAO_EC_Event_Channel_Base * event_channel) throw ()
+                           TAO_EC_Event_Channel_Base * event_channel) noexcept
 {
   try
     {

--- a/TAO/orbsvcs/orbsvcs/Event/EC_Channel_Destroyer.h
+++ b/TAO/orbsvcs/orbsvcs/Event/EC_Channel_Destroyer.h
@@ -24,7 +24,7 @@ struct TAO_RTEvent_Serv_Export TAO_EC_Channel_Destroyer_Functor
   typedef  TAO_EC_Event_Channel_Base * argument;
 
   /// Destroy @c event_channel
-  void operator() (TAO_EC_Event_Channel_Base * event_channel) throw ();
+  void operator() (TAO_EC_Event_Channel_Base * event_channel) noexcept;
 };
 
 /**

--- a/TAO/orbsvcs/orbsvcs/Event/EC_ProxySupplier.cpp
+++ b/TAO/orbsvcs/orbsvcs/Event/EC_ProxySupplier.cpp
@@ -128,7 +128,7 @@ TAO_EC_ProxyPushSupplier::cleanup_i ()
 }
 
 void
-TAO_EC_ProxyPushSupplier::deactivate () throw ()
+TAO_EC_ProxyPushSupplier::deactivate () noexcept
 {
   try
     {

--- a/TAO/orbsvcs/orbsvcs/Event/EC_ProxySupplier.h
+++ b/TAO/orbsvcs/orbsvcs/Event/EC_ProxySupplier.h
@@ -69,7 +69,7 @@ public:
     RtecEventChannelAdmin::ProxyPushSupplier_ptr &proxy) = 0;
 
   /// Deactivate from the POA
-  virtual void deactivate () throw ();
+  virtual void deactivate () noexcept;
 
   /// Disconnect this from
   virtual void disconnect_push_supplier () = 0;

--- a/TAO/orbsvcs/orbsvcs/Event/EC_Proxy_Disconnector.cpp
+++ b/TAO/orbsvcs/orbsvcs/Event/EC_Proxy_Disconnector.cpp
@@ -10,7 +10,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 void
 TAO_EC_Supplier_Proxy_Disconnect_Functor::operator() (
-                       RtecEventComm::PushSupplier_ptr supplier) throw ()
+                       RtecEventComm::PushSupplier_ptr supplier) noexcept
 {
   try
     {
@@ -23,7 +23,7 @@ TAO_EC_Supplier_Proxy_Disconnect_Functor::operator() (
 
 void
 TAO_EC_Consumer_Proxy_Disconnect_Functor::operator() (
-                       RtecEventComm::PushConsumer_ptr consumer) throw ()
+                       RtecEventComm::PushConsumer_ptr consumer) noexcept
 {
   try
     {

--- a/TAO/orbsvcs/orbsvcs/Event/EC_Proxy_Disconnector.h
+++ b/TAO/orbsvcs/orbsvcs/Event/EC_Proxy_Disconnector.h
@@ -24,7 +24,7 @@ struct TAO_RTEvent_Serv_Export TAO_EC_Supplier_Proxy_Disconnect_Functor
   typedef  RtecEventComm::PushSupplier_ptr argument;
 
   /// Disconnect from @c supplier
-  void operator() (RtecEventComm::PushSupplier_ptr supplier) throw ();
+  void operator() (RtecEventComm::PushSupplier_ptr supplier) noexcept;
 };
 
 /**
@@ -49,7 +49,7 @@ struct TAO_RTEvent_Serv_Export TAO_EC_Consumer_Proxy_Disconnect_Functor
   typedef  RtecEventComm::PushConsumer_ptr argument;
 
   /// Disconnect from @c consumer
-  void operator() (RtecEventComm::PushConsumer_ptr consumer) throw ();
+  void operator() (RtecEventComm::PushConsumer_ptr consumer) noexcept;
 };
 
 /**

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/Utils/ScopeGuard.h
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/Utils/ScopeGuard.h
@@ -43,13 +43,13 @@ protected:
   ~ScopeGuardImplBase()
   {
   }
-  ScopeGuardImplBase(const ScopeGuardImplBase& other) throw()
+  ScopeGuardImplBase(const ScopeGuardImplBase& other) noexcept
     : dismissed_(other.dismissed_)
   {
     other.Dismiss();
   }
   template <typename J>
-  static void SafeExecute(J& j) throw()
+  static void SafeExecute(J& j) noexcept
   {
     if (!j.dismissed_)
       try
@@ -63,10 +63,10 @@ protected:
 
   mutable bool dismissed_;
 public:
-  ScopeGuardImplBase() throw() : dismissed_(false)
+  ScopeGuardImplBase() noexcept : dismissed_(false)
   {
   }
-  void Dismiss() const throw()
+  void Dismiss() const noexcept
   {
     dismissed_ = true;
   }
@@ -82,7 +82,7 @@ public:
   {
     return ScopeGuardImpl0<F>(fun);
   }
-  ~ScopeGuardImpl0() throw()
+  ~ScopeGuardImpl0() noexcept
   {
     SafeExecute(*this);
   }
@@ -111,7 +111,7 @@ public:
   {
     return ScopeGuardImpl1<F, P1>(fun, p1);
   }
-  ~ScopeGuardImpl1() throw()
+  ~ScopeGuardImpl1() noexcept
   {
     SafeExecute(*this);
   }
@@ -141,7 +141,7 @@ public:
   {
     return ScopeGuardImpl2<F, P1, P2>(fun, p1, p2);
   }
-  ~ScopeGuardImpl2() throw()
+  ~ScopeGuardImpl2() noexcept
   {
     SafeExecute(*this);
   }
@@ -172,7 +172,7 @@ public:
   {
     return ScopeGuardImpl3<F, P1, P2, P3>(fun, p1, p2, p3);
   }
-  ~ScopeGuardImpl3() throw()
+  ~ScopeGuardImpl3() noexcept
   {
     SafeExecute(*this);
   }
@@ -206,7 +206,7 @@ public:
   {
     return ObjScopeGuardImpl0<Obj, MemFun>(obj, memFun);
   }
-  ~ObjScopeGuardImpl0() throw()
+  ~ObjScopeGuardImpl0() noexcept
   {
     SafeExecute(*this);
   }
@@ -235,7 +235,7 @@ public:
   {
     return ObjScopeGuardImpl1<Obj, MemFun, P1>(obj, memFun, p1);
   }
-  ~ObjScopeGuardImpl1() throw()
+  ~ObjScopeGuardImpl1() noexcept
   {
     SafeExecute(*this);
   }
@@ -265,7 +265,7 @@ public:
   {
     return ObjScopeGuardImpl2<Obj, MemFun, P1, P2>(obj, memFun, p1, p2);
   }
-  ~ObjScopeGuardImpl2() throw()
+  ~ObjScopeGuardImpl2() noexcept
   {
     SafeExecute(*this);
   }

--- a/TAO/orbsvcs/tests/Notify/Bug_3688b_Regression/TestBroadcaster.cpp
+++ b/TAO/orbsvcs/tests/Notify/Bug_3688b_Regression/TestBroadcaster.cpp
@@ -1,13 +1,10 @@
 #include "TestBroadcaster.h"
 
-
 TestBroadcaster::TestBroadcaster()
 {
-} /* end of TestBroadcaster::TestBroadcaster */
+}
 
-
-TestBroadcaster::~TestBroadcaster()
-  throw()
+TestBroadcaster::~TestBroadcaster() noexcept
 {
   // ensure nothrow guarantee
   try
@@ -17,13 +14,11 @@ TestBroadcaster::~TestBroadcaster()
   catch(...)
   {
   }
-} /* end of TestBroadcaster::~TestBroadcaster */
-
+}
 
 bool TestBroadcaster::connect(
   CORBA::ORB_ptr p_orb,
-  std::string const & rc_channelIor
-)
+  std::string const & rc_channelIor)
 {
   try
   {
@@ -59,8 +54,7 @@ bool TestBroadcaster::connect(
   }
 
   return true;
-} /* end of TestBroadcaster::connect */
-
+}
 
 bool TestBroadcaster::disconnect()
 {
@@ -111,10 +105,9 @@ bool TestBroadcaster::sendData()
   }
 
   return true;
-} /* end of TestBroadcaster::sendData */
-
+}
 
 bool TestBroadcaster::isConnected() const
 {
   return !CORBA::is_nil(mv_sequenceProxyPushConsumer.in());
-} /* end of TestBroadcaster::isConnected */
+}

--- a/TAO/orbsvcs/tests/Notify/Bug_3688b_Regression/TestBroadcaster.h
+++ b/TAO/orbsvcs/tests/Notify/Bug_3688b_Regression/TestBroadcaster.h
@@ -15,8 +15,7 @@ class bug3688_Export TestBroadcaster
     TestBroadcaster ();
 
     /// Destructor.
-    ~TestBroadcaster ()
-      throw ();
+    ~TestBroadcaster () noexcept;
 
     bool connect(
       CORBA::ORB_ptr p_orb,

--- a/TAO/tao/Asynch_Reply_Dispatcher_Base.h
+++ b/TAO/tao/Asynch_Reply_Dispatcher_Base.h
@@ -132,7 +132,7 @@ namespace TAO
   class TAO_Export ARDB_Refcount_Functor
   {
   public:
-    void operator() (TAO_Asynch_Reply_Dispatcher_Base *ardb) throw ();
+    void operator() (TAO_Asynch_Reply_Dispatcher_Base *ardb) noexcept;
   };
 }
 

--- a/TAO/tao/Asynch_Reply_Dispatcher_Base.inl
+++ b/TAO/tao/Asynch_Reply_Dispatcher_Base.inl
@@ -5,7 +5,7 @@ namespace TAO
 {
   ACE_INLINE void
   ARDB_Refcount_Functor::operator () (
-      TAO_Asynch_Reply_Dispatcher_Base *ardb) throw ()
+      TAO_Asynch_Reply_Dispatcher_Base *ardb) noexcept
   {
     (void) ardb->intrusive_remove_ref (ardb);
   }

--- a/TAO/tao/Bounded_Array_Sequence_T.h
+++ b/TAO/tao/Bounded_Array_Sequence_T.h
@@ -72,7 +72,7 @@ public:
   inline value_type * get_buffer(CORBA::Boolean orphan = false) {
     return impl_.get_buffer(orphan);
   }
-  inline void swap(bounded_array_sequence & rhs) throw() {
+  inline void swap(bounded_array_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
   static value_type * allocbuf(CORBA::ULong maximum) {

--- a/TAO/tao/Bounded_Basic_String_Sequence_T.h
+++ b/TAO/tao/Bounded_Basic_String_Sequence_T.h
@@ -88,7 +88,7 @@ public:
   inline value_type * get_buffer(CORBA::Boolean orphan = false) {
     return impl_.get_buffer(orphan);
   }
-  inline void swap(bounded_basic_string_sequence & rhs) throw() {
+  inline void swap(bounded_basic_string_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
 

--- a/TAO/tao/Bounded_Object_Reference_Sequence_T.h
+++ b/TAO/tao/Bounded_Object_Reference_Sequence_T.h
@@ -90,7 +90,7 @@ public:
     return impl_.get_buffer(orphan);
   }
   // @copydoc TAO::details::generic_sequence::swap
-  inline void swap(bounded_object_reference_sequence & rhs) throw() {
+  inline void swap(bounded_object_reference_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
 

--- a/TAO/tao/Bounded_Value_Sequence_T.h
+++ b/TAO/tao/Bounded_Value_Sequence_T.h
@@ -84,7 +84,7 @@ public:
     return impl_.get_buffer(orphan);
   }
   // @copydoc TAO::details::generic_sequence::swap()
-  inline void swap(bounded_value_sequence & rhs) throw() {
+  inline void swap(bounded_value_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
   static value_type * allocbuf(CORBA::ULong maximum) {

--- a/TAO/tao/Generic_Sequence_T.h
+++ b/TAO/tao/Generic_Sequence_T.h
@@ -315,7 +315,7 @@ public:
     return tmp.buffer_;
   }
 
-  void swap(generic_sequence & rhs) throw()
+  void swap(generic_sequence & rhs) noexcept
   {
     std::swap(maximum_, rhs.maximum_);
     std::swap(length_, rhs.length_);

--- a/TAO/tao/Messaging/AMH_Response_Handler.cpp
+++ b/TAO/tao/Messaging/AMH_Response_Handler.cpp
@@ -331,7 +331,7 @@ TAO_AMH_Response_Handler::_remove_ref ()
 namespace TAO
 {
   void
-  ARH_Refcount_Functor::operator () (TAO_AMH_Response_Handler *arh) throw ()
+  ARH_Refcount_Functor::operator () (TAO_AMH_Response_Handler *arh) noexcept
   {
     (void) arh->_remove_ref ();
   }

--- a/TAO/tao/Messaging/AMH_Response_Handler.h
+++ b/TAO/tao/Messaging/AMH_Response_Handler.h
@@ -198,7 +198,7 @@ namespace TAO
   class TAO_Messaging_Export ARH_Refcount_Functor
   {
   public:
-    void operator() (TAO_AMH_Response_Handler *arh) throw ();
+    void operator() (TAO_AMH_Response_Handler *arh) noexcept;
   };
 }
 

--- a/TAO/tao/PortableServer/Servant_var.cpp
+++ b/TAO/tao/PortableServer/Servant_var.cpp
@@ -31,7 +31,7 @@ PortableServer::Servant_var<T>::_duplicate (T * p)
 }
 
 template <class T>
-PortableServer::Servant_var<T>::~Servant_var ()  /* throw () */
+PortableServer::Servant_var<T>::~Servant_var ()  /* noexcept */
 {
   // Unfortunately, there is no throw spec on _remove_ref, so we
   // can't assume that it will not throw.  If it does, then we are in

--- a/TAO/tao/PortableServer/Servant_var.h
+++ b/TAO/tao/PortableServer/Servant_var.h
@@ -32,7 +32,7 @@ namespace PortableServer
    * @author Jody Hagins
    *
    * @todo Life would be much easier if _add_ref() and _remove_ref() had
-   *       throw specs of "throw ()", that can be hidden in static
+   *       throw specs of "noexcept", that can be hidden in static
    *       methods though.
    */
   template<class T>

--- a/TAO/tao/PortableServer/Servant_var.inl
+++ b/TAO/tao/PortableServer/Servant_var.inl
@@ -5,7 +5,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 template <class T>
 ACE_INLINE void
-PortableServer::Servant_var<T>::swap (Servant_var<T> & rhs) /* throw () */
+PortableServer::Servant_var<T>::swap (Servant_var<T> & rhs) /* noexcept */
 {
   std::swap (this->ptr_, rhs.ptr_);
 }

--- a/TAO/tao/Unbounded_Array_Sequence_T.h
+++ b/TAO/tao/Unbounded_Array_Sequence_T.h
@@ -77,7 +77,7 @@ public:
   inline value_type * get_buffer(CORBA::Boolean orphan = false) {
     return impl_.get_buffer(orphan);
   }
-  inline void swap(unbounded_array_sequence & rhs) throw() {
+  inline void swap(unbounded_array_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
   static value_type * allocbuf(CORBA::ULong maximum) {

--- a/TAO/tao/Unbounded_Basic_String_Sequence_T.h
+++ b/TAO/tao/Unbounded_Basic_String_Sequence_T.h
@@ -98,7 +98,7 @@ public:
     return impl_.get_buffer(orphan);
   }
   // @copydoc TAO::details::generic_sequence::swap
-  inline void swap(unbounded_basic_string_sequence & rhs) throw() {
+  inline void swap(unbounded_basic_string_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
 

--- a/TAO/tao/Unbounded_Object_Reference_Sequence_T.h
+++ b/TAO/tao/Unbounded_Object_Reference_Sequence_T.h
@@ -92,7 +92,7 @@ public:
     return impl_.get_buffer(orphan);
   }
   // @copydoc TAO::details::generic_sequence::swap()
-  inline void swap(unbounded_object_reference_sequence & rhs) throw() {
+  inline void swap(unbounded_object_reference_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
 

--- a/TAO/tao/Unbounded_Octet_Sequence_T.h
+++ b/TAO/tao/Unbounded_Octet_Sequence_T.h
@@ -223,7 +223,7 @@ public:
     return !this->operator==(rhs);
   }
 
-  inline void swap(unbounded_value_sequence & rhs) throw() {
+  inline void swap(unbounded_value_sequence & rhs) noexcept {
     std::swap (mb_, rhs.mb_);
     std::swap (maximum_, rhs.maximum_);
     std::swap (length_, rhs.length_);

--- a/TAO/tao/Unbounded_Value_Sequence_T.h
+++ b/TAO/tao/Unbounded_Value_Sequence_T.h
@@ -77,7 +77,7 @@ public:
   inline value_type * get_buffer(CORBA::Boolean orphan = false) {
     return impl_.get_buffer(orphan);
   }
-  inline void swap(unbounded_value_sequence & rhs) throw() {
+  inline void swap(unbounded_value_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
   static value_type * allocbuf(CORBA::ULong maximum) {

--- a/TAO/tao/Utils/Implicit_Deactivator.cpp
+++ b/TAO/tao/Utils/Implicit_Deactivator.cpp
@@ -5,7 +5,7 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 void
 TAO::Utils::Implicit_Deactivation_Functor::operator () (
-   PortableServer::ServantBase * servant) throw ()
+   PortableServer::ServantBase * servant) noexcept
 {
   try
     {

--- a/TAO/tao/Utils/Implicit_Deactivator.h
+++ b/TAO/tao/Utils/Implicit_Deactivator.h
@@ -36,7 +36,7 @@ namespace TAO
       typedef PortableServer::ServantBase * argument;
 
       // Deactivate an implicitly activated servant
-      void operator() (PortableServer::ServantBase * servant) throw ();
+      void operator() (PortableServer::ServantBase * servant) noexcept;
     };
 
     /**

--- a/TAO/tao/Utils/ORB_Destroyer.cpp
+++ b/TAO/tao/Utils/ORB_Destroyer.cpp
@@ -3,7 +3,7 @@
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 void
-TAO::Utils::ORB_Destroyer_Functor::operator() (CORBA::ORB_ptr orb) throw ()
+TAO::Utils::ORB_Destroyer_Functor::operator() (CORBA::ORB_ptr orb) noexcept
 {
   try
     {

--- a/TAO/tao/Utils/ORB_Destroyer.h
+++ b/TAO/tao/Utils/ORB_Destroyer.h
@@ -35,7 +35,7 @@ namespace TAO
       typedef CORBA::ORB_ptr argument;
 
       /// Destroy the ORB
-      void operator() (CORBA::ORB_ptr orb) throw ();
+      void operator() (CORBA::ORB_ptr orb) noexcept;
     };
 
     /**

--- a/TAO/tao/Utils/PolicyList_Destroyer.cpp
+++ b/TAO/tao/Utils/PolicyList_Destroyer.cpp
@@ -6,7 +6,7 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO::Utils::PolicyList_Destroyer::~PolicyList_Destroyer() throw ()
+TAO::Utils::PolicyList_Destroyer::~PolicyList_Destroyer() noexcept
 {
   for (CORBA::ULong i = 0; i != length(); ++i)
     {

--- a/TAO/tao/Utils/PolicyList_Destroyer.h
+++ b/TAO/tao/Utils/PolicyList_Destroyer.h
@@ -34,7 +34,7 @@ namespace TAO
     {
     public:
       PolicyList_Destroyer(CORBA::ULong length_hint);
-      ~PolicyList_Destroyer() throw ();
+      ~PolicyList_Destroyer() noexcept;
     };
   } // namespace Utils
 } // namespace TAO

--- a/TAO/tao/Valuetype/Bounded_Valuetype_Sequence_T.h
+++ b/TAO/tao/Valuetype/Bounded_Valuetype_Sequence_T.h
@@ -79,7 +79,7 @@ public:
   inline value_type * get_buffer(CORBA::Boolean orphan = false) {
     return impl_.get_buffer(orphan);
   }
-  inline void swap(bounded_valuetype_sequence & rhs) throw() {
+  inline void swap(bounded_valuetype_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
 

--- a/TAO/tao/Valuetype/Unbounded_Valuetype_Sequence_T.h
+++ b/TAO/tao/Valuetype/Unbounded_Valuetype_Sequence_T.h
@@ -82,7 +82,7 @@ public:
   inline value_type * get_buffer(CORBA::Boolean orphan = false) {
     return impl_.get_buffer(orphan);
   }
-  inline void swap(unbounded_valuetype_sequence & rhs) throw() {
+  inline void swap(unbounded_valuetype_sequence & rhs) noexcept {
     impl_.swap(rhs.impl_);
   }
 

--- a/TAO/tests/Bug_2936_Regression/PersistentPOA.cpp
+++ b/TAO/tests/Bug_2936_Regression/PersistentPOA.cpp
@@ -13,12 +13,9 @@ PersistentPoa::PersistentPoa ()
 {
 }
 
-
-PersistentPoa::~PersistentPoa ()
-  throw ()
+PersistentPoa::~PersistentPoa () noexcept
 {
 }
-
 
 int PersistentPoa::init (int argc, ACE_TCHAR *argv[])
 {

--- a/TAO/tests/Bug_2936_Regression/PersistentPOA.h
+++ b/TAO/tests/Bug_2936_Regression/PersistentPOA.h
@@ -18,16 +18,13 @@ class bug2936_Export PersistentPoa
     PersistentPoa ();
 
     /// Destructor.
-    ~PersistentPoa ()
-      throw ();
+    ~PersistentPoa () noexcept;
 
-  // protected types and methods
   protected:
     virtual int init (int argc, ACE_TCHAR *argv[]);
 
     virtual int fini ();
 
-  // private methods and instance variables
   private:
     CORBA::ORB_var                 mv_orb;
     PortableServer::POA_var        mv_rootPOA;

--- a/TAO/tests/Bug_3251_Regression/PersistentPoa.cpp
+++ b/TAO/tests/Bug_3251_Regression/PersistentPoa.cpp
@@ -8,8 +8,7 @@ PersistentPoa::PersistentPoa ()
 {
 }
 
-PersistentPoa::~PersistentPoa ()
-  throw ()
+PersistentPoa::~PersistentPoa () noexcept
 {
 }
 

--- a/TAO/tests/Bug_3251_Regression/PersistentPoa.h
+++ b/TAO/tests/Bug_3251_Regression/PersistentPoa.h
@@ -16,8 +16,7 @@ class bug_3251_Export PersistentPoa:  public ACE_Service_Object
   public:
     PersistentPoa ();
 
-    ~PersistentPoa ()
-      throw ();
+    ~PersistentPoa () noexcept;
 
   // protected types and methods
   protected:

--- a/TAO/tests/ORB_Local_Config/Bug_2612/DllOrb.cpp
+++ b/TAO/tests/ORB_Local_Config/Bug_2612/DllOrb.cpp
@@ -24,8 +24,7 @@ DllOrb::DllOrb (int nthreads)
 {
 }
 
-DllOrb::~DllOrb ()
-  throw ()
+DllOrb::~DllOrb () noexcept
 {
 #if defined (ACE_HAS_THREADS)
   delete mp_barrier;

--- a/TAO/tests/ORB_Local_Config/Bug_2612/DllOrb.h
+++ b/TAO/tests/ORB_Local_Config/Bug_2612/DllOrb.h
@@ -26,7 +26,7 @@ class DllOrb_Export DllOrb
     DllOrb (int nthreads = 1);
 
     /// Destructor.
-    ~DllOrb () throw ();
+    ~DllOrb () noexcept;
 
     CORBA::ORB_ptr orb () const;
 

--- a/TAO/tests/POA/DSI/Database_i.cpp
+++ b/TAO/tests/POA/DSI/Database_i.cpp
@@ -358,7 +358,7 @@ DatabaseImpl::Employee::operator new (size_t size, const std::nothrow_t &)
 }
 
 void
-DatabaseImpl::Employee::operator delete (void *ptr, const std::nothrow_t&) throw ()
+DatabaseImpl::Employee::operator delete (void *ptr, const std::nothrow_t&) noexcept
 {
   DATABASE::instance ()->free (ptr);
 }

--- a/TAO/tests/POA/DSI/Database_i.h
+++ b/TAO/tests/POA/DSI/Database_i.h
@@ -112,7 +112,7 @@ public:
 
     /// Overloaded new operator, nothrow_t variant.
     void *operator new (size_t bytes, const std::nothrow_t &nt);
-    void operator delete (void *p, const std::nothrow_t&) throw ();
+    void operator delete (void *p, const std::nothrow_t&) noexcept;
     void *operator new (size_t);
     void operator delete (void *pointer);
 

--- a/TAO/utils/wxNamingViewer/wxAutoDialog.h
+++ b/TAO/utils/wxNamingViewer/wxAutoDialog.h
@@ -3,15 +3,14 @@
 #ifndef i_wxAutoDialog_h
 #define i_wxAutoDialog_h
 
-
 template <class D>
 class WxAutoDialog
 {
 public:
-  explicit WxAutoDialog( D* dialog) throw():dialog( dialog) {}
-  ~WxAutoDialog() throw() { dialog->Destroy(); }
+  explicit WxAutoDialog( D* dialog) noexcept:dialog( dialog) {}
+  ~WxAutoDialog() noexcept { dialog->Destroy(); }
 
-  D* operator->() const throw() { return dialog; }
+  D* operator->() const noexcept { return dialog; }
 
 protected:
   D* dialog;


### PR DESCRIPTION
    * ACE/ace/Auto_Functor.h:
    * ACE/ace/Local_Name_Space_T.cpp:
    * ACE/ace/Svc_Handler.cpp:
    * ACE/ace/Svc_Handler.h:
    * ACE/ace/config-lite.h:
    * ACE/ace/config-macros.h:
    * ACE/examples/DLL/Newsweek.cpp:
    * ACE/examples/DLL/Newsweek.h:
    * ACE/examples/DLL/Today.cpp:
    * ACE/examples/DLL/Today.h:
    * ACE/examples/Shared_Malloc/test_persistence.cpp:
    * ACE/tests/DLL_Test_Impl.cpp:
    * ACE/tests/DLL_Test_Impl.h:
    * ACE/tests/Dynamic_Test.cpp:
    * TAO/orbsvcs/orbsvcs/ESF/ESF_Peer_Admin.h:
    * TAO/orbsvcs/orbsvcs/ESF/ESF_Proxy_Admin.h:
    * TAO/orbsvcs/orbsvcs/Event/EC_Channel_Destroyer.cpp:
    * TAO/orbsvcs/orbsvcs/Event/EC_Channel_Destroyer.h:
    * TAO/orbsvcs/orbsvcs/Event/EC_ProxySupplier.cpp:
    * TAO/orbsvcs/orbsvcs/Event/EC_ProxySupplier.h:
    * TAO/orbsvcs/orbsvcs/Event/EC_Proxy_Disconnector.cpp:
    * TAO/orbsvcs/orbsvcs/Event/EC_Proxy_Disconnector.h:
    * TAO/orbsvcs/orbsvcs/FtRtEvent/Utils/ScopeGuard.h:
    * TAO/orbsvcs/tests/Notify/Bug_3688b_Regression/TestBroadcaster.cpp:
    * TAO/orbsvcs/tests/Notify/Bug_3688b_Regression/TestBroadcaster.h:
    * TAO/tao/Asynch_Reply_Dispatcher_Base.h:
    * TAO/tao/Asynch_Reply_Dispatcher_Base.inl:
    * TAO/tao/Bounded_Array_Sequence_T.h:
    * TAO/tao/Bounded_Basic_String_Sequence_T.h:
    * TAO/tao/Bounded_Object_Reference_Sequence_T.h:
    * TAO/tao/Bounded_Value_Sequence_T.h:
    * TAO/tao/Generic_Sequence_T.h:
    * TAO/tao/Messaging/AMH_Response_Handler.cpp:
    * TAO/tao/Messaging/AMH_Response_Handler.h:
    * TAO/tao/PortableServer/Servant_var.cpp:
    * TAO/tao/PortableServer/Servant_var.h:
    * TAO/tao/PortableServer/Servant_var.inl:
    * TAO/tao/Unbounded_Array_Sequence_T.h:
    * TAO/tao/Unbounded_Basic_String_Sequence_T.h:
    * TAO/tao/Unbounded_Object_Reference_Sequence_T.h:
    * TAO/tao/Unbounded_Octet_Sequence_T.h:
    * TAO/tao/Unbounded_Value_Sequence_T.h:
    * TAO/tao/Utils/Implicit_Deactivator.cpp:
    * TAO/tao/Utils/Implicit_Deactivator.h:
    * TAO/tao/Utils/ORB_Destroyer.cpp:
    * TAO/tao/Utils/ORB_Destroyer.h:
    * TAO/tao/Utils/PolicyList_Destroyer.cpp:
    * TAO/tao/Utils/PolicyList_Destroyer.h:
    * TAO/tao/Valuetype/Bounded_Valuetype_Sequence_T.h:
    * TAO/tao/Valuetype/Unbounded_Valuetype_Sequence_T.h:
    * TAO/tests/Bug_2936_Regression/PersistentPOA.cpp:
    * TAO/tests/Bug_2936_Regression/PersistentPOA.h:
    * TAO/tests/Bug_3251_Regression/PersistentPoa.cpp:
    * TAO/tests/Bug_3251_Regression/PersistentPoa.h:
    * TAO/tests/ORB_Local_Config/Bug_2612/DllOrb.cpp:
    * TAO/tests/ORB_Local_Config/Bug_2612/DllOrb.h:
    * TAO/tests/POA/DSI/Database_i.cpp:
    * TAO/tests/POA/DSI/Database_i.h:
    * TAO/utils/wxNamingViewer/wxAutoDialog.h: