### PR TITLE
fix for #2286 - avoid header compilation failure in %install phase

### DIFF
--- a/ACE/rpmbuild/ace-tao.spec
+++ b/ACE/rpmbuild/ace-tao.spec
@@ -1099,7 +1099,7 @@ BASEHDR="$BASEHDR `find \
 for j in $BASEHDR; do
         echo $j >> rawhdrs.log
         echo '#include <'$j'>' | \
-        g++ %{inline} \
+        g++ -std=c++17 %{inline} \
             -I . \
             -I protocols \
             $TAO_MM_OPTS \


### PR DESCRIPTION
Adding -std=c++17 to avoid header compilation failure which removes them from the list of headers.
Fixing #2286 - tested on openSUSE15.6 with gcc 7.5 compiler which is not c++17 or newer by default.

The explanation for working with g++ 14.2 (on openSUSE Tumbleweed) is that the compiler is by default c++17 while g++ 7.5 is c++14 even if the compiler is capable of handling c++17 specs - which is actually used in compilation.