### PR TITLE
fix missed headers in linux build

### DIFF
--- a/ACE/ace/ace.mpc
+++ b/ACE/ace/ace.mpc
@@ -411,6 +411,8 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
     IO_Cntl_Msg.h
     Intrusive_Auto_Ptr.h
     Lock_Adapter_T.h
+    Log_Msg_Backend.h
+    Log_Msg_Callback.h
     Log_Priority.h
     Malloc_Base.h
     Metrics_Cache.h

--- a/ACE/ace/ace_for_tao.mpc
+++ b/ACE/ace/ace_for_tao.mpc
@@ -316,6 +316,8 @@ project(ACE_FOR_TAO) : acedefaults, install, svcconf, uuid, versioned_namespace,
     If_Then_Else.h
     IO_Cntl_Msg.h
     Lock_Adapter_T.h
+    Log_Msg_Backend.h
+    Log_Msg_Callback.h
     Log_Priority.h
     Malloc_Base.h
     MMAP_Memory_Pool.h


### PR DESCRIPTION
On release version Log_Msg_Backend.h and Log_Msg_Callback.h missed after building.