### PR TITLE
Replace std::unary_function<> with std::function<>

### DIFF
--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -69,8 +69,8 @@ protected:
 ACE_END_VERSIONED_NAMESPACE_DECL
 
 #if !defined (ACE_LACKS_AUTO_PTR)
-#  include <memory>  // NOTE:  Workaround only, still needed! 2023-08-23 CK
-using std::auto_ptr; // FIXME(CK): This does NOT compile with c++17 or newer!!!
+#  include <memory>
+using std::auto_ptr;
 #else /* !ACE_LACKS_AUTO_PTR */
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -68,16 +68,9 @@ protected:
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 
-// NOTE: ACE7 and TAO3 require C++11 support or newer; jwillemsen commented on Jun 1, 2021
 #if !defined (ACE_LACKS_AUTO_PTR)
-#  include <memory>
-
-#  ifdef ACE_HAS_CPP17
-// NOTE: we must only use std::unique_ptr; CK
-#  else
-// FIXME: we are still using std::auto_ptr;
-#  endif
-
+#  include <memory>  // NOTE:  Workaround only, still needed! 2023-08-23 CK
+using std::auto_ptr; // FIXME(CK): This does NOT compile with c++17 or newer!!!
 #else /* !ACE_LACKS_AUTO_PTR */
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Auto_Ptr.h
+++ b/ACE/ace/Auto_Ptr.h
@@ -68,9 +68,16 @@ protected:
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 
+// NOTE: ACE7 and TAO3 require C++11 support or newer; jwillemsen commented on Jun 1, 2021
 #if !defined (ACE_LACKS_AUTO_PTR)
-#include <memory>
-using std::auto_ptr;
+#  include <memory>
+
+#  ifdef ACE_HAS_CPP17
+// NOTE: we must only use std::unique_ptr; CK
+#  else
+// FIXME: we are still using std::auto_ptr;
+#  endif
+
 #else /* !ACE_LACKS_AUTO_PTR */
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/ACE/tests/Reactor_Remove_Resume_Test_Dev_Poll.cpp
+++ b/ACE/tests/Reactor_Remove_Resume_Test_Dev_Poll.cpp
@@ -375,7 +375,7 @@ dev_poll_reactor_factory ()
  *
  * Reactor test execution functor.
  */
-struct Run_Test : public std::unary_function<reactor_factory_type, void>
+struct Run_Test : public std::function<void(reactor_factory_type)>
 {
   /// Function call operator overload.
   void operator() (reactor_factory_type factory)

--- a/TAO/orbsvcs/orbsvcs/Event/ECG_CDR_Message_Receiver.cpp
+++ b/TAO/orbsvcs/orbsvcs/Event/ECG_CDR_Message_Receiver.cpp
@@ -8,6 +8,8 @@
 #include "ace/ACE.h"
 #include "ace/OS_NS_string.h"
 
+#include <memory>
+
 #if !defined(__ACE_INLINE__)
 #include "orbsvcs/Event/ECG_CDR_Message_Receiver.inl"
 #endif /* __ACE_INLINE__ */

--- a/TAO/orbsvcs/orbsvcs/Notify/Refcountable.cpp
+++ b/TAO/orbsvcs/orbsvcs/Notify/Refcountable.cpp
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <memory>
 #include <typeinfo.h>
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -44,8 +45,8 @@ private:
   TAO_Notify_Tracker();
   ~TAO_Notify_Tracker();
 
-  friend class std::auto_ptr< TAO_Notify_Tracker >;
-  static std::auto_ptr< TAO_Notify_Tracker > s_instance;
+  friend class std::unique_ptr< TAO_Notify_Tracker >;
+  static std::unique_ptr< TAO_Notify_Tracker > s_instance;
   mutable TAO_SYNCH_MUTEX lock_;
   typedef std::map<int, Entry> EntityMap;
   EntityMap map_;
@@ -133,7 +134,7 @@ TAO_Notify_Refcountable::_decr_refcnt ()
 
 #if (TAO_NOTIFY_REFCOUNT_DIAGNOSTICS != 0)
 
-std::auto_ptr< TAO_Notify_Tracker > TAO_Notify_Tracker::s_instance;
+std::unique_ptr< TAO_Notify_Tracker > TAO_Notify_Tracker::s_instance;
 
 TAO_Notify_Tracker::TAO_Notify_Tracker()
 : id_counter_(0)

--- a/TAO/tests/Any/Recursive/client.cpp
+++ b/TAO/tests/Any/Recursive/client.cpp
@@ -399,7 +399,7 @@ directly_recursive_valuetype_typecodefactory_test (CORBA::ORB_ptr /* orb */,
  * Test method invocation functor.
  */
 template <typename T>
-struct Caller : public std::unary_function<T, void>
+struct Caller : public std::function<void(T)>
 {
   /// Constructor.
   Caller (CORBA::ORB_ptr o, Test::Hello_ptr h)

--- a/TAO/tests/Bug_2804_Regression/client.cpp
+++ b/TAO/tests/Bug_2804_Regression/client.cpp
@@ -97,7 +97,7 @@ recursive_union_test (CORBA::ORB_ptr /* orb */,
  * Test method invocation functor.
  */
 template <typename T>
-struct Caller : public std::unary_function<T, void>
+struct Caller : public std::function<void(T)>
 {
   /// Constructor.
   Caller (CORBA::ORB_ptr o, Test::Hello_ptr h)

--- a/TAO/tests/Bug_2844_Regression/client.cpp
+++ b/TAO/tests/Bug_2844_Regression/client.cpp
@@ -96,7 +96,7 @@ nested_recursive_struct_test (CORBA::ORB_ptr /* orb */,
  * Test method invocation functor.
  */
 template <typename T>
-struct Caller : public std::unary_function<T, void>
+struct Caller : public std::function<void(T)>
 {
   /// Constructor.
   Caller (CORBA::ORB_ptr o, Test::Hello_ptr h)

--- a/TAO/tests/Bug_2918_Regression/client.cpp
+++ b/TAO/tests/Bug_2918_Regression/client.cpp
@@ -97,7 +97,7 @@ repeated_struct_test (CORBA::ORB_ptr /* orb */,
  * Test method invocation functor.
  */
 template <typename T>
-struct Caller : public std::unary_function<T, void>
+struct Caller : public std::function<void(T)>
 {
   /// Constructor.
   Caller (CORBA::ORB_ptr o, Test::Hello_ptr h)

--- a/TAO/tests/Bug_3919_Regression/client.cpp
+++ b/TAO/tests/Bug_3919_Regression/client.cpp
@@ -168,7 +168,7 @@ nested_recursive_typecode_test (CORBA::ORB_ptr /* orb */,
  * Test method invocation functor.
  */
 template <typename T>
-struct Caller : public std::unary_function<T, void>
+struct Caller : public std::function<void(T)>
 {
   /// Constructor.
   Caller (CORBA::ORB_ptr o, Test::Hello_ptr h)


### PR DESCRIPTION
(deprecated in C++11) and removed in C++17