### PR TITLE
TAO/TAO-INSTALL.html : Fix "Building and Installing TAO from git"

### DIFF
--- a/TAO/TAO-INSTALL.html
+++ b/TAO/TAO-INSTALL.html
@@ -562,7 +562,7 @@ quickly.
    <CODE>-type bmake</CODE> for Borland C++ make files.</LI><p/>
    <LI> Build ACE+TAO together in one shot. To do that please issue
   the following commands: <p>
-  <CODE> $ACE_ROOT/bin/mwc.pl TAO_ACE.mwc </CODE> <p>
+  <CODE> $ACE_ROOT/bin/mwc.pl TAO_ACE.mwc -type gnuace </CODE> <p>
    from <CODE>$TAO_ROOT</CODE>. This will generate GNUmakefiles for
   ACE, gperf, and core ACE+TAO libraries. Issuing a
   <CODE>'make'</CODE> from <CODE>$TAO_ROOT </CODE> will build all of


### PR DESCRIPTION
In section `Building and Installing TAO from git`, if I execute the given command for
`Build ACE+TAO together in one shot`, I get
```
ERROR: There is no longer a default project type.
       Please specify one in MPC.cfg or use the -type option.
```
Adding the missing `-type gnuace` solves the problem.