### PR TITLE
Remove workaround for obsolete compiler

### DIFF
--- a/ACE/tests/Compiler_Features_27_Test.cpp
+++ b/ACE/tests/Compiler_Features_27_Test.cpp
@@ -22,11 +22,8 @@ run_main (int, ACE_TCHAR *[])
 {
   ACE_START_TEST (ACE_TEXT("Compiler_Features_27_Test"));
 
-  // Visual Studio 2015 has a small issue with this construct
-#if !(defined (_MSC_VER) && (_MSC_VER < 1910))
   Foo any;
   any <<= std::move("abc");
-#endif
 
   ACE_END_TEST;
 


### PR DESCRIPTION
    * ACE/tests/Compiler_Features_27_Test.cpp: