### PR TITLE
Make ACE 7.0.11 and TAO 3.0.11 public available

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN ACE-7.0.11 and ACE-7.0.12
+======================================================
+
 USER VISIBLE CHANGES BETWEEN ACE-7.0.10 and ACE-7.0.11
 ======================================================
 

--- a/ACE/bin/copy-local-script.sh
+++ b/ACE/bin/copy-local-script.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 for i in *.gz *.bz2 *.zip *.md5; do
-  d=`echo $i | sed 's/\.[tz][ai][rp]/-7.0.11&/'`
+  d=`echo $i | sed 's/\.[tz][ai][rp]/-7.0.12&/'`
   echo "Copying $i to $d"
   cp -ip $i $d
 done

--- a/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
+++ b/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
@@ -2,7 +2,7 @@
 
 if test -z $1; then newdate=`date -u +%Y_%m_%d`; else newdate=$1; fi
 if test -z $2; then prefix=`date -u +%Y%m%d%a`; else prefix=$2; fi
-if test -z $3; then olddate=2022_11_17; else olddate=$3; fi
+if test -z $3; then olddate=2022_12_19; else olddate=$3; fi
 if test -z $ACE_ROOT; then ACE_ROOT=..; fi
 if test -z $TAO_ROOT; then TAO_ROOT=${ACE_ROOT}/TAO; fi
 #

--- a/ACE/docs/Download.html
+++ b/ACE/docs/Download.html
@@ -90,81 +90,81 @@ Windows line feeds. For all other platforms download a .gz/.bz2 package.
 </P>
 
 <UL>
-<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 7.0.10 and TAO 3.0.10
-(ACE+TAO x.0.10), please use the links below to download it.<P>
+<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 7.0.11 and TAO 3.0.11
+(ACE+TAO x.0.11), please use the links below to download it.<P>
 
 <TABLE BORDER="4">
   <TR><TH>Filename</TH><TH>Description</TH><TH>Full</TH><TH>Sources only</TH></TR>
   <TR><TD>ACE+TAO.tar.gz</TD>
       <TD>ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE+TAO-7.0.10.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.0.10.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE+TAO-7.0.11.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.0.11.tar.gz">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE+TAO-src-7.0.10.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.0.10.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE+TAO-src-7.0.11.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.0.11.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE+TAO.tar.bz2</TD>
       <TD>ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE+TAO-7.0.10.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.0.10.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE+TAO-7.0.11.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.0.11.tar.bz2">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE+TAO-src-7.0.10.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.0.10.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE+TAO-src-7.0.11.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.0.11.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE+TAO.zip</TD>
       <TD>ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE+TAO-7.0.10.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.0.10.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE+TAO-7.0.11.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.0.11.zip">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE+TAO-src-7.0.10.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.0.10.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE+TAO-src-7.0.11.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.0.11.zip">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.tar.gz</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-html-7.0.10.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.0.10.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-html-7.0.11.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.0.11.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.tar.bz2</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-html-7.0.10.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.0.10.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-html-7.0.11.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.0.11.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.zip</TD>
       <TD>Doxygen documentation for ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-html-7.0.10.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.0.10.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-html-7.0.11.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.0.11.zip">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.tar.gz</TD>
       <TD>ACE only (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-7.0.10.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.0.10.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-7.0.11.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.0.11.tar.gz">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-src-7.0.10.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.0.10.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-src-7.0.11.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.0.11.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.tar.bz2</TD>
       <TD>ACE only (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-7.0.10.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.0.10.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-7.0.11.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.0.11.tar.bz2">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-src-7.0.10.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.0.10.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-src-7.0.11.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.0.11.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.zip</TD>
       <TD>ACE only (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-7.0.10.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.0.10.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-7.0.11.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.0.11.zip">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_10/ACE-src-7.0.10.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.0.10.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_11/ACE-src-7.0.11.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.0.11.zip">FTP</A>]
       </TD>
   </TR>
 </TABLE>

--- a/ACE/etc/index.html
+++ b/ACE/etc/index.html
@@ -30,6 +30,7 @@
     <hr>
     We do have the documentation for previous releases
     <ul>
+      <LI><P><A HREF="7.0.11/html">7.0.11</A></P></LI>
       <LI><P><A HREF="7.0.10/html">7.0.10</A></P></LI>
       <LI><P><A HREF="7.0.9/html">7.0.9</A></P></LI>
       <LI><P><A HREF="7.0.8/html">7.0.8</A></P></LI>

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN TAO-3.0.11 and TAO-3.0.12
+======================================================
+
 USER VISIBLE CHANGES BETWEEN TAO-3.0.10 and TAO-3.0.11
 ======================================================
 


### PR DESCRIPTION
    * ACE/NEWS:
    * ACE/bin/copy-local-script.sh:
    * ACE/bin/diff-builds-and-group-fixed-tests-only.sh:
    * ACE/docs/Download.html:
    * ACE/etc/index.html:
    * TAO/NEWS: