### PR TITLE
[ace6tao2] MPC_LIB_MODIFIER is now set by MPC for bmake

### DIFF
--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -7,7 +7,6 @@ project: ipv6, vc_warnings, build_files, test_files, svc_conf_files, ace_unicode
   // Support the alternative Borland Make project type
   specific(bmake) {
     unicode_flags += -DACE_USES_WCHAR
-    macros += MPC_LIB_MODIFIER=\\"$(LIBMODIFIER)$(ULIBMODIFIER)\\"
     debug_macros += ACE_NO_INLINE=1
   }
 


### PR DESCRIPTION
…FIER is now set by MPC

    * ACE/bin/MakeProjectCreator/config/acedefaults.mpb: