### PR TITLE
Remove duplicate reactor timer management functions

### DIFF
--- a/ACE/ace/Reactor.h
+++ b/ACE/ace/Reactor.h
@@ -571,18 +571,6 @@ public:
                                const ACE_Time_Value &interval =
                                 ACE_Time_Value::zero);
 
-  template<class Rep1, class Period1, class Rep2 = int, class Period2 = std::ratio<1>>
-  long schedule_timer (ACE_Event_Handler *event_handler,
-                       const void *arg,
-                       const std::chrono::duration<Rep1, Period1>& delay,
-                       const std::chrono::duration<Rep2, Period2>& interval =
-                        std::chrono::duration<Rep2, Period2>::zero ())
-  {
-    ACE_Time_Value const tv_delay (delay);
-    ACE_Time_Value const tv_interval (interval);
-    return this->schedule_timer (event_handler, arg, tv_delay, tv_interval);
-  }
-
   /**
    * Reset recurring timer interval.
    *
@@ -596,14 +584,6 @@ public:
    */
   virtual int reset_timer_interval (long timer_id,
                                     const ACE_Time_Value &interval);
-
-  template<class Rep, class Period>
-  int reset_timer_interval (long timer_id,
-                            const std::chrono::duration<Rep, Period>& interval)
-  {
-    ACE_Time_Value const tv_interval (interval);
-    return this->reset_timer_interval (timer_id, tv_interval);
-  }
 
   /**
    * Cancel timer.


### PR DESCRIPTION
- Problem: `ACE_Reactor` implements functions `schedule_timer` and `reset_timer_interval` which it already inherits from `ACE_Reactor_Timer_Interface`. The functions are identical in these 2 classes.

- Solution: Remove the functions in `ACE_Reactor` and keep them in the base `ACE_Reactor_Timer_Interface` class.