### PR TITLE
Removed gcc 4 workaround for C++11, we require C++14 as minimum

### DIFF
--- a/ACE/include/makeinclude/platform_g++_common.GNU
+++ b/ACE/include/makeinclude/platform_g++_common.GNU
@@ -72,15 +72,6 @@ else
 CXX_MINOR_VERSION := $(shell $(CXX_FOR_VERSION_TEST) -dumpversion | sed -e 's/[^0-9\.]//g' | sed -e 's/^[0-9]*\.//' | sed -e 's/\..*$$//')
 endif
 
-# gcc 4 has C++03 as default C++ version, enable this to be C++11
-ifeq ($(findstring $(CXX_MAJOR_VERSION),4),$(CXX_MAJOR_VERSION))
-  c++11 ?= 1
-  # gcc 4 has a problem that it warnings about missing initializers
-  # for an std::array containing std::string even when {{}} is used
-  # as it should
-  FLAGS_C_CC += -Wno-missing-field-initializers
-endif
-
 CXX_FULL_VERSION := $(shell $(CXX_FOR_VERSION_TEST) --version)
 
 # Only modify LDFLAGS if DLD has been set.

--- a/ACE/include/makeinclude/platform_gcc_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_gcc_clang_common.GNU
@@ -61,10 +61,6 @@ else
   else
     ifeq ($(c++14),1)
       CCFLAGS += -std=c++14
-    else
-      ifeq ($(c++11),1)
-        CCFLAGS += -std=c++11
-      endif # c++11
     endif # c++14
   endif #c++17
 endif #c++20

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -35,10 +35,6 @@ ifeq ($(optimize),0)
   CPPFLAGS += -O0
 endif
 
-ifeq ($(c++11),1)
-  CCFLAGS += -std=c++11
-endif
-
 ifeq ($(c++14),1)
   CCFLAGS += -std=c++14
 endif

--- a/ACE/include/makeinclude/platform_linux_icc.GNU
+++ b/ACE/include/makeinclude/platform_linux_icc.GNU
@@ -56,10 +56,6 @@ ifeq ($(ipo),1)
   CPPFLAGS += -ipo
 endif
 
-ifeq ($(c++11),1)
-  CCFLAGS += -std=c++11
-endif
-
 CFLAGS  += -w1
 ifeq ($(threads),1)
     CPPFLAGS  += -D_REENTRANT

--- a/ACE/include/makeinclude/platform_qnx_gcc.GNU
+++ b/ACE/include/makeinclude/platform_qnx_gcc.GNU
@@ -34,7 +34,7 @@ SOFLAGS += $(CPPFLAGS) -shared
 SOBUILD = $(COMPILE.cc) $(PIC) -o $(VSHDIR)$*.so $<
 PRELIB  = @true
 
-# Test for template  instantiation, add to SOFLAGS if SONAME set,
+# Test for template instantiation, add to SOFLAGS if SONAME set,
 # add -E to LDFLAGS if using GNU ld
 #
 include $(ACE_ROOT)/include/makeinclude/platform_g++_common.GNU


### PR DESCRIPTION
    * ACE/include/makeinclude/platform_g++_common.GNU: