### PR TITLE
Make use of std::numeric_limits instead of ACE wrapper

### DIFF
--- a/ACE/ace/Mem_Map.cpp
+++ b/ACE/ace/Mem_Map.cpp
@@ -121,7 +121,7 @@ ACE_Mem_Map::map_it (ACE_HANDLE handle,
           // Make sure that we have not been asked to do the impossible.
           if (static_cast<ACE_UINT64> (length_request)
               + static_cast<ACE_UINT64> (offset)
-              > static_cast<ACE_UINT64> (ACE_Numeric_Limits<ACE_OFF_T>::max ()))
+              > static_cast<ACE_UINT64> (std::numeric_limits<ACE_OFF_T>::max ()))
             return -1;
 
           // File length implicitly requested by user

--- a/ACE/ace/OS_NS_stdlib.cpp
+++ b/ACE/ace/OS_NS_stdlib.cpp
@@ -23,7 +23,7 @@
 # include "ace/OS_NS_ctype.h"
 # include "ace/OS_NS_sys_time.h"
 # include "ace/OS_NS_Thread.h"
-# include "ace/Numeric_Limits.h"
+# include <limits>
 #endif  /* ACE_LACKS_MKSTEMP */
 
 #if defined (ACE_HAS_ALLOC_HOOKS)
@@ -1137,7 +1137,7 @@ ACE_OS::mkstemp_emulation (ACE_TCHAR * s)
   // meaning multiple threads could potentially initialize this value
   // in parallel.
   float const MAX_VAL =
-    static_cast<float> (ACE_Numeric_Limits<char>::max ());
+    static_cast<float> (std::numeric_limits<char>::max ());
 
   // Use high-order bits rather than low-order ones (e.g. rand() %
   // MAX_VAL).  See Numerical Recipes in C: The Art of Scientific

--- a/ACE/ace/SString.cpp
+++ b/ACE/ace/SString.cpp
@@ -2,7 +2,7 @@
 #include "ace/OS_Memory.h"
 #include "ace/SString.h"
 #include "ace/OS_NS_string.h"
-#include "ace/Numeric_Limits.h"
+#include <limits>
 
 #if !defined (ACE_LACKS_IOSTREAM_TOTALLY)
 // FUZZ: disable check_for_streams_include
@@ -159,7 +159,7 @@ ACE_NS_WString::ACE_NS_WString (const ACE_UINT16 *s,
 // *****************************************************************
 
 ACE_SString::size_type const ACE_SString::npos =
-  ACE_Numeric_Limits<ACE_SString::size_type>::max ();
+  std::numeric_limits<ACE_SString::size_type>::max ();
 
 ACE_ALLOC_HOOK_DEFINE(ACE_SString)
 

--- a/ACE/ace/String_Base_Const.cpp
+++ b/ACE/ace/String_Base_Const.cpp
@@ -1,9 +1,9 @@
 #include "ace/String_Base_Const.h"
-#include "ace/Numeric_Limits.h"
+#include <limits>
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_String_Base_Const::size_type const ACE_String_Base_Const::npos =
-  ACE_Numeric_Limits<ACE_String_Base_Const::size_type>::max ();
+  std::numeric_limits<ACE_String_Base_Const::size_type>::max ();
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Time_Value.cpp
+++ b/ACE/ace/Time_Value.cpp
@@ -8,7 +8,7 @@
 #include "ace/Time_Value.inl"
 #endif /* __ACE_INLINE__ */
 
-#include "ace/Numeric_Limits.h"
+#include <limits>
 #include "ace/If_Then_Else.h"
 #include "ace/OS_NS_math.h"
 #include "ace/Time_Policy.h"
@@ -29,7 +29,7 @@ const ACE_Time_Value ACE_Time_Value::zero;
 /// dynamic subpriority strategies in the ACE_Dynamic_Message_Queue class.
 /// Note: this object requires static construction.
 const ACE_Time_Value ACE_Time_Value::max_time (
-  ACE_Numeric_Limits<time_t>::max (),
+  std::numeric_limits<time_t>::max (),
   ACE_ONE_SECOND_IN_USECS - 1);
 
 ACE_ALLOC_HOOK_DEFINE (ACE_Time_Value)
@@ -173,15 +173,15 @@ ACE_Time_Value::normalize (bool saturate)
       suseconds_t const usec = static_cast<suseconds_t> (this->tv_.tv_usec - sec * ACE_ONE_SECOND_IN_USECS);
 
       if (saturate && this->tv_.tv_sec > 0 && sec > 0 &&
-          ACE_Numeric_Limits<time_t>::max() - this->tv_.tv_sec < sec)
+          std::numeric_limits<time_t>::max() - this->tv_.tv_sec < sec)
         {
-          this->tv_.tv_sec = ACE_Numeric_Limits<time_t>::max();
+          this->tv_.tv_sec = std::numeric_limits<time_t>::max();
           this->tv_.tv_usec = ACE_ONE_SECOND_IN_USECS - 1;
         }
       else if (saturate && this->tv_.tv_sec < 0 && sec < 0 &&
-               ACE_Numeric_Limits<time_t>::min() - this->tv_.tv_sec > sec)
+               std::numeric_limits<time_t>::min() - this->tv_.tv_sec > sec)
         {
-          this->tv_.tv_sec = ACE_Numeric_Limits<time_t>::min();
+          this->tv_.tv_sec = std::numeric_limits<time_t>::min();
           this->tv_.tv_usec = -ACE_ONE_SECOND_IN_USECS + 1;
         }
       else
@@ -231,17 +231,17 @@ ACE_Time_Value::operator *= (double d)
 
   // shall we saturate the result?
   static const float_type max_int =
-    ACE_Numeric_Limits<time_t>::max() + 0.999999;
+    std::numeric_limits<time_t>::max() + 0.999999;
   static const float_type min_int =
-    ACE_Numeric_Limits<time_t>::min() - 0.999999;
+    std::numeric_limits<time_t>::min() - 0.999999;
 
   if (sec_total > max_int)
     {
-      this->set(ACE_Numeric_Limits<time_t>::max(), ACE_ONE_SECOND_IN_USECS-1);
+      this->set(std::numeric_limits<time_t>::max(), ACE_ONE_SECOND_IN_USECS-1);
     }
   else if (sec_total < min_int)
     {
-      this->set(ACE_Numeric_Limits<time_t>::min(), -ACE_ONE_SECOND_IN_USECS+1);
+      this->set(std::numeric_limits<time_t>::min(), -ACE_ONE_SECOND_IN_USECS+1);
     }
   else
     {
@@ -274,11 +274,11 @@ ACE_Time_Value::operator *= (double d)
       // recheck for saturation
       if (sec_total > max_int)
         {
-          this->set (ACE_Numeric_Limits<time_t>::max(), ACE_ONE_SECOND_IN_USECS - 1);
+          this->set (std::numeric_limits<time_t>::max(), ACE_ONE_SECOND_IN_USECS - 1);
         }
       else if (sec_total < min_int)
         {
-          this->set (ACE_Numeric_Limits<time_t>::min(), -ACE_ONE_SECOND_IN_USECS + 1);
+          this->set (std::numeric_limits<time_t>::min(), -ACE_ONE_SECOND_IN_USECS + 1);
         }
       else
         {

--- a/ACE/ace/Time_Value.inl
+++ b/ACE/ace/Time_Value.inl
@@ -70,14 +70,14 @@ ACE_INLINE void
 ACE_Time_Value::set (double d)
 {
   // ACE_OS_TRACE ("ACE_Time_Value::set");
-  if (d < ACE_Numeric_Limits<time_t>::min())
+  if (d < std::numeric_limits<time_t>::min())
     {
-      this->tv_.tv_sec = ACE_Numeric_Limits<time_t>::min();
+      this->tv_.tv_sec = std::numeric_limits<time_t>::min();
       this->tv_.tv_usec = -ACE_ONE_SECOND_IN_USECS + 1;
     }
-  else if (d > ACE_Numeric_Limits<time_t>::max())
+  else if (d > std::numeric_limits<time_t>::max())
     {
-      this->tv_.tv_sec = ACE_Numeric_Limits<time_t>::max();
+      this->tv_.tv_sec = std::numeric_limits<time_t>::max();
       this->tv_.tv_usec = ACE_ONE_SECOND_IN_USECS - 1;
     }
   else

--- a/ACE/ace/Timer_Heap_T.cpp
+++ b/ACE/ace/Timer_Heap_T.cpp
@@ -6,7 +6,7 @@
 #include "ace/Guard_T.h"
 #include "ace/OS_NS_errno.h"
 #include "ace/OS_NS_string.h"
-#include "ace/Numeric_Limits.h"
+#include <limits>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -108,9 +108,9 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Heap_T (
   ACE_TRACE ("ACE_Timer_Heap_T::ACE_Timer_Heap_T");
 
   // Possibly reduce size to fit in a long.
-  if (size > static_cast<size_t> (ACE_Numeric_Limits<long>::max ()))
+  if (size > static_cast<size_t> (std::numeric_limits<long>::max ()))
     {
-      size = static_cast<size_t> (ACE_Numeric_Limits<long>::max ());
+      size = static_cast<size_t> (std::numeric_limits<long>::max ());
       this->max_size_ = size;
     }
 
@@ -181,8 +181,8 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Heap_T (
   ACE_TRACE ("ACE_Timer_Heap_T::ACE_Timer_Heap_T");
 
   // Possibly reduce size to fit in a long.
-  if (this->max_size_ > static_cast<size_t> (ACE_Numeric_Limits<long>::max ()))
-    this->max_size_ = static_cast<size_t> (ACE_Numeric_Limits<long>::max ());
+  if (this->max_size_ > static_cast<size_t> (std::numeric_limits<long>::max ()))
+    this->max_size_ = static_cast<size_t> (std::numeric_limits<long>::max ());
 
   // Create the heap array.
 #if defined (ACE_HAS_ALLOC_HOOKS)

--- a/ACE/ace/Truncate.h
+++ b/ACE/ace/Truncate.h
@@ -23,7 +23,7 @@
 
 #include "ace/Global_Macros.h"
 #include "ace/If_Then_Else.h"
-#include "ace/Numeric_Limits.h"
+#include <limits>
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -393,8 +393,8 @@ namespace ACE_Utils
     TO operator() (FROM val)
     {
       return
-        (comparator::greater_than (val, ACE_Numeric_Limits<TO>::max ())
-         ? ACE_Numeric_Limits<TO>::max ()
+        (comparator::greater_than (val, std::numeric_limits<TO>::max ())
+         ? std::numeric_limits<TO>::max ()
          : static_cast<TO> (val));
     }
 

--- a/ACE/tests/Bug_2434_Regression_Test.cpp
+++ b/ACE/tests/Bug_2434_Regression_Test.cpp
@@ -16,7 +16,7 @@
 #include "test_config.h"
 #include "ace/ACE.h"
 #include "ace/Time_Value.h"
-#include "ace/Numeric_Limits.h"
+#include <limits>
 
 int
 run_main (int, ACE_TCHAR *[])
@@ -28,11 +28,11 @@ run_main (int, ACE_TCHAR *[])
   ACE_Time_Value tv1;
   ACE_Time_Value tv2;
 
-  const time_t max_time_t = ACE_Numeric_Limits<time_t>::max ();
-  const time_t min_time_t = ACE_Numeric_Limits<time_t>::min ();
+  const time_t max_time_t = std::numeric_limits<time_t>::max ();
+  const time_t min_time_t = std::numeric_limits<time_t>::min ();
 
   // test protection against overflows
-  // ACE_TEST_ASSERT( ACE_Time_Value(max_time_t,ACE_ONE_SECOND_IN_USECS) != ACE_Time_Value(ACE_Numeric_Limits<time_t>::min()) );
+  // ACE_TEST_ASSERT( ACE_Time_Value(max_time_t,ACE_ONE_SECOND_IN_USECS) != ACE_Time_Value(std::numeric_limits<time_t>::min()) );
 
   // test saturated result
   tv1.set (max_time_t - 1, 499999);

--- a/ACE/tests/Integer_Truncate_Test.cpp
+++ b/ACE/tests/Integer_Truncate_Test.cpp
@@ -11,8 +11,7 @@
 #include "test_config.h"
 
 #include <ace/Truncate.h>
-#include <ace/Numeric_Limits.h>
-
+#include <limits>
 #include <algorithm>
 #include <functional>
 
@@ -36,7 +35,7 @@ sizeof_from_lt_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) < sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should not be truncated.
+      std::numeric_limits<from_type>::max ();  // Should not be truncated.
 
     if (truncate_cast<to_type> (f) != static_cast<to_type> (f))
       {
@@ -56,7 +55,7 @@ sizeof_from_lt_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) < sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should not be truncated.
+      std::numeric_limits<from_type>::max ();  // Should not be truncated.
 
     if (truncate_cast<to_type> (f) != static_cast<to_type> (f))
       {
@@ -77,7 +76,7 @@ sizeof_from_lt_sizeof_to ()
 
     from_type f1 = -1;  // Should not be truncated.
     from_type f2 =
-      ACE_Numeric_Limits<from_type>::max ();  // Should not be truncated.
+      std::numeric_limits<from_type>::max ();  // Should not be truncated.
 
     if (truncate_cast<to_type> (f1) != f1
         || truncate_cast<to_type> (f2) != f2)
@@ -98,7 +97,7 @@ sizeof_from_lt_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) < sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should not be truncated.
+      std::numeric_limits<from_type>::max ();  // Should not be truncated.
 
     if (truncate_cast<to_type> (f) != static_cast<to_type> (f))
       {
@@ -136,7 +135,7 @@ sizeof_from_eq_sizeof_to ()
 
     from_type f1 = -1;  // Should not be truncated.
     from_type f2 =
-      ACE_Numeric_Limits<from_type>::max ();  // Should not be truncated.
+      std::numeric_limits<from_type>::max ();  // Should not be truncated.
 
     if (static_cast<from_type> (truncate_cast<to_type> (f1)) != f1
         || static_cast<from_type> (truncate_cast<to_type> (f2)) != f2)
@@ -157,9 +156,9 @@ sizeof_from_eq_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) == sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should be truncated.
+      std::numeric_limits<from_type>::max ();  // Should be truncated.
 
-    if (truncate_cast<to_type> (f) != ACE_Numeric_Limits<to_type>::max ())
+    if (truncate_cast<to_type> (f) != std::numeric_limits<to_type>::max ())
       {
         success = false;
 
@@ -178,7 +177,7 @@ sizeof_from_eq_sizeof_to ()
 
     from_type f1 = -1;  // Should not be truncated.
     from_type f2 =
-      ACE_Numeric_Limits<from_type>::max ();  // Should not be truncated.
+      std::numeric_limits<from_type>::max ();  // Should not be truncated.
 
     if (truncate_cast<to_type> (f1) != f1
         || truncate_cast<to_type> (f2) != f2)
@@ -199,7 +198,7 @@ sizeof_from_eq_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) == sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should not be truncated.
+      std::numeric_limits<from_type>::max ();  // Should not be truncated.
 
     if (truncate_cast<to_type> (f) != f)
       {
@@ -236,9 +235,9 @@ sizeof_from_gt_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) > sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should be truncated.
+      std::numeric_limits<from_type>::max ();  // Should be truncated.
 
-    if (truncate_cast<to_type> (f) != ACE_Numeric_Limits<to_type>::max ())
+    if (truncate_cast<to_type> (f) != std::numeric_limits<to_type>::max ())
       {
         success = false;
 
@@ -256,9 +255,9 @@ sizeof_from_gt_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) > sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should be truncated.
+      std::numeric_limits<from_type>::max ();  // Should be truncated.
 
-    if (truncate_cast<to_type> (f) != ACE_Numeric_Limits<to_type>::max ())
+    if (truncate_cast<to_type> (f) != std::numeric_limits<to_type>::max ())
       {
         success = false;
 
@@ -277,10 +276,10 @@ sizeof_from_gt_sizeof_to ()
 
     from_type f1 = -1;  // Should not be truncated.
     from_type f2 =
-      ACE_Numeric_Limits<from_type>::max ();  // Should be truncated.
+      std::numeric_limits<from_type>::max ();  // Should be truncated.
 
     if (truncate_cast<to_type> (f1) != f1
-        || truncate_cast<to_type> (f2) != ACE_Numeric_Limits<to_type>::max ())
+        || truncate_cast<to_type> (f2) != std::numeric_limits<to_type>::max ())
       {
         success = false;
 
@@ -298,9 +297,9 @@ sizeof_from_gt_sizeof_to ()
     ACE_TEST_ASSERT (sizeof (from_type) > sizeof (to_type));
 
     from_type f =
-      ACE_Numeric_Limits<from_type>::max ();  // Should be truncated.
+      std::numeric_limits<from_type>::max ();  // Should be truncated.
 
-    if (truncate_cast<to_type> (f) != ACE_Numeric_Limits<to_type>::max ())
+    if (truncate_cast<to_type> (f) != std::numeric_limits<to_type>::max ())
       {
         success = false;
 

--- a/ACE/tests/New_Fail_Test.cpp
+++ b/ACE/tests/New_Fail_Test.cpp
@@ -20,7 +20,7 @@
 #include "ace/Log_Msg.h"
 #include "ace/OS_Memory.h"
 #include "ace/CORBA_macros.h"
-#include "ace/Numeric_Limits.h"
+#include <limits>
 
 // This test allocates all of the heap memory, forcing 'new' to fail
 // because of a lack of memory.  The ACE_NEW macros should prevent an
@@ -33,7 +33,7 @@
 
 // Most we can do, by half. Using max alone gets "invalid allocation size"
 // messages on stdout on Windows.
-static const size_t BIG_BLOCK = ACE_Numeric_Limits<size_t>::max () / 2;
+static const size_t BIG_BLOCK = std::numeric_limits<size_t>::max () / 2;
 
 // Shouldn't take many "as much as possible" tries to get a failure.
 static const int MAX_ALLOCS_IN_TEST = 2;

--- a/ACE/tests/New_Fail_Test.cpp
+++ b/ACE/tests/New_Fail_Test.cpp
@@ -31,12 +31,12 @@
 // wrong.  The allocated memory is always freed to avoid masking a leak
 // somewhere else in the test.
 
-// Most we can do, by half. Using max alone gets "invalid allocation size"
+// Most we can do, by quarter. Using max alone gets "invalid allocation size"
 // messages on stdout on Windows.
-static const size_t BIG_BLOCK = std::numeric_limits<size_t>::max () / 2;
+constexpr size_t BIG_BLOCK = std::numeric_limits<size_t>::max () / 4;
 
 // Shouldn't take many "as much as possible" tries to get a failure.
-static const int MAX_ALLOCS_IN_TEST = 2;
+constexpr int MAX_ALLOCS_IN_TEST = 2;
 
 static void
 try_ace_new (char **p)

--- a/ACE/tests/Reactor_Fairness_Test.cpp
+++ b/ACE/tests/Reactor_Fairness_Test.cpp
@@ -23,7 +23,7 @@
 #include "ace/Select_Reactor.h"
 #include "ace/TP_Reactor.h"
 #include <memory>
-#include "ace/Numeric_Limits.h"
+#include <limits>
 #include "ace/Signal.h"
 #include "ace/Atomic_Op.h"
 #include "ace/Thread_Mutex.h"
@@ -72,7 +72,7 @@ namespace {
                   ACE_TEXT ("Results (%d entries):\n"),
                   reports.size()));
       unsigned int max_chunks = 0;
-      unsigned int min_chunks = ACE_Numeric_Limits<unsigned int>::max();
+      unsigned int min_chunks = std::numeric_limits<unsigned int>::max();
       for (report_map::iterator iter = reports.begin();
            iter != reports.end ();
            ++iter)

--- a/ACE/tests/Time_Value_Test.cpp
+++ b/ACE/tests/Time_Value_Test.cpp
@@ -17,8 +17,7 @@
 #include "ace/ACE.h"
 #include "ace/Time_Value.h"
 
-#include "ace/Numeric_Limits.h"
-
+#include <limits>
 #include <sstream>
 
 int
@@ -140,23 +139,23 @@ run_main (int, ACE_TCHAR *[])
   ACE_TEST_ASSERT (ACE_Time_Value::max_time.usec () != -1);
 
   // Test performance of normalize()
-  ACE_Time_Value v1(ACE_Numeric_Limits<time_t>::max(),
-                    ACE_Numeric_Limits<suseconds_t>::max());
-  ACE_Time_Value v2(ACE_Numeric_Limits<time_t>::min(),
-                   ACE_Numeric_Limits<suseconds_t>::min());
-  ACE_Time_Value v3(ACE_Numeric_Limits<time_t>::max(),
-                    ACE_Numeric_Limits<suseconds_t>::min());
-  ACE_Time_Value v4(ACE_Numeric_Limits<time_t>::min(),
-                    ACE_Numeric_Limits<suseconds_t>::max());
+  ACE_Time_Value v1(std::numeric_limits<time_t>::max(),
+                    std::numeric_limits<suseconds_t>::max());
+  ACE_Time_Value v2(std::numeric_limits<time_t>::min(),
+                   std::numeric_limits<suseconds_t>::min());
+  ACE_Time_Value v3(std::numeric_limits<time_t>::max(),
+                    std::numeric_limits<suseconds_t>::min());
+  ACE_Time_Value v4(std::numeric_limits<time_t>::min(),
+                    std::numeric_limits<suseconds_t>::max());
 
-  v1.set(ACE_Numeric_Limits<time_t>::max(),
-         ACE_Numeric_Limits<suseconds_t>::max());
-  v2.set(ACE_Numeric_Limits<time_t>::min(),
-         ACE_Numeric_Limits<suseconds_t>::min());
-  v3.set(ACE_Numeric_Limits<time_t>::max(),
-         ACE_Numeric_Limits<suseconds_t>::min());
-  v4.set(ACE_Numeric_Limits<time_t>::min(),
-         ACE_Numeric_Limits<suseconds_t>::max());
+  v1.set(std::numeric_limits<time_t>::max(),
+         std::numeric_limits<suseconds_t>::max());
+  v2.set(std::numeric_limits<time_t>::min(),
+         std::numeric_limits<suseconds_t>::min());
+  v3.set(std::numeric_limits<time_t>::max(),
+         std::numeric_limits<suseconds_t>::min());
+  v4.set(std::numeric_limits<time_t>::min(),
+         std::numeric_limits<suseconds_t>::max());
 
   v1.set(DBL_MAX);
 

--- a/TAO/TAO_IDL/be/be_codegen.cpp
+++ b/TAO/TAO_IDL/be/be_codegen.cpp
@@ -26,7 +26,7 @@
 #include "ace/OS_NS_ctype.h"
 #include "ace/OS_NS_sys_time.h"
 #include "ace/OS_NS_unistd.h"
-#include "ace/Numeric_Limits.h"
+#include <limits>
 
 TAO_CodeGen * tao_cg = nullptr;
 
@@ -3738,7 +3738,7 @@ TAO_CodeGen::make_rand_extension (char * const t)
   // meaning multiple threads could potentially initialize this value
   // in parallel.
   float const MAX_VAL =
-    static_cast<float> (ACE_Numeric_Limits<char>::max ());
+    static_cast<float> (std::numeric_limits<char>::max ());
 
   // Use high-order bits rather than low-order ones (e.g. rand() %
   // MAX_VAL).  See Numerical Recipes in C: The Art of Scientific

--- a/TAO/tao/Storable_FlatFileStream.cpp
+++ b/TAO/tao/Storable_FlatFileStream.cpp
@@ -16,7 +16,6 @@
 #include "ace/OS_NS_fcntl.h"
 #include "ace/OS_NS_sys_stat.h"
 #include "ace/OS_NS_strings.h"
-#include "ace/Numeric_Limits.h"
 #include "ace/Truncate.h"
 #include "tao/debug.h"
 
@@ -24,6 +23,7 @@
 #include <mntent.h>
 #endif /* ACE_HAS_MNTENT */
 
+#include <limits>
 #include <memory>
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -417,8 +417,8 @@ TAO::Storable_FlatFileStream::operator >> (ACE_CString& str)
 {
   int bufSize = 0;
   ACE_CString::size_type const max_buf_len =
-    ACE_Numeric_Limits<ACE_CString::size_type>::max ();
-  int const max_int = ACE_Numeric_Limits<int>::max ();
+    std::numeric_limits<ACE_CString::size_type>::max ();
+  int const max_int = std::numeric_limits<int>::max ();
   switch (fscanf(fl_, "%d\n", &bufSize))
     {
     case 0:


### PR DESCRIPTION
    * ACE/ace/Mem_Map.cpp:
    * ACE/ace/OS_NS_stdlib.cpp:
    * ACE/ace/SString.cpp:
    * ACE/ace/String_Base_Const.cpp:
    * ACE/ace/Time_Value.cpp:
    * ACE/ace/Time_Value.inl:
    * ACE/ace/Timer_Heap_T.cpp:
    * ACE/ace/Truncate.h:
    * ACE/tests/Bug_2434_Regression_Test.cpp:
    * ACE/tests/Integer_Truncate_Test.cpp:
    * ACE/tests/New_Fail_Test.cpp:
    * ACE/tests/Reactor_Fairness_Test.cpp:
    * ACE/tests/Time_Value_Test.cpp:
    * TAO/TAO_IDL/be/be_codegen.cpp:
    * TAO/tao/Storable_FlatFileStream.cpp: