### PR TITLE
Fixed typos

### DIFF
--- a/ACE/ace/Configuration.h
+++ b/ACE/ace/Configuration.h
@@ -349,7 +349,7 @@ public:
    * error The path consists of sections separated by the backslash
    * '\' or forward slash '/'.
    * Returns 0 on success, -1 if <create) is 0 and the path refers
-   * a nonexistant section
+   * a non-existent section
    */
   int expand_path (const ACE_Configuration_Section_Key& key,
                    const ACE_TString& path_in,

--- a/ACE/protocols/tests/HTBP/Reactor_Tests/test_config.h
+++ b/ACE/protocols/tests/HTBP/Reactor_Tests/test_config.h
@@ -96,7 +96,7 @@ const size_t ACE_MAX_THREADS = 4;
 
 #if defined (VXWORKS)
 // This is the only way I could figure out to avoid an error
-// about attempting to unlink a non-existant file.
+// about attempting to unlink a non-existent file.
 #define ACE_INIT_LOG(NAME) \
   ACE_TCHAR temp[MAXPATHLEN]; \
   ACE_OS::sprintf (temp, ACE_TEXT ("%s%s%s"), \
@@ -198,7 +198,7 @@ ACE_Test_Output::set_output (const ACE_TCHAR *filename, int append)
 #if defined (VXWORKS)
   // This is the only way I could figure out to avoid a console
   // warning about opening an existing file (w/o O_CREAT), or
-  // attempting to unlink a non-existant one.
+  // attempting to unlink a non-existent one.
   ACE_HANDLE fd = ACE_OS::open (temp,
                                 O_WRONLY|O_CREAT,
                                 S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);

--- a/ACE/tests/Test_Output.cpp
+++ b/ACE/tests/Test_Output.cpp
@@ -110,7 +110,7 @@ ACE_Test_Output::set_output (const ACE_TCHAR *filename, int append)
 #if defined (ACE_VXWORKS)
   // This is the only way I could figure out to avoid a console
   // warning about opening an existing file (w/o O_CREAT), or
-  // attempting to unlink a non-existant one.
+  // attempting to unlink a non-existent one.
   ACE_HANDLE fd = ACE_OS::open (temp,
                                 O_WRONLY|O_CREAT,
                                 S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);

--- a/TAO/orbsvcs/tests/HTIOP/AMI/Test_Output.cpp
+++ b/TAO/orbsvcs/tests/HTIOP/AMI/Test_Output.cpp
@@ -99,7 +99,7 @@ ACE_Test_Output::set_output (const ACE_TCHAR *filename, int append)
 #if defined (VXWORKS)
   // This is the only way I could figure out to avoid a console
   // warning about opening an existing file (w/o O_CREAT), or
-  // attempting to unlink a non-existant one.
+  // attempting to unlink a non-existent one.
   ACE_HANDLE fd = ACE_OS::open (temp,
                                 O_WRONLY|O_CREAT,
                                 S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);

--- a/TAO/orbsvcs/tests/HTIOP/BiDirectional/Test_Output.cpp
+++ b/TAO/orbsvcs/tests/HTIOP/BiDirectional/Test_Output.cpp
@@ -99,7 +99,7 @@ ACE_Test_Output::set_output (const ACE_TCHAR *filename, int append)
 #if defined (VXWORKS)
   // This is the only way I could figure out to avoid a console
   // warning about opening an existing file (w/o O_CREAT), or
-  // attempting to unlink a non-existant one.
+  // attempting to unlink a non-existent one.
   ACE_HANDLE fd = ACE_OS::open (temp,
                                 O_WRONLY|O_CREAT,
                                 S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);

--- a/TAO/orbsvcs/tests/HTIOP/Hello/Test_Output.cpp
+++ b/TAO/orbsvcs/tests/HTIOP/Hello/Test_Output.cpp
@@ -99,7 +99,7 @@ ACE_Test_Output::set_output (const ACE_TCHAR *filename, int append)
 #if defined (VXWORKS)
   // This is the only way I could figure out to avoid a console
   // warning about opening an existing file (w/o O_CREAT), or
-  // attempting to unlink a non-existant one.
+  // attempting to unlink a non-existent one.
   ACE_HANDLE fd = ACE_OS::open (temp,
                                 O_WRONLY|O_CREAT,
                                 S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);

--- a/TAO/tao/PI/PICurrent_Impl.cpp
+++ b/TAO/tao/PI/PICurrent_Impl.cpp
@@ -150,7 +150,7 @@ TAO::PICurrent_Impl::~PICurrent_Impl ()
     this->impending_change_callback_->convert_from_lazy_to_real_copy ();
 
   // If we have logically copied another table, ensure it is told about our
-  // demise so that it will not call our non-existant
+  // demise so that it will not call our non-existent
   // convert_from_lazy_to_real_copy() when it changes/destructs.
   if (0 != this->lazy_copy_)
     this->lazy_copy_->set_callback_for_impending_change (0);

--- a/TAO/tests/POA/FindPOA/FindPOA.cpp
+++ b/TAO/tests/POA/FindPOA/FindPOA.cpp
@@ -64,7 +64,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
       poa_manager->activate ();
 
-      // Try to find a non-existant POA.  Since the Adapter Activator
+      // Try to find a non-existent POA.  Since the Adapter Activator
       // has not been installed yet, this call should fail.
       find_non_existant_POA (root_poa.in (),
                              "firstPOA",
@@ -88,7 +88,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         first_poa->find_POA (name.c_str (),
                              1);
 
-      // Try to find a non-existant POA.  Even though the Adapter
+      // Try to find a non-existent POA.  Even though the Adapter
       // Activator has been installed, this call should fail because
       // the activate (if not found) flag is 0.
       find_non_existant_POA (root_poa.in (),


### PR DESCRIPTION
    * ACE/ace/Configuration.h:
    * ACE/protocols/tests/HTBP/Reactor_Tests/test_config.h:
    * ACE/tests/Test_Output.cpp:
    * TAO/orbsvcs/tests/HTIOP/AMI/Test_Output.cpp:
    * TAO/orbsvcs/tests/HTIOP/BiDirectional/Test_Output.cpp:
    * TAO/orbsvcs/tests/HTIOP/Hello/Test_Output.cpp:
    * TAO/tao/PI/PICurrent_Impl.cpp:
    * TAO/tests/POA/FindPOA/FindPOA.cpp: