### PR TITLE
spelling: changed implImented to implEmented

### DIFF
--- a/TAO/ChangeLogs/ChangeLog-2012a
+++ b/TAO/ChangeLogs/ChangeLog-2012a
@@ -681,7 +681,7 @@ Mon May 21 14:15:00 UTC 2012  Simon Massey  <simon dot massey at prismtech dot c
 
         * docs/dynany/index.html:
         Missed updating this document with changes of Wed Feb 29 16:30:00 UTC 2012.
-        DynamicAny Value and BoxedValue types are implimented.
+        DynamicAny Value and BoxedValue types are implemented.
 
 Sat May 19 14:28:57 CEST 2012  Johnny Willemsen  <jwillemsen@remedy.nl>
 

--- a/TAO/examples/OBV/Typed_Events/Event_Types_impl.cpp
+++ b/TAO/examples/OBV/Typed_Events/Event_Types_impl.cpp
@@ -20,7 +20,7 @@ Event_impl::~Event_impl ()
 Event_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -63,7 +63,7 @@ Temperature_impl::~Temperature_impl ()
 Temperature_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -106,7 +106,7 @@ Position_impl::~Position_impl ()
 Position_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -186,7 +186,7 @@ Log_Msg_impl::~Log_Msg_impl ()
 Log_Msg_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -243,7 +243,7 @@ Event_List_Link_impl::~Event_List_Link_impl ()
 Event_List_Link_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -292,7 +292,7 @@ Event_List_impl::~Event_List_impl ()
 Event_List_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -431,7 +431,7 @@ Temperature_Criterion_impl::~Temperature_Criterion_impl ()
 Temperature_Criterion_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -490,7 +490,7 @@ Position_Criterion_impl::~Position_Criterion_impl ()
 Position_Criterion_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -546,7 +546,7 @@ Log_Msg_Criterion_impl::~Log_Msg_Criterion_impl ()
 Log_Msg_Criterion_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 
@@ -599,7 +599,7 @@ Criterion_List_impl::~Criterion_List_impl ()
 Criterion_List_impl::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 

--- a/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_ObjectReferenceFactory.cpp
+++ b/TAO/orbsvcs/orbsvcs/LoadBalancing/LB_ObjectReferenceFactory.cpp
@@ -50,7 +50,7 @@ TAO_LB_ObjectReferenceFactory::TAO_LB_ObjectReferenceFactory (
 TAO_LB_ObjectReferenceFactory::_copy_value ()
 {
   ::CORBA::ValueBase *ret_val= 0;
-  // Not implimented
+  // Not implemented
   return ret_val;
 }
 

--- a/TAO/tao/DynamicAny/DynValue_i.h
+++ b/TAO/tao/DynamicAny/DynValue_i.h
@@ -135,7 +135,7 @@ private:
   /// Read the value from the input stream
   void from_inputCDR (TAO_InputCDR &);
 
-  /// These are not implimented!
+  /// These are not implemented!
   /// Use copy() or assign() instead of these.
   TAO_DynValue_i (const TAO_DynValue_i &src);
   TAO_DynValue_i &operator= (const TAO_DynValue_i &src);

--- a/TAO/tao/Valuetype/ValueBase.cpp
+++ b/TAO/tao/Valuetype/ValueBase.cpp
@@ -68,7 +68,7 @@ CORBA::ValueBase::_copy_value ()
   ACE_VERSIONED_NAMESPACE_NAME::__ace_assert (
     __FILE__,
     __LINE__,
-    ACE_TEXT_CHAR_TO_TCHAR ("Valuetype's _copy_value() should be implimented in user's most derived class"));
+    ACE_TEXT_CHAR_TO_TCHAR ("Valuetype's _copy_value() should be implemented in user's most derived class"));
   return 0;
 }
 


### PR DESCRIPTION
It was a warning when running lintian when making an OpenDDS deb file.

I: opendds: spelling-error-in-binary usr/lib/libTAO_IDL_FE.so.2.5.21 explictly explicitly
I: opendds: spelling-error-in-binary usr/lib/libTAO_Valuetype.so.2.5.21 implimented implemented