### PR TITLE
[ACE 6] Avoid potential out-of-bounds read in ACE_CDR::Fixed::from_string

### DIFF
--- a/ACE/ace/CDR_Base.cpp
+++ b/ACE/ace/CDR_Base.cpp
@@ -935,7 +935,7 @@ ACE_CDR::Fixed ACE_CDR::Fixed::from_string (const char *str)
       ++f.digits_;
     }
 
-  if (!f.scale_ && str[span - f.digits_ - 1] == '.')
+  if (!f.scale_ && span > f.digits_ && str[span - f.digits_ - 1] == '.')
     f.scale_ = f.digits_;
 
   if (idx >= 0)


### PR DESCRIPTION
Found this bug during development of OpenDDS/OpenDDS#4466
Existing test cases cover it, but need valgrind/asan to report the error