### PR TITLE
Reset ACE_Process_Options std handles after closed

### DIFF
--- a/ACE/ace/Process.cpp
+++ b/ACE/ace/Process.cpp
@@ -1121,10 +1121,18 @@ ACE_Process_Options::release_handles ()
       ACE_OS::close (startup_info_.hStdInput);
       ACE_OS::close (startup_info_.hStdOutput);
       ACE_OS::close (startup_info_.hStdError);
+
+      startup_info_.hStdInput = ACE_INVALID_HANDLE;
+      startup_info_.hStdOutput = ACE_INVALID_HANDLE;
+      startup_info_.hStdError = ACE_INVALID_HANDLE;
 #else /* ACE_WIN32 */
       ACE_OS::close (stdin_);
       ACE_OS::close (stdout_);
       ACE_OS::close (stderr_);
+
+      stdin_ = ACE_INVALID_HANDLE;
+      stdout_ = ACE_INVALID_HANDLE;
+      stderr_ = ACE_INVALID_HANDLE;
 #endif /* ACE_WIN32 */
       set_handles_called_ = 0;
     }


### PR DESCRIPTION
When calling `ACE_Process_Options::release_handles` after `ACE_Process::spawn` , std handles must be reset after closed to **avoid** closing again in `ACE_Process_Options` dtor.