### PR TITLE
[ACE 6] Port to Linux platforms that use musl-libc instead of glibc

### DIFF
--- a/.github/workflows/linux-container.yml
+++ b/.github/workflows/linux-container.yml
@@ -1,0 +1,56 @@
+name: linux-container
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * SUN'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-22.04
+    name: alpine-3.18
+    env:
+      ACE_ROOT: ${{ github.workspace }}/ACE
+      TAO_ROOT: ${{ github.workspace }}/TAO
+      MPC_ROOT: ${{ github.workspace }}/MPC
+    steps:
+    - name: Checkout ACE_TAO
+      uses: actions/checkout@v4
+    - name: Checkout MPC
+      uses: actions/checkout@v4
+      with:
+        repository: DOCGroup/MPC
+        path: ${{ env.MPC_ROOT }}
+    - name: Write configuation files
+      run: |
+        echo '#include "ace/config-linux.h"' > ${{ env.ACE_ROOT }}/ace/config.h
+        echo 'include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU' > ${{ env.ACE_ROOT }}/include/makeinclude/platform_macros.GNU
+    - name: Build in container
+      uses: addnab/docker-run-action@v3
+      with:
+        image: alpine:3.18
+        options: -v ${{ github.workspace }}:${{ github.workspace }}
+        run: |
+          apk add --no-cache git bash make g++ perl linux-headers
+          export ACE_ROOT=${{ env.ACE_ROOT }}
+          export TAO_ROOT=${{ env.TAO_ROOT }}
+          export MPC_ROOT=${{ env.MPC_ROOT }}
+          perl ${{ env.ACE_ROOT }}/bin/mwc.pl -type gnuace ${{ env.TAO_ROOT }}/TAO_ACE.mwc -workers 4
+          perl ${{ env.ACE_ROOT }}/bin/mwc.pl -type gnuace ${{ env.ACE_ROOT }}/tests/tests.mwc -workers 4
+          perl ${{ env.ACE_ROOT }}/bin/mwc.pl -type gnuace ${{ env.TAO_ROOT }}/tests/IDL_Test -workers 4
+          perl ${{ env.ACE_ROOT }}/bin/mwc.pl -type gnuace ${{ env.TAO_ROOT }}/tests/IDLv4 -workers 4
+          make -j 6 -C ${{ env.TAO_ROOT }}
+          make -j 6 -C ${{ env.ACE_ROOT }}/tests
+          make -j 6 -C ${{ env.TAO_ROOT }}/tests/IDL_Test
+          make -j 6 -C ${{ env.TAO_ROOT }}/tests/IDLv4

--- a/ACE/ace/Dev_Poll_Reactor.cpp
+++ b/ACE/ace/Dev_Poll_Reactor.cpp
@@ -1122,10 +1122,10 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
 
   // Define bits to check for while dispatching.
 #if defined (ACE_HAS_EVENT_POLL)
-  const __uint32_t out_event = EPOLLOUT;
-  const __uint32_t exc_event = EPOLLPRI;
-  const __uint32_t in_event  = EPOLLIN;
-  const __uint32_t err_event = EPOLLHUP | EPOLLERR;
+  const ACE_UINT32 out_event = EPOLLOUT;
+  const ACE_UINT32 exc_event = EPOLLPRI;
+  const ACE_UINT32 in_event  = EPOLLIN;
+  const ACE_UINT32 err_event = EPOLLHUP | EPOLLERR;
 #else
   const short out_event = POLLOUT;
   const short exc_event = POLLPRI;
@@ -1138,7 +1138,7 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
   // is invalid, there's no event there. Else process it. In any event, we
   // have the event, so clear event_ for the next thread.
   const ACE_HANDLE handle = this->event_.data.fd;
-  __uint32_t revents      = this->event_.events;
+  ACE_UINT32 revents      = this->event_.events;
   this->event_.data.fd = ACE_INVALID_HANDLE;
   this->event_.events = 0;
   if (handle != ACE_INVALID_HANDLE)

--- a/ACE/ace/config-linux.h
+++ b/ACE/ace/config-linux.h
@@ -106,7 +106,7 @@
 
 #define ACE_HAS_UALARM
 
-#if (__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10)
+#if defined (__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10))
 // Although the scandir man page says otherwise, this setting is correct.
 // The setting was fixed in 2.10, so do not use the hack after that.
 #  define ACE_SCANDIR_CMP_USES_CONST_VOIDPTR
@@ -120,7 +120,9 @@
 #define ACE_HAS_SYSV_IPC
 
 // Compiler/platform defines a union semun for SysV shared memory.
-#define ACE_HAS_SEMUN
+#if defined (__GLIBC__)
+# define ACE_HAS_SEMUN
+#endif
 
 #if defined (__powerpc__) && !defined (ACE_SIZEOF_LONG_DOUBLE)
 // 32bit PowerPC Linux uses 128bit long double
@@ -186,10 +188,6 @@
 #    undef ACE_SCANDIR_CMP_USES_VOIDPTR
 #  endif /* ACE_SCANDIR_CMP_USES_VOIDPTR */
 
-#  if defined (ACE_SCANDIR_CMP_USES_CONST_VOIDPTR)
-#    undef ACE_SCANDIR_CMP_USES_CONST_VOIDPTR
-#  endif /* ACE_SCANDIR_CMP_USES_CONST_VOIDPTR */
-
 #  if defined (ACE_HAS_EXECINFO_H)
 #    undef ACE_HAS_EXECINFO_H
 #  endif /* ACE_HAS_EXECINFO_H */
@@ -198,11 +196,26 @@
 #    undef __GLIBC__
 #  endif /* __GLIBC__ */
 
-#  if defined(ACE_HAS_SEMUN)
-#    undef ACE_HAS_SEMUN
-#  endif /* ACE_HAS_SEMUN */
-
 #endif /* __UCLIBC__ */
+
+#if !defined (__GLIBC__) && !defined (__UCLIBC__)
+// Assume musl, it has no equivalent macro
+
+#define ACE_HAS_CPU_SET_T
+#define ACE_HAS_PTHREADS
+#define ACE_HAS_PTHREADS_UNIX98_EXT
+#define ACE_HAS_RECURSIVE_MUTEXES
+#define ACE_HAS_SIGINFO_T
+#define ACE_HAS_SIGTIMEDWAIT
+#define ACE_HAS_SOCKLEN_T
+#define ACE_HAS_UCONTEXT_T
+
+#define ACE_LACKS_ISCTYPE
+#define ACE_LACKS_NETDB_REENTRANT_FUNCTIONS
+#define ACE_LACKS_SIGINFO_H
+#define ACE_LACKS_SYS_SYSCTL_H
+
+#endif
 
 #include /**/ "ace/post.h"
 

--- a/ACE/ace/os_include/sys/os_types.h
+++ b/ACE/ace/os_include/sys/os_types.h
@@ -32,6 +32,10 @@
 #  include /**/ <types.h>
 #endif /* ACE_HAS_TYPES_H */
 
+#if !defined (ACE_LACKS_FCNTL_H)
+# include /**/ <fcntl.h>
+#endif /* !ACE_LACKS_FCNTL_H */
+
 # if defined (ACE_USES_STD_NAMESPACE_FOR_STDC_LIB) && \
              (ACE_USES_STD_NAMESPACE_FOR_STDC_LIB != 0)
 using std::time_t;


### PR DESCRIPTION
Port to Linux platforms that use musl-libc instead of glibc

(cherry picked from commit caeb54519f2a0017cb10a96b0855c8c974ff14b6)

Conflicts:
ACE/ace/os_include/sys/os_types.h