### PR TITLE
spelling: changed 'explictly' to 'explicitly'

### DIFF
--- a/TAO/ChangeLogs/ChangeLog-2004a
+++ b/TAO/ChangeLogs/ChangeLog-2004a
@@ -1836,7 +1836,7 @@ Sun Jun 13 07:56:20 2004  Phil Mesnier  <mesnier_p@ociweb.com>
 Sun Jun 14 11:36:12 UTC 2004  Johnny Willemsen  <jwillemsen@remedy.nl>
 
         * tao/PortableServer/Operation_Table.cpp:
-          Also on AIX we must explictly instantiate static template members.
+          Also on AIX we must explicitly instantiate static template members.
           To make things easier to maintenance use the new
           ACE_HAS_EXPLICIT_STATIC_TEMPLATE_MEMBER_INSTANTIATION macro to check
           whether we need to do this. This macro is set for the GNU compiler for
@@ -8244,7 +8244,7 @@ Wed Feb 11 13:17:11 UTC 2004  Johnny Willemsen  <jwillemsen@remedy.nl>
 Wed Feb 11 11:28:56 UTC 2004  Johnny Willemsen  <jwillemsen@remedy.nl>
 
         * examples/Simple/chat/chat.mpc:
-          Added idl files explictly so that the order in which the idl files
+          Added idl files explicitly so that the order in which the idl files
           are compiled is fixed and correct.
 
 Wed Feb 11 10:22:11 UTC 2004  Johnny Willemsen  <jwillemsen@remedy.nl>

--- a/TAO/TAO_IDL/util/utl_err.cpp
+++ b/TAO/TAO_IDL/util/utl_err.cpp
@@ -186,7 +186,7 @@ error_string (UTL_Error::ErrorCode c)
       return "Warning - spelling differs from IDL keyword only in case: ";
     case UTL_Error::EIDL_ANONYMOUS_ERROR:
       return "anonymous types require the IDL version to be 4 or later or must "
-        "be explictly enabled using -as";
+        "be explicitly enabled using -as";
     case UTL_Error::EIDL_ANONYMOUS_WARNING:
       return "anonymous type found";
     case UTL_Error::EIDL_ANONYMOUS_EXPLICIT_ERROR:


### PR DESCRIPTION
It was a warning when running lintian when making an OpenDDS deb file.

I: opendds: spelling-error-in-binary usr/lib/libTAO_IDL_FE.so.2.5.21 explictly explicitly

@jwillemsen It's probably better to rebase this with the previous commit