### PR TITLE
Implemented OpenSSL 1.1.0 TLS methods and deprecated SSLv23 ones.

### DIFF
--- a/ACE/ace/SSL/SSL_Context.cpp
+++ b/ACE/ace/SSL/SSL_Context.cpp
@@ -261,6 +261,23 @@ ACE_SSL_Context::set_mode (int mode)
   SSL_METHOD *method = 0;
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+  switch (mode)
+    {
+    case ACE_SSL_Context::TLS_client:
+      method = ::TLS_server_method ();
+      break;
+    case ACE_SSL_Context::TLS_server:
+      method = ::TLS_client_method ();
+      break;
+    case ACE_SSL_Context::TLS:
+      method = ::TLS_method ();
+      break;
+    default:
+      method = ::TLS_method ();
+      break;
+    }
+#else
   switch (mode)
     {
     case ACE_SSL_Context::SSLv23_client:
@@ -276,7 +293,7 @@ ACE_SSL_Context::set_mode (int mode)
       method = ::SSLv23_method ();
       break;
     }
-
+#endif
   this->context_ = ::SSL_CTX_new (method);
   if (this->context_ == 0)
     return -1;
@@ -479,7 +496,11 @@ ACE_SSL_Context::load_trusted_ca (const char* ca_file,
 
   // For TLS/SSL servers scan all certificates in ca_file and ca_dir and
   // list them as acceptable CAs when requesting a client certificate.
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+  if (mode_ == TLS || mode_ == TLS_server)
+#else
   if (mode_ == SSLv23 || mode_ == SSLv23_server)
+#endif
     {
       // Note: The STACK_OF(X509_NAME) pointer is a copy of the pointer in
       // the CTX; any changes to it by way of these function calls will

--- a/ACE/ace/SSL/SSL_Context.h
+++ b/ACE/ace/SSL/SSL_Context.h
@@ -67,7 +67,7 @@ private:
 // when C library routines are passed CallBack functions pointers that are
 // actually C++ functions.
 //
-// Unfortunatly you can not specify extern "C" linkage anywhere inside a class
+// Unfortunately you can not specify extern "C" linkage anywhere inside a class
 // declaration or inside a function prototype for individual parameters. I.e:
 //   class { extern "C" int (*callback_) (int, void *); };
 // to store a function pointer as a data member of the class is illegal as is:
@@ -78,7 +78,7 @@ private:
 // Since we need an extern "C" function pointer as a parameter to be stored
 // in the class and handled by member functions, we are forced to declare
 // a typedef of that extern "C" function pointer that we can then use.
-// Again unfortunatly you also are not allowed to simply add the extern "C"
+// Again unfortunately you also are not allowed to simply add the extern "C"
 // to the typedef itself, instead you have to place the typedef declaration
 // inside an extern "C" block, thus:
 
@@ -104,9 +104,15 @@ public:
 
   enum {
     INVALID_METHOD = -1,
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    TLS_client,
+    TLS_server,
+    TLS
+#else
     SSLv23_client,
     SSLv23_server,
     SSLv23
+#endif
   };
 
   /// Constructor
@@ -130,7 +136,11 @@ public:
    * If the mode is not set, then the class automatically initializes
    * itself to the default mode.
    */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+  int set_mode (int mode = ACE_SSL_Context::TLS);
+#else
   int set_mode (int mode = ACE_SSL_Context::SSLv23);
+#endif
 
   int get_mode () const;
 
@@ -268,7 +278,7 @@ public:
    *
    *  @doc Use this method when certificate chain verification is
    *  required.  The default server behaviour is SSL_VERIFY_NONE
-   *  i.e. client certicates are requested for verified. This method
+   *  i.e. client certificates are requested for verified. This method
    *  can be used to configure server to request client certificates
    *  and perform the certificate verification. If <strict> is set
    *  true the client connection is rejected when certificate
@@ -301,7 +311,7 @@ public:
   /**
    * Set and query the default verify mode for this context, it is
    * inherited by all the ACE_SSL objects created using the context.
-   * It can be overriden on a per-ACE_SSL object.
+   * It can be overridden on a per-ACE_SSL object.
    */
   void default_verify_mode (int mode);
   int default_verify_mode () const;
@@ -309,7 +319,7 @@ public:
   /**
    * Set and query the default verify callback for this context, it is
    * inherited by all the ACE_SSL objects created using the context.
-   * It can be overriden on a per-ACE_SSL object.
+   * It can be overridden on a per-ACE_SSL object.
    */
   void default_verify_callback (extern_C_CallBackVerify_t);
   extern_C_CallBackVerify_t  default_verify_callback () const;


### PR DESCRIPTION
SSLv23_method(), SSLv23_server_method() and SSLv23_client_method() were deprecated and the preferred TLS_method(), TLS_server_method() and TLS_client_method() functions were added in OpenSSL 1.1.0.

All version-specific methods were deprecated in OpenSSL 1.1.0.

[SSLv23_method](https://www.openssl.org/docs/man3.0/man3/SSLv23_method.html)