### PR TITLE
Add headers and other source files to the list of files to be installed.

### DIFF
--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -1128,23 +1128,13 @@ cat mmraw.list |\
         sort -u > allhdrs.list
 
 # Add missing headers.
-echo ace/QtReactor/QtReactor.h >> allhdrs.list
-# pick up additional ACE files required to build external packages
 ls ace/*{.h,inl,_T.cpp} >> allhdrs.list
 %if 0%{?_with_tao:1}%{?_without_tao:0}
-echo TAO/tao/QtResource/QtResource_Factory.h >> allhdrs.list
-echo TAO/tao/QtResource/QtResource_Loader.h >> allhdrs.list
-echo TAO/tao/PortableServer/get_arg.h >> allhdrs.list
-echo TAO/orbsvcs/orbsvcs/ESF/ESF_Proxy_List.{h,inl,cpp} >> allhdrs.list
-echo TAO/orbsvcs/orbsvcs/ESF/ESF_Proxy_RB_Tree.{h,inl,cpp} >> allhdrs.list
-# pick up additional TAO files required to build external packages
 ls TAO/tao/*{.h,.inl,_T.cpp} >> allhdrs.list
 ls TAO/tao/*/*{.h,.inl,_T.cpp,_var.cpp} >> allhdrs.list
-ls TAO/tao/AnyTypeCode/*{h,.inl,.cpp} >> allhdrs.list
-# ls TAO/tao/PortableServer/*{h,.inl,_T.cpp,_var.cpp} >> allhdrs.list
 ls TAO/orbsvcs/orbsvcs/*{.idl,.h,.inl,_T.cpp} >> allhdrs.list
-# ls TAO/orbsvcs/orbsvcs/ESF/*{.idl,.h,.inl,_T.cpp} >> allhdrs.list
-ls TAO/orbsvcs/orbsvcs/*/*{.idl,.h,.inl,_T.cpp} >> allhdrs.list
+ls TAO/orbsvcs/orbsvcs/*/*{.h,.inl,_T.cpp} >> allhdrs.list
+ls TAO/orbsvcs/orbsvcs/ESF/*.cpp >> allhdrs.list
 %endif
 
 # Install headers and create header lists

--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -1129,12 +1129,22 @@ cat mmraw.list |\
 
 # Add missing headers.
 echo ace/QtReactor/QtReactor.h >> allhdrs.list
+# pick up additional ACE files required to build external packages
+ls ace/*{.h,inl,_T.cpp} >> allhdrs.list
 %if 0%{?_with_tao:1}%{?_without_tao:0}
 echo TAO/tao/QtResource/QtResource_Factory.h >> allhdrs.list
 echo TAO/tao/QtResource/QtResource_Loader.h >> allhdrs.list
 echo TAO/tao/PortableServer/get_arg.h >> allhdrs.list
 echo TAO/orbsvcs/orbsvcs/ESF/ESF_Proxy_List.{h,inl,cpp} >> allhdrs.list
 echo TAO/orbsvcs/orbsvcs/ESF/ESF_Proxy_RB_Tree.{h,inl,cpp} >> allhdrs.list
+# pick up additional TAO files required to build external packages
+ls TAO/tao/*{.h,.inl,_T.cpp} >> allhdrs.list
+ls TAO/tao/*/*{.h,.inl,_T.cpp,_var.cpp} >> allhdrs.list
+ls TAO/tao/AnyTypeCode/*{h,.inl,.cpp} >> allhdrs.list
+# ls TAO/tao/PortableServer/*{h,.inl,_T.cpp,_var.cpp} >> allhdrs.list
+ls TAO/orbsvcs/orbsvcs/*{.idl,.h,.inl,_T.cpp} >> allhdrs.list
+# ls TAO/orbsvcs/orbsvcs/ESF/*{.idl,.h,.inl,_T.cpp} >> allhdrs.list
+ls TAO/orbsvcs/orbsvcs/*/*{.idl,.h,.inl,_T.cpp} >> allhdrs.list
 %endif
 
 # Install headers and create header lists

--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -1128,10 +1128,10 @@ cat mmraw.list |\
         sort -u > allhdrs.list
 
 # Add missing headers.
-ls ace/*{.h,inl,_T.cpp} >> allhdrs.list
+ls ace/*{.h,.inl,.cpp} >> allhdrs.list
 %if 0%{?_with_tao:1}%{?_without_tao:0}
 ls TAO/tao/*{.h,.inl,_T.cpp} >> allhdrs.list
-ls TAO/tao/*/*{.h,.inl,_T.cpp,_var.cpp} >> allhdrs.list
+ls TAO/tao/*/*{.h,.inl,.cpp} >> allhdrs.list
 ls TAO/orbsvcs/orbsvcs/*{.idl,.h,.inl,_T.cpp} >> allhdrs.list
 ls TAO/orbsvcs/orbsvcs/*/*{.h,.inl,_T.cpp} >> allhdrs.list
 ls TAO/orbsvcs/orbsvcs/ESF/*.cpp >> allhdrs.list


### PR DESCRIPTION
This includes stubs and skeletons for IDL interfaces and files required to extend interfaces. This is a superset of files which are known to be required to build external packages.

The current scheme for building the RPM uses dependencies from (some) built objects to deduce which files were required to be installed. But many other files are not in the core product but are required for external projects to use these components.