### PR TITLE
Don't use Copy_Disabled, just delete the methods, use default for var…

### DIFF
--- a/ACE/ACEXML/common/InputSource.h
+++ b/ACE/ACEXML/common/InputSource.h
@@ -19,7 +19,6 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "ACEXML/common/CharStream.h"
-#include "ace/Copy_Disabled.h"
 
 /**
  * @class ACEXML_InputSource
@@ -49,7 +48,7 @@
  *
  * @sa ACEXML_CharStream
  */
-class ACEXML_Export ACEXML_InputSource : private ACE_Copy_Disabled
+class ACEXML_Export ACEXML_InputSource
 {
 public:
   /**
@@ -57,6 +56,10 @@ public:
    */
   ACEXML_InputSource ();
 
+  ACEXML_InputSource (const ACEXML_InputSource &) = delete;
+  ACEXML_InputSource (ACEXML_InputSource &&) = delete;
+  ACEXML_InputSource &operator= (const ACEXML_InputSource &) = delete;
+  ACEXML_InputSource &operator= (ACEXML_InputSource &&) = delete;
 
   /**
    * Create a new input source with a ACEXML_Char stream.

--- a/ACE/ACEXML/common/LocatorImpl.h
+++ b/ACE/ACEXML/common/LocatorImpl.h
@@ -20,7 +20,6 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "ACEXML/common/Locator.h"
-#include "ace/Copy_Disabled.h"
 
 /**
  * @class ACEXML_LocatorImpl
@@ -58,8 +57,7 @@
  * @sa ACEXML_Locator
  */
 class ACEXML_Export ACEXML_LocatorImpl :
-  public ACEXML_Locator,
-  private ACE_Copy_Disabled
+  public ACEXML_Locator
 {
 public:
   /*
@@ -80,6 +78,11 @@ public:
    * scope of DocumentHandler methods).
    */
   ACEXML_LocatorImpl (const ACEXML_Locator& locator);
+
+  ACEXML_LocatorImpl (const ACEXML_LocatorImpl &) = delete;
+  ACEXML_LocatorImpl (ACEXML_LocatorImpl &&) = delete;
+  ACEXML_LocatorImpl &operator= (const ACEXML_LocatorImpl &) = delete;
+  ACEXML_LocatorImpl &operator= (ACEXML_LocatorImpl &&) = delete;
 
   /*
    * Destructor.

--- a/ACE/Kokyu/DSRT_CV_Dispatcher_Impl_T.h
+++ b/ACE/Kokyu/DSRT_CV_Dispatcher_Impl_T.h
@@ -9,7 +9,6 @@
 #define DSRT_CV_DISPATCHER_IMPL_T_H
 #include /**/ "ace/pre.h"
 #include "ace/Task.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -23,8 +22,7 @@ namespace Kokyu
 {
   template<class DSRT_Scheduler_Traits>
   class DSRT_CV_Dispatcher_Impl :
-    public DSRT_Dispatcher_Impl<DSRT_Scheduler_Traits>,
-    public ACE_Copy_Disabled
+    public DSRT_Dispatcher_Impl<DSRT_Scheduler_Traits>
   {
   public:
     typedef typename
@@ -35,6 +33,11 @@ namespace Kokyu
 
     DSRT_CV_Dispatcher_Impl (ACE_Sched_Params::Policy sched_policy,
                              int sched_scope);
+
+    DSRT_CV_Dispatcher_Impl (const DSRT_CV_Dispatcher_Impl &) = delete;
+    DSRT_CV_Dispatcher_Impl (DSRT_CV_Dispatcher_Impl &&) = delete;
+    DSRT_CV_Dispatcher_Impl &operator= (const DSRT_CV_Dispatcher_Impl &) = delete;
+    DSRT_CV_Dispatcher_Impl &operator= (DSRT_CV_Dispatcher_Impl &&) = delete;
 
     int init_i (const DSRT_ConfigInfo&);
 

--- a/ACE/Kokyu/DSRT_Direct_Dispatcher_Impl_T.h
+++ b/ACE/Kokyu/DSRT_Direct_Dispatcher_Impl_T.h
@@ -15,7 +15,6 @@
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
-#include "ace/Copy_Disabled.h"
 #include "Kokyu_dsrt.h"
 #include "DSRT_Sched_Queue_T.h"
 #include "DSRT_Dispatcher_Impl_T.h"
@@ -25,8 +24,7 @@ namespace Kokyu
   template<class DSRT_Scheduler_Traits>
   class DSRT_Direct_Dispatcher_Impl :
     public ACE_Task_Base,
-    public DSRT_Dispatcher_Impl<DSRT_Scheduler_Traits>,
-    public ACE_Copy_Disabled
+    public DSRT_Dispatcher_Impl<DSRT_Scheduler_Traits>
   {
   public:
     typedef typename
@@ -37,6 +35,11 @@ namespace Kokyu
 
     DSRT_Direct_Dispatcher_Impl (ACE_Sched_Params::Policy sched_policy,
                                  int sched_scope);
+
+    DSRT_Direct_Dispatcher_Impl (const DSRT_Direct_Dispatcher_Impl &) = delete;
+    DSRT_Direct_Dispatcher_Impl (DSRT_Direct_Dispatcher_Impl &&) = delete;
+    DSRT_Direct_Dispatcher_Impl &operator= (const DSRT_Direct_Dispatcher_Impl &) = delete;
+    DSRT_Direct_Dispatcher_Impl &operator= (DSRT_Direct_Dispatcher_Impl &&) = delete;
 
     int init_i (const DSRT_ConfigInfo&);
 

--- a/ACE/Kokyu/DSRT_Dispatch_Item_T.h
+++ b/ACE/Kokyu/DSRT_Dispatch_Item_T.h
@@ -9,7 +9,6 @@
 #define DSRT_DISPATCH_ITEM_H
 #include /**/ "ace/pre.h"
 #include "ace/Bound_Ptr.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -26,7 +25,7 @@ namespace Kokyu
    */
 
   template <class DSRT_Scheduler_Traits>
-  class DSRT_Dispatch_Item : private ACE_Copy_Disabled
+  class DSRT_Dispatch_Item
   {
     typedef typename
     DSRT_Scheduler_Traits::Guid_t Guid_t;
@@ -42,6 +41,11 @@ namespace Kokyu
 
   public:
     DSRT_Dispatch_Item (Guid_t guid, const DSRT_QoSDescriptor&);
+
+    DSRT_Dispatch_Item (const DSRT_Dispatch_Item &) = delete;
+    DSRT_Dispatch_Item (DSRT_Dispatch_Item &&) = delete;
+    DSRT_Dispatch_Item &operator= (const DSRT_Dispatch_Item &) = delete;
+    DSRT_Dispatch_Item &operator= (DSRT_Dispatch_Item &&) = delete;
 
     /// Get the guid.
     Guid_t guid ();

--- a/ACE/Kokyu/Kokyu.h
+++ b/ACE/Kokyu/Kokyu.h
@@ -58,6 +58,7 @@ namespace Kokyu
   class Kokyu_Export Dispatcher
   {
   public:
+    Dispatcher () = default;
     Dispatcher (const Dispatcher &) = delete;
     Dispatcher (Dispatcher &&) = delete;
     Dispatcher &operator= (const Dispatcher &) = delete;

--- a/ACE/Kokyu/Kokyu.h
+++ b/ACE/Kokyu/Kokyu.h
@@ -11,7 +11,6 @@
 #ifndef KOKYU_H
 #define KOKYU_H
 #include /**/ "ace/pre.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -56,9 +55,14 @@ namespace Kokyu
    * Dispatcher is the class that users will be using to achieve
    * dynamic dispatching of events in an event channel.
    */
-  class Kokyu_Export Dispatcher : private ACE_Copy_Disabled
+  class Kokyu_Export Dispatcher
   {
   public:
+    Dispatcher (const Dispatcher &) = delete;
+    Dispatcher (Dispatcher &&) = delete;
+    Dispatcher &operator= (const Dispatcher &) = delete;
+    Dispatcher &operator= (Dispatcher &&) = delete;
+
     /// Dispatch a command object based on the qos info supplied.
     int dispatch (const Dispatch_Command*, const QoSDescriptor&);
 
@@ -90,9 +94,14 @@ namespace Kokyu
    * Factory class creates a dispatcher for EC and configures the
    * interface object with the appropriate implementation.
    */
-  class Kokyu_Export Dispatcher_Factory : private ACE_Copy_Disabled
+  class Kokyu_Export Dispatcher_Factory
   {
   public:
+    Dispatcher_Factory (const Dispatcher_Factory &) = delete;
+    Dispatcher_Factory (Dispatcher_Factory &&) = delete;
+    Dispatcher_Factory &operator= (const Dispatcher_Factory &) = delete;
+    Dispatcher_Factory &operator= (Dispatcher_Factory &&) = delete;
+
     /**
       * Create a dispatcher for dynamic dispatching of commands
       * (eg. events). The caller is responsible for freeing the

--- a/ACE/Kokyu/Kokyu_dsrt.h
+++ b/ACE/Kokyu/Kokyu_dsrt.h
@@ -59,6 +59,8 @@ namespace Kokyu
     /// Shut down the dispatcher. The dispatcher will stop processing requests.
     int shutdown ();
 
+    DSRT_Dispatcher () = default;
+
     DSRT_Dispatcher (const DSRT_Dispatcher &) = delete;
     DSRT_Dispatcher (DSRT_Dispatcher &&) = delete;
     DSRT_Dispatcher &operator= (const DSRT_Dispatcher &) = delete;

--- a/ACE/Kokyu/Kokyu_dsrt.h
+++ b/ACE/Kokyu/Kokyu_dsrt.h
@@ -8,7 +8,6 @@
 #ifndef KOKYU_DSRT_H
 #define KOKYU_DSRT_H
 #include /**/ "ace/pre.h"
-#include "ace/Copy_Disabled.h"
 
 #include "kokyu_export.h"
 #include "Kokyu_defs.h"
@@ -31,7 +30,7 @@ namespace Kokyu
    * dynamic scheduling of threads.
    */
   template <class DSRT_Scheduler_Traits>
-  class DSRT_Dispatcher : private ACE_Copy_Disabled
+  class DSRT_Dispatcher
   {
   public:
     typedef typename DSRT_Scheduler_Traits::Guid_t Guid_t;
@@ -60,6 +59,11 @@ namespace Kokyu
     /// Shut down the dispatcher. The dispatcher will stop processing requests.
     int shutdown ();
 
+    DSRT_Dispatcher (const DSRT_Dispatcher &) = delete;
+    DSRT_Dispatcher (DSRT_Dispatcher &&) = delete;
+    DSRT_Dispatcher &operator= (const DSRT_Dispatcher &) = delete;
+    DSRT_Dispatcher &operator= (DSRT_Dispatcher &&) = delete;
+
     /// Non virtual destructor. Read as <b><i>this class not available
     /// for inheritance<i></b>.
     ~DSRT_Dispatcher ();
@@ -82,9 +86,14 @@ namespace Kokyu
    */
 
   template <class DSRT_Scheduler_Traits>
-  class DSRT_Dispatcher_Factory : private ACE_Copy_Disabled
+  class DSRT_Dispatcher_Factory
   {
   public:
+    DSRT_Dispatcher_Factory (const DSRT_Dispatcher_Factory &) = delete;
+    DSRT_Dispatcher_Factory (DSRT_Dispatcher_Factory &&) = delete;
+    DSRT_Dispatcher_Factory &operator= (const DSRT_Dispatcher_Factory &) = delete;
+    DSRT_Dispatcher_Factory &operator= (DSRT_Dispatcher_Factory &&) = delete;
+
     typedef std::unique_ptr<DSRT_Dispatcher<DSRT_Scheduler_Traits> > DSRT_Dispatcher_Auto_Ptr;
 
     /**

--- a/ACE/ace/Activation_Queue.h
+++ b/ACE/ace/Activation_Queue.h
@@ -21,7 +21,6 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "ace/Message_Queue.h"
-#include "ace/Copy_Disabled.h"
 #include "ace/Condition_Thread_Mutex.h"
 
 /// Define to be compatible with the terminology in the POSA2 book!

--- a/ACE/ace/Caching_Utility_T.h
+++ b/ACE/ace/Caching_Utility_T.h
@@ -21,7 +21,6 @@
 
 #include "ace/Global_Macros.h"
 #include "ace/Cleanup_Strategies_T.h"
-#include "ace/Copy_Disabled.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -40,7 +39,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
  * entries to be cleaned up will be delegated.
  */
 template <class KEY, class VALUE, class CONTAINER, class ITERATOR, class ATTRIBUTES>
-class ACE_Pair_Caching_Utility : private ACE_Copy_Disabled
+class ACE_Pair_Caching_Utility
 {
 public:
   typedef ACE_Cleanup_Strategy<KEY, VALUE, CONTAINER> CLEANUP_STRATEGY;
@@ -51,6 +50,11 @@ public:
 
   /// Destructor.
   ~ACE_Pair_Caching_Utility ();
+
+  ACE_Pair_Caching_Utility (const ACE_Pair_Caching_Utility &) = delete;
+  ACE_Pair_Caching_Utility (ACE_Pair_Caching_Utility &&) = delete;
+  ACE_Pair_Caching_Utility &operator= (const ACE_Pair_Caching_Utility &) = delete;
+  ACE_Pair_Caching_Utility &operator= (ACE_Pair_Caching_Utility &&) = delete;
 
   /**
    * Purge entries from the @a container. The Cleanup_Strategy will do the
@@ -87,7 +91,7 @@ protected:
  * be cleaned up will be delegated.
  */
 template <class KEY, class VALUE, class CONTAINER, class ITERATOR, class ATTRIBUTES>
-class ACE_Recyclable_Handler_Caching_Utility : private ACE_Copy_Disabled
+class ACE_Recyclable_Handler_Caching_Utility
 {
 public:
   typedef ACE_Recyclable_Handler_Cleanup_Strategy<KEY, VALUE, CONTAINER> CLEANUP_STRATEGY;
@@ -99,6 +103,11 @@ public:
 
   /// Destructor.
   ~ACE_Recyclable_Handler_Caching_Utility ();
+
+  ACE_Recyclable_Handler_Caching_Utility (const ACE_Recyclable_Handler_Caching_Utility &) = delete;
+  ACE_Recyclable_Handler_Caching_Utility (ACE_Recyclable_Handler_Caching_Utility &&) = delete;
+  ACE_Recyclable_Handler_Caching_Utility &operator= (const ACE_Recyclable_Handler_Caching_Utility &) = delete;
+  ACE_Recyclable_Handler_Caching_Utility &operator= (ACE_Recyclable_Handler_Caching_Utility &&) = delete;
 
   /**
    * Purge entries from the @a container. The Cleanup_Strategy will do
@@ -137,7 +146,7 @@ protected:
  * delegated.
  */
 template <class KEY, class VALUE, class CONTAINER, class ITERATOR, class ATTRIBUTES>
-class ACE_Refcounted_Recyclable_Handler_Caching_Utility : private ACE_Copy_Disabled
+class ACE_Refcounted_Recyclable_Handler_Caching_Utility
 {
 public:
   typedef ACE_Refcounted_Recyclable_Handler_Cleanup_Strategy<KEY, VALUE, CONTAINER> CLEANUP_STRATEGY;
@@ -149,6 +158,11 @@ public:
 
   /// Destructor.
   ~ACE_Refcounted_Recyclable_Handler_Caching_Utility ();
+
+  ACE_Refcounted_Recyclable_Handler_Caching_Utility (const ACE_Refcounted_Recyclable_Handler_Caching_Utility &) = delete;
+  ACE_Refcounted_Recyclable_Handler_Caching_Utility (ACE_Refcounted_Recyclable_Handler_Caching_Utility &&) = delete;
+  ACE_Refcounted_Recyclable_Handler_Caching_Utility &operator= (const ACE_Refcounted_Recyclable_Handler_Caching_Utility &) = delete;
+  ACE_Refcounted_Recyclable_Handler_Caching_Utility &operator= (ACE_Refcounted_Recyclable_Handler_Caching_Utility &&) = delete;
 
   /**
    * Purge entries from the @a container. The Cleanup_Strategy will do
@@ -193,7 +207,7 @@ protected:
  * class to which the entries to be cleaned up will be delegated.
  */
 template <class KEY, class VALUE, class CONTAINER, class ITERATOR, class ATTRIBUTES>
-class ACE_Handler_Caching_Utility : private ACE_Copy_Disabled
+class ACE_Handler_Caching_Utility
 {
 public:
   typedef ACE_Handler_Cleanup_Strategy<KEY, VALUE, CONTAINER> CLEANUP_STRATEGY;
@@ -202,6 +216,11 @@ public:
   /// Constructor.
   ACE_Handler_Caching_Utility (ACE_Cleanup_Strategy<KEY, VALUE, CONTAINER> *cleanup_strategy = 0,
                                bool delete_cleanup_strategy = false);
+
+  ACE_Handler_Caching_Utility (const ACE_Handler_Caching_Utility &) = delete;
+  ACE_Handler_Caching_Utility (ACE_Handler_Caching_Utility &&) = delete;
+  ACE_Handler_Caching_Utility &operator= (const ACE_Handler_Caching_Utility &) = delete;
+  ACE_Handler_Caching_Utility &operator= (ACE_Handler_Caching_Utility &&) = delete;
 
   /// Destructor.
   ~ACE_Handler_Caching_Utility ();
@@ -246,7 +265,7 @@ protected:
  * be cleaned up will be delegated.
  */
 template <class KEY, class VALUE, class CONTAINER, class ITERATOR, class ATTRIBUTES>
-class ACE_Null_Caching_Utility : private ACE_Copy_Disabled
+class ACE_Null_Caching_Utility
 {
 public:
   typedef ACE_Null_Cleanup_Strategy<KEY, VALUE, CONTAINER> CLEANUP_STRATEGY;
@@ -255,6 +274,11 @@ public:
   /// Constructor.
   ACE_Null_Caching_Utility (ACE_Cleanup_Strategy<KEY, VALUE, CONTAINER> *cleanup_strategy = 0,
                             bool delete_cleanup_strategy = false);
+
+  ACE_Null_Caching_Utility (const ACE_Null_Caching_Utility &) = delete;
+  ACE_Null_Caching_Utility (ACE_Null_Caching_Utility &&) = delete;
+  ACE_Null_Caching_Utility &operator= (const ACE_Null_Caching_Utility &) = delete;
+  ACE_Null_Caching_Utility &operator= (ACE_Null_Caching_Utility &&) = delete;
 
   /// Destructor.
   ~ACE_Null_Caching_Utility ();

--- a/ACE/ace/Cleanup.cpp
+++ b/ACE/ace/Cleanup.cpp
@@ -20,10 +20,6 @@ ACE_Cleanup::cleanup (void *)
   delete this;
 }
 
-ACE_Cleanup::~ACE_Cleanup ()
-{
-}
-
 /*****************************************************************************/
 
 extern "C" void
@@ -81,14 +77,6 @@ ACE_Cleanup_Info_Node::operator!= (const ACE_Cleanup_Info_Node &o) const
 
 
 /*****************************************************************************/
-
-ACE_OS_Exit_Info::ACE_OS_Exit_Info ()
-{
-}
-
-ACE_OS_Exit_Info::~ACE_OS_Exit_Info ()
-{
-}
 
 int
 ACE_OS_Exit_Info::at_exit_i (void *object,

--- a/ACE/ace/Cleanup.h
+++ b/ACE/ace/Cleanup.h
@@ -47,7 +47,7 @@ public:
   ACE_Cleanup ();
 
   /// Destructor.
-  virtual ~ACE_Cleanup ();
+  virtual ~ACE_Cleanup () = default;
 
   /// Cleanup method that, by default, simply deletes itself.
   virtual void cleanup (void *param = 0);
@@ -117,10 +117,10 @@ class ACE_Export ACE_OS_Exit_Info
 {
 public:
   /// Default constructor.
-  ACE_OS_Exit_Info ();
+  ACE_OS_Exit_Info () = default;
 
   /// Destructor.
-  ~ACE_OS_Exit_Info ();
+  ~ACE_OS_Exit_Info () = default;
 
   /// Use to register a cleanup hook.
   int at_exit_i (void *object, ACE_CLEANUP_FUNC cleanup_hook, void *param, const char* name = 0);

--- a/ACE/ace/Cleanup.h
+++ b/ACE/ace/Cleanup.h
@@ -50,12 +50,12 @@ public:
   virtual ~ACE_Cleanup () = default;
 
   /// Cleanup method that, by default, simply deletes itself.
-  virtual void cleanup (void *param = 0);
+  virtual void cleanup (void *param = nullptr);
 };
 
 /// Adapter for cleanup, used by ACE_Object_Manager.
 extern "C" ACE_Export
-void ACE_CLEANUP_DESTROYER_NAME (ACE_Cleanup *, void *param = 0);
+void ACE_CLEANUP_DESTROYER_NAME (ACE_Cleanup *, void *param = nullptr);
 
 /**
  * @class ACE_Cleanup_Info_Node

--- a/ACE/ace/Cleanup_Strategies_T.cpp
+++ b/ACE/ace/Cleanup_Strategies_T.cpp
@@ -11,11 +11,6 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ////////////////////////////////////////////////////////////////////////////
 
-template <class KEY, class VALUE, class CONTAINER>
-ACE_Cleanup_Strategy<KEY, VALUE, CONTAINER>::~ACE_Cleanup_Strategy ()
-{
-}
-
 template <class KEY, class VALUE, class CONTAINER> int
 ACE_Cleanup_Strategy<KEY, VALUE, CONTAINER>::cleanup (CONTAINER &container,
                                                       KEY *key,

--- a/ACE/ace/Cleanup_Strategies_T.h
+++ b/ACE/ace/Cleanup_Strategies_T.h
@@ -37,7 +37,7 @@ class ACE_Cleanup_Strategy
 {
 public:
   /// Destructor.
-  virtual ~ACE_Cleanup_Strategy ();
+  virtual ~ACE_Cleanup_Strategy () = default;
 
   /// The method which will do the cleanup of the entry in the container.
   virtual int cleanup (CONTAINER &container, KEY *key, VALUE *value);

--- a/ACE/ace/Codeset_IBM1047.cpp
+++ b/ACE/ace/Codeset_IBM1047.cpp
@@ -63,14 +63,6 @@ namespace
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_IBM1047_ISO8859::ACE_IBM1047_ISO8859 ()
-{
-}
-
-ACE_IBM1047_ISO8859::~ACE_IBM1047_ISO8859 ()
-{
-}
-
 ACE_CDR::ULong
 ACE_IBM1047_ISO8859::ncs ()
 {
@@ -211,14 +203,6 @@ ACE_IBM1047_ISO8859::write_char_array (ACE_OutputCDR& out,
 }
 
 // ****************************************************************
-
-ACE_ISO8859_IBM1047::ACE_ISO8859_IBM1047 ()
-{
-}
-
-ACE_ISO8859_IBM1047::~ACE_ISO8859_IBM1047 ()
-{
-}
 
 ACE_CDR::ULong
 ACE_ISO8859_IBM1047::ncs ()

--- a/ACE/ace/Codeset_IBM1047.h
+++ b/ACE/ace/Codeset_IBM1047.h
@@ -43,10 +43,10 @@ class ACE_Export ACE_IBM1047_ISO8859 : public ACE_Char_Codeset_Translator
 {
 public:
   /// A do nothing constructor.
-  ACE_IBM1047_ISO8859 ();
+  ACE_IBM1047_ISO8859 ()= default;
 
   /// Virtual destruction
-  virtual ~ACE_IBM1047_ISO8859 ();
+  virtual ~ACE_IBM1047_ISO8859 () = default;
 
   // = Documented in $ACE_ROOT/ace/CDR_Stream.h
   virtual ACE_CDR::Boolean read_char (ACE_InputCDR &,
@@ -88,10 +88,10 @@ class ACE_Export ACE_ISO8859_IBM1047 : public ACE_Char_Codeset_Translator
 {
 public:
   /// A do nothing constructor.
-  ACE_ISO8859_IBM1047 ();
+  ACE_ISO8859_IBM1047 () = default;
 
   /// Virtual destruction
-  virtual ~ACE_ISO8859_IBM1047 ();
+  virtual ~ACE_ISO8859_IBM1047 () = default;
 
   // = Documented in $ACE_ROOT/ace/CDR_Stream.h
   virtual ACE_CDR::Boolean read_char (ACE_InputCDR &,

--- a/ACE/ace/Compression/Compressor.h
+++ b/ACE/ace/Compression/Compressor.h
@@ -22,7 +22,6 @@
 #include "ace/Guard_T.h"
 #include "ace/Thread_Mutex.h"
 #include "ace/Synch_Traits.h"
-#include "ace/Copy_Disabled.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Configuration.cpp
+++ b/ACE/ace/Configuration.cpp
@@ -449,10 +449,6 @@ ACE_Configuration_Win32Registry::ACE_Configuration_Win32Registry (HKEY hKey, u_l
 }
 
 
-ACE_Configuration_Win32Registry::~ACE_Configuration_Win32Registry ()
-{
-}
-
 int
 ACE_Configuration_Win32Registry::open_section (const ACE_Configuration_Section_Key& base,
                                                const ACE_TCHAR* sub_section,
@@ -1059,10 +1055,6 @@ ACE_Configuration_Value_IntId::ACE_Configuration_Value_IntId (const ACE_Configur
 {
 }
 
-ACE_Configuration_Value_IntId::~ACE_Configuration_Value_IntId ()
-{
-}
-
 ACE_Configuration_Value_IntId& ACE_Configuration_Value_IntId::operator= (const ACE_Configuration_Value_IntId& rhs)
 {
   if (this != &rhs)
@@ -1143,10 +1135,6 @@ ACE_Configuration_Section_IntId::ACE_Configuration_Section_IntId (VALUE_MAP* val
 ACE_Configuration_Section_IntId::ACE_Configuration_Section_IntId (const ACE_Configuration_Section_IntId& rhs)
   : value_hash_map_ (rhs.value_hash_map_),
     section_hash_map_ (rhs.section_hash_map_)
-{
-}
-
-ACE_Configuration_Section_IntId::~ACE_Configuration_Section_IntId ()
 {
 }
 

--- a/ACE/ace/Configuration.h
+++ b/ACE/ace/Configuration.h
@@ -454,7 +454,7 @@ public:
                                             u_long security_access = KEY_ALL_ACCESS);
 
   /// Destructor
-  virtual ~ACE_Configuration_Win32Registry ();
+  virtual ~ACE_Configuration_Win32Registry () = default;
 
   virtual int open_section (const ACE_Configuration_Section_Key& base,
                             const ACE_TCHAR* sub_section,
@@ -627,7 +627,7 @@ public:
   ACE_Configuration_Value_IntId (const ACE_Configuration_Value_IntId& rhs);
 
   /// Destructor
-  ~ACE_Configuration_Value_IntId ();
+  ~ACE_Configuration_Value_IntId () = default;
 
   /// Assignment operator
   ACE_Configuration_Value_IntId& operator= (
@@ -683,7 +683,7 @@ public:
   ACE_Configuration_Section_IntId (const ACE_Configuration_Section_IntId& rhs);
 
   /// Destructor
-  ~ACE_Configuration_Section_IntId ();
+  ~ACE_Configuration_Section_IntId () = default;
 
   /// Assignment operator
   ACE_Configuration_Section_IntId& operator= (

--- a/ACE/ace/Containers_T.cpp
+++ b/ACE/ace/Containers_T.cpp
@@ -1421,11 +1421,6 @@ ACE_DNode<T>::ACE_DNode (const T &i, ACE_DNode<T> *n, ACE_DNode<T> *p)
 {
 }
 
-template <class T>
-ACE_DNode<T>::~ACE_DNode ()
-{
-}
-
 // ****************************************************************
 
 template <class T> void

--- a/ACE/ace/Containers_T.h
+++ b/ACE/ace/Containers_T.h
@@ -311,7 +311,7 @@ class ACE_DNode
 
 public:
   /// This isn't necessary, but it keeps some compilers happy.
-  ~ACE_DNode ();
+  ~ACE_DNode () = default;
 
   /// Declare the dynamic allocation hooks.
   ACE_ALLOC_HOOK_DECLARE;

--- a/ACE/ace/Countdown_Time_T.h
+++ b/ACE/ace/Countdown_Time_T.h
@@ -21,7 +21,6 @@
 
 #include "ace/Time_Value.h"
 #include "ace/Time_Policy.h"
-#include "ace/Copy_Disabled.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -35,12 +34,18 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
  * updated.
  */
 template <typename TIME_POLICY = ACE_Default_Time_Policy>
-class ACE_Countdown_Time_T : private ACE_Copy_Disabled
+class ACE_Countdown_Time_T
 {
 public:
   /// Cache the @a max_wait_time and call @c start().
   ACE_Countdown_Time_T (ACE_Time_Value *max_wait_time,
                         TIME_POLICY const & time_policy = TIME_POLICY());
+
+  ACE_Countdown_Time_T (const ACE_Countdown_Time_T &) = delete;
+  ACE_Countdown_Time_T (ACE_Countdown_Time_T &&) = delete;
+  ACE_Countdown_Time_T &operator= (const ACE_Countdown_Time_T &) = delete;
+  ACE_Countdown_Time_T &operator= (ACE_Countdown_Time_T &&) = delete;
+
 
   /// Destructor, makes sure the max_wait_time that got passed as pointer
   /// to the constructor is updated with the time elapsed.

--- a/ACE/ace/Dynamic.h
+++ b/ACE/ace/Dynamic.h
@@ -36,7 +36,7 @@ public:
   ACE_Dynamic ();
 
   /// Destructor.
-  ~ACE_Dynamic ();
+  ~ACE_Dynamic () = default;
 
   /**
    * Sets a flag that indicates that the object was dynamically

--- a/ACE/ace/Dynamic.inl
+++ b/ACE/ace/Dynamic.inl
@@ -1,12 +1,6 @@
 // -*- C++ -*-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_INLINE
-ACE_Dynamic::~ACE_Dynamic ()
-{
-  // ACE_TRACE ("ACE_Dynamic::~ACE_Dynamic");
-}
-
 ACE_INLINE void
 ACE_Dynamic::set ()
 {

--- a/ACE/ace/Dynamic_Message_Strategy.cpp
+++ b/ACE/ace/Dynamic_Message_Strategy.cpp
@@ -26,12 +26,6 @@ ACE_Dynamic_Message_Strategy::ACE_Dynamic_Message_Strategy (unsigned long static
 {
 }
 
-// dtor
-
-ACE_Dynamic_Message_Strategy::~ACE_Dynamic_Message_Strategy ()
-{
-}
-
 ACE_Dynamic_Message_Strategy::Priority_Status
 ACE_Dynamic_Message_Strategy::priority_status (ACE_Message_Block & mb,
                                                const ACE_Time_Value & tv)
@@ -122,10 +116,6 @@ ACE_Deadline_Message_Strategy::ACE_Deadline_Message_Strategy (unsigned long stat
 {
 }
 
-ACE_Deadline_Message_Strategy::~ACE_Deadline_Message_Strategy ()
-{
-}
-
 void
 ACE_Deadline_Message_Strategy::convert_priority (ACE_Time_Value & priority,
                                                  const ACE_Message_Block & mb)
@@ -161,10 +151,6 @@ ACE_Laxity_Message_Strategy::ACE_Laxity_Message_Strategy (unsigned long static_b
                                   static_bit_field_shift,
                                   dynamic_priority_max,
                                   dynamic_priority_offset)
-{
-}
-
-ACE_Laxity_Message_Strategy::~ACE_Laxity_Message_Strategy ()
 {
 }
 

--- a/ACE/ace/Dynamic_Message_Strategy.h
+++ b/ACE/ace/Dynamic_Message_Strategy.h
@@ -68,7 +68,7 @@ public:
                                 unsigned long dynamic_priority_offset);
 
   /// Virtual destructor.
-  virtual ~ACE_Dynamic_Message_Strategy ();
+  virtual ~ACE_Dynamic_Message_Strategy () = default;
 
   /// Updates the message's priority and returns its priority status.
   Priority_Status priority_status (ACE_Message_Block &mb,
@@ -156,7 +156,7 @@ public:
                                  unsigned long dynamic_priority_offset = 0x200000UL); // 2^(22-1)
 
   /// Virtual destructor.
-  virtual ~ACE_Deadline_Message_Strategy ();
+  virtual ~ACE_Deadline_Message_Strategy () = default;
 
   /// Dynamic priority conversion function based on time to deadline.
   virtual void convert_priority (ACE_Time_Value &priority,
@@ -191,7 +191,7 @@ public:
                                unsigned long dynamic_priority_offset = 0x200000UL); // 2^(22-1)
 
   /// virtual dtor.
-  virtual ~ACE_Laxity_Message_Strategy ();
+  virtual ~ACE_Laxity_Message_Strategy () = default;
 
   /// Dynamic priority conversion function based on laxity.
   virtual void convert_priority (ACE_Time_Value &priority,

--- a/ACE/ace/ETCL/ETCL_Constraint.cpp
+++ b/ACE/ace/ETCL/ETCL_Constraint.cpp
@@ -12,14 +12,6 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ETCL_Constraint::ETCL_Constraint ()
-{
-}
-
-ETCL_Constraint::~ETCL_Constraint ()
-{
-}
-
 int
 ETCL_Constraint::accept (ETCL_Constraint_Visitor * /* visitor */)
 {

--- a/ACE/ace/ETCL/ETCL_Constraint.h
+++ b/ACE/ace/ETCL/ETCL_Constraint.h
@@ -34,8 +34,8 @@ class ACE_ETCL_Export ETCL_Constraint
 {
 public:
   /// Constructor and destructor
-  ETCL_Constraint ();
-  virtual ~ETCL_Constraint ();
+  ETCL_Constraint () = default;
+  virtual ~ETCL_Constraint () = default;
 
   virtual int accept (ETCL_Constraint_Visitor *visitor);
 

--- a/ACE/ace/ETCL/ETCL_Constraint.h
+++ b/ACE/ace/ETCL/ETCL_Constraint.h
@@ -176,7 +176,7 @@ class ACE_ETCL_Export ETCL_Union_Value : public ETCL_Constraint
 public:
   ETCL_Union_Value (int sign,
                     ETCL_Constraint *integer);
-  explicit ETCL_Union_Value (ETCL_Constraint *string = 0);
+  explicit ETCL_Union_Value (ETCL_Constraint *string = nullptr);
   virtual ~ETCL_Union_Value ();
 
   int sign () const;
@@ -194,8 +194,8 @@ private:
 class ACE_ETCL_Export ETCL_Union_Pos : public ETCL_Constraint
 {
 public:
-  ETCL_Union_Pos (ETCL_Constraint *union_value = 0,
-                  ETCL_Constraint *component = 0);
+  ETCL_Union_Pos (ETCL_Constraint *union_value = nullptr,
+                  ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Union_Pos ();
 
   ETCL_Union_Value *union_value () const;
@@ -211,8 +211,8 @@ private:
 class ACE_ETCL_Export ETCL_Component_Pos : public ETCL_Constraint
 {
 public:
-  ETCL_Component_Pos (ETCL_Constraint *integer = 0,
-                      ETCL_Constraint *component = 0);
+  ETCL_Component_Pos (ETCL_Constraint *integer = nullptr,
+                      ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Component_Pos ();
 
   ETCL_Literal_Constraint *integer () const;
@@ -228,8 +228,8 @@ private:
 class ACE_ETCL_Export ETCL_Component_Assoc : public ETCL_Constraint
 {
 public:
-  ETCL_Component_Assoc (ETCL_Constraint *identifier = 0,
-                        ETCL_Constraint *component = 0);
+  ETCL_Component_Assoc (ETCL_Constraint *identifier = nullptr,
+                        ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Component_Assoc ();
 
   ETCL_Identifier *identifier () const;
@@ -245,8 +245,8 @@ private:
 class ACE_ETCL_Export ETCL_Component_Array : public ETCL_Constraint
 {
 public:
-  ETCL_Component_Array (ETCL_Constraint *integer = 0,
-                        ETCL_Constraint *component = 0);
+  ETCL_Component_Array (ETCL_Constraint *integer = nullptr,
+                        ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Component_Array ();
 
   ETCL_Literal_Constraint *integer () const;
@@ -277,8 +277,8 @@ private:
 class ACE_ETCL_Export ETCL_Component : public ETCL_Constraint
 {
 public:
-  ETCL_Component (ETCL_Constraint *identifier = 0,
-                  ETCL_Constraint *component = 0);
+  ETCL_Component (ETCL_Constraint *identifier = nullptr,
+                  ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Component ();
 
   ETCL_Identifier *identifier () const;
@@ -294,7 +294,7 @@ private:
 class ACE_ETCL_Export ETCL_Dot : public ETCL_Constraint
 {
 public:
-  explicit ETCL_Dot (ETCL_Constraint *component = 0);
+  explicit ETCL_Dot (ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Dot ();
 
   ETCL_Constraint *component () const;
@@ -308,7 +308,7 @@ private:
 class ACE_ETCL_Export ETCL_Eval : public ETCL_Constraint
 {
 public:
-  explicit ETCL_Eval (ETCL_Constraint *component = 0);
+  explicit ETCL_Eval (ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Eval ();
 
   ETCL_Constraint *component () const;
@@ -322,7 +322,7 @@ private:
 class ACE_ETCL_Export ETCL_Default : public ETCL_Constraint
 {
 public:
-  explicit ETCL_Default (ETCL_Constraint *component = 0);
+  explicit ETCL_Default (ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Default ();
 
   ETCL_Constraint *component () const;
@@ -336,7 +336,7 @@ private:
 class ACE_ETCL_Export ETCL_Exist : public ETCL_Constraint
 {
 public:
-  explicit ETCL_Exist (ETCL_Constraint *component = 0);
+  explicit ETCL_Exist (ETCL_Constraint *component = nullptr);
   virtual ~ETCL_Exist ();
 
   ETCL_Constraint *component () const;
@@ -389,7 +389,7 @@ class ACE_ETCL_Export ETCL_Preference : public ETCL_Constraint
 public:
   ETCL_Preference () = default;
   ETCL_Preference (int type,
-                   ETCL_Constraint *subexpr = 0);
+                   ETCL_Constraint *subexpr = nullptr);
   virtual ~ETCL_Preference ();
 
   int type () const;

--- a/ACE/ace/ETCL/ETCL_Constraint_Visitor.cpp
+++ b/ACE/ace/ETCL/ETCL_Constraint_Visitor.cpp
@@ -11,14 +11,6 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ETCL_Constraint_Visitor::ETCL_Constraint_Visitor ()
-{
-}
-
-ETCL_Constraint_Visitor::~ETCL_Constraint_Visitor ()
-{
-}
-
 int
 ETCL_Constraint_Visitor::visit_literal (ETCL_Literal_Constraint *)
 {

--- a/ACE/ace/ETCL/ETCL_Constraint_Visitor.h
+++ b/ACE/ace/ETCL/ETCL_Constraint_Visitor.h
@@ -41,8 +41,8 @@ class ETCL_Preference;
 class ACE_ETCL_Export ETCL_Constraint_Visitor
 {
 public:
-  ETCL_Constraint_Visitor ();
-  virtual ~ETCL_Constraint_Visitor ();
+  ETCL_Constraint_Visitor () = default;
+  virtual ~ETCL_Constraint_Visitor () = default;
 
   virtual int visit_literal (ETCL_Literal_Constraint *);
   virtual int visit_identifier (ETCL_Identifier *);

--- a/ACE/ace/Env_Value_T.h
+++ b/ACE/ace/Env_Value_T.h
@@ -19,7 +19,6 @@
 #include /**/ "ace/config-all.h"
 #include "ace/Global_Macros.h"
 #include "ace/OS_NS_stdlib.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -36,7 +35,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
  * value.
  */
 template <class T>
-class ACE_Env_Value : private ACE_Copy_Disabled
+class ACE_Env_Value
 {
 public:
   /**
@@ -49,8 +48,13 @@ public:
   /// Constructor that calls open().
   ACE_Env_Value (const ACE_TCHAR *varname, const T &vardefault);
 
+  ACE_Env_Value (const ACE_Env_Value &) = delete;
+  ACE_Env_Value (ACE_Env_Value &&) = delete;
+  ACE_Env_Value &operator= (const ACE_Env_Value &) = delete;
+  ACE_Env_Value &operator= (ACE_Env_Value &&) = delete;
+
   /// Destroy the value.
-  ~ACE_Env_Value ();
+  ~ACE_Env_Value () = default;
 
   /// Returns the value as type T.
   operator T ();

--- a/ACE/ace/Env_Value_T.inl
+++ b/ACE/ace/Env_Value_T.inl
@@ -50,9 +50,4 @@ ACE_Env_Value<T>::varname () const
   return this->varname_;
 }
 
-template <class T> ACE_INLINE
-ACE_Env_Value<T>::~ACE_Env_Value ()
-{
-}
-
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Framework_Component.h
+++ b/ACE/ace/Framework_Component.h
@@ -43,7 +43,6 @@
 
 #include "ace/os_include/os_signal.h"
 #include "ace/Thread_Mutex.h"
-#include "ace/Copy_Disabled.h"
 #include "ace/Synch_Traits.h"
 
 #define ACE_DEFAULT_FRAMEWORK_REPOSITORY_SIZE 1024
@@ -56,7 +55,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
  * @brief Base class that defines a uniform interface for all managed
  * framework components.
  */
-class ACE_Export ACE_Framework_Component : private ACE_Copy_Disabled
+class ACE_Export ACE_Framework_Component
 {
 public:
   friend class ACE_Framework_Repository;
@@ -65,6 +64,11 @@ public:
   ACE_Framework_Component (void *_this,
                            const ACE_TCHAR *dll_name = 0,
                            const ACE_TCHAR *name = 0);
+
+  ACE_Framework_Component (const ACE_Framework_Component &) = delete;
+  ACE_Framework_Component (ACE_Framework_Component &&) = delete;
+  ACE_Framework_Component &operator= (const ACE_Framework_Component &) = delete;
+  ACE_Framework_Component &operator= (ACE_Framework_Component &&) = delete;
 
   /// Close the contained singleton.
   virtual void close_singleton () = 0;
@@ -93,7 +97,7 @@ private:
  * destruction, framework components are destroyed in the reverse order
  * that they were added originally.
  */
-class ACE_Export ACE_Framework_Repository : private ACE_Copy_Disabled
+class ACE_Export ACE_Framework_Repository
 {
 public:
   // This is just to silence a compiler warning about no public ctors
@@ -103,6 +107,11 @@ public:
   {
     DEFAULT_SIZE = ACE_DEFAULT_FRAMEWORK_REPOSITORY_SIZE
   };
+
+  ACE_Framework_Repository (const ACE_Framework_Repository &) = delete;
+  ACE_Framework_Repository (ACE_Framework_Repository &&) = delete;
+  ACE_Framework_Repository &operator= (const ACE_Framework_Repository &) = delete;
+  ACE_Framework_Repository &operator= (ACE_Framework_Repository &&) = delete;
 
   /// Close down the repository and free up dynamically allocated
   /// resources.

--- a/ACE/ace/Future_Set.h
+++ b/ACE/ace/Future_Set.h
@@ -39,12 +39,16 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
  * using the ACE_Future_Set::next_readable() method.
  */
 template <class T>
-class ACE_Future_Set : public ACE_Future_Observer<T>,
-                       private ACE_Copy_Disabled
+class ACE_Future_Set : public ACE_Future_Observer<T>
 {
 public:
   /// Constructor.
   ACE_Future_Set (ACE_Message_Queue<ACE_SYNCH> *future_notification_queue_ = 0);
+
+  ACE_Future_Set (const ACE_Future_Set &) = delete;
+  ACE_Future_Set (ACE_Future_Set &&) = delete;
+  ACE_Future_Set &operator= (const ACE_Future_Set &) = delete;
+  ACE_Future_Set &operator= (ACE_Future_Set &&) = delete;
 
   /// Destructor.
   ~ACE_Future_Set ();

--- a/ACE/ace/Intrusive_List.h
+++ b/ACE/ace/Intrusive_List.h
@@ -106,8 +106,8 @@ private:
    *
    */
   //@{
-  ACE_Intrusive_List (const ACE_Intrusive_List<T> &);
-  ACE_Intrusive_List<T>& operator= (const ACE_Intrusive_List<T> &);
+  ACE_Intrusive_List (const ACE_Intrusive_List<T> &) = delete;
+  ACE_Intrusive_List<T>& operator= (const ACE_Intrusive_List<T> &) = delete;
   //@}
 
 private:

--- a/ACE/ace/Map_T.cpp
+++ b/ACE/ace/Map_T.cpp
@@ -286,11 +286,6 @@ ACE_Map_Impl<KEY, VALUE, IMPLEMENTATION, ITERATOR, REVERSE_ITERATOR, ENTRY>::ren
   return temp;
 }
 
-template <class T, class VALUE>
-ACE_Active_Map_Manager_Iterator_Adapter<T, VALUE>::~ACE_Active_Map_Manager_Iterator_Adapter ()
-{
-}
-
 template <class T, class VALUE> ACE_Iterator_Impl<T> *
 ACE_Active_Map_Manager_Iterator_Adapter<T, VALUE>::clone () const
 {

--- a/ACE/ace/Map_T.h
+++ b/ACE/ace/Map_T.h
@@ -722,7 +722,7 @@ public:
   ACE_Active_Map_Manager_Iterator_Adapter (const ACE_Map_Iterator<ACE_Active_Map_Manager_Key, VALUE, ACE_Null_Mutex> &impl);
 
   /// Destructor.
-  virtual ~ACE_Active_Map_Manager_Iterator_Adapter ();
+  virtual ~ACE_Active_Map_Manager_Iterator_Adapter () = default;
 
   /// Clone.
   virtual ACE_Iterator_Impl<T> *clone () const;

--- a/ACE/ace/Mem_Map.h
+++ b/ACE/ace/Mem_Map.h
@@ -20,7 +20,6 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "ace/Global_Macros.h"
-#include "ace/Copy_Disabled.h"
 #include "ace/os_include/sys/os_mman.h"
 #include "ace/os_include/os_limits.h"
 #include "ace/os_include/os_fcntl.h"
@@ -36,11 +35,16 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
  * This class works with both the mmap(2) UNIX system and the
  * Win32 family of memory mapping system calls.
  */
-class ACE_Export ACE_Mem_Map : private ACE_Copy_Disabled
+class ACE_Export ACE_Mem_Map
 {
 public:
   /// Default constructor.
   ACE_Mem_Map ();
+
+  ACE_Mem_Map (const ACE_Mem_Map &) = delete;
+  ACE_Mem_Map (ACE_Mem_Map &&) = delete;
+  ACE_Mem_Map &operator= (const ACE_Mem_Map &) = delete;
+  ACE_Mem_Map &operator= (ACE_Mem_Map &&) = delete;
 
   /// Map a file from an open file descriptor @a handle.  This function
   /// will lookup the length of the file if it is not given.

--- a/ACE/ace/Message_Queue.cpp
+++ b/ACE/ace/Message_Queue.cpp
@@ -7,10 +7,6 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_Message_Queue_Base::~ACE_Message_Queue_Base ()
-{
-}
-
 int
 ACE_Message_Queue_Base::state ()
 {

--- a/ACE/ace/Message_Queue.h
+++ b/ACE/ace/Message_Queue.h
@@ -79,7 +79,7 @@ public:
   virtual int close () = 0;
 
   /// Close down the message queue and release all resources.
-  virtual ~ACE_Message_Queue_Base ();
+  virtual ~ACE_Message_Queue_Base () = default;
 
   // = Enqueue and dequeue methods.
 
@@ -200,9 +200,8 @@ public:
   virtual void dump () const = 0;
 
 private:
-  // = Disallow copying and assignment.
-  ACE_Message_Queue_Base (const ACE_Message_Queue_Base &);
-  void operator= (const ACE_Message_Queue_Base &);
+  ACE_Message_Queue_Base (const ACE_Message_Queue_Base &) = delete;
+  void operator= (const ACE_Message_Queue_Base &) = delete;
 
 protected:
   /// Indicates the state of the queue, which can be

--- a/ACE/ace/Metrics_Cache_T.cpp
+++ b/ACE/ace/Metrics_Cache_T.cpp
@@ -194,13 +194,6 @@ ACE_Metrics_Cache (u_long table_size,
   dequeue_probes_ [1] = 0;
 }
 
-// Destructor.
-
-template <class ACE_LOCK, class ALLOCATOR>
-ACE_Metrics_Cache<ACE_LOCK, ALLOCATOR>::~ACE_Metrics_Cache ()
-{
-}
-
 // Obtain an allocator pointer correctly thunked for the current
 // address space.  If there is no allocator stored in the instance,
 // the singleton allocator in the current process is used.

--- a/ACE/ace/Metrics_Cache_T.h
+++ b/ACE/ace/Metrics_Cache_T.h
@@ -127,7 +127,7 @@ public:
                      ALLOCATOR * allocatorPtr = (ALLOCATOR*)ALLOCATOR::instance());
 
   /// Destructor.
-  ~ACE_Metrics_Cache ();
+  ~ACE_Metrics_Cache () = default;
 
   // = Dispatching metrics.
 

--- a/ACE/ace/Monitor_Control/Constraint_Interpreter.cpp
+++ b/ACE/ace/Monitor_Control/Constraint_Interpreter.cpp
@@ -14,14 +14,6 @@ namespace ACE
 {
   namespace Monitor_Control
   {
-    Constraint_Interpreter::Constraint_Interpreter ()
-    {
-    }
-
-    Constraint_Interpreter::~Constraint_Interpreter ()
-    {
-    }
-
     int
     Constraint_Interpreter::build_tree (const char *constraints)
     {

--- a/ACE/ace/Monitor_Control/Constraint_Interpreter.h
+++ b/ACE/ace/Monitor_Control/Constraint_Interpreter.h
@@ -44,9 +44,9 @@ namespace ACE
       : public ETCL_Interpreter
     {
     public:
-      Constraint_Interpreter ();
+      Constraint_Interpreter () = default;
 
-      virtual ~Constraint_Interpreter ();
+      virtual ~Constraint_Interpreter () = default;
 
       /**
        * This method builds an expression tree representing the

--- a/ACE/ace/Msg_WFMO_Reactor.cpp
+++ b/ACE/ace/Msg_WFMO_Reactor.cpp
@@ -22,10 +22,6 @@ ACE_Msg_WFMO_Reactor::ACE_Msg_WFMO_Reactor (size_t size,
 {
 }
 
-ACE_Msg_WFMO_Reactor::~ACE_Msg_WFMO_Reactor ()
-{
-}
-
 DWORD
 ACE_Msg_WFMO_Reactor::wait_for_multiple_events (int timeout,
                                                 int alertable)

--- a/ACE/ace/Msg_WFMO_Reactor.h
+++ b/ACE/ace/Msg_WFMO_Reactor.h
@@ -55,7 +55,7 @@ public:
                         ACE_Timer_Queue * = 0);
 
   /// Close down the ACE_Msg_WFMO_Reactor and release all of its resources.
-  virtual ~ACE_Msg_WFMO_Reactor ();
+  virtual ~ACE_Msg_WFMO_Reactor () = default;
 
   /**
    * This event loop driver blocks for up to @a max_wait_time before

--- a/ACE/ace/Multihomed_INET_Addr.cpp
+++ b/ACE/ace/Multihomed_INET_Addr.cpp
@@ -315,9 +315,4 @@ ACE_Multihomed_INET_Addr::get_addresses(sockaddr_in6 *addrs,
 }
 #endif /* ACE_HAS_IPV6 */
 
-
-ACE_Multihomed_INET_Addr::~ACE_Multihomed_INET_Addr ()
-{
-}
-
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Multihomed_INET_Addr.h
+++ b/ACE/ace/Multihomed_INET_Addr.h
@@ -102,7 +102,7 @@ public:
   /// Use compiler-generated assignment operator.
 
   /// Default destructor.
-  ~ACE_Multihomed_INET_Addr ();
+  ~ACE_Multihomed_INET_Addr () = default;
 
   // = Direct initialization methods.
 

--- a/ACE/ace/Object_Manager.h
+++ b/ACE/ace/Object_Manager.h
@@ -118,7 +118,7 @@ template <class T> class ACE_Cleanup_Adapter;
  * can be used to register any object or array for any
  * cleanup activity at program termination.
  * 2) ACE_Object_Manager::at_exit (ACE_Cleanup *object,
- * void *param = 0);
+ * void *param = nullptr);
  * can be used to register an ACE_Cleanup object
  * for any cleanup activity at program termination.
  * The final mechanism is not general purpose, but can only
@@ -242,7 +242,7 @@ public:
    * shutting down, ENOMEM if insufficient virtual memory, or EEXIST
    * if the object (or array) had already been registered.
    */
-  static int at_exit (ACE_Cleanup *object, void *param = 0, const char* name = 0);
+  static int at_exit (ACE_Cleanup *object, void *param = nullptr, const char* name = nullptr);
 
 #if defined (ACE_HAS_TSS_EMULATION)
   static int init_tss ();

--- a/ACE/ace/Service_Gestalt.h
+++ b/ACE/ace/Service_Gestalt.h
@@ -63,7 +63,7 @@ class ACE_Svc_Conf_Param;
  * it. This feature is important for the derived classes and the
  * Service Config in particular.
  */
-class ACE_Export ACE_Service_Gestalt : private ACE_Copy_Disabled
+class ACE_Export ACE_Service_Gestalt
 {
 public:
   enum
@@ -82,6 +82,11 @@ public:
   ACE_Service_Gestalt (size_t size = DEFAULT_SIZE,
                        bool svc_repo_is_owned = true,
                        bool no_static_svcs = true);
+
+  ACE_Service_Gestalt (const ACE_Service_Gestalt &) = delete;
+  ACE_Service_Gestalt (ACE_Service_Gestalt &&) = delete;
+  ACE_Service_Gestalt &operator= (const ACE_Service_Gestalt &) = delete;
+  ACE_Service_Gestalt &operator= (ACE_Service_Gestalt &&) = delete;
 
   /// Perform user-specified close activities and remove dynamic
   /// memory.

--- a/ACE/ace/Singleton.h
+++ b/ACE/ace/Singleton.h
@@ -82,7 +82,7 @@ public:
 
   /// Cleanup method, used by @c ace_cleanup_destroyer to destroy the
   /// ACE_Singleton.
-  virtual void cleanup (void *param = 0);
+  virtual void cleanup (void *param = nullptr);
 
   /// Explicitly delete the Singleton instance.
   static void close ();
@@ -178,7 +178,7 @@ public:
 
   /// Cleanup method, used by <ace_cleanup_destroyer> to destroy the
   /// singleton.
-  virtual void cleanup (void *param = 0);
+  virtual void cleanup (void *param = nullptr);
 
   /// Dump the state of the object.
   static void dump ();
@@ -271,7 +271,7 @@ template <class TYPE, class ACE_LOCK>
 class ACE_DLL_Singleton_T
 {
 public:
-  //void cleanup (void *param = 0);
+  //void cleanup (void *param = nullptr);
 
   /// Global access point to the Singleton.
   static TYPE *instance ();

--- a/ACE/ace/TSS_T.h
+++ b/ACE/ace/TSS_T.h
@@ -32,7 +32,6 @@
 # endif /* ACE_HAS_THREADS && (ACE_HAS_THREAD_SPECIFIC_STORAGE || ACE_HAS_TSS_EMULATION) */
 
 #include "ace/Thread_Mutex.h"
-#include "ace/Copy_Disabled.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -72,7 +71,7 @@ class ACE_TSS_Adapter;
  * limits its lifetime appropriately.
  */
 template <class TYPE>
-class ACE_TSS : private ACE_Copy_Disabled
+class ACE_TSS
 {
 public:
   /**
@@ -88,7 +87,12 @@ public:
    *                 threads use the ts_object (TYPE *) method to set
    *                 a specific value.
    */
-  ACE_TSS (TYPE *ts_obj = 0);
+  ACE_TSS (TYPE *ts_obj = nullptr);
+
+  ACE_TSS (const ACE_TSS &) = delete;
+  ACE_TSS (ACE_TSS &&) = delete;
+  ACE_TSS &operator= (const ACE_TSS &) = delete;
+  ACE_TSS &operator= (ACE_TSS &&) = delete;
 
   /// Deregister this object from thread-specific storage administration.
   /// Will cause all threads' copies of TYPE to be destroyed.

--- a/ACE/ace/Task_Ex_T.h
+++ b/ACE/ace/Task_Ex_T.h
@@ -56,8 +56,7 @@ template <ACE_SYNCH_DECL, class TIME_POLICY> class ACE_Module;
  * code is in action.
  */
 template <ACE_SYNCH_DECL, class ACE_MESSAGE_TYPE, class TIME_POLICY = ACE_System_Time_Policy>
-class ACE_Task_Ex : public ACE_Task_Base,
-                    private ACE_Copy_Disabled
+class ACE_Task_Ex : public ACE_Task_Base
 {
 public:
   friend class ACE_Module<ACE_SYNCH_USE, TIME_POLICY>;
@@ -71,8 +70,12 @@ public:
    * then we'll allocate one dynamically.  Otherwise, we'll use the
    * one passed as a parameter.
    */
-  ACE_Task_Ex (ACE_Thread_Manager *thr_mgr = 0,
-            MESSAGE_QUEUE_EX *mq = 0);
+  ACE_Task_Ex (ACE_Thread_Manager *thr_mgr = nullptr, MESSAGE_QUEUE_EX *mq = nullptr);
+
+  ACE_Task_Ex (const ACE_Task_Ex &) = delete;
+  ACE_Task_Ex (ACE_Task_Ex &&) = delete;
+  ACE_Task_Ex &operator= (const ACE_Task_Ex &) = delete;
+  ACE_Task_Ex &operator= (ACE_Task_Ex &&) = delete;
 
   /// Destructor.
   virtual ~ACE_Task_Ex ();

--- a/ACE/ace/Thread_Manager.h
+++ b/ACE/ace/Thread_Manager.h
@@ -133,7 +133,7 @@ public:
    /// Constructor
    ACE_At_Thread_Exit_Func (void *object,
                             ACE_CLEANUP_FUNC func,
-                            void *param = 0);
+                            void *param = nullptr);
 
   virtual ~ACE_At_Thread_Exit_Func ();
 

--- a/ACE/ace/Timer_Hash_T.h
+++ b/ACE/ace/Timer_Hash_T.h
@@ -39,7 +39,6 @@ class ACE_Event_Handler;
  */
 template <class TYPE, class FUNCTOR, class ACE_LOCK>
 class ACE_Timer_Hash_Upcall
-  : private ACE_Copy_Disabled
 {
 public:
   typedef ACE_Timer_Queue_T<ACE_Event_Handler *,
@@ -53,6 +52,11 @@ public:
 
   /// Constructor that specifies a Timer_Hash to call up to
   ACE_Timer_Hash_Upcall (ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK> *timer_hash);
+
+  ACE_Timer_Hash_Upcall (const ACE_Timer_Hash_Upcall &) = delete;
+  ACE_Timer_Hash_Upcall (ACE_Timer_Hash_Upcall &&) = delete;
+  ACE_Timer_Hash_Upcall &operator= (const ACE_Timer_Hash_Upcall &) = delete;
+  ACE_Timer_Hash_Upcall &operator= (ACE_Timer_Hash_Upcall &&) = delete;
 
   /// This method is called when a timer is registered.
   int registration (TIMER_QUEUE &timer_queue,

--- a/ACE/ace/Timer_Queue_T.cpp
+++ b/ACE/ace/Timer_Queue_T.cpp
@@ -31,7 +31,6 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 template <class TYPE, class FUNCTOR> ACE_INLINE
 ACE_Timer_Queue_Upcall_Base<TYPE, FUNCTOR>::ACE_Timer_Queue_Upcall_Base (FUNCTOR * upcall_functor)
   : ACE_Abstract_Timer_Queue<TYPE>()
-  , ACE_Copy_Disabled()
   , upcall_functor_(upcall_functor)
   , delete_upcall_functor_ (upcall_functor == 0)
 {

--- a/ACE/ace/Timer_Queue_T.h
+++ b/ACE/ace/Timer_Queue_T.h
@@ -24,7 +24,6 @@
 #include "ace/Abstract_Timer_Queue.h"
 #include "ace/Timer_Queue_Iterator.h"
 #include "ace/Time_Policy.h"
-#include "ace/Copy_Disabled.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -39,11 +38,15 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 template<typename TYPE, typename FUNCTOR>
 class ACE_Timer_Queue_Upcall_Base
   : public ACE_Abstract_Timer_Queue<TYPE>
-  , private ACE_Copy_Disabled
 {
 public:
   // Constructor
   explicit ACE_Timer_Queue_Upcall_Base(FUNCTOR * upcall_functor = nullptr);
+
+  ACE_Timer_Queue_Upcall_Base (const ACE_Timer_Queue_Upcall_Base &) = delete;
+  ACE_Timer_Queue_Upcall_Base (ACE_Timer_Queue_Upcall_Base &&) = delete;
+  ACE_Timer_Queue_Upcall_Base &operator= (const ACE_Timer_Queue_Upcall_Base &) = delete;
+  ACE_Timer_Queue_Upcall_Base &operator= (ACE_Timer_Queue_Upcall_Base &&) = delete;
 
   /// Destructor
   virtual ~ACE_Timer_Queue_Upcall_Base ();

--- a/ACE/ace/Timer_Wheel_T.h
+++ b/ACE/ace/Timer_Wheel_T.h
@@ -13,7 +13,6 @@
 #include /**/ "ace/pre.h"
 
 #include "ace/Timer_Queue_T.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once

--- a/ACE/apps/gperf/src/Gen_Perf.h
+++ b/ACE/apps/gperf/src/Gen_Perf.h
@@ -27,17 +27,21 @@
 #include "Options.h"
 #include "Key_List.h"
 #include "Bool_Array.h"
-#include "ace/Copy_Disabled.h"
 
 /*
  * Provides high-level routines to manipulate the keyword list
  * structures the code generation output.
  */
-class Gen_Perf : private ACE_Copy_Disabled
+class Gen_Perf
 {
 public:
   /// Constructor.
   Gen_Perf ();
+
+  Gen_Perf (const Gen_Perf &) = delete;
+  Gen_Perf (Gen_Perf &&) = delete;
+  Gen_Perf &operator= (const Gen_Perf &) = delete;
+  Gen_Perf &operator= (Gen_Perf &&) = delete;
 
   /// Destructor
   ~Gen_Perf ();

--- a/ACE/apps/gperf/src/Hash_Table.h
+++ b/ACE/apps/gperf/src/Hash_Table.h
@@ -32,7 +32,6 @@
 
 #include "Options.h"
 #include "List_Node.h"
-#include "ace/Copy_Disabled.h"
 
 /**
  * Hash table used to check for duplicate keyword entries.
@@ -43,11 +42,16 @@
  * ACE_Hash_Map_Manager.  Perhaps we should implement a new
  * ACE_Hash_Map that uses double hashing, however!
  */
-class Hash_Table : private ACE_Copy_Disabled
+class Hash_Table
 {
 public:
   /// Constructor
   Hash_Table (size_t s);
+
+  Hash_Table (const Hash_Table &) = delete;
+  Hash_Table (Hash_Table &&) = delete;
+  Hash_Table &operator= (const Hash_Table &) = delete;
+  Hash_Table &operator= (Hash_Table &&) = delete;
 
   /// Destructor
   ~Hash_Table ();

--- a/ACE/apps/gperf/src/Iterator.h
+++ b/ACE/apps/gperf/src/Iterator.h
@@ -31,7 +31,6 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "Options.h"
-#include "ace/Copy_Disabled.h"
 
 /**
  * Provides an Iterator that expands and decodes a control string
@@ -45,7 +44,7 @@
  * No errors are handled in these routines, they are passed back
  * to the calling routines via a user-supplied Error_Value
  */
-class Iterator : private ACE_Copy_Disabled
+class Iterator
 {
 public:
   Iterator (char *s,
@@ -54,6 +53,11 @@ public:
             int word_end,
             int bad_val,
             int key_end);
+  Iterator (const Iterator &) = delete;
+  Iterator (Iterator &&) = delete;
+  Iterator &operator= (const Iterator &) = delete;
+  Iterator &operator= (Iterator &&) = delete;
+
   int operator () ();
 
 private:

--- a/ACE/apps/gperf/src/Key_List.h
+++ b/ACE/apps/gperf/src/Key_List.h
@@ -28,16 +28,22 @@
 
 #include "List_Node.h"
 #include "Vectors.h"
-#include "ace/Copy_Disabled.h"
 
 /**
  * Describes a duplicate entry.
  *
  * This is used for generating code by the <Key_List>.
  */
-class Duplicate_Entry : private ACE_Copy_Disabled
+class Duplicate_Entry
 {
 public:
+  Duplicate_Entry () = default;
+  Duplicate_Entry (const Duplicate_Entry &) = delete;
+  Duplicate_Entry (Duplicate_Entry &&) = delete;
+  Duplicate_Entry &operator= (const Duplicate_Entry &) = delete;
+  Duplicate_Entry &operator= (Duplicate_Entry &&) = delete;
+  ~Duplicate_Entry () = default;
+
   /// Hash value for this particular duplicate set.
   int hash_value;
 
@@ -56,10 +62,14 @@ public:
  * the Gen_Perf.hash function.  A Key_List is a singly-linked list
  * of List_Nodes.
  */
-class Key_List : private ACE_Copy_Disabled
+class Key_List
 {
 public:
   Key_List ();
+  Key_List (const Key_List &) = delete;
+  Key_List (Key_List &&) = delete;
+  Key_List &operator= (const Key_List &) = delete;
+  Key_List &operator= (Key_List &&) = delete;
   ~Key_List ();
   int keyword_list_length ();
   int max_key_length ();

--- a/ACE/apps/gperf/src/List_Node.h
+++ b/ACE/apps/gperf/src/List_Node.h
@@ -31,17 +31,21 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "Options.h"
-#include "ace/Copy_Disabled.h"
 
 /**
  * Data and function members for defining values and operations of
  * a list node.
  */
-class List_Node : private ACE_Copy_Disabled
+class List_Node
 {
 public:
   /// Constructor.
   List_Node (char *key, int len);
+
+  List_Node (const List_Node &) = delete;
+  List_Node (List_Node &&) = delete;
+  List_Node &operator= (const List_Node &) = delete;
+  List_Node &operator= (List_Node &&) = delete;
 
   /// Destructor.
   ~List_Node ();

--- a/ACE/apps/gperf/src/Options.h
+++ b/ACE/apps/gperf/src/Options.h
@@ -26,7 +26,6 @@
 
 #include "ace/Log_Msg.h"
 #include "ace/SString.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -91,10 +90,14 @@ enum
  *
  * @todo The Options class should be changed to use the Singleton pattern.
  */
-class Options : private ACE_Copy_Disabled
+class Options
 {
 public:
   Options ();
+  Options (const Options &) = delete;
+  Options (Options &&) = delete;
+  Options &operator= (const Options &) = delete;
+  Options &operator= (Options &&) = delete;
   ~Options ();
   int operator[] (Option_Type option);
   int parse_args (int argc, ACE_TCHAR *argv[]);

--- a/ACE/tests/TSS_Leak_Test.cpp
+++ b/ACE/tests/TSS_Leak_Test.cpp
@@ -4,12 +4,17 @@
 #include "ace/Task.h"
 #include "ace/Barrier.h"
 
-struct X : private ACE_Copy_Disabled
+struct X
 {
   static int count_;
 
   X() { ++count_; }
   ~X() { --count_; }
+
+  X (const X &) = delete;
+  X (X &&) = delete;
+  X &operator= (const X &) = delete;
+  X &operator= (X &&) = delete;
 };
 
 int X::count_;

--- a/TAO/orbsvcs/orbsvcs/Notify/Event.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/Event.h
@@ -37,7 +37,6 @@ class TAO_Notify_EventType;
  */
 class TAO_Notify_Serv_Export TAO_Notify_Event
     : public TAO_Notify_Refcountable
-    , private ACE_Copy_Disabled
 {
 public:
   typedef TAO_Notify_Refcountable_Guard_T<TAO_Notify_Event> Ptr;

--- a/TAO/orbsvcs/orbsvcs/Notify/Event.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/Event.h
@@ -25,8 +25,6 @@
 #include "orbsvcs/CosNotifyFilterC.h"
 #include "orbsvcs/CosNotificationC.h"
 
-#include "ace/Copy_Disabled.h"
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 class TAO_Notify_Consumer;
@@ -46,8 +44,14 @@ public:
 
   // Codes to distinguish marshaled events in persistent storage
   enum {MARSHAL_ANY=1,MARSHAL_STRUCTURED=2};
+
   /// Constructor
   TAO_Notify_Event ();
+
+  TAO_Notify_Event (const TAO_Notify_Event &) = delete;
+  TAO_Notify_Event (TAO_Notify_Event &&) = delete;
+  TAO_Notify_Event &operator= (const TAO_Notify_Event &) = delete;
+  TAO_Notify_Event &operator= (TAO_Notify_Event &&) = delete;
 
   /// Destructor
   virtual ~TAO_Notify_Event ();

--- a/TAO/orbsvcs/orbsvcs/Notify/Event_Map_Entry_T.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/Event_Map_Entry_T.h
@@ -16,7 +16,6 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Copy_Disabled.h"
 #include "ace/Atomic_Op.h"
 #include "ace/CORBA_macros.h"
 #include "tao/ORB_Constants.h"
@@ -33,13 +32,18 @@ template <class PROXY> class TAO_ESF_Proxy_Collection;
  * @brief The entry stored in the event map.
  */
 template <class PROXY>
-class TAO_Notify_Event_Map_Entry_T : private ACE_Copy_Disabled
+class TAO_Notify_Event_Map_Entry_T
 {
 public:
   typedef TAO_ESF_Proxy_Collection<PROXY> COLLECTION;
 
   /// Constructor
   TAO_Notify_Event_Map_Entry_T ();
+
+  TAO_Notify_Event_Map_Entry_T (const TAO_Notify_Event_Map_Entry_T &) = delete;
+  TAO_Notify_Event_Map_Entry_T (TAO_Notify_Event_Map_Entry_T &&) = delete;
+  TAO_Notify_Event_Map_Entry_T &operator= (const TAO_Notify_Event_Map_Entry_T &) = delete;
+  TAO_Notify_Event_Map_Entry_T &operator= (TAO_Notify_Event_Map_Entry_T &&) = delete;
 
   /// Destructor
   ~TAO_Notify_Event_Map_Entry_T ();

--- a/TAO/orbsvcs/orbsvcs/Notify/POA_Helper.h
+++ b/TAO/orbsvcs/orbsvcs/Notify/POA_Helper.h
@@ -21,8 +21,6 @@
 
 #include "tao/PortableServer/PortableServer.h"
 
-#include "ace/Copy_Disabled.h"
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /**
@@ -30,11 +28,16 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
  *
  * @brief POA Abstraction.
  */
-class TAO_Notify_Serv_Export TAO_Notify_POA_Helper : private ACE_Copy_Disabled
+class TAO_Notify_Serv_Export TAO_Notify_POA_Helper
 {
 public:
   /// Default Constructor
   TAO_Notify_POA_Helper ();
+
+  TAO_Notify_POA_Helper (const TAO_Notify_POA_Helper &) = delete;
+  TAO_Notify_POA_Helper (TAO_Notify_POA_Helper &&) = delete;
+  TAO_Notify_POA_Helper &operator= (const TAO_Notify_POA_Helper &) = delete;
+  TAO_Notify_POA_Helper &operator= (TAO_Notify_POA_Helper &&) = delete;
 
   /// Create a new PortableServer::POA.
   void init (PortableServer::POA_ptr parent_poa, const char* poa_name);

--- a/TAO/orbsvcs/performance-tests/RTEvent/lib/Task_Activator.h
+++ b/TAO/orbsvcs/performance-tests/RTEvent/lib/Task_Activator.h
@@ -8,7 +8,6 @@
 #define TAO_PERF_RTEC_TASK_ACTIVATOR_H
 
 #include "ace/Task.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -20,7 +19,7 @@
  * @brief Simplify the activation and destruction of tasks
  */
 template<class Task>
-class Task_Activator : private ACE_Copy_Disabled
+class Task_Activator
 {
 public:
   /// Constructor
@@ -50,6 +49,11 @@ public:
                   int scheduling_class,
                   int nthreads,
                   Task *task);
+
+  Task_Activator (const Task_Activator &) = delete;
+  Task_Activator (Task_Activator &&) = delete;
+  Task_Activator &operator= (const Task_Activator &) = delete;
+  Task_Activator &operator= (Task_Activator &&) = delete;
 
   /// Destructor
   /**

--- a/TAO/tao/Connection_Handler.h
+++ b/TAO/tao/Connection_Handler.h
@@ -21,7 +21,6 @@
 
 #include "tao/Basic_Types.h"
 #include "ace/Event_Handler.h"
-#include "ace/Copy_Disabled.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_SOCK;
@@ -202,19 +201,23 @@ private:
  * @brief TAO_Auto_Reference acts as a "smart pointer" for
  * reference-countable instances.
  *
- * It increments the refrence count in the constructor and decrements
- * it in the destructor. The only requiement for the template
+ * It increments the reference count in the constructor and decrements
+ * it in the destructor. The only requirement for the template
  * parameter is to be a class that provides add_reference() and
  * remove_reference().
  */
 template <class T> class TAO_Auto_Reference
-  : private ACE_Copy_Disabled
 {
 public:
   TAO_Auto_Reference (T& r): ref_ (r)
   {
     ref_.add_reference ();
   }
+
+  TAO_Auto_Reference (const TAO_Auto_Reference &) = delete;
+  TAO_Auto_Reference (TAO_Auto_Reference &&) = delete;
+  TAO_Auto_Reference &operator= (const TAO_Auto_Reference &) = delete;
+  TAO_Auto_Reference &operator= (TAO_Auto_Reference &&) = delete;
 
   ~TAO_Auto_Reference ()
   {

--- a/TAO/tao/Messaging/AMH_Response_Handler.cpp
+++ b/TAO/tao/Messaging/AMH_Response_Handler.cpp
@@ -12,8 +12,6 @@
 #include "tao/SystemException.h"
 #include "tao/PortableServer/ForwardRequestC.h"
 
-#include "ace/Copy_Disabled.h"
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 TAO_AMH_Response_Handler::TAO_AMH_Response_Handler ()

--- a/TAO/tao/On_Demand_Fragmentation_Strategy.h
+++ b/TAO/tao/On_Demand_Fragmentation_Strategy.h
@@ -15,7 +15,6 @@
 
 #include "tao/GIOP_Fragmentation_Strategy.h"
 #include "ace/CDR_Base.h"
-#include "ace/Copy_Disabled.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -38,8 +37,7 @@ class TAO_Transport;
  *
  * @see TAO_GIOP_Fragmentation_Strategy
  */
-class TAO_On_Demand_Fragmentation_Strategy
-  : public TAO_GIOP_Fragmentation_Strategy
+class TAO_On_Demand_Fragmentation_Strategy : public TAO_GIOP_Fragmentation_Strategy
 {
 public:
   /// Constructor.

--- a/TAO/tao/TAO_Singleton.h
+++ b/TAO/tao/TAO_Singleton.h
@@ -81,8 +81,7 @@ protected:
  * unloaded.
  */
 template <class TYPE, class ACE_LOCK>
-class TAO_TSS_Singleton : public ACE_Cleanup,
-                          private ACE_Copy_Disabled
+class TAO_TSS_Singleton : public ACE_Cleanup
 {
 public:
   /// Global access point to the Singleton.
@@ -98,6 +97,11 @@ public:
 protected:
   /// Default constructor.
   TAO_TSS_Singleton ();
+
+  TAO_TSS_Singleton (const TAO_TSS_Singleton &) = delete;
+  TAO_TSS_Singleton (TAO_TSS_Singleton &&) = delete;
+  TAO_TSS_Singleton &operator= (const TAO_TSS_Singleton &) = delete;
+  TAO_TSS_Singleton &operator= (TAO_TSS_Singleton &&) = delete;
 
   /// Contained instance.
   ACE_TSS_TYPE (TYPE) instance_;

--- a/TAO/tao/TAO_Singleton.h
+++ b/TAO/tao/TAO_Singleton.h
@@ -50,7 +50,7 @@ public:
 
   /// Cleanup method, used by @c ace_cleanup_destroyer to destroy the
   /// singleton.
-  virtual void cleanup (void *param = 0);
+  virtual void cleanup (void *param = nullptr);
 
   /// Dump the state of the object.
   static void dump ();
@@ -89,7 +89,7 @@ public:
 
   /// Cleanup method, used by @c ace_cleanup_destroyer to destroy the
   /// singleton.
-  virtual void cleanup (void *param = 0);
+  virtual void cleanup (void *param = nullptr);
 
   /// Dump the state of the object.
   static void dump ();

--- a/TAO/tao/TAO_Singleton_Manager.h
+++ b/TAO/tao/TAO_Singleton_Manager.h
@@ -94,7 +94,7 @@ public:
    * memory, or EEXIST if the object (or array) had already been
    * registered.
    */
-  static int at_exit (ACE_Cleanup *object, void *param = 0, const char* name = 0);
+  static int at_exit (ACE_Cleanup *object, void *param = nullptr, const char* name = nullptr);
 
   /// Register an object (or array) for cleanup at process
   /// termination.

--- a/TAO/tao/Utils/Server_Main.h
+++ b/TAO/tao/Utils/Server_Main.h
@@ -56,7 +56,6 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "tao/orbconf.h"
-#include "ace/Copy_Disabled.h"
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -65,10 +64,14 @@ namespace TAO
   namespace Utils
   {
     template <typename SERVANT>
-    class Server_Main : private ACE_Copy_Disabled
+    class Server_Main
     {
     public:
       Server_Main(const char * name);
+      Server_Main (const Server_Main &) = delete;
+      Server_Main (Server_Main &&) = delete;
+      Server_Main &operator= (const Server_Main &) = delete;
+      Server_Main &operator= (Server_Main &&) = delete;
       ~Server_Main();
 
       int run (int argc, ACE_TCHAR *argv[]);

--- a/TAO/tests/Sequence_Unit_Tests/testing_counters.hpp
+++ b/TAO/tests/Sequence_Unit_Tests/testing_counters.hpp
@@ -11,7 +11,6 @@
  */
 
 #include "testing_exception.hpp"
-#include "ace/Copy_Disabled.h"
 
 #include <iostream>
 
@@ -56,7 +55,6 @@ private:
  *        number of times.
  */
 class expected_calls
-  : private ACE_Copy_Disabled
 {
 public:
   inline expected_calls(call_counter const & counter)
@@ -64,6 +62,11 @@ public:
     , previous_count_(counter.current_count())
     , counter_(counter)
   { }
+
+  expected_calls (const expected_calls &) = delete;
+  expected_calls (expected_calls &&) = delete;
+  expected_calls &operator= (const expected_calls &) = delete;
+  expected_calls &operator= (expected_calls &&) = delete;
 
   inline bool expect(long n)
   {


### PR DESCRIPTION
…ious destructors

    * ACE/ace/Activation_Queue.h:
    * ACE/ace/Caching_Utility_T.h:
    * ACE/ace/Cleanup.cpp:
    * ACE/ace/Cleanup.h:
    * ACE/ace/Cleanup_Strategies_T.cpp:
    * ACE/ace/Cleanup_Strategies_T.h:
    * ACE/ace/Codeset_IBM1047.cpp:
    * ACE/ace/Codeset_IBM1047.h:
    * ACE/ace/Compression/Compressor.h:
    * ACE/ace/Configuration.cpp:
    * ACE/ace/Configuration.h:
    * ACE/ace/Containers_T.cpp:
    * ACE/ace/Containers_T.h:
    * ACE/ace/Countdown_Time_T.h:
    * ACE/ace/Dynamic.h:
    * ACE/ace/Dynamic.inl:
    * ACE/ace/Dynamic_Message_Strategy.cpp:
    * ACE/ace/Dynamic_Message_Strategy.h:
    * ACE/ace/ETCL/ETCL_Constraint.cpp:
    * ACE/ace/ETCL/ETCL_Constraint.h:
    * ACE/ace/ETCL/ETCL_Constraint_Visitor.cpp:
    * ACE/ace/ETCL/ETCL_Constraint_Visitor.h:
    * ACE/ace/Env_Value_T.h:
    * ACE/ace/Env_Value_T.inl:
    * ACE/ace/Framework_Component.h:
    * ACE/ace/Future_Set.h:
    * ACE/ace/Map_T.cpp:
    * ACE/ace/Mem_Map.h:
    * ACE/ace/Message_Queue.cpp:
    * ACE/ace/Service_Gestalt.h:
    * ACE/ace/TSS_T.h:
    * ACE/ace/Task_Ex_T.h:
    * ACE/ace/Timer_Hash_T.h:
    * ACE/ace/Timer_Queue_T.cpp:
    * ACE/ace/Timer_Queue_T.h:
    * ACE/ace/Timer_Wheel_T.h:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined class definitions by replacing empty or custom destructors and constructors with default implementations.
  - Enforced non-copyable and non-movable semantics by explicitly deleting copy and move constructors and assignment operators across multiple classes.
  - Updated pointer initialization to modern standards using `nullptr` instead of numeric literals.

- **Chores**
  - Removed outdated header dependencies to simplify and clean up the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->