### PR TITLE
Only emit the require_truncation_ boolean if CDR support is enabled.

### DIFF
--- a/TAO/TAO_IDL/be/be_visitor_valuetype/valuetype_obv_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_valuetype/valuetype_obv_ch.cpp
@@ -237,8 +237,12 @@ be_visitor_valuetype_obv_ch::visit_valuetype (be_valuetype *node)
           this->gen_pd (node);
         }
 
-      *os << be_nl
-          << "CORBA::Boolean require_truncation_ {false};" << be_uidt_nl
+      if (be_global->cdr_support ())
+        {
+          *os << be_nl
+              << "CORBA::Boolean require_truncation_ {false};";
+        }
+      *os << be_uidt_nl
           << "};";
     }
 


### PR DESCRIPTION
Based on https://github.com/DOCGroup/ACE_TAO/pull/2001