### PR TITLE
Fixed a race condition caused by the double checked locking pattern

### DIFF
--- a/ACE/ace/Barrier.cpp
+++ b/ACE/ace/Barrier.cpp
@@ -78,11 +78,10 @@ ACE_Barrier::wait ()
   ACE_TRACE ("ACE_Barrier::wait");
   ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, -1);
 
-  ACE_Sub_Barrier *sbp =
-    this->sub_barrier_[this->current_generation_];
+  ACE_Sub_Barrier *sbp = this->sub_barrier_[this->current_generation_];
 
   // Check for shutdown...
-  if (sbp == 0)
+  if (sbp == nullptr)
     {
       errno = ESHUTDOWN;
       return -1;
@@ -127,19 +126,18 @@ ACE_Barrier::shutdown ()
   ACE_TRACE ("ACE_Barrier::shutdown");
   ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, -1);
 
-  ACE_Sub_Barrier *sbp =
-    this->sub_barrier_[this->current_generation_];
+  ACE_Sub_Barrier *sbp = this->sub_barrier_[this->current_generation_];
 
   // Check for shutdown...
-  if (sbp == 0)
+  if (sbp == nullptr)
     {
       errno = ESHUTDOWN;
       return -1;
     }
 
   // Flag the shutdown
-  this->sub_barrier_[0] = 0;
-  this->sub_barrier_[1] = 0;
+  this->sub_barrier_[0] = nullptr;
+  this->sub_barrier_[1] = nullptr;
   // Tell all the threads waiting on the barrier to continue on their way.
   sbp->running_threads_ = this->count_;
   sbp->barrier_finished_.broadcast ();

--- a/ACE/ace/Future.cpp
+++ b/ACE/ace/Future.cpp
@@ -20,28 +20,8 @@ ACE_ALLOC_HOOK_DEFINE_Tc(ACE_Future_Rep)
 ACE_ALLOC_HOOK_DEFINE_Tc(ACE_Future)
 
 template <class T>
-ACE_Future_Holder<T>::ACE_Future_Holder ()
-{
-}
-
-template <class T>
 ACE_Future_Holder<T>::ACE_Future_Holder (const ACE_Future<T> &item)
   : item_ (item)
-{
-}
-
-template <class T>
-ACE_Future_Holder<T>::~ACE_Future_Holder ()
-{
-}
-
-template <class T>
-ACE_Future_Observer<T>::ACE_Future_Observer ()
-{
-}
-
-template <class T>
-ACE_Future_Observer<T>::~ACE_Future_Observer ()
 {
 }
 
@@ -74,10 +54,10 @@ ACE_Future_Rep<T>::dump () const
 template <class T> ACE_Future_Rep<T> *
 ACE_Future_Rep<T>::internal_create ()
 {
-  ACE_Future_Rep<T> *temp = 0;
+  ACE_Future_Rep<T> *temp {};
   ACE_NEW_RETURN (temp,
                   ACE_Future_Rep<T> (),
-                  0);
+                  nullptr);
   return temp;
 }
 
@@ -95,9 +75,9 @@ ACE_Future_Rep<T>::create ()
 template <class T> ACE_Future_Rep<T> *
 ACE_Future_Rep<T>::attach (ACE_Future_Rep<T>*& rep)
 {
-  ACE_ASSERT (rep != 0);
+  ACE_ASSERT (rep != nullptr);
   // Use value_ready_mutex_ for both condition and ref count management
-  ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, r_mon, rep->value_ready_mutex_, 0);
+  ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, r_mon, rep->value_ready_mutex_, nullptr);
   ++rep->ref_count_;
   return rep;
 }
@@ -105,7 +85,7 @@ ACE_Future_Rep<T>::attach (ACE_Future_Rep<T>*& rep)
 template <class T> void
 ACE_Future_Rep<T>::detach (ACE_Future_Rep<T>*& rep)
 {
-  ACE_ASSERT (rep != 0);
+  ACE_ASSERT (rep != nullptr);
   // Use value_ready_mutex_ for both condition and ref count management
   ACE_GUARD (ACE_SYNCH_RECURSIVE_MUTEX, r_mon, rep->value_ready_mutex_);
 
@@ -122,8 +102,8 @@ ACE_Future_Rep<T>::detach (ACE_Future_Rep<T>*& rep)
 template <class T> void
 ACE_Future_Rep<T>::assign (ACE_Future_Rep<T>*& rep, ACE_Future_Rep<T>* new_rep)
 {
-  ACE_ASSERT (rep != 0);
-  ACE_ASSERT (new_rep != 0);
+  ACE_ASSERT (rep != nullptr);
+  ACE_ASSERT (new_rep != nullptr);
   // Use value_ready_mutex_ for both condition and ref count management
   ACE_GUARD (ACE_SYNCH_RECURSIVE_MUTEX, r_mon, rep->value_ready_mutex_);
 
@@ -143,9 +123,7 @@ ACE_Future_Rep<T>::assign (ACE_Future_Rep<T>*& rep, ACE_Future_Rep<T>* new_rep)
 
 template <class T>
 ACE_Future_Rep<T>::ACE_Future_Rep ()
-  : value_ (0),
-    ref_count_ (0),
-    value_ready_ (value_ready_mutex_)
+  : value_ready_ (value_ready_mutex_)
 {
 }
 
@@ -158,7 +136,7 @@ ACE_Future_Rep<T>::~ACE_Future_Rep ()
 template <class T> int
 ACE_Future_Rep<T>::ready () const
 {
-  return this->value_ != 0;
+  return this->value_ != nullptr;
 }
 
 template <class T> int
@@ -166,7 +144,7 @@ ACE_Future_Rep<T>::set (const T &r,
                         ACE_Future<T> &caller)
 {
   // If the value is already produced, ignore it...
-  if (this->value_ == 0)
+  if (this->value_ == nullptr)
     {
       ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX,
                         ace_mon,
@@ -175,18 +153,15 @@ ACE_Future_Rep<T>::set (const T &r,
       // Otherwise, create a new result value.  Note the use of the
       // Double-checked locking pattern to avoid multiple allocations.
 
-      if (this->value_ == 0)       // Still no value, so proceed
+      if (this->value_ == nullptr)       // Still no value, so proceed
         {
           ACE_NEW_RETURN (this->value_,
                           T (r),
                           -1);
 
           // Remove and notify all subscribed observers.
-          typename OBSERVER_COLLECTION::iterator iterator =
-            this->observer_collection_.begin ();
-
-          typename OBSERVER_COLLECTION::iterator end =
-            this->observer_collection_.end ();
+          typename OBSERVER_COLLECTION::iterator iterator = this->observer_collection_.begin ();
+          typename OBSERVER_COLLECTION::iterator end = this->observer_collection_.end ();
 
           while (iterator != end)
             {
@@ -210,7 +185,7 @@ ACE_Future_Rep<T>::get (T &value,
                         ACE_Time_Value *tv) const
 {
   // If the value is already produced, return it.
-  if (this->value_ == 0)
+  if (this->value_ == nullptr)
     {
       ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, ace_mon,
                         this->value_ready_mutex_,
@@ -218,7 +193,7 @@ ACE_Future_Rep<T>::get (T &value,
       // If the value is not yet defined we must block until the
       // producer writes to it.
 
-      while (this->value_ == 0)
+      while (this->value_ == nullptr)
         // Perform a timed wait.
         if (this->value_ready_.wait (tv) == -1)
           return -1;
@@ -242,7 +217,7 @@ ACE_Future_Rep<T>::attach (ACE_Future_Observer<T> *observer,
   int result = 1;
 
   // If the value is already produced, then notify observer
-  if (this->value_ == 0)
+  if (this->value_ == nullptr)
     result = this->observer_collection_.insert (observer);
   else
     observer->update (caller);
@@ -264,7 +239,7 @@ template <class T>
 ACE_Future_Rep<T>::operator T ()
 {
   // If the value is already produced, return it.
-  if (this->value_ == 0)
+  if (this->value_ == nullptr)
     {
       // Constructor of ace_mon acquires the mutex.
       ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, ace_mon, this->value_ready_mutex_, 0);
@@ -274,7 +249,7 @@ ACE_Future_Rep<T>::operator T ()
 
       // Wait ``forever.''
 
-      while (this->value_ == 0)
+      while (this->value_ == nullptr)
         if (this->value_ready_.wait () == -1)
           // What to do in this case since we've got to indicate
           // failure somehow?  Exceptions would be nice, but they're
@@ -356,8 +331,7 @@ ACE_Future<T>::ready () const
 }
 
 template <class T> int
-ACE_Future<T>::get (T &value,
-                    ACE_Time_Value *tv) const
+ACE_Future<T>::get (T &value, ACE_Time_Value *tv) const
 {
   // We return the ACE_Future_rep.
   return this->future_rep_->get (value, tv);

--- a/ACE/ace/Future.h
+++ b/ACE/ace/Future.h
@@ -197,7 +197,7 @@ private:
   int ready () const;
 
   /// Pointer to the result.
-  T *value_;
+  std::atomic<T*> value_;
 
   /// Reference count.
   int ref_count_;

--- a/ACE/ace/Future.h
+++ b/ACE/ace/Future.h
@@ -16,6 +16,7 @@
 
 #include /**/ "ace/pre.h"
 
+#include <atomic>
 #include "ace/Unbounded_Set.h"
 #include "ace/Strategies_T.h"
 

--- a/ACE/ace/Future.h
+++ b/ACE/ace/Future.h
@@ -48,15 +48,13 @@ class ACE_Future_Holder
 {
 public:
   ACE_Future_Holder (const ACE_Future<T> &future);
-  ~ACE_Future_Holder ();
+  ~ACE_Future_Holder () = default;
+  ACE_Future_Holder () = delete;
 
   /// Declare the dynamic allocation hooks.
   ACE_ALLOC_HOOK_DECLARE;
 
   ACE_Future<T> item_;
-
-protected:
-  ACE_Future_Holder ();
 };
 
 /**
@@ -74,7 +72,7 @@ class ACE_Future_Observer
 {
 public:
   /// Destructor
-  virtual ~ACE_Future_Observer ();
+  virtual ~ACE_Future_Observer () = default;
 
   /// Called by the ACE_Future in which we are subscribed to when
   /// its value is written to.
@@ -85,7 +83,7 @@ public:
 
 protected:
   /// Constructor
-  ACE_Future_Observer ();
+  ACE_Future_Observer () = default;
 };
 
 /**
@@ -198,10 +196,10 @@ private:
   int ready () const;
 
   /// Pointer to the result.
-  std::atomic<T*> value_;
+  std::atomic<T*> value_ {};
 
   /// Reference count.
-  int ref_count_;
+  int ref_count_ {};
 
   typedef ACE_Future_Observer<T> OBSERVER;
 

--- a/ACE/ace/Future_Set.cpp
+++ b/ACE/ace/Future_Set.cpp
@@ -59,14 +59,13 @@ ACE_Future_Set<T>::is_empty () const
 template <class T> int
 ACE_Future_Set<T>::insert (ACE_Future<T> &future)
 {
-  FUTURE_HOLDER *future_holder;
+  FUTURE_HOLDER *future_holder {};
   ACE_NEW_RETURN (future_holder,
                   FUTURE_HOLDER (future),
                   -1);
 
   FUTURE_REP *future_rep = future.get_rep ();
-  int result = this->future_map_.bind (future_rep,
-                                       future_holder);
+  int const result = this->future_map_.bind (future_rep, future_holder);
 
   // If a new map entry was created, then attach to the future,
   // otherwise we were already attached to the future or some error
@@ -83,7 +82,7 @@ ACE_Future_Set<T>::insert (ACE_Future<T> &future)
 template <class T> void
 ACE_Future_Set<T>::update (const ACE_Future<T> &future)
 {
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
   FUTURE &local_future = const_cast<ACE_Future<T> &> (future);
 
   ACE_NEW (mb,
@@ -100,12 +99,11 @@ ACE_Future_Set<T>::next_readable (ACE_Future<T> &future,
   if (this->is_empty ())
     return 0;
 
-  ACE_Message_Block *mb = 0;
-  FUTURE_REP *future_rep = 0;
+  ACE_Message_Block *mb = nullptr;
+  FUTURE_REP *future_rep = nullptr;
 
   // Wait for a "readable future" signal from the message queue.
-  if (this->future_notification_queue_->dequeue_head (mb,
-                                                      tv) != -1)
+  if (this->future_notification_queue_->dequeue_head (mb, tv) != -1)
     {
       // Extract future rep from the message block.
       future_rep = reinterpret_cast<FUTURE_REP *> (mb->base ());
@@ -117,9 +115,8 @@ ACE_Future_Set<T>::next_readable (ACE_Future<T> &future,
     return 0;
 
   // Remove the hash map entry with the specified future rep from our map.
-  FUTURE_HOLDER *future_holder = 0;
-  if (this->future_map_.find (future_rep,
-                              future_holder) != -1)
+  FUTURE_HOLDER *future_holder = nullptr;
+  if (this->future_map_.find (future_rep, future_holder) != -1)
     {
       future = future_holder->item_;
       this->future_map_.unbind (future_rep);

--- a/ACE/tests/Future_Stress_Test.cpp
+++ b/ACE/tests/Future_Stress_Test.cpp
@@ -3,10 +3,10 @@
 /**
  *  @file    Future_Stress_Test.cpp
  *
- *  This example tests the ACE Future set() and get() operations in 
+ *  This example tests the ACE Future set() and get() operations in
  *  multithreaded environment and concurrent access.
  *
- *  Usage: Future_Stress_Test [-t <duration in seconds>]   
+ *  Usage: Future_Stress_Test [-t <duration in seconds>]
  *            [-n <number of threads>]
  *
  *  @see https://github.com/DOCGroup/ACE_TAO/issues/2163
@@ -45,11 +45,11 @@ void* worker (void* args)
 
 void* runner (void* args)
 {
-  ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner start\n")));      
+  ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner start\n")));
 
   std::random_device              rd;
   std::mt19937                    gen(rd());
-  std::uniform_int_distribution<> dis(1,1000000);  
+  std::uniform_int_distribution<> dis(1,1000000);
   ACE_Time_Value* duration = static_cast<ACE_Time_Value*>(args);
   ACE_Countdown_Time timer(duration);
   timer.start();
@@ -58,17 +58,17 @@ void* runner (void* args)
   {
     if( ++runNum % 5000 == 0 )
     {
-      ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner iteration %u\n"), runNum));      
+      ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner iteration %u\n"), runNum));
     }
     ACE_Future<int> result;
     Worker_Config config;
     config.a = dis(gen);
     config.b = dis(gen);
-    config.c = dis(gen);    
+    config.c = dis(gen);
     config.result = result;
     ACE_hthread_t thread_id;
     int expected_res = config.a+config.b*config.c;
-    int actual_res = -1;    
+    int actual_res = -1;
     if (ACE_Thread::spawn((ACE_THR_FUNC)worker,
                         (void *)&config, THR_NEW_LWP | THR_JOINABLE, 0,
                         &thread_id) == -1)
@@ -82,13 +82,13 @@ void* runner (void* args)
       // hit the bug...
       ACE_ERROR ((LM_INFO,
           ACE_TEXT ("unexpected ACE_Future result\n")));
-      abort(); 
-    } 
+      abort();
+    }
     ACE_THR_FUNC_RETURN status;
     ACE_Thread::join(thread_id, &status);
     timer.update();
   } while( *duration != ACE_Time_Value::zero );
-   ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner done\n"), runNum));        
+   ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner done\n"), runNum));
 
    return 0;
 }
@@ -97,7 +97,7 @@ int
 run_main (int argc, ACE_TCHAR *argv[])
 {
   ACE_START_TEST (ACE_TEXT ("Future_Stress_Test"));
-   
+
   ACE_Time_Value duration(5);
   long n_threads = 5;
 
@@ -122,17 +122,17 @@ run_main (int argc, ACE_TCHAR *argv[])
         valid = false;
         break;
     }
-  }  
+  }
 
   if (valid)
   {
-    ACE_Thread_Manager::instance ()->spawn_n (n_threads, 
+    ACE_Thread_Manager::instance ()->spawn_n (n_threads,
       ACE_THR_FUNC (runner),
       (void *) &duration,
       THR_NEW_LWP | THR_DETACHED);
 
     ACE_Thread_Manager::instance ()->wait ();
-    ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) All threads finished, cleanup and exit\n")));   
+    ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) All threads finished, cleanup and exit\n")));
   }
   ACE_END_TEST;
   return 0;

--- a/ACE/tests/Future_Stress_Test.cpp
+++ b/ACE/tests/Future_Stress_Test.cpp
@@ -1,0 +1,148 @@
+
+//=============================================================================
+/**
+ *  @file    Future_Stress_Test.cpp
+ *
+ *  This example tests the ACE Future set() and get() operations in 
+ *  multithreaded environment and concurrent access.
+ *
+ *  Usage: Future_Stress_Test [-t <duration in seconds>]   
+ *            [-n <number of threads>]
+ *
+ *  @see https://github.com/DOCGroup/ACE_TAO/issues/2163
+ *
+ *  @author Andres Kruse <Frank.Hilliger@cs-sol.de>
+ */
+//=============================================================================
+
+#include "test_config.h"
+#include <ace/Time_Value.h>
+#include <ace/Countdown_Time.h>
+#include <ace/Future.h>
+#include <ace/Get_Opt.h>
+
+#include <random>
+
+
+#if defined (ACE_HAS_THREADS)
+
+struct Worker_Config
+{
+  int a;
+  int b;
+  int c;
+  ACE_Future<int> result;
+};
+
+void* worker (void* args)
+{
+  Worker_Config* config = static_cast<Worker_Config*>(args);
+  int r = config->a + config->b * config->c;
+  config->result.set(r);
+
+  return 0;
+}
+
+void* runner (void* args)
+{
+  ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner start\n")));      
+
+  std::random_device              rd;
+  std::mt19937                    gen(rd());
+  std::uniform_int_distribution<> dis(1,1000000);  
+  ACE_Time_Value* duration = static_cast<ACE_Time_Value*>(args);
+  ACE_Countdown_Time timer(duration);
+  timer.start();
+  uint64_t runNum = 0;
+  do
+  {
+    if( ++runNum % 5000 == 0 )
+    {
+      ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner iteration %u\n"), runNum));      
+    }
+    ACE_Future<int> result;
+    Worker_Config config;
+    config.a = dis(gen);
+    config.b = dis(gen);
+    config.c = dis(gen);    
+    config.result = result;
+    ACE_hthread_t thread_id;
+    int expected_res = config.a+config.b*config.c;
+    int actual_res = -1;    
+    if (ACE_Thread::spawn((ACE_THR_FUNC)worker,
+                        (void *)&config, THR_NEW_LWP | THR_JOINABLE, 0,
+                        &thread_id) == -1)
+    {
+        ACE_ERROR ((LM_INFO,
+              ACE_TEXT ("worker thread spawn failed\n")));
+    }
+    result.get(actual_res);
+    if( actual_res != expected_res )
+    {
+      // hit the bug...
+      ACE_ERROR ((LM_INFO,
+          ACE_TEXT ("unexpected ACE_Future result\n")));
+      abort(); 
+    } 
+    ACE_THR_FUNC_RETURN status;
+    ACE_Thread::join(thread_id, &status);
+    timer.update();
+  } while( *duration != ACE_Time_Value::zero );
+   ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) runner done\n"), runNum));        
+
+   return 0;
+}
+
+int
+run_main (int argc, ACE_TCHAR *argv[])
+{
+  ACE_START_TEST (ACE_TEXT ("Future_Stress_Test"));
+   
+  ACE_Time_Value duration(5);
+  long n_threads = 5;
+
+  ACE_Get_Opt getopt (argc, argv, ACE_TEXT ("t:n:"));
+  bool valid = true;
+  int c;
+  while ((c = getopt ()) != -1 && valid)
+  {
+  //FUZZ: enable check_for_lack_ACE_OS
+    switch (c)
+    {
+      case 't':
+        duration.set(ACE_OS::atoi (getopt.opt_arg ()));
+        break;
+      case 'n':
+        n_threads = ACE_OS::atoi (getopt.opt_arg ());
+        break;
+      default:
+        ACE_ERROR ((LM_ERROR,
+                    "Usage: Future_Stress_Test [-t <duration in seconds>]"
+                    "\t[-n <number of threads>]\n"));
+        valid = false;
+        break;
+    }
+  }  
+
+  if (valid)
+  {
+    ACE_Thread_Manager::instance ()->spawn_n (n_threads, 
+      ACE_THR_FUNC (runner),
+      (void *) &duration,
+      THR_NEW_LWP | THR_DETACHED);
+
+    ACE_Thread_Manager::instance ()->wait ();
+    ACE_DEBUG ((LM_DEBUG, ACE_TEXT ("(%t) All threads finished, cleanup and exit\n")));   
+  }
+  ACE_END_TEST;
+  return 0;
+}
+
+#else
+int
+run_main (int, ACE_TCHAR *[])
+{
+  ACE_ERROR ((LM_INFO,
+              ACE_TEXT ("threads not supported on this platform\n")));
+}
+#endif /* ACE_HAS_THREADS */

--- a/ACE/tests/Future_Stress_Test.cpp
+++ b/ACE/tests/Future_Stress_Test.cpp
@@ -70,7 +70,7 @@ void* runner (void* args)
     int expected_res = config.a+config.b*config.c;
     int actual_res = -1;
     if (ACE_Thread::spawn((ACE_THR_FUNC)worker,
-                        (void *)&config, THR_NEW_LWP | THR_JOINABLE, 0,
+                        static_cast<void*>(&config), THR_NEW_LWP | THR_JOINABLE, 0,
                         &thread_id) == -1)
     {
         ACE_ERROR ((LM_INFO,
@@ -128,7 +128,7 @@ run_main (int argc, ACE_TCHAR *argv[])
   {
     ACE_Thread_Manager::instance ()->spawn_n (n_threads,
       ACE_THR_FUNC (runner),
-      (void *) &duration,
+      static_cast<void*>(&duration),
       THR_NEW_LWP | THR_DETACHED);
 
     ACE_Thread_Manager::instance ()->wait ();

--- a/ACE/tests/run_test.lst
+++ b/ACE/tests/run_test.lst
@@ -127,6 +127,7 @@ FIFO_Test: !ACE_FOR_TAO
 Framework_Component_Test: !STATIC !nsk
 Future_Set_Test: !nsk !ACE_FOR_TAO
 Future_Test: !nsk !ACE_FOR_TAO
+Future_Stress_Test: !nsk !ACE_FOR_TAO
 Get_Opt_Test
 Handle_Set_Test: !ACE_FOR_TAO
 Hash_Map_Bucket_Iterator_Test

--- a/ACE/tests/tests.mpc
+++ b/ACE/tests/tests.mpc
@@ -960,6 +960,14 @@ project(Future Set Test) : acetest {
   }
 }
 
+project(Future Stress Test) : acetest {
+  avoids += ace_for_tao
+  exename = Future_Stress_Test
+  Source_Files {
+    Future_Stress_Test.cpp
+  }
+}
+
 project(Get Opt Test) : acetest {
   exename = Get_Opt_Test
   Source_Files {


### PR DESCRIPTION
Fixed a race condition caused by the double checked locking pattern by using an std::atomic that ensures correct and deterministic create and assignment logic.
Issue #2163 