### PR TITLE
Call next_profile_i as last step of add_forward_profiles instead of l…

### DIFF
--- a/TAO/tao/IORTable/Table_Adapter.cpp
+++ b/TAO/tao/IORTable/Table_Adapter.cpp
@@ -35,10 +35,8 @@ TAO_Table_Adapter::~TAO_Table_Adapter ()
 ACE_Lock *
 TAO_Table_Adapter::create_lock (TAO_SYNCH_MUTEX &thread_lock)
 {
-  ACE_Lock *the_lock = 0;
-  ACE_NEW_RETURN (the_lock,
-                  ACE_Lock_Adapter<TAO_SYNCH_MUTEX> (thread_lock),
-                  0);
+  ACE_Lock *the_lock = nullptr;
+  ACE_NEW_NORETURN (the_lock, ACE_Lock_Adapter<TAO_SYNCH_MUTEX> (thread_lock));
   return the_lock;
 }
 
@@ -46,7 +44,7 @@ void
 TAO_Table_Adapter::open ()
 {
   ACE_GUARD (ACE_Lock, ace_mon, *this->lock_);
-  TAO_IOR_Table_Impl *impl = 0;
+  TAO_IOR_Table_Impl *impl = nullptr;
   ACE_NEW_THROW_EX (impl,
                     TAO_IOR_Table_Impl (),
                     CORBA::NO_MEMORY ());
@@ -60,7 +58,7 @@ TAO_Table_Adapter::close (int)
 {
   ACE_GUARD (ACE_Lock, ace_mon, *this->lock_);
   this->closed_ = true;
-  this->root_ = 0;
+  this->root_ = nullptr;
 }
 
 void
@@ -149,7 +147,6 @@ TAO_Table_Adapter::initialize_collocated_object (TAO_Stub *stub)
       // This call will set the appropriate collocation values
       // to correspond to the reference we found in the table.
       stub->add_forward_profiles (forward_to->_stubobj ()->base_profiles ());
-      stub->next_profile ();
     }
 
   // 0 for success
@@ -196,10 +193,8 @@ TAO_Table_Adapter_Factory::TAO_Table_Adapter_Factory ()
 TAO_Adapter*
 TAO_Table_Adapter_Factory::create (TAO_ORB_Core *oc)
 {
-  TAO_Adapter* ptr = 0;
-  ACE_NEW_RETURN (ptr,
-                 TAO_Table_Adapter (*oc),
-                 0);
+  TAO_Adapter* ptr = nullptr;
+  ACE_NEW_NORETURN (ptr, TAO_Table_Adapter (*oc));
   return ptr;
 }
 

--- a/TAO/tao/Invocation_Adapter.cpp
+++ b/TAO/tao/Invocation_Adapter.cpp
@@ -393,13 +393,6 @@ namespace TAO
 
     // Reset the profile in the stubs
     stub->add_forward_profiles (stubobj->base_profiles (), permanent_forward);
-
-    if (stub->next_profile () == nullptr)
-      throw ::CORBA::TRANSIENT (
-        CORBA::SystemException::_tao_minor_code (
-          TAO_INVOCATION_LOCATION_FORWARD_MINOR_CODE,
-          0),
-        CORBA::COMPLETED_NO);
   }
 
   TAO::Collocation_Strategy

--- a/TAO/tao/LocateRequest_Invocation_Adapter.cpp
+++ b/TAO/tao/LocateRequest_Invocation_Adapter.cpp
@@ -155,15 +155,6 @@ namespace TAO
 
     // Reset the profile in the stubs
     stub->add_forward_profiles (stubobj->base_profiles (), permanent_forward);
-
-    if (stub->next_profile () == nullptr)
-      throw ::CORBA::TRANSIENT (
-        CORBA::SystemException::_tao_minor_code (
-          TAO_INVOCATION_LOCATION_FORWARD_MINOR_CODE,
-          0),
-        CORBA::COMPLETED_NO);
-
-    return;
   }
 
 } // End namespace TAO

--- a/TAO/tao/Stub.cpp
+++ b/TAO/tao/Stub.cpp
@@ -155,6 +155,16 @@ TAO_Stub::add_forward_profiles (const TAO_MProfile &mprofiles,
   // Since we have been forwarded, we must set profile_success_ to false
   // since we are starting a new with a new set of profiles!
   this->profile_success_ = false;
+
+  // Set the new forward profile.
+  if (this->next_profile_i () == nullptr)
+    {
+      throw ::CORBA::TRANSIENT (
+              CORBA::SystemException::_tao_minor_code (
+                  TAO_INVOCATION_LOCATION_FORWARD_MINOR_CODE,
+                  0),
+              CORBA::COMPLETED_NO);
+    }
 }
 
 int

--- a/TAO/tao/Stub.h
+++ b/TAO/tao/Stub.h
@@ -188,6 +188,9 @@ public:
    * permanent_forward=true is only valid if currently used profile
    * set represents a GroupObject (IOGR), otherwise this flag will be
    * ignored.
+   *
+   * Updates the profile in use to be the first profile of
+   * the newly set forward target.
    */
   void add_forward_profiles (const TAO_MProfile &mprofiles,
                              const CORBA::Boolean permanent_forward = false);
@@ -299,9 +302,10 @@ private:
   int get_profile_ior_info (TAO_MProfile &profile, IOP::IOR *&ior_info);
 
 private:
-  // = Disallow copy construction and assignment.
-  TAO_Stub (const TAO_Stub &);
-  TAO_Stub &operator = (const TAO_Stub &);
+  TAO_Stub (const TAO_Stub &) = delete;
+  TAO_Stub (TAO_Stub &&) = delete;
+  TAO_Stub &operator = (const TAO_Stub &) = delete;
+  TAO_Stub &operator = (TAO_Stub &&) = delete;
 
 protected:
   /// Automatically manage the ORB_Core reference count

--- a/TAO/tests/Permanent_Forward/README
+++ b/TAO/tests/Permanent_Forward/README
@@ -1,5 +1,3 @@
-
-
 This program tests the various forward and forward-permanent
 combinations possible in applications.  The tests operates directly on
 Objects and TAO_Stub interfaces.

--- a/TAO/tests/Permanent_Forward/StubTest.cpp
+++ b/TAO/tests/Permanent_Forward/StubTest.cpp
@@ -36,7 +36,7 @@ is_endpoint (TAO_Profile *profile, const char *host, unsigned short port)
     const char     * endpoint_host = iiop_endpoint->host();
     unsigned short   endpoint_port = iiop_endpoint->port();
 
-    bool retval =
+    bool const retval =
       ACE_OS::strcmp (endpoint_host, host)==0
       && endpoint_port == port;
 
@@ -58,7 +58,7 @@ equal_endpoint (TAO_Profile *profile, TAO_Profile *other)
     const char     * other_endpoint_host = other_iiop_endpoint->host();
     unsigned short   other_endpoint_port = other_iiop_endpoint->port();
 
-    bool retval =
+    bool const retval =
       ACE_OS::strcmp (endpoint_host, other_endpoint_host)==0
       && endpoint_port == other_endpoint_port;
 
@@ -112,7 +112,7 @@ test_forward_permanent (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 4444));
 
@@ -165,7 +165,7 @@ test_forward_permanent_mix (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 2222));
 
@@ -174,7 +174,7 @@ test_forward_permanent_mix (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 3333));
 
@@ -186,7 +186,7 @@ test_forward_permanent_mix (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 4444));
 
@@ -203,7 +203,7 @@ test_forward_permanent_mix (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 2222));
 
@@ -212,7 +212,7 @@ test_forward_permanent_mix (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 3333));
 
@@ -224,7 +224,7 @@ test_forward_permanent_mix (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 5555));
 
@@ -270,7 +270,7 @@ test_forward (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 2222));
 
@@ -280,7 +280,7 @@ test_forward (CORBA::ORB_ptr orb)
 
   FRANKS_ASSERT (stub1->forward_profiles () != 0);
 
-  profile = stub1->next_profile ();
+  profile = stub1->profile_in_use ();
 
   FRANKS_ASSERT (is_endpoint (profile, "192.168.1.2", 3333));
 


### PR DESCRIPTION
…etting the caller do this, which opens a possible race condition

    * TAO/tao/IORTable/Table_Adapter.cpp:
    * TAO/tao/Invocation_Adapter.cpp:
    * TAO/tao/LocateRequest_Invocation_Adapter.cpp:
    * TAO/tao/Stub.cpp:
    * TAO/tao/Stub.h: