### PR TITLE
support retrieving the underlying queue

### DIFF
--- a/ACE/ace/Message_Queue_T.cpp
+++ b/ACE/ace/Message_Queue_T.cpp
@@ -691,6 +691,13 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::set_time_pol
   this->queue_.set_time_policy (rhs);
 }
 
+template <class ACE_MESSAGE_TYPE, ACE_SYNCH_DECL, class TIME_POLICY>
+ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> &
+ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::queue ()
+{
+  return this->queue_;
+}
+
 template <ACE_SYNCH_DECL, class TIME_POLICY>
 ACE_Message_Queue_Iterator<ACE_SYNCH_USE, TIME_POLICY>::ACE_Message_Queue_Iterator (ACE_Message_Queue <ACE_SYNCH_USE, TIME_POLICY> &q)
   : queue_ (q)

--- a/ACE/ace/Message_Queue_T.h
+++ b/ACE/ace/Message_Queue_T.h
@@ -1388,6 +1388,9 @@ public:
   /// Declare the dynamic allocation hooks.
   ACE_ALLOC_HOOK_DECLARE;
 
+  /// Returns a reference to the underlying queue.
+  virtual ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> &queue ();
+
 protected:
   /// Implement this via an ACE_Message_Queue.
   ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> queue_;


### PR DESCRIPTION
this supports e.g. iteration through ACE_Message_Queue_Ex without grabbing/releasing the lock in each step because iterators can now access the underlying queue(/lock) directly.