### PR TITLE
macOS: sizeof long double is different on ARM64

### DIFF
--- a/ACE/ace/config-macosx-leopard.h
+++ b/ACE/ace/config-macosx-leopard.h
@@ -16,7 +16,7 @@
 #endif /* ! __ACE_INLINE__ */
 
 #if !defined (ACE_SIZEOF_LONG_DOUBLE)
-#  define ACE_SIZEOF_LONG_DOUBLE 16
+#  define ACE_SIZEOF_LONG_DOUBLE __SIZEOF_LONG_DOUBLE__
 #endif // ACE_SIZEOF_LONG_DOUBLE
 
 #if defined (__GNUG__)

--- a/ACE/ace/config-macosx-tiger.h
+++ b/ACE/ace/config-macosx-tiger.h
@@ -9,7 +9,7 @@
 #endif /* ! __ACE_INLINE__ */
 
 #if !defined (ACE_SIZEOF_LONG_DOUBLE)
-#  define ACE_SIZEOF_LONG_DOUBLE 16
+#  define ACE_SIZEOF_LONG_DOUBLE __SIZEOF_LONG_DOUBLE__
 #endif // ACE_SIZEOF_LONG_DOUBLE
 
 #if defined (__GNUG__)


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly