### PR TITLE
Fix detection of MacOSX SDKs older than 10.10

### DIFF
--- a/ACE/ace/config-macosx.h
+++ b/ACE/ace/config-macosx.h
@@ -12,24 +12,24 @@
 #include "config-macosx-elcapitan.h"
 #elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
 #include "config-macosx-yosemite.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100900
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
 #include "config-macosx-mavericks.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100800
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
 #include "config-macosx-mountainlion.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100700
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
 #include "config-macosx-lion.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100600
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
 #include "config-macosx-snowleopard.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100500
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
 #include "config-macosx-leopard.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100400
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1040
 #include "config-macosx-tiger.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100300
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
 #include "config-macosx-panther.h"
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 100200
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED >= 1020
 #include "config-macosx-jaguar.h"
 #else
-#error Cannot detect MacOSX version
+#error Cannot detect MacOSX SDK version
 #endif
 
 #endif // ACE_CONFIG_MACOSX_ALL_H


### PR DESCRIPTION
Building ACE 8.0.0 on Mac OS X 10.6 fails:

```
../ace/config-macosx.h:32:2: error: Cannot detect MacOSX version
#error Cannot detect MacOSX version
 ^
```

because you are using the wrong `__MAC_OS_X_VERSION_MAX_ALLOWED` values for SDK versions earlier than 10.10. This PR fixes it. It also clarifies the error message: `__MAC_OS_X_VERSION_MAX_ALLOWED` represents the version of the SDK, not the version of macOS currently being used on the build machine nor the minimum version of macOS that will be required to run the compiled program. (The latter would be the deployment target.)