### PR TITLE
[ACE 6] ACE_INET_Addr::set errantly succeeds when ACE_LACKS_GETSERVBYNAME

### DIFF
--- a/ACE/ace/INET_Addr.cpp
+++ b/ACE/ace/INET_Addr.cpp
@@ -471,12 +471,11 @@ static int get_port_number_from_name (const char port_name[],
     }
 
   // We try to resolve port number from its name.
+  port_number = -1;
 #if defined (ACE_LACKS_GETSERVBYNAME)
-  port_number = 0;
   ACE_UNUSED_ARG (port_name);
   ACE_UNUSED_ARG (protocol);
 #else
-  port_number = -1;
   servent sentry;
   ACE_SERVENT_DATA buf;
   servent *sp = ACE_OS::getservbyname_r (port_name,

--- a/ACE/tests/INET_Addr_Test.cpp
+++ b/ACE/tests/INET_Addr_Test.cpp
@@ -158,6 +158,43 @@ static bool test_multiple (void)
   return success;
 }
 
+static bool test_port_names()
+{
+  bool success = true;
+
+  ACE_INET_Addr addr;
+
+#if defined (ACE_LACKS_GETSERVBYNAME)
+  // Since we don't have getservbyname, the call to set should fail.
+  // Check that the call does in fact fail.
+  if (addr.set("telnet") == 0)
+    {
+      ACE_ERROR ((LM_ERROR, ACE_TEXT ("set with 'telnet' succeeded (expected failure)\n")));
+      success = false;
+    }
+#else
+  if (addr.set("telnet") != 0)
+    {
+      ACE_ERROR ((LM_ERROR, ACE_TEXT ("set with 'telnet' failed (expected success)\n")));
+      success = false;
+    }
+
+  if (addr != ACE_INET_Addr("0.0.0.0:23"))
+    {
+      ACE_ERROR ((LM_ERROR, ACE_TEXT ("set with 'telnet' failed to yield correct address\n")));
+      success = false;
+    }
+#endif /* ACE_LACKS_GETSERVBYNAME */
+
+  if (addr.set("not a port name") == 0)
+    {
+      ACE_ERROR ((LM_ERROR, ACE_TEXT ("set with 'not a port name' succeeded (expected failure)\n")));
+      success = false;
+    }
+
+  return success;
+}
+
 struct Address {
   const char* name;
   bool loopback;
@@ -565,6 +602,9 @@ int run_main (int, ACE_TCHAR *[])
                   ACE_TEXT ("Address equality check failed after assignment\n")));
       status = 1;
     }
+
+  if (!test_port_names ())
+    status = 1;
 
   ACE_END_TEST;
 


### PR DESCRIPTION
Merged #2080 to ace6tao2:
`ACE_INET_Addr::set` errantly succeeds when ACE_LACKS_GETSERVBYNAME

(cherry picked from commit a65d91cdc463e7cf6cf509138956b2d38c5e5727)