### PR TITLE
Added new CECShutdownWaitCompletion command line argument to not wait…

### DIFF
--- a/TAO/docs/cec_options.html
+++ b/TAO/docs/cec_options.html
@@ -343,6 +343,19 @@ static CEC_Factory "-CECDispatching reactive ....."
             </P>
          </TD>
         </TR>
+
+        <!-- <TR NAME="CECProxyDisconnectRetries"> -->
+        <TR>
+          <TD><CODE>-CECShutdownWaitCompletion</CODE>
+            <EM>true|false</EM>
+          </TD>
+          <TD><P>Default <CODE>true</CODE> which means we wait on all events in the queue
+          to be processed on shutdown, in case of <CODE>false</CODE> all pending events in the queue are flushed
+          on shutdown.
+            </P>
+         </TD>
+        </TR>
+
       </TABLE>
     </P>
 

--- a/TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.cpp
+++ b/TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.cpp
@@ -312,6 +312,32 @@ TAO_CEC_Default_Factory::init (int argc, ACE_TCHAR* argv[])
             }
         }
 
+      else if (ACE_OS::strcasecmp (arg, ACE_TEXT("-CECShutdownWaitCompletion")) == 0)
+        {
+          arg_shifter.consume_arg ();
+
+          if (arg_shifter.is_parameter_next ())
+            {
+              const ACE_TCHAR* opt = arg_shifter.get_current ();
+              if (ACE_OS::strcasecmp (opt, ACE_TEXT("false")) == 0)
+                {
+                  this->wait_for_shutdown_thread_completion_ = false;
+                }
+              else if (ACE_OS::strcasecmp (opt, ACE_TEXT("true")) == 0)
+                {
+                  this->wait_for_shutdown_thread_completion_ = true;
+                }
+              else
+                {
+                  ACE_ERROR ((LM_ERROR,
+                              "CEC_Default_Factory - "
+                              "unsupported true/false for wait_for_shutdown_thread_completion option <%s>\n",
+                              opt));
+                }
+              arg_shifter.consume_arg ();
+            }
+        }
+
       else if (ACE_OS::strcasecmp (arg, ACE_TEXT("-CECConsumerControlPeriod")) == 0)
         {
           arg_shifter.consume_arg ();
@@ -439,8 +465,9 @@ TAO_CEC_Default_Factory::create_dispatching (TAO_CEC_EventChannel *)
     return new TAO_CEC_MT_Dispatching (this->dispatching_threads_,
                                       this->dispatching_threads_flags_,
                                       this->dispatching_threads_priority_,
-                                      this->dispatching_threads_force_active_);
-  return 0;
+                                      this->dispatching_threads_force_active_,
+                                      this->wait_for_shutdown_thread_completion_);
+  return nullptr;
 }
 
 #if defined (TAO_HAS_TYPED_EVENT_CHANNEL)
@@ -453,8 +480,9 @@ TAO_CEC_Default_Factory::create_dispatching (TAO_CEC_TypedEventChannel *)
     return new TAO_CEC_MT_Dispatching (this->dispatching_threads_,
                                       this->dispatching_threads_flags_,
                                       this->dispatching_threads_priority_,
-                                      this->dispatching_threads_force_active_);
-  return 0;
+                                      this->dispatching_threads_force_active_,
+                                      this->wait_for_shutdown_thread_completion_);
+  return nullptr;
 }
 #endif /* TAO_HAS_TYPED_EVENT_CHANNEL */
 

--- a/TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.cpp
+++ b/TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.cpp
@@ -329,9 +329,9 @@ TAO_CEC_Default_Factory::init (int argc, ACE_TCHAR* argv[])
                 }
               else
                 {
-                  ACE_ERROR ((LM_ERROR,
+                  ORBSVCS_ERROR ((LM_ERROR,
                               "CEC_Default_Factory - "
-                              "unsupported true/false for wait_for_shutdown_thread_completion option <%s>\n",
+                              "unsupported true/false for CECShutdownWaitCompletion option <%s>\n",
                               opt));
                 }
               arg_shifter.consume_arg ();

--- a/TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.h
+++ b/TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.h
@@ -208,6 +208,9 @@ private:
 
   /// The number of retries before disconnecting a proxy
   unsigned int proxy_disconnect_retries_;
+
+  /// The flag which allows or not to wait the message queue threads completion
+  bool wait_for_shutdown_thread_completion_ { true };
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/orbsvcs/orbsvcs/CosEvent/CEC_MT_Dispatching.h
+++ b/TAO/orbsvcs/orbsvcs/CosEvent/CEC_MT_Dispatching.h
@@ -43,7 +43,8 @@ public:
   TAO_CEC_MT_Dispatching (int nthreads,
                          int thread_creation_flags,
                          int thread_priority,
-                         int force_activate);
+                         int force_activate,
+                         bool shutdown_completion);
 
   // = The EC_Dispatching methods.
   virtual void activate ();
@@ -64,18 +65,18 @@ private:
   ACE_Thread_Manager thread_manager_;
 
   /// The number of active tasks
-  int nthreads_;
+  int const nthreads_;
 
   /// The flags (THR_BOUND, THR_NEW_LWP, etc.) used to create the
   /// dispatching threads.
-  int thread_creation_flags_;
+  int const thread_creation_flags_;
 
   /// The priority of the dispatching threads.
-  int thread_priority_;
+  int const thread_priority_;
 
   /// If activation at the requested priority fails then we fallback on
   /// the defaults for thread activation.
-  int force_activate_;
+  int const force_activate_;
 
   /// The dispatching task
   TAO_CEC_Dispatching_Task task_;
@@ -85,6 +86,9 @@ private:
 
   /// Are the threads running?
   int active_;
+
+  /// The flag which allows or not to wait the message queue threads completion
+  bool const wait_for_shutdown_thread_completion_;
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
… on processing all pending events on shutdown but just flush the queue

    * TAO/docs/cec_options.html:
    * TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.cpp:
    * TAO/orbsvcs/orbsvcs/CosEvent/CEC_Default_Factory.h:
    * TAO/orbsvcs/orbsvcs/CosEvent/CEC_MT_Dispatching.cpp:
    * TAO/orbsvcs/orbsvcs/CosEvent/CEC_MT_Dispatching.h: