### PR TITLE
Use =default for skeleton copy constructor

### DIFF
--- a/TAO/TAO_IDL/be/be_interface.cpp
+++ b/TAO/TAO_IDL/be/be_interface.cpp
@@ -2228,45 +2228,6 @@ be_interface::is_a_helper (be_interface * /*derived*/,
 }
 
 int
-be_interface::copy_ctor_helper (be_interface *derived,
-                                be_interface *base,
-                                TAO_OutStream *os)
-{
-  // We can't call ourselves in a copy constructor, and
-  // abstract interfaces don't exist on the skeleton side.
-  if (derived == base || base->is_abstract () || derived->nmembers () > 0)
-    {
-      return 0;
-    }
-
-  *os << "," << be_idt_nl;
-
-  bool is_rh_base =
-    (ACE_OS::strcmp (base->flat_name (), "Messaging_ReplyHandler") == 0);
-
-  if (is_rh_base)
-    {
-      *os << "::POA_Messaging::ReplyHandler (rhs)";
-    }
-  else if (base->is_nested ())
-    {
-      be_decl *scope = nullptr;
-      scope = dynamic_cast<be_scope*> (base->defined_in ())->decl ();
-
-      *os << "POA_" << scope->name () << "::"
-          << base->local_name () << " (rhs)";
-    }
-  else
-    {
-      *os << base->full_skel_name () << " (rhs)";
-    }
-
-  *os << be_uidt;
-
-  return 0;
-}
-
-int
 be_interface::in_mult_inheritance_helper (be_interface *derived,
                                           be_interface *base,
                                           TAO_OutStream *)

--- a/TAO/TAO_IDL/be/be_visitor_interface/interface_ih.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface/interface_ih.cpp
@@ -81,7 +81,7 @@ be_visitor_interface_ih::visit_interface (be_interface *node)
           << be_global->impl_class_prefix () << namebuf
           << be_global->impl_class_suffix () << " (const "
           << be_global->impl_class_prefix () << namebuf
-          << be_global->impl_class_suffix () << "&);" <<be_nl <<be_nl;
+          << be_global->impl_class_suffix () << "&) = default;" <<be_nl <<be_nl;
     }
 
   if (be_global->gen_assign_op ())

--- a/TAO/TAO_IDL/be/be_visitor_interface/interface_is.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface/interface_is.cpp
@@ -62,52 +62,6 @@ be_visitor_interface_is::visit_interface (be_interface *node)
   *os << "{" <<be_nl;
   *os << "}" << be_nl_2;
 
-  if (be_global->gen_copy_ctor () && !node->is_local ())
-    {
-      *os << "//Implementation Skeleton Copy Constructor" << be_nl;
-
-      *os << be_global->impl_class_prefix () << node->flat_name ()
-          << be_global->impl_class_suffix () <<"::"
-          << be_global->impl_class_prefix () << node->flat_name ()
-          << be_global->impl_class_suffix () << " (const "
-          << be_global->impl_class_prefix () << node->flat_name ()
-          << be_global->impl_class_suffix () << "& rhs)" << be_idt_nl
-          << ": TAO_Abstract_ServantBase (rhs)," << be_nl
-          << "  TAO_ServantBase (rhs)";
-
-      if (node->traverse_inheritance_graph (be_interface::copy_ctor_helper,
-                                            os)
-           == -1)
-        {
-          ACE_ERROR_RETURN ((LM_ERROR,
-                             "be_visitor_interface_is::visit_interface - "
-                             " copy ctor generation failed\n"),
-                            -1);
-        }
-
-      if (!node->is_local ())
-        {
-          *os << "," << be_nl;
-
-          if (node->is_nested ())
-            {
-              be_decl *scope = nullptr;
-              scope = dynamic_cast<be_scope*> (node->defined_in ())->decl ();
-
-              *os << "  POA_" << scope->name () << "::"
-                  << node->local_name () << " (rhs)";
-            }
-          else
-            {
-              *os << "  " << node->full_skel_name () << " (rhs)";
-            }
-        }
-
-      *os << be_uidt_nl
-          << "{" << be_nl
-          << "}" << be_nl << be_uidt_nl;
-    }
-
   if (be_global->gen_assign_op ())
     {
       *os << "//Implementation Skeleton Copy Assignment" << be_nl;

--- a/TAO/TAO_IDL/be/be_visitor_interface/interface_sh.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface/interface_sh.cpp
@@ -115,7 +115,7 @@ be_visitor_interface_sh::visit_interface (be_interface *node)
 
   // Copy constructor and destructor.
   *os << class_name.c_str () << " (const "
-      << class_name.c_str () << "& rhs);" << be_nl
+      << class_name.c_str () << "& rhs) = default;" << be_nl
       << "virtual ~" << class_name.c_str () << " () = default;" << be_nl_2;
 
   // _is_a

--- a/TAO/TAO_IDL/be/be_visitor_interface/interface_ss.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_interface/interface_ss.cpp
@@ -109,8 +109,7 @@ be_visitor_interface_ss::visit_interface (be_interface *node)
       << local_name_prefix << node_local_name
       << " ()";
 
-  bool const init_bases = node->nmembers () == 0;
-  if (init_bases)
+  if (node->nmembers () == 0)
     {
       *os << be_idt_nl << ": TAO_ServantBase ()" << be_uidt_nl;
     }
@@ -123,33 +122,6 @@ be_visitor_interface_ss::visit_interface (be_interface *node)
   *os << "{" << be_idt_nl
       << "this->optable_ = std::addressof (tao_" << flat_name
       << "_optable);" << be_uidt_nl
-      << "}" << be_nl_2;
-
-  // find if we are at the top scope or inside some module
-  *os << full_skel_name << "::"
-      << local_name_prefix << node_local_name << " ("
-      << "const " << local_name_prefix
-      << node_local_name << " &"
-      << (init_bases ? "rhs" : "") << ")";
-
-  if (init_bases)
-    {
-      *os << be_idt_nl
-          << ": TAO_Abstract_ServantBase (rhs)," << be_nl
-          << "  TAO_ServantBase (rhs)";
-    }
-
-  if (this->generate_copy_ctor (node, os) == -1)
-    {
-      ACE_ERROR_RETURN ((LM_ERROR,
-                         ACE_TEXT ("be_visitor_interface_ss::")
-                         ACE_TEXT ("visit_interface - ")
-                         ACE_TEXT (" copy ctor generation failed\n")),
-                        -1);
-    }
-
-  *os << be_uidt_nl
-      << "{" << be_nl
       << "}" << be_nl_2;
 
   // Generate code for elements in the scope (e.g., operations).
@@ -454,14 +426,6 @@ be_visitor_interface_ss::generate_proxy_classes (be_interface *node)
     }
 
   return 0;
-}
-
-int
-be_visitor_interface_ss::generate_copy_ctor (be_interface *node,
-                                             TAO_OutStream *os)
-{
-  return node->traverse_inheritance_graph (be_interface::copy_ctor_helper,
-                                           os);
 }
 
 ACE_CString

--- a/TAO/TAO_IDL/be_include/be_interface.h
+++ b/TAO/TAO_IDL/be_include/be_interface.h
@@ -177,12 +177,6 @@ public:
                                              be_interface *,
                                              TAO_OutStream *os);
 
-  /// Helper method passed to the template method to invoke ctors of all the
-  /// base classes.
-  static int copy_ctor_helper (be_interface *,
-                               be_interface *,
-                               TAO_OutStream *os);
-
   /// Helper method to determine if the interface node is involved in some kind
   /// of multiple inheritance or not. Required on the skeleton side.
   static int in_mult_inheritance_helper (be_interface *,

--- a/TAO/TAO_IDL/be_include/be_visitor_interface/interface_ss.h
+++ b/TAO/TAO_IDL/be_include/be_visitor_interface/interface_ss.h
@@ -45,8 +45,7 @@ protected:
 
   virtual int generate_amh_classes (be_interface *node);
   virtual int generate_proxy_classes (be_interface *node);
-  virtual int generate_copy_ctor (be_interface *node,
-                                  TAO_OutStream *os);
+
   virtual ACE_CString generate_flat_name (be_interface *node);
   virtual ACE_CString generate_local_name (be_interface *node);
   virtual ACE_CString generate_full_skel_name (be_interface *node);


### PR DESCRIPTION
Fixes additional warnings introduced in #2306 