### PR TITLE
[ace6tao2] Allow disabling of ACE_OS::readdir_r

### DIFF
--- a/ACE/ace/Dirent.inl
+++ b/ACE/ace/Dirent.inl
@@ -56,9 +56,18 @@ ACE_INLINE int
 ACE_Dirent::read (struct ACE_DIRENT *entry,
                   struct ACE_DIRENT **result)
 {
-  return this->dirp_
-         ? ACE_OS::readdir_r (this->dirp_, entry, result)
-         : 0;
+  int status = EBADF;
+  if (this->dirp_ && entry && result)
+    {
+      ACE_DIRENT* ptr = ACE_OS::readdir (this->dirp_);
+      if (ptr)
+        {
+          *entry = *ptr;
+        }
+      *result = ptr;
+      status = 0;
+    }
+  return status;
 }
 
 ACE_INLINE void

--- a/ACE/ace/OS_NS_dirent.cpp
+++ b/ACE/ace/OS_NS_dirent.cpp
@@ -181,7 +181,6 @@ ACE_OS::scandir_emulation (const ACE_TCHAR *dirname,
   int nfiles = 0;
   int fail = 0;
 
-  // @@ This code shoulduse readdir_r() rather than readdir().
   for (dp = ACE_OS::readdir (dirp);
        dp != 0;
        dp = ACE_OS::readdir (dirp))

--- a/ACE/ace/OS_NS_dirent.h
+++ b/ACE/ace/OS_NS_dirent.h
@@ -86,10 +86,12 @@ namespace ACE_OS {
   ACE_NAMESPACE_INLINE_FUNCTION
   struct ACE_DIRENT *readdir (ACE_DIR *);
 
+#if !defined (ACE_DISABLE_READDIR_R)
   ACE_NAMESPACE_INLINE_FUNCTION
   int readdir_r (ACE_DIR *dirp,
                  struct ACE_DIRENT *entry,
                  struct ACE_DIRENT **result);
+#endif /* !ACE_DISABLE_READDIR_R */
 
   ACE_NAMESPACE_INLINE_FUNCTION
   void rewinddir (ACE_DIR *);

--- a/ACE/ace/OS_NS_dirent.inl
+++ b/ACE/ace/OS_NS_dirent.inl
@@ -65,6 +65,7 @@ readdir (ACE_DIR *d)
 #endif /* ACE_HAS_DIRENT */
 }
 
+#if !defined (ACE_DISABLE_READDIR_R)
 ACE_INLINE int
 readdir_r (ACE_DIR *dirp,
            struct ACE_DIRENT *entry,
@@ -94,6 +95,7 @@ readdir_r (ACE_DIR *dirp,
 
 #endif /* ACE_HAS_REENTRANT_FUNCTIONS */
 }
+#endif /* !ACE_DISABLE_READDIR_R */
 
 ACE_INLINE void
 rewinddir (ACE_DIR *d)


### PR DESCRIPTION
Only use `readdir` internally since `readdir_r` is deprecated.

This change will not apply to ACE 7, since readdir_r was removed.