### PR TITLE
Changed the default to C++17 for QNX and g++ versions older as 11 (11…

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,9 @@
 USER VISIBLE CHANGES BETWEEN ACE-7.1.3 and ACE-7.1.4
 ====================================================
 
+. With g++ versions < 11 we default to C++17 as
+  minimum C++ standards level
+
 USER VISIBLE CHANGES BETWEEN ACE-7.1.2 and ACE-7.1.3
 ====================================================
 

--- a/ACE/include/makeinclude/platform_g++_common.GNU
+++ b/ACE/include/makeinclude/platform_g++_common.GNU
@@ -74,6 +74,20 @@ endif
 
 CXX_FULL_VERSION := $(shell $(CXX_FOR_VERSION_TEST) --version)
 
+# Minimum C++ level is now C++17, gcc until version 11 have an older version as default
+ifeq ($(findstring $(CXX_MAJOR_VERSION),7),$(CXX_MAJOR_VERSION))
+  c++std ?= c++17
+endif
+ifeq ($(findstring $(CXX_MAJOR_VERSION),8),$(CXX_MAJOR_VERSION))
+  c++std ?= c++17
+endif
+ifeq ($(findstring $(CXX_MAJOR_VERSION),9),$(CXX_MAJOR_VERSION))
+  c++std ?= c++17
+endif
+ifeq ($(findstring $(CXX_MAJOR_VERSION),10),$(CXX_MAJOR_VERSION))
+  c++std ?= c++17
+endif
+
 # Only modify LDFLAGS if DLD has been set.
 ifneq ($(DLD),)
   ifeq ($(DLD),$(CXX_FOR_VERSION_TEST)) # only try this is we are using ld through gcc

--- a/ACE/include/makeinclude/platform_qnx_gcc.GNU
+++ b/ACE/include/makeinclude/platform_qnx_gcc.GNU
@@ -6,7 +6,7 @@ debug ?= 1
 optimize ?= 0
 threads ?= 1
 pipes ?= 0
-c++std ?= gnu++14
+c++std ?= gnu++17
 
 CCFLAGS += -fexceptions
 LDFLAGS += -fexceptions


### PR DESCRIPTION
… has C++17 as default)

    * ACE/include/makeinclude/platform_g++_common.GNU:
    * ACE/include/makeinclude/platform_qnx_gcc.GNU: