### PR TITLE
Extended output CDR classes to serialize a std::string_view directly

### DIFF
--- a/ACE/ace/CDR_Size.h
+++ b/ACE/ace/CDR_Size.h
@@ -79,6 +79,7 @@ public:
   ACE_CDR::Boolean write_wstring (ACE_CDR::ULong length,
                                   const ACE_CDR::WChar *x);
   ACE_CDR::Boolean write_string (const std::string &x);
+  ACE_CDR::Boolean write_string_view (const std::string_view &x);
 #if !defined(ACE_LACKS_STD_WSTRING)
   ACE_CDR::Boolean write_wstring (const std::wstring &x);
 #endif
@@ -230,6 +231,8 @@ extern ACE_Export ACE_CDR::Boolean operator<< (ACE_SizeCDR &ss,
                                                const ACE_CDR::WChar* x);
 extern ACE_Export ACE_CDR::Boolean operator<< (ACE_SizeCDR &ss,
                                                const std::string& x);
+extern ACE_Export ACE_CDR::Boolean operator<< (ACE_SizeCDR &ss,
+                                               const std::string_view& x);
 #if !defined(ACE_LACKS_STD_WSTRING)
 extern ACE_Export ACE_CDR::Boolean operator<< (ACE_SizeCDR &ss,
                                                const std::wstring& x);

--- a/ACE/ace/CDR_Size.inl
+++ b/ACE/ace/CDR_Size.inl
@@ -152,6 +152,15 @@ ACE_SizeCDR::write_string (const std::string &x)
                              x.empty () ? 0 : x.c_str ());
 }
 
+ACE_INLINE ACE_CDR::Boolean
+ACE_SizeCDR::write_string_view (const std::string_view &x)
+{
+  ACE_CDR::ULong len =
+    static_cast<ACE_CDR::ULong> (x.size ());
+  return this->write_string (len,
+                             x.empty () ? 0 : x.data ());
+}
+
 #if !defined(ACE_LACKS_STD_WSTRING)
 ACE_INLINE ACE_CDR::Boolean
 ACE_SizeCDR::write_wstring (const std::wstring &x)
@@ -396,6 +405,13 @@ ACE_INLINE ACE_CDR::Boolean
 operator<< (ACE_SizeCDR &ss, const std::string& x)
 {
   ss.write_string (x);
+  return ss.good_bit ();
+}
+
+ACE_INLINE ACE_CDR::Boolean
+operator<< (ACE_SizeCDR &ss, const std::string_view& x)
+{
+  ss.write_string_view (x);
   return ss.good_bit ();
 }
 

--- a/ACE/ace/CDR_Stream.h
+++ b/ACE/ace/CDR_Stream.h
@@ -57,6 +57,7 @@
 #endif /* ACE_HAS_MONITOR_POINTS==1 */
 
 #include <string>
+#include <string_view>
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -284,6 +285,7 @@ public:
   ACE_CDR::Boolean write_wstring (ACE_CDR::ULong length,
                                   const ACE_CDR::WChar *x);
   ACE_CDR::Boolean write_string (const std::string &x);
+  ACE_CDR::Boolean write_string_view (const std::string_view &x);
 #if !defined(ACE_LACKS_STD_WSTRING)
   ACE_CDR::Boolean write_wstring (const std::wstring &x);
 #endif
@@ -1437,6 +1439,8 @@ extern ACE_Export ACE_CDR::Boolean operator<< (ACE_OutputCDR &os,
                                                ACE_OutputCDR::from_std_string x);
 extern ACE_Export ACE_CDR::Boolean operator<< (ACE_OutputCDR &os,
                                                const std::string& x);
+extern ACE_Export ACE_CDR::Boolean operator<< (ACE_OutputCDR &os,
+                                               const std::string_view& x);
 #if !defined(ACE_LACKS_STD_WSTRING)
 extern ACE_Export ACE_CDR::Boolean operator<< (ACE_OutputCDR &os,
                                                ACE_OutputCDR::from_std_wstring x);

--- a/ACE/ace/CDR_Stream.inl
+++ b/ACE/ace/CDR_Stream.inl
@@ -368,6 +368,15 @@ ACE_OutputCDR::write_string (const std::string &x)
                              x.empty () ? 0 : x.c_str ());
 }
 
+ACE_INLINE ACE_CDR::Boolean
+ACE_OutputCDR::write_string_view (const std::string_view &x)
+{
+  ACE_CDR::ULong const len =
+    static_cast<ACE_CDR::ULong> (x.size ());
+  return this->write_string (len,
+                             x.empty () ? 0 : x.data ());
+}
+
 #if !defined(ACE_LACKS_STD_WSTRING)
 ACE_INLINE ACE_CDR::Boolean
 ACE_OutputCDR::write_wstring (const std::wstring &x)
@@ -1382,6 +1391,13 @@ ACE_INLINE ACE_CDR::Boolean
 operator<< (ACE_OutputCDR &os, const std::string& x)
 {
   os.write_string (x);
+  return os.good_bit ();
+}
+
+ACE_INLINE ACE_CDR::Boolean
+operator<< (ACE_OutputCDR &os, const std::string_view& x)
+{
+  os.write_string_view (x);
   return os.good_bit ();
 }
 

--- a/ACE/tests/CDR_Test.cpp
+++ b/ACE/tests/CDR_Test.cpp
@@ -111,6 +111,7 @@ short_stream ()
   ACE_CDR::WChar *wstr = wchar2;
   ACE_CString str ("Test String");
   std::string std_str ("std string");
+  std::string_view std_stringview {"std stringview"};
 #if !defined(ACE_LACKS_STD_WSTRING)
   std::wstring std_wstr (L"std wstring");
 #endif
@@ -136,6 +137,7 @@ short_stream ()
   os << str;
   os << wstr;
   os << std_str;
+  os << std_stringview;
 #if !defined(ACE_LACKS_STD_WSTRING)
   os << std_wstr;
 #endif
@@ -158,6 +160,7 @@ short_stream ()
   ss << str;
   ss << wstr;
   ss << std_str;
+  ss << std_stringview;
 #if !defined(ACE_LACKS_STD_WSTRING)
   ss << std_wstr;
 #endif
@@ -215,6 +218,7 @@ short_stream ()
   ACE_CDR::WChar *wstr1 = 0;
   ACE_CString str1;
   std::string std_str1;
+  std::string std_stringview1;
 #if !defined(ACE_LACKS_STD_WSTRING)
   std::wstring std_wstr1;
 #endif
@@ -246,6 +250,7 @@ short_stream ()
   //       std::string, or the like.
   std::unique_ptr<ACE_CDR::WChar[]> safe_wstr (wstr1);
   is >> std_str1;
+  is >> std_stringview1;
 #if !defined(ACE_LACKS_STD_WSTRING)
   is >> std_wstr1;
 #endif
@@ -289,6 +294,12 @@ short_stream ()
     ACE_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("%p\n"),
                        ACE_TEXT ("std::string transfer error")),
+                      1);
+
+  if (std_stringview1 != std_stringview)
+    ACE_ERROR_RETURN ((LM_ERROR,
+                       ACE_TEXT ("%p\n"),
+                       ACE_TEXT ("std::string_view transfer error")),
                       1);
 
 #if !defined(ACE_LACKS_STD_WSTRING)

--- a/TAO/tao/CDR.h
+++ b/TAO/tao/CDR.h
@@ -492,6 +492,8 @@ TAO_Export CORBA::Boolean operator<< (TAO_OutputCDR &os,
 TAO_Export CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       const std::string &x);
 TAO_Export CORBA::Boolean operator<< (TAO_OutputCDR &os,
+                                      const std::string_view &x);
+TAO_Export CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       ACE_OutputCDR::from_std_string x);
 #if !defined(ACE_LACKS_STD_WSTRING)
 TAO_Export CORBA::Boolean operator<< (TAO_OutputCDR &os,

--- a/TAO/tao/CDR.inl
+++ b/TAO/tao/CDR.inl
@@ -461,6 +461,15 @@ ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
 }
 
 ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
+                                      const std::string_view &x)
+{
+  return
+    os.fragment_stream (ACE_CDR::OCTET_ALIGN,
+                        sizeof (char))
+    && static_cast<ACE_OutputCDR &> (os) << x;
+}
+
+ACE_INLINE CORBA::Boolean operator<< (TAO_OutputCDR &os,
                                       ACE_OutputCDR::from_std_string x)
 {
   if (x.bound_ != 0 &&


### PR DESCRIPTION
    * ACE/ace/CDR_Size.h:
    * ACE/ace/CDR_Size.inl:
    * ACE/ace/CDR_Stream.h:
    * ACE/ace/CDR_Stream.inl:
    * ACE/tests/CDR_Test.cpp:
    * TAO/tao/CDR.h:
    * TAO/tao/CDR.inl: