### PR TITLE
Fix error in ACE_Process_Options::inherit_environment ()

### DIFF
--- a/ACE/ace/Process.cpp
+++ b/ACE/ace/Process.cpp
@@ -932,7 +932,7 @@ ACE_Process_Options::inherit_environment ()
           size_t const idx = temp_narrow_env.size ();
           temp_narrow_env.resize (idx + len + 1, 0);
           ACE_OS::strncpy (&temp_narrow_env[idx], wta.char_rep (), len);
-          iter += len;
+          iter += ACE_OS::strlen(iter);
         }
       temp_narrow_env.push_back (0);
       existing_environment = &temp_narrow_env[0];


### PR DESCRIPTION
While using ACE_Wide_To_Ascii string conversion class (and correspondingly ::WideCharToMultiByte) there must be expected that the length of the output multi-byte string is not equal to the length of the input Unicode string. That's why we the variable _iter_ used to iterate over the original Unicode environment variables must be increased by the source string length (and not by the length of converted string).