### PR TITLE
C++17 is the minimum required C++ level to compile ACE/TAO after this PR

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,8 +40,9 @@ jobs:
     - name: checkout MPC
       uses: actions/checkout@v4
       with:
-        repository: DOCGroup/MPC
+        repository: jwillemsen/MPC
         path: ${{ env.MPC_ROOT }}
+        ref: jwi-cmakelanguagestandard
     - name: Add Repo
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,9 +40,8 @@ jobs:
     - name: checkout MPC
       uses: actions/checkout@v4
       with:
-        repository: jwillemsen/MPC
+        repository: DOCGroup/MPC
         path: ${{ env.MPC_ROOT }}
-        ref: jwi-cmakelanguagestandard
     - name: Add Repo
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,6 +120,12 @@ jobs:
             Repo: llvm-toolchain-$(lsb_release -cs)-15
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
             os: ubuntu-22.04
+          - CC: clang-16
+            CXX: clang++-16
+            PackageDeps: clang-16
+            Repo: llvm-toolchain-$(lsb_release -cs)-16
+            platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
+            os: ubuntu-22.04
           - feature: CORBA/e micro
             CC: gcc-10
             CXX: g++-10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -230,6 +230,10 @@ jobs:
       with:
         languages: cpp
       if: matrix.feature == 'CodeQL'
+    - name: Print compiler version
+      run: |
+        ${env:CXX} -dumpversion
+      shell: pwsh
     - name: Run mwc.pl on $(TAO_ROOT)/TAO_ACE.mwc
       run: |
         perl ${env:ACE_ROOT}/bin/mwc.pl -type gnuace ${env:TAO_ROOT}/TAO_ACE.mwc -workers 4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -232,8 +232,7 @@ jobs:
       if: matrix.feature == 'CodeQL'
     - name: Print compiler version
       run: |
-        ${env:CXX} -dumpversion
-      shell: pwsh
+        ${{ matrix.CXX }} -dumpversion
     - name: Run mwc.pl on $(TAO_ROOT)/TAO_ACE.mwc
       run: |
         perl ${env:ACE_ROOT}/bin/mwc.pl -type gnuace ${env:TAO_ROOT}/TAO_ACE.mwc -workers 4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -230,9 +230,6 @@ jobs:
       with:
         languages: cpp
       if: matrix.feature == 'CodeQL'
-    - name: Print compiler version
-      run: |
-        ${{ matrix.CXX }} -dumpversion
     - name: Run mwc.pl on $(TAO_ROOT)/TAO_ACE.mwc
       run: |
         perl ${env:ACE_ROOT}/bin/mwc.pl -type gnuace ${env:TAO_ROOT}/TAO_ACE.mwc -workers 4

--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,4 +1,4 @@
-USER VISIBLE CHANGES BETWEEN ACE-7.1.4 and ACE-7.1.5
+SER VISIBLE CHANGES BETWEEN ACE-7.1.4 and ACE-7.2.0
 ====================================================
 
 . ACE/TAO now require C++17 or newer

--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,10 @@
 USER VISIBLE CHANGES BETWEEN ACE-7.1.4 and ACE-7.1.5
 ====================================================
 
+. ACE/TAO now require C++17 or newer
+
+. Add support for Embarcadero C++ Builder bcc64x compiler
+
 USER VISIBLE CHANGES BETWEEN ACE-7.1.3 and ACE-7.1.4
 ====================================================
 

--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,4 +1,4 @@
-SER VISIBLE CHANGES BETWEEN ACE-7.1.4 and ACE-7.2.0
+USER VISIBLE CHANGES BETWEEN ACE-7.1.4 and ACE-7.2.0
 ====================================================
 
 . ACE/TAO now require C++17 or newer

--- a/ACE/ace/Global_Macros.h
+++ b/ACE/ace/Global_Macros.h
@@ -57,8 +57,8 @@
 # define ACE_SET_BITS(WORD, BITS) (WORD |= (BITS))
 # define ACE_CLR_BITS(WORD, BITS) (WORD &= ~(BITS))
 
-#if !defined (ACE_HAS_CPP14)
-# error ACE/TAO require C++14 compliance, please upgrade your compiler and/or fix the platform configuration for your environment
+#if !defined (ACE_HAS_CPP17)
+# error ACE/TAO require C++17 compliance, please upgrade your compiler and/or fix the platform configuration for your environment
 #endif
 
 #define ACE_UNIMPLEMENTED_FUNC(f) f = delete;

--- a/ACE/ace/checked_iterator.h
+++ b/ACE/ace/checked_iterator.h
@@ -11,7 +11,7 @@
  * Some compilers (e.g. MSVC++ >= 8) issue security related
  * diagnostics if algorithms such as std::copy() are used in an unsafe
  * way.  Normally this isn't an issue if STL container iterators are
- * used in conjuction with the standard algorithms.  However, in cases
+ * used in conjunction with the standard algorithms.  However, in cases
  * where application-specific iterators are use with standard
  * algorithms that could potentially overrun a buffer, extra care must
  * be taken to prevent such an overrun.  If supported, checked

--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -56,3 +56,9 @@ feature(!threads) {
     platform_libs -= rt
   }
 }
+
+feature(vc_languagestandard) {
+  specific(vs2017,vs2019,vs2022) {
+    languagestandard = /std:c++17
+  }
+}

--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -57,8 +57,8 @@ feature(!threads) {
   }
 }
 
-feature(vc_languagestandard) {
+feature(vc_languagestandard2017) {
   specific(vs2017,vs2019,vs2022) {
-    languagestandard = /std:c++17
+    LanguageStandard = stdcpp17
   }
 }

--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -61,7 +61,7 @@ feature(ace_languagestandard2017) {
   specific(vs2017,vs2019,vs2022) {
     LanguageStandard = stdcpp17
   }
-  specific(cmake)
+  specific(cmake) {
     languagestandard = 17
   }
 }

--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -57,8 +57,11 @@ feature(!threads) {
   }
 }
 
-feature(vc_languagestandard2017) {
+feature(ace_languagestandard2017) {
   specific(vs2017,vs2019,vs2022) {
     LanguageStandard = stdcpp17
+  }
+  specific(cmake)
+    languagestandard = 17
   }
 }

--- a/ACE/bin/MakeProjectCreator/config/vc_warnings.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vc_warnings.mpb
@@ -51,6 +51,17 @@ feature(vc_avoid_winsock_warnings) {
   }
 }
 
+feature(vc_avoid_stdext_arr_iters_warning) {
+  specific(prop:microsoft) {
+    macros += _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
+  }
+  verbatim(cmake, macros, 1) {
+    if(MSVC)
+    "  add_compile_definitions(_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)"
+    endif()
+  }
+}
+
 feature(vc_avoid_hides_local_declaration) {
   specific(vc14) {
     DisableSpecificWarnings += 4456

--- a/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
@@ -29,7 +29,7 @@ feature(vc_avoid_hides_class_member) {
   }
 }
 
-feature(vc_languagestandard2017) {
+feature(ace_languagestandard2017) {
   specific(nmake) {
     compile_flags += /std:c++17
   }

--- a/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
@@ -29,8 +29,8 @@ feature(vc_avoid_hides_class_member) {
   }
 }
 
-feature(vc_languagestandard) {
+feature(vc_languagestandard2017) {
   specific(nmake) {
-    languagestandard = /std:c++17
+    compile_flags += /std:c++17
   }
 }

--- a/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2017nmake.mpb
@@ -28,3 +28,9 @@ feature(vc_avoid_hides_class_member) {
     DisableSpecificWarnings += 4458
   }
 }
+
+feature(vc_languagestandard) {
+  specific(nmake) {
+    languagestandard = /std:c++17
+  }
+}

--- a/ACE/bin/MakeProjectCreator/config/vs2019nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2019nmake.mpb
@@ -29,7 +29,7 @@ feature(vc_avoid_hides_class_member) {
   }
 }
 
-feature(vc_languagestandard2017) {
+feature(ace_languagestandard2017) {
   specific(nmake) {
     compile_flags += /std:c++17
   }

--- a/ACE/bin/MakeProjectCreator/config/vs2019nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2019nmake.mpb
@@ -29,8 +29,8 @@ feature(vc_avoid_hides_class_member) {
   }
 }
 
-feature(vc_languagestandard) {
+feature(vc_languagestandard2017) {
   specific(nmake) {
-    languagestandard = /std:c++17
+    compile_flags += /std:c++17
   }
 }

--- a/ACE/bin/MakeProjectCreator/config/vs2019nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2019nmake.mpb
@@ -28,3 +28,9 @@ feature(vc_avoid_hides_class_member) {
     DisableSpecificWarnings += 4458
   }
 }
+
+feature(vc_languagestandard) {
+  specific(nmake) {
+    languagestandard = /std:c++17
+  }
+}

--- a/ACE/bin/MakeProjectCreator/config/vs2022nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2022nmake.mpb
@@ -29,7 +29,7 @@ feature(vc_avoid_hides_class_member) {
   }
 }
 
-feature(vc_languagestandard2017) {
+feature(ace_languagestandard2017) {
   specific(nmake) {
     compile_flags += /std:c++17
   }

--- a/ACE/bin/MakeProjectCreator/config/vs2022nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2022nmake.mpb
@@ -29,8 +29,8 @@ feature(vc_avoid_hides_class_member) {
   }
 }
 
-feature(vc_languagestandard) {
+feature(vc_languagestandard2017) {
   specific(nmake) {
-    languagestandard = /std:c++17
+    compile_flags += /std:c++17
   }
 }

--- a/ACE/bin/MakeProjectCreator/config/vs2022nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2022nmake.mpb
@@ -28,3 +28,9 @@ feature(vc_avoid_hides_class_member) {
     DisableSpecificWarnings += 4458
   }
 }
+
+feature(vc_languagestandard) {
+  specific(nmake) {
+    languagestandard = /std:c++17
+  }
+}

--- a/ACE/include/makeinclude/platform_gcc_clang_common.GNU
+++ b/ACE/include/makeinclude/platform_gcc_clang_common.GNU
@@ -51,19 +51,13 @@ endif # shared_libs
 
 ifneq ($(c++std),)
   CCFLAGS += -std=$(c++std)
-endif
-
-ifeq ($(c++20),1)
+else ifeq ($(c++20),1)
   CCFLAGS += -std=c++20
-else
-  ifeq ($(c++17),1)
-    CCFLAGS += -std=c++17
-  else
-    ifeq ($(c++14),1)
-      CCFLAGS += -std=c++14
-    endif # c++14
-  endif #c++17
-endif #c++20
+else ifeq ($(c++17),1)
+  CCFLAGS += -std=c++17
+else ifeq ($(c++14),1)
+  CCFLAGS += -std=c++14
+endif
 
 # If no option has been specified, set templates to automatic
 # version of the compiler.

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -15,7 +15,8 @@ endif
 ifeq (cmd,$(findstring cmd,$(SHELL)))
 CXX_MAJOR_VERSION := $(firstword $(subst ., ,$(CXX_VERSION)))
 else
-CXX_MAJOR_VERSION := $(shell $(CXX) -dumpversion | sed -e 's/[^0-9\.]//g' | sed -e 's/\..*$$//')
+CXX_MAJOR_DOT = $(word $2,$(subst ., ,$1))
+CXX_MAJOR_VERSION := $(call CXX_MAJOR_DOT,$(CXX_VERSION),1)
 endif
 
 # clang 16 and newer default to C++17

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -43,17 +43,11 @@ endif
 
 ifneq ($(c++std),)
   CCFLAGS += -std=$(c++std)
-endif
-
-ifeq ($(c++20),1)
+else ifeq ($(c++20),1)
   CCFLAGS += -std=c++20
-endif
-
-ifeq ($(c++17),1)
+else ifeq ($(c++17),1)
   CCFLAGS += -std=c++17
-endif
-
-ifeq ($(c++14),1)
+else ifeq ($(c++14),1)
   CCFLAGS += -std=c++14
 endif
 

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -20,7 +20,7 @@ CXX_MAJOR_VERSION := $(call CXX_MAJOR_DOT,$(CXX_VERSION),1)
 endif
 
 # clang 16 and newer default to C++17
-ifeq ($(CXX_MAJOR_VERSION),$(filter $(CXX_MAJOR_VERSION),6 7 8 9 10 11 12 13 14 15))
+ifeq ($(CXX_MAJOR_VERSION),$(filter $(CXX_MAJOR_VERSION),4 5 6 7 8 9 10 11 12 13 14 15))
   c++std ?= c++17
 endif
 

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -35,6 +35,14 @@ ifeq ($(optimize),0)
   CPPFLAGS += -O0
 endif
 
+ifeq ($(c++20),1)
+  CCFLAGS += -std=c++20
+endif
+
+ifeq ($(c++17),1)
+  CCFLAGS += -std=c++17
+endif
+
 ifeq ($(c++14),1)
   CCFLAGS += -std=c++14
 endif

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -18,6 +18,11 @@ else
 CXX_MAJOR_VERSION := $(shell $(CXX) -dumpversion | sed -e 's/[^0-9\.]//g' | sed -e 's/\..*$$//')
 endif
 
+# clang 16 and newer default to C++17
+ifeq ($(CXX_MAJOR_VERSION),$(filter $(CXX_MAJOR_VERSION),6 7 8 9 10 11 12 13 14 15))
+  c++std ?= c++17
+endif
+
 CCFLAGS += $(CFLAGS)
 DCFLAGS += -g
 DLD     = $(CXX)
@@ -33,6 +38,14 @@ OCFLAGS += -O3
 
 ifeq ($(optimize),0)
   CPPFLAGS += -O0
+endif
+
+ifeq ($(CXX_MAJOR_VERSION),7)
+  c++std ?= c++17
+endif
+
+ifneq ($(c++std),)
+  CCFLAGS += -std=$(c++std)
 endif
 
 ifeq ($(c++20),1)

--- a/ACE/include/makeinclude/platform_linux_clang.GNU
+++ b/ACE/include/makeinclude/platform_linux_clang.GNU
@@ -41,10 +41,6 @@ ifeq ($(optimize),0)
   CPPFLAGS += -O0
 endif
 
-ifeq ($(CXX_MAJOR_VERSION),7)
-  c++std ?= c++17
-endif
-
 ifneq ($(c++std),)
   CCFLAGS += -std=$(c++std)
 endif

--- a/ACE/include/makeinclude/platform_macosx_common.GNU
+++ b/ACE/include/makeinclude/platform_macosx_common.GNU
@@ -42,7 +42,7 @@ SOBUILD   = -o $(VSHDIR)$*.dylib $<
 ifeq ($(findstring g++,$(CXX)),)#
   include $(ACE_ROOT)/include/makeinclude/platform_g++_common.GNU
 else
-  c++17 ?= 1
+  c++std ?= c++17
   include $(ACE_ROOT)/include/makeinclude/platform_clang_common.GNU
 endif
 

--- a/ACE/include/makeinclude/platform_macosx_common.GNU
+++ b/ACE/include/makeinclude/platform_macosx_common.GNU
@@ -42,7 +42,7 @@ SOBUILD   = -o $(VSHDIR)$*.dylib $<
 ifeq ($(findstring g++,$(CXX)),)#
   include $(ACE_ROOT)/include/makeinclude/platform_g++_common.GNU
 else
-  c++14 ?= 1
+  c++17 ?= 1
   include $(ACE_ROOT)/include/makeinclude/platform_clang_common.GNU
 endif
 

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,4 +1,4 @@
-USER VISIBLE CHANGES BETWEEN TAO-3.1.4 and TAO-3.1.5
+USER VISIBLE CHANGES BETWEEN TAO-3.1.4 and TAO-3.2.0
 ====================================================
 
 USER VISIBLE CHANGES BETWEEN TAO-3.1.3 and TAO-3.1.4

--- a/TAO/tests/Oneway_Send_Timeouts/Server_Task.h
+++ b/TAO/tests/Oneway_Send_Timeouts/Server_Task.h
@@ -26,12 +26,7 @@ public:
         ACE_ARGV my_args (args_.c_str ());
 
         // Initialize Server ORB in new thread
-
-#ifdef ACE_HAS_CPP14
         server_ = std::make_unique<Server> (my_args.argc (), my_args.argv ());
-#else
-        server_.reset (new Server(my_args.argc (), my_args.argv ()));
-#endif
 
         ACE_ASSERT (server_);
         initializer = true;

--- a/TAO/tests/Oneway_Send_Timeouts/main.cpp
+++ b/TAO/tests/Oneway_Send_Timeouts/main.cpp
@@ -37,11 +37,7 @@ bool MyMain::init_server (const ACE_TCHAR* args)
   // main thread and extra thread for backdoor operations
   int thread_pool = 2;
 
-#ifdef ACE_HAS_CPP14
   server_task_ = std::make_unique<Server_Task> (my_args);
-#else
-  server_task_.reset (new Server_Task (my_args));
-#endif
 
   ACE_ASSERT (server_task_);
 
@@ -79,11 +75,7 @@ bool MyMain::init_client (const ACE_TCHAR* args)
   std::string my_args (ACE_TEXT_ALWAYS_CHAR (args));
   int thread_pool = 1;
 
-#ifdef ACE_HAS_CPP14
   client_task_ = std::make_unique<Client_Task> (my_args);
-#else
-  client_task_.reset (new Client_Task (my_args));
-#endif
 
   ACE_ASSERT (client_task_);
 


### PR DESCRIPTION
Includes changes to set the C++ compiler default for Visual Studio 2017/2019/2022 to C++17