### PR TITLE
Use std::move, nullptr, const, layout changes

### DIFF
--- a/TAO/tao/DiffServPolicy/DiffServ_Network_Priority_Hook.cpp
+++ b/TAO/tao/DiffServPolicy/DiffServ_Network_Priority_Hook.cpp
@@ -13,11 +13,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-
-TAO_DiffServ_Network_Priority_Hook::~TAO_DiffServ_Network_Priority_Hook()
-{
-}
-
 void
 TAO_DiffServ_Network_Priority_Hook::update_network_priority (
   TAO_Root_POA &poa, TAO_POA_Policy_Set &policy_set)

--- a/TAO/tao/DiffServPolicy/DiffServ_Network_Priority_Hook.h
+++ b/TAO/tao/DiffServPolicy/DiffServ_Network_Priority_Hook.h
@@ -29,7 +29,7 @@ class TAO_DiffServPolicy_Export TAO_DiffServ_Network_Priority_Hook
   : public TAO_Network_Priority_Hook
 {
 public:
-  virtual ~TAO_DiffServ_Network_Priority_Hook();
+  ~TAO_DiffServ_Network_Priority_Hook() override = default;
 
   /// This function is a hook, that is called from the Root_POA's
   /// constructor. It allows the POA to cache the server side network
@@ -37,13 +37,13 @@ public:
   /// policy-specified DiffServ codepoint.
   ///
   void update_network_priority (TAO_Root_POA &poa,
-                                TAO_POA_Policy_Set &poa_policy_set);
+                                TAO_POA_Policy_Set &poa_policy_set) override;
 
   /// This function is a hook, that is used by the POA's servant dispatcher
   /// when it tries to assign DiffServ codepoints on the replies.
   ///
   void set_dscp_codepoint (TAO_ServerRequest &req,
-                           TAO_Root_POA &poa);
+                           TAO_Root_POA &poa) override;
 };
 
 

--- a/TAO/tao/DiffServPolicy/DiffServ_Protocols_Hooks.cpp
+++ b/TAO/tao/DiffServPolicy/DiffServ_Protocols_Hooks.cpp
@@ -11,18 +11,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO_DS_Network_Priority_Protocols_Hooks::
-TAO_DS_Network_Priority_Protocols_Hooks ()
-  : orb_core_ (0)
-{
-}
-
-
-TAO_DS_Network_Priority_Protocols_Hooks::
-~TAO_DS_Network_Priority_Protocols_Hooks ()
-{
-}
-
 void
 TAO_DS_Network_Priority_Protocols_Hooks::init_hooks (TAO_ORB_Core *orb_core)
 {

--- a/TAO/tao/DiffServPolicy/DiffServ_Protocols_Hooks.h
+++ b/TAO/tao/DiffServPolicy/DiffServ_Protocols_Hooks.h
@@ -31,10 +31,10 @@ class TAO_DiffServPolicy_Export TAO_DS_Network_Priority_Protocols_Hooks
 {
 public:
   /// Constructor
-  TAO_DS_Network_Priority_Protocols_Hooks ();
+  TAO_DS_Network_Priority_Protocols_Hooks () = default;
 
   /// Destructor
-  virtual ~TAO_DS_Network_Priority_Protocols_Hooks ();
+  virtual ~TAO_DS_Network_Priority_Protocols_Hooks () = default;
 
   /// Initialize the network priority protocols hooks instance.
   void init_hooks (TAO_ORB_Core *orb_core);

--- a/TAO/tao/DiffServPolicy/DiffServ_Protocols_Hooks.h
+++ b/TAO/tao/DiffServPolicy/DiffServ_Protocols_Hooks.h
@@ -56,7 +56,7 @@ public:
   CORBA::Long get_dscp_codepoint (TAO_Service_Context &sc);
 
 protected:
-  TAO_ORB_Core *orb_core_;
+  TAO_ORB_Core *orb_core_ {};
 };
 
 

--- a/TAO/tao/EndpointPolicy/EndpointPolicy_i.cpp
+++ b/TAO/tao/EndpointPolicy/EndpointPolicy_i.cpp
@@ -17,11 +17,6 @@ TAO_EndpointPolicy_i::TAO_EndpointPolicy_i (const TAO_EndpointPolicy_i &rhs)
 {
 }
 
-TAO_EndpointPolicy_i::~TAO_EndpointPolicy_i ()
-{
-}
-
-
 CORBA::PolicyType
 TAO_EndpointPolicy_i::policy_type ()
 {
@@ -31,20 +26,20 @@ TAO_EndpointPolicy_i::policy_type ()
 TAO_EndpointPolicy_i *
 TAO_EndpointPolicy_i::clone () const
 {
-  TAO_EndpointPolicy_i *copy = 0;
+  TAO_EndpointPolicy_i *copy {};
   ACE_NEW_RETURN (copy,
                   TAO_EndpointPolicy_i (*this),
-                  0);
+                  nullptr);
   return copy;
 }
 
 EndpointPolicy::EndpointList *
 TAO_EndpointPolicy_i::value ()
 {
-  EndpointPolicy::EndpointList* list = 0;
+  EndpointPolicy::EndpointList* list {};
   ACE_NEW_RETURN (list,
                   EndpointPolicy::EndpointList (this->value_),
-                  0);
+                  nullptr);
 
   return list;
 }
@@ -52,7 +47,7 @@ TAO_EndpointPolicy_i::value ()
 CORBA::Policy_ptr
 TAO_EndpointPolicy_i::copy ()
 {
-  TAO_EndpointPolicy_i* servant = 0;
+  TAO_EndpointPolicy_i* servant {};
   ACE_NEW_THROW_EX (servant,
                     TAO_EndpointPolicy_i (*this),
                     CORBA::NO_MEMORY ());

--- a/TAO/tao/EndpointPolicy/EndpointPolicy_i.h
+++ b/TAO/tao/EndpointPolicy/EndpointPolicy_i.h
@@ -50,7 +50,7 @@ public:
   /// Copy constructor.
   TAO_EndpointPolicy_i (const TAO_EndpointPolicy_i &rhs);
 
-  virtual ~TAO_EndpointPolicy_i ();
+  virtual ~TAO_EndpointPolicy_i () = default;
 
   /// Returns a copy of this>
   virtual TAO_EndpointPolicy_i *clone () const;

--- a/TAO/tao/EndpointPolicy/Endpoint_Acceptor_Filter_Factory.cpp
+++ b/TAO/tao/EndpointPolicy/Endpoint_Acceptor_Filter_Factory.cpp
@@ -7,13 +7,8 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-
-TAO_Endpoint_Acceptor_Filter_Factory::~TAO_Endpoint_Acceptor_Filter_Factory()
-{
-}
-
- TAO_Acceptor_Filter*
- TAO_Endpoint_Acceptor_Filter_Factory::create_object (TAO_POA_Manager& poamanager)
+TAO_Acceptor_Filter*
+TAO_Endpoint_Acceptor_Filter_Factory::create_object (TAO_POA_Manager& poamanager)
 {
   CORBA::PolicyList& policies = poamanager.get_policies ();
 

--- a/TAO/tao/EndpointPolicy/Endpoint_Acceptor_Filter_Factory.h
+++ b/TAO/tao/EndpointPolicy/Endpoint_Acceptor_Filter_Factory.h
@@ -37,7 +37,7 @@ class TAO_EndpointPolicy_Export TAO_Endpoint_Acceptor_Filter_Factory
   : public TAO_Acceptor_Filter_Factory
 {
 public:
-  virtual ~TAO_Endpoint_Acceptor_Filter_Factory();
+  virtual ~TAO_Endpoint_Acceptor_Filter_Factory() = default;
 
   /// Create a new TAO_Endpoint_Acceptor_Filter object.
   TAO_Acceptor_Filter* create_object (TAO_POA_Manager& poamanager);

--- a/TAO/tao/EndpointPolicy/IIOPEndpointValue_i.cpp
+++ b/TAO/tao/EndpointPolicy/IIOPEndpointValue_i.cpp
@@ -23,17 +23,13 @@ IIOPEndpointValue_i::IIOPEndpointValue_i (const char *host, CORBA::UShort port)
     this->addr_.set_type (-1);
 }
 
-IIOPEndpointValue_i::~IIOPEndpointValue_i ()
-{
-}
-
 CORBA::Boolean
 IIOPEndpointValue_i::is_equivalent (const TAO_Endpoint * endpoint) const
 {
   const TAO_IIOP_Endpoint *iep =
     dynamic_cast<const TAO_IIOP_Endpoint *>(endpoint);
-  if (iep == 0)
-    return 0;
+  if (iep == nullptr)
+    return false;
   return this->addr_.get_type() != -1 ? this->addr_ == iep->object_addr() :
     this->is_equivalent_i (iep->port(), iep->host());
 }
@@ -54,7 +50,7 @@ IIOPEndpointValue_i::validate_acceptor(TAO_Acceptor * acceptor,
                                        bool is_multi_prot) const
 {
   TAO_IIOP_Acceptor *iacc = dynamic_cast<TAO_IIOP_Acceptor *>(acceptor);
-  if (iacc == 0)
+  if (iacc == nullptr)
     return false;
 
 #if 0

--- a/TAO/tao/EndpointPolicy/IIOPEndpointValue_i.h
+++ b/TAO/tao/EndpointPolicy/IIOPEndpointValue_i.h
@@ -66,7 +66,7 @@ public:
   /// of one-off values.
   IIOPEndpointValue_i (const char *host, CORBA::UShort port);
 
-  virtual ~IIOPEndpointValue_i ();
+  virtual ~IIOPEndpointValue_i () = default;
 
   /// The is_equivalent test is used by the endpoint policy framework
   /// for testing if a target endpoint is the same as the endpoint

--- a/TAO/tao/PortableServer/Active_Object_Map.cpp
+++ b/TAO/tao/PortableServer/Active_Object_Map.cpp
@@ -95,7 +95,7 @@ TAO_Active_Object_Map::TAO_Active_Object_Map (
 {
   TAO_Active_Object_Map::set_system_id_size (creation_parameters);
 
-  TAO_Id_Uniqueness_Strategy *id_uniqueness_strategy = 0;
+  TAO_Id_Uniqueness_Strategy *id_uniqueness_strategy {};
 
   if (unique_id_policy)
     {
@@ -118,7 +118,7 @@ TAO_Active_Object_Map::TAO_Active_Object_Map (
   // Give ownership to the unique pointer.
   std::unique_ptr<TAO_Id_Uniqueness_Strategy> new_id_uniqueness_strategy (id_uniqueness_strategy);
 
-  TAO_Lifespan_Strategy *lifespan_strategy = 0;
+  TAO_Lifespan_Strategy *lifespan_strategy {};
 
   if (persistent_id_policy)
     {
@@ -142,7 +142,7 @@ TAO_Active_Object_Map::TAO_Active_Object_Map (
   // Give ownership to the unique pointer.
   std::unique_ptr<TAO_Lifespan_Strategy> new_lifespan_strategy (lifespan_strategy);
 
-  TAO_Id_Assignment_Strategy *id_assignment_strategy = 0;
+  TAO_Id_Assignment_Strategy *id_assignment_strategy {};
 
   if (user_id_policy)
     {
@@ -177,7 +177,7 @@ TAO_Active_Object_Map::TAO_Active_Object_Map (
   // Give ownership to the unique pointer.
   std::unique_ptr<TAO_Id_Assignment_Strategy> new_id_assignment_strategy (id_assignment_strategy);
 
-  TAO_Id_Hint_Strategy *id_hint_strategy = 0;
+  TAO_Id_Hint_Strategy *id_hint_strategy {};
   if ((user_id_policy
        || creation_parameters.allow_reactivation_of_system_ids_)
       && creation_parameters.use_active_hint_in_ids_)
@@ -199,7 +199,7 @@ TAO_Active_Object_Map::TAO_Active_Object_Map (
   // Give ownership to the unique pointer.
   std::unique_ptr<TAO_Id_Hint_Strategy> new_id_hint_strategy (id_hint_strategy);
 
-  servant_map *sm = 0;
+  servant_map *sm {};
   if (unique_id_policy)
     {
       switch (creation_parameters.reverse_object_lookup_strategy_for_unique_id_policy_)
@@ -233,7 +233,7 @@ TAO_Active_Object_Map::TAO_Active_Object_Map (
   // Give ownership to the unique pointer.
   std::unique_ptr<servant_map> new_servant_map (sm);
 
-  user_id_map *uim = 0;
+  user_id_map *uim {};
   if (user_id_policy
       || creation_parameters.allow_reactivation_of_system_ids_)
     {
@@ -348,7 +348,7 @@ TAO_Active_Object_Map::is_user_id_in_map (
   bool &priorities_match,
   bool &deactivated)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   bool result = false;
   int const find_result = this->user_id_map_->find (user_id, entry);
 
@@ -388,9 +388,8 @@ int
 TAO_Unique_Id_Strategy::is_servant_in_map (PortableServer::Servant servant,
                                            bool &deactivated)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
-  int result = this->active_object_map_->servant_map_->find (servant,
-                                                             entry);
+  TAO_Active_Object_Map_Entry *entry{};
+  int result = this->active_object_map_->servant_map_->find (servant, entry);
   if (result == 0)
     {
       result = 1;
@@ -510,9 +509,8 @@ int
 TAO_Unique_Id_Strategy::unbind_using_user_id (
   const PortableServer::ObjectId &user_id)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
-  int result = this->active_object_map_->user_id_map_->unbind (user_id,
-                                                               entry);
+  TAO_Active_Object_Map_Entry *entry {};
+  int result = this->active_object_map_->user_id_map_->unbind (user_id, entry);
   if (result == 0)
     {
       if (TAO_debug_level > 7)
@@ -558,7 +556,7 @@ TAO_Unique_Id_Strategy::find_user_id_using_servant (
   PortableServer::Servant servant,
   PortableServer::ObjectId_out user_id)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   int result = this->active_object_map_->servant_map_->find (servant, entry);
 
   if (result == 0)
@@ -584,7 +582,7 @@ TAO_Unique_Id_Strategy::find_system_id_using_servant (
   PortableServer::ObjectId_out system_id,
   CORBA::Short &priority)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   int result = this->active_object_map_->servant_map_->find (servant,
                                                              entry);
   if (result == 0)
@@ -705,7 +703,7 @@ int
 TAO_Multiple_Id_Strategy::unbind_using_user_id (
   const PortableServer::ObjectId &user_id)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   int result = this->active_object_map_->user_id_map_->unbind (user_id,
                                                                entry);
   if (result == 0)

--- a/TAO/tao/PortableServer/Active_Object_Map.cpp
+++ b/TAO/tao/PortableServer/Active_Object_Map.cpp
@@ -354,7 +354,7 @@ TAO_Active_Object_Map::is_user_id_in_map (
 
   if (find_result == 0)
     {
-      if (entry->servant_ == 0)
+      if (entry->servant_ == nullptr)
         {
           if (entry->priority_ != priority)
             {
@@ -420,7 +420,7 @@ TAO_Unique_Id_Strategy::bind_using_user_id (
 
   if (result == 0)
     {
-      if (servant != 0)
+      if (servant != nullptr)
         {
           entry->servant_ = servant;
 
@@ -451,24 +451,19 @@ TAO_Unique_Id_Strategy::bind_using_user_id (
       if (result == 0)
         {
           result =
-            this->active_object_map_->user_id_map_->bind (entry->user_id_,
-                                                          entry);
+            this->active_object_map_->user_id_map_->bind (entry->user_id_, entry);
           if (result == 0)
             {
-              if (servant != 0)
+              if (servant != nullptr)
                 {
                   result =
-                    this->active_object_map_->servant_map_->bind (
-                      entry->servant_,
-                      entry);
+                    this->active_object_map_->servant_map_->bind (entry->servant_, entry);
                 }
 
               if (result != 0)
                 {
-                  this->active_object_map_->user_id_map_->unbind (
-                    entry->user_id_);
-                  this->active_object_map_->id_hint_strategy_->unbind (
-                    *entry);
+                  this->active_object_map_->user_id_map_->unbind (entry->user_id_);
+                  this->active_object_map_->id_hint_strategy_->unbind (*entry);
                   delete entry;
                 }
               else
@@ -640,12 +635,11 @@ TAO_Multiple_Id_Strategy::bind_using_user_id (
   CORBA::Short priority,
   TAO_Active_Object_Map_Entry *&entry)
 {
-  int result =
-    this->active_object_map_->user_id_map_->find (user_id, entry);
+  int result = this->active_object_map_->user_id_map_->find (user_id, entry);
 
   if (result == 0)
     {
-      if (servant != 0)
+      if (servant != nullptr)
         {
           entry->servant_ = servant;
         }
@@ -944,7 +938,7 @@ TAO_System_Id_With_Unique_Id_Strategy::bind_using_system_id (
 
       if (result == 0)
         {
-          if (servant != 0)
+          if (servant != nullptr)
             {
               result =
                 this->active_object_map_->servant_map_->bind (entry->servant_,

--- a/TAO/tao/PortableServer/Active_Object_Map.inl
+++ b/TAO/tao/PortableServer/Active_Object_Map.inl
@@ -17,7 +17,7 @@ TAO_Active_Object_Map::bind_using_system_id_returning_system_id (
   CORBA::Short priority,
   PortableServer::ObjectId_out system_id)
 {
-  if (servant == 0 && !this->using_active_maps_)
+  if (servant == nullptr && !this->using_active_maps_)
     {
       PortableServer::ObjectId id;
 
@@ -51,7 +51,7 @@ TAO_Active_Object_Map::bind_using_system_id_returning_user_id (
   CORBA::Short priority,
   PortableServer::ObjectId_out user_id)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
 
   int const result = this->id_assignment_strategy_->bind_using_system_id (servant, priority, entry);
   if (result == 0)
@@ -67,7 +67,7 @@ TAO_Active_Object_Map::bind_using_user_id (
   const PortableServer::ObjectId &user_id,
   CORBA::Short priority)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   return this->id_uniqueness_strategy_->bind_using_user_id (servant, user_id, priority, entry);
 }
 
@@ -86,7 +86,7 @@ TAO_Active_Object_Map::find_system_id_using_user_id (
       return 0;
     }
 
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   int result =
     this->id_uniqueness_strategy_->bind_using_user_id (0,
                                                        user_id,
@@ -148,7 +148,7 @@ TAO_Active_Object_Map::find_servant_using_user_id (
   const PortableServer::ObjectId &user_id,
   PortableServer::Servant &servant)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   int result = this->user_id_map_->find (user_id, entry);
 
   if (result == 0)
@@ -157,7 +157,7 @@ TAO_Active_Object_Map::find_servant_using_user_id (
         {
           result = -1;
         }
-      else if (entry->servant_ == 0)
+      else if (entry->servant_ == nullptr)
         {
           result = -1;
         }
@@ -210,12 +210,12 @@ TAO_Active_Object_Map::find_servant_and_system_id_using_user_id (
   PortableServer::ObjectId_out system_id,
   CORBA::Short &priority)
 {
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
   int result = this->find_entry_using_user_id (user_id, entry);
 
   if (result == 0)
     {
-      if (entry->servant_ == 0)
+      if (entry->servant_ == nullptr)
         {
           result = -1;
         }

--- a/TAO/tao/PortableServer/Active_Object_Map.inl
+++ b/TAO/tao/PortableServer/Active_Object_Map.inl
@@ -21,29 +21,25 @@ TAO_Active_Object_Map::bind_using_system_id_returning_system_id (
     {
       PortableServer::ObjectId id;
 
-      int result = this->user_id_map_->create_key (id);
+      int const result = this->user_id_map_->create_key (id);
 
       if (result == 0)
         {
           ACE_NEW_RETURN (system_id,
-                          PortableServer::ObjectId (id),
+                          PortableServer::ObjectId (std::move(id)),
                           -1);
         }
 
       return result;
     }
 
-  TAO_Active_Object_Map_Entry *entry = 0;
+  TAO_Active_Object_Map_Entry *entry {};
 
-  int result =
-    this->id_assignment_strategy_->bind_using_system_id (servant,
-                                                         priority,
-                                                         entry);
+  int result = this->id_assignment_strategy_->bind_using_system_id (servant, priority, entry);
 
   if (result == 0)
     {
-      result = this->id_hint_strategy_->system_id (system_id,
-                                                   *entry);
+      result = this->id_hint_strategy_->system_id (system_id, *entry);
     }
 
   return result;
@@ -57,10 +53,7 @@ TAO_Active_Object_Map::bind_using_system_id_returning_user_id (
 {
   TAO_Active_Object_Map_Entry *entry = 0;
 
-  int result =
-    this->id_assignment_strategy_->bind_using_system_id (servant,
-                                                         priority,
-                                                         entry);
+  int const result = this->id_assignment_strategy_->bind_using_system_id (servant, priority, entry);
   if (result == 0)
     ACE_NEW_RETURN (user_id,
                     PortableServer::ObjectId (entry->user_id_),
@@ -75,10 +68,7 @@ TAO_Active_Object_Map::bind_using_user_id (
   CORBA::Short priority)
 {
   TAO_Active_Object_Map_Entry *entry = 0;
-  return this->id_uniqueness_strategy_->bind_using_user_id (servant,
-                                                            user_id,
-                                                            priority,
-                                                            entry);
+  return this->id_uniqueness_strategy_->bind_using_user_id (servant, user_id, priority, entry);
 }
 
 ACE_INLINE int
@@ -253,7 +243,7 @@ TAO_Active_Object_Map::find_user_id_using_system_id (
   if (this->id_hint_strategy_->recover_key (system_id, id) == 0)
     {
       ACE_NEW_RETURN (user_id,
-                      PortableServer::ObjectId (id),
+                      PortableServer::ObjectId (std::move(id)),
                       -1);
     }
 

--- a/TAO/tao/PortableServer/Collocated_Object_Proxy_Broker.cpp
+++ b/TAO/tao/PortableServer/Collocated_Object_Proxy_Broker.cpp
@@ -50,7 +50,7 @@ namespace TAO
   Collocated_Object_Proxy_Broker::_repository_id (CORBA::Object_ptr target)
   {
     TAO_Stub *stub = target->_stubobj ();
-    char * _tao_retval = 0;
+    char * _tao_retval {};
 
     try
       {
@@ -163,7 +163,7 @@ namespace TAO
   CORBA::InterfaceDef_ptr
   Collocated_Object_Proxy_Broker::_get_interface (CORBA::Object_ptr target)
   {
-    CORBA::InterfaceDef_ptr _tao_retval = 0;
+    CORBA::InterfaceDef_ptr _tao_retval {};
 
     TAO_Stub *stub = target->_stubobj ();
 

--- a/TAO/tao/PortableServer/Default_Servant_Dispatcher.cpp
+++ b/TAO/tao/PortableServer/Default_Servant_Dispatcher.cpp
@@ -18,7 +18,7 @@ TAO_Default_Servant_Dispatcher::create_Root_POA (const ACE_CString &name,
                                                  TAO_ORB_Core &orb_core,
                                                  TAO_Object_Adapter *object_adapter)
 {
-  TAO_Root_POA *poa = 0;
+  TAO_Root_POA *poa {};
 
   ACE_NEW_THROW_EX (poa,
                     TAO_Root_POA (name,

--- a/TAO/tao/PortableServer/Default_Servant_Dispatcher.cpp
+++ b/TAO/tao/PortableServer/Default_Servant_Dispatcher.cpp
@@ -5,10 +5,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO_Default_Servant_Dispatcher::~TAO_Default_Servant_Dispatcher ()
-{
-}
-
 TAO_Root_POA *
 TAO_Default_Servant_Dispatcher::create_Root_POA (const ACE_CString &name,
                                                  PortableServer::POAManager_ptr poa_manager,

--- a/TAO/tao/PortableServer/Default_Servant_Dispatcher.h
+++ b/TAO/tao/PortableServer/Default_Servant_Dispatcher.h
@@ -34,7 +34,7 @@ class TAO_PortableServer_Export TAO_Default_Servant_Dispatcher
   : public TAO_Servant_Dispatcher
 {
 public:
-  virtual ~TAO_Default_Servant_Dispatcher ();
+  virtual ~TAO_Default_Servant_Dispatcher () = default;
 
   /// Pre_invoke remote request.
   void pre_invoke_remote_request (

--- a/TAO/tao/PortableServer/IdAssignmentPolicy.cpp
+++ b/TAO/tao/PortableServer/IdAssignmentPolicy.cpp
@@ -20,7 +20,7 @@ namespace TAO
     CORBA::Policy_ptr
     IdAssignmentPolicy::copy ()
     {
-      IdAssignmentPolicy *copy = 0;
+      IdAssignmentPolicy *copy {};
       ACE_NEW_THROW_EX (copy,
                         IdAssignmentPolicy (this->value_),
                         CORBA::NO_MEMORY ());

--- a/TAO/tao/PortableServer/ImplicitActivationPolicy.cpp
+++ b/TAO/tao/PortableServer/ImplicitActivationPolicy.cpp
@@ -19,7 +19,7 @@ namespace TAO
     CORBA::Policy_ptr
     ImplicitActivationPolicy::copy ()
     {
-      ImplicitActivationPolicy *copy = 0;
+      ImplicitActivationPolicy *copy {};
       ACE_NEW_THROW_EX (copy,
                         ImplicitActivationPolicy (this->value_),
                         CORBA::NO_MEMORY ());

--- a/TAO/tao/PortableServer/LifespanPolicy.cpp
+++ b/TAO/tao/PortableServer/LifespanPolicy.cpp
@@ -21,7 +21,7 @@ namespace TAO
     CORBA::Policy_ptr
     LifespanPolicy::copy ()
     {
-      LifespanPolicy *copy = 0;
+      LifespanPolicy *copy {};
       ACE_NEW_THROW_EX (copy,
                         LifespanPolicy (this->value_),
                         CORBA::NO_MEMORY ());

--- a/TAO/tao/PortableServer/LifespanStrategyPersistent.cpp
+++ b/TAO/tao/PortableServer/LifespanStrategyPersistent.cpp
@@ -85,7 +85,7 @@ namespace TAO
             }
 #endif /* !TAO_AS_STATIC_LIBS */
 
-          if (adapter != 0)
+          if (adapter != nullptr)
             {
               adapter->imr_notify_startup (this->poa_);
             }
@@ -110,7 +110,7 @@ namespace TAO
         ACE_Dynamic_Service<ImR_Client_Adapter>::instance (
           TAO_Root_POA::imr_client_adapter_name ());
 
-      if (adapter != 0)
+      if (adapter != nullptr)
         {
           adapter->imr_notify_shutdown (this->poa_);
         }

--- a/TAO/tao/PortableServer/LifespanStrategyPersistent.cpp
+++ b/TAO/tao/PortableServer/LifespanStrategyPersistent.cpp
@@ -72,7 +72,7 @@ namespace TAO
           // In case we build shared, try to load the ImR Client library, in a
           // static build we just can't do this, so don't try it, lower layers
           // output an error then.
-          if (adapter == 0)
+          if (adapter == nullptr)
             {
               ACE_Service_Config::process_directive (
                 ACE_DYNAMIC_VERSIONED_SERVICE_DIRECTIVE(
@@ -147,7 +147,7 @@ namespace TAO
       ImR_Client_Adapter *adapter =
         ACE_Dynamic_Service<ImR_Client_Adapter>::instance (
           TAO_Root_POA::imr_client_adapter_name ());
-      if (adapter == 0)
+      if (adapter == nullptr)
         {
           // couldn't load adapter, already reported error
           return CORBA::Object::_nil ();

--- a/TAO/tao/PortableServer/Network_Priority_Hook.cpp
+++ b/TAO/tao/PortableServer/Network_Priority_Hook.cpp
@@ -4,10 +4,6 @@
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO_Network_Priority_Hook::~TAO_Network_Priority_Hook()
-{
-}
-
 void
 TAO_Network_Priority_Hook::update_network_priority (
   TAO_Root_POA &poa, TAO_POA_Policy_Set &)

--- a/TAO/tao/PortableServer/Network_Priority_Hook.h
+++ b/TAO/tao/PortableServer/Network_Priority_Hook.h
@@ -39,14 +39,13 @@ class TAO_PortableServer_Export TAO_Network_Priority_Hook
   : public ACE_Service_Object
 {
 public:
-  virtual ~TAO_Network_Priority_Hook();
+  ~TAO_Network_Priority_Hook() override = default;
 
-  virtual void update_network_priority (TAO_Root_POA& poa,
-                                        TAO_POA_Policy_Set& poa_policy_set);
+  void update_network_priority (TAO_Root_POA& poa,
+                                TAO_POA_Policy_Set& poa_policy_set) override;
 
 
-  virtual void set_dscp_codepoint (TAO_ServerRequest &req,
-                                   TAO_Root_POA& poa);
+  void set_dscp_codepoint (TAO_ServerRequest &req, TAO_Root_POA& poa) override;
 
   /// Static initializer ensures the factory is loaded
   static int initialize ();

--- a/TAO/tao/PortableServer/Network_Priority_Hook.h
+++ b/TAO/tao/PortableServer/Network_Priority_Hook.h
@@ -41,11 +41,11 @@ class TAO_PortableServer_Export TAO_Network_Priority_Hook
 public:
   ~TAO_Network_Priority_Hook() override = default;
 
-  void update_network_priority (TAO_Root_POA& poa,
-                                TAO_POA_Policy_Set& poa_policy_set) override;
+  virtual void update_network_priority (TAO_Root_POA& poa,
+                                        TAO_POA_Policy_Set& poa_policy_set);
 
 
-  void set_dscp_codepoint (TAO_ServerRequest &req, TAO_Root_POA& poa) override;
+  virtual void set_dscp_codepoint (TAO_ServerRequest &req, TAO_Root_POA& poa);
 
   /// Static initializer ensures the factory is loaded
   static int initialize ();

--- a/TAO/tao/PortableServer/Object_Adapter.cpp
+++ b/TAO/tao/PortableServer/Object_Adapter.cpp
@@ -922,10 +922,6 @@ TAO_Object_Adapter::get_collocated_servant (const TAO_MProfile &mp)
 
 // ****************************************************************
 
-TAO_Object_Adapter::Hint_Strategy::~Hint_Strategy ()
-{
-}
-
 void
 TAO_Object_Adapter::Hint_Strategy::object_adapter (TAO_Object_Adapter *oa)
 {
@@ -934,10 +930,6 @@ TAO_Object_Adapter::Hint_Strategy::object_adapter (TAO_Object_Adapter *oa)
 
 TAO_Object_Adapter::Active_Hint_Strategy::Active_Hint_Strategy (CORBA::ULong map_size)
   : persistent_poa_system_map_ (map_size)
-{
-}
-
-TAO_Object_Adapter::Active_Hint_Strategy::~Active_Hint_Strategy ()
 {
 }
 
@@ -1006,10 +998,6 @@ TAO_Object_Adapter::Active_Hint_Strategy::unbind_persistent_poa (
       this->object_adapter_->persistent_poa_name_map_->unbind (folded_name);
 
   return result;
-}
-
-TAO_Object_Adapter::No_Hint_Strategy::~No_Hint_Strategy ()
-{
 }
 
 int

--- a/TAO/tao/PortableServer/Object_Adapter.cpp
+++ b/TAO/tao/PortableServer/Object_Adapter.cpp
@@ -976,20 +976,18 @@ TAO_Object_Adapter::Active_Hint_Strategy::bind_persistent_poa (
   poa_name_out system_name)
 {
   poa_name name = folded_name;
-  int result = this->persistent_poa_system_map_.bind_modify_key (poa,
-                                                                 name);
+  int result = this->persistent_poa_system_map_.bind_modify_key (poa, name);
 
   if (result == 0)
     {
       result =
-        this->object_adapter_->persistent_poa_name_map_->bind (folded_name,
-                                                               poa);
+        this->object_adapter_->persistent_poa_name_map_->bind (folded_name, poa);
 
       if (result != 0)
         this->persistent_poa_system_map_.unbind (name);
       else
         ACE_NEW_RETURN (system_name,
-                        poa_name (name),
+                        poa_name (std::move(name)),
                         -1);
     }
 

--- a/TAO/tao/PortableServer/Object_Adapter.cpp
+++ b/TAO/tao/PortableServer/Object_Adapter.cpp
@@ -157,7 +157,7 @@ TAO_Object_Adapter::TAO_Object_Adapter (const TAO_Server_Strategy_Factory::Activ
 {
   TAO_Object_Adapter::set_transient_poa_name_size (creation_parameters);
 
-  Hint_Strategy *hint_strategy = 0;
+  Hint_Strategy *hint_strategy {};
   if (creation_parameters.use_active_hint_in_poa_names_)
     ACE_NEW (hint_strategy,
              Active_Hint_Strategy (creation_parameters.poa_map_size_));
@@ -170,7 +170,7 @@ TAO_Object_Adapter::TAO_Object_Adapter (const TAO_Server_Strategy_Factory::Activ
 
   new_hint_strategy->object_adapter (this);
 
-  persistent_poa_name_map *ppnm = 0;
+  persistent_poa_name_map *ppnm {};
   switch (creation_parameters.poa_lookup_strategy_for_persistent_id_policy_)
     {
     case TAO_LINEAR:
@@ -195,7 +195,7 @@ TAO_Object_Adapter::TAO_Object_Adapter (const TAO_Server_Strategy_Factory::Activ
   // Give ownership to the unique pointer.
   std::unique_ptr<persistent_poa_name_map> new_persistent_poa_name_map (ppnm);
 
-  transient_poa_map *tpm = 0;
+  transient_poa_map *tpm {};
   switch (creation_parameters.poa_lookup_strategy_for_transient_id_policy_)
     {
 #if (TAO_HAS_MINIMUM_POA_MAPS == 0)
@@ -305,7 +305,7 @@ TAO_Object_Adapter::~TAO_Object_Adapter ()
 ACE_Lock *
 TAO_Object_Adapter::create_lock (TAO_SYNCH_MUTEX &thread_lock)
 {
-  ACE_Lock *the_lock = 0;
+  ACE_Lock *the_lock {};
   ACE_NEW_RETURN (the_lock,
                   ACE_Lock_Adapter<TAO_SYNCH_MUTEX> (thread_lock),
                   0);
@@ -428,7 +428,7 @@ TAO_Object_Adapter::activate_poa (const poa_name &folded_name,
        iterator != end;
        ++iterator)
     {
-      TAO_Root_POA *current = 0;
+      TAO_Root_POA *current {};
 
       try
         {
@@ -469,7 +469,7 @@ TAO_Object_Adapter::find_transient_poa (const poa_name &system_name,
       result = this->transient_poa_map_->find (system_name, poa);
     }
 
-  if (poa == 0
+  if (poa == nullptr
       || (result == 0 && !poa->validate_lifespan (false, poa_creation_time)))
     result = -1;
 
@@ -504,11 +504,11 @@ TAO_Object_Adapter::locate_servant_i (const TAO::ObjectKey &key)
   ACE_FUNCTION_TIMEPROBE (TAO_POA_LOCATE_SERVANT_START);
 
   PortableServer::ObjectId id;
-  TAO_Root_POA *poa = 0;
+  TAO_Root_POA *poa {};
 
   this->locate_poa (key, id, poa);
 
-  PortableServer::Servant servant = 0;
+  PortableServer::Servant servant {};
   TAO_Servant_Location const servant_location =
     poa->locate_servant_i (id, servant);
 
@@ -644,22 +644,22 @@ TAO_Object_Adapter::close (int wait_for_completion)
   // destroyed. In the case of the POA, this means that all object
   // etherealizations have finished and root POA has been destroyed
   // (implying that all descendent POAs have also been destroyed).
-  TAO_Root_POA *root = 0;
+  TAO_Root_POA *root {};
 #if (TAO_HAS_MINIMUM_POA == 0) && !defined (CORBA_E_COMPACT) && !defined (CORBA_E_MICRO)
-  TAO_POAManager_Factory* factory = 0;
+  TAO_POAManager_Factory* factory {};
 #endif
   {
     ACE_GUARD (ACE_Lock, ace_mon, this->lock ());
-    if (this->root_ == 0)
+    if (this->root_ == nullptr)
       return;
     root = this->root_;
-    this->root_ = 0;
+    this->root_ = nullptr;
 
 #if (TAO_HAS_MINIMUM_POA == 0) && !defined (CORBA_E_COMPACT) && !defined (CORBA_E_MICRO)
-    if (this->poa_manager_factory_ == 0)
+    if (this->poa_manager_factory_ == nullptr)
       return;
     factory = this->poa_manager_factory_;
-    this->poa_manager_factory_ = 0;
+    this->poa_manager_factory_ = nullptr;
 #endif
   }
   CORBA::Boolean etherealize_objects = true;
@@ -904,7 +904,7 @@ TAO_Object_Adapter::get_collocated_servant (const TAO_MProfile &mp)
                              TAO_Root_POA::TAO_OBJECTKEY_PREFIX_SIZE) != 0)
         continue;
 
-      TAO_ServantBase *servant = 0;
+      TAO_ServantBase *servant {};
 
       try
         {

--- a/TAO/tao/PortableServer/Object_Adapter.h
+++ b/TAO/tao/PortableServer/Object_Adapter.h
@@ -211,7 +211,7 @@ public:
   class TAO_PortableServer_Export Hint_Strategy
   {
   public:
-    virtual ~Hint_Strategy ();
+    virtual ~Hint_Strategy ()= default;
 
     virtual int find_persistent_poa (const poa_name &system_name,
                                      TAO_Root_POA *&poa) = 0;
@@ -226,7 +226,7 @@ public:
     void object_adapter (TAO_Object_Adapter *oa);
 
   protected:
-    TAO_Object_Adapter *object_adapter_;
+    TAO_Object_Adapter *object_adapter_ {};
   };
 
   /**
@@ -243,17 +243,16 @@ public:
   public:
     Active_Hint_Strategy (CORBA::ULong map_size);
 
-    virtual ~Active_Hint_Strategy ();
+    ~Active_Hint_Strategy () override = default;
 
-    virtual int find_persistent_poa (const poa_name &system_name,
-                                     TAO_Root_POA *&poa);
+    int find_persistent_poa (const poa_name &system_name, TAO_Root_POA *&poa) override;
 
-    virtual int bind_persistent_poa (const poa_name &folded_name,
-                                     TAO_Root_POA *poa,
-                                     poa_name_out system_name);
+    int bind_persistent_poa (const poa_name &folded_name,
+                             TAO_Root_POA *poa,
+                             poa_name_out system_name) override;
 
-    virtual int unbind_persistent_poa (const poa_name &folded_name,
-                                       const poa_name &system_name);
+    int unbind_persistent_poa (const poa_name &folded_name,
+                               const poa_name &system_name) override;
 
   protected:
     typedef ACE_Active_Map_Manager_Adapter<
@@ -278,17 +277,17 @@ public:
   class TAO_PortableServer_Export No_Hint_Strategy : public Hint_Strategy
   {
   public:
-    virtual ~No_Hint_Strategy ();
+    ~No_Hint_Strategy () override = default;
 
     virtual int find_persistent_poa (const poa_name &system_name,
-                                     TAO_Root_POA *&poa);
+                                     TAO_Root_POA *&poa) override;
 
     virtual int bind_persistent_poa (const poa_name &folded_name,
                                      TAO_Root_POA *poa,
-                                     poa_name_out system_name);
+                                     poa_name_out system_name) override;
 
     virtual int unbind_persistent_poa (const poa_name &folded_name,
-                                       const poa_name &system_name);
+                                       const poa_name &system_name) override;
   };
 
   friend class No_Hint_Strategy;

--- a/TAO/tao/PortableServer/Object_Adapter.h
+++ b/TAO/tao/PortableServer/Object_Adapter.h
@@ -279,15 +279,15 @@ public:
   public:
     ~No_Hint_Strategy () override = default;
 
-    virtual int find_persistent_poa (const poa_name &system_name,
-                                     TAO_Root_POA *&poa) override;
+    int find_persistent_poa (const poa_name &system_name,
+                             TAO_Root_POA *&poa) override;
 
-    virtual int bind_persistent_poa (const poa_name &folded_name,
-                                     TAO_Root_POA *poa,
-                                     poa_name_out system_name) override;
+    int bind_persistent_poa (const poa_name &folded_name,
+                             TAO_Root_POA *poa,
+                             poa_name_out system_name) override;
 
-    virtual int unbind_persistent_poa (const poa_name &folded_name,
-                                       const poa_name &system_name) override;
+    int unbind_persistent_poa (const poa_name &folded_name,
+                               const poa_name &system_name) override;
   };
 
   friend class No_Hint_Strategy;

--- a/TAO/tao/PortableServer/Object_Adapter.inl
+++ b/TAO/tao/PortableServer/Object_Adapter.inl
@@ -80,10 +80,7 @@ TAO_Object_Adapter::find_poa (const poa_name &system_name,
     }
   else
     {
-      return this->find_transient_poa (system_name,
-                                       root,
-                                       poa_creation_time,
-                                       poa);
+      return this->find_transient_poa (system_name, root, poa_creation_time, poa);
     }
 }
 
@@ -92,12 +89,12 @@ TAO_Object_Adapter::bind_transient_poa (TAO_Root_POA *poa,
                                         poa_name_out system_name)
 {
   poa_name name;
-  int result = this->transient_poa_map_->bind_create_key (poa, name);
+  int const result = this->transient_poa_map_->bind_create_key (poa, name);
 
   if (result == 0)
     {
       ACE_NEW_RETURN (system_name,
-                      poa_name (name),
+                      poa_name (std::move(name)),
                       -1);
     }
 
@@ -109,9 +106,7 @@ TAO_Object_Adapter::bind_persistent_poa (const poa_name &folded_name,
                                          TAO_Root_POA *poa,
                                          poa_name_out system_name)
 {
-  return this->hint_strategy_->bind_persistent_poa (folded_name,
-                                                    poa,
-                                                    system_name);
+  return this->hint_strategy_->bind_persistent_poa (folded_name, poa, system_name);
 }
 
 ACE_INLINE int
@@ -124,8 +119,7 @@ ACE_INLINE int
 TAO_Object_Adapter::unbind_persistent_poa (const poa_name &folded_name,
                                            const poa_name &system_name)
 {
-  return this->hint_strategy_->unbind_persistent_poa (folded_name,
-                                                      system_name);
+  return this->hint_strategy_->unbind_persistent_poa (folded_name, system_name);
 }
 
 ACE_INLINE TAO_Root_POA *

--- a/TAO/tao/PortableServer/Operation_Table_Binary_Search.cpp
+++ b/TAO/tao/PortableServer/Operation_Table_Binary_Search.cpp
@@ -35,7 +35,7 @@ TAO_Binary_Search_OpTable::find (const char *opname,
 
   TAO_operation_db_entry const * const entry = lookup (opname);
 
-  if (entry == 0)
+  if (entry == nullptr)
     TAOLIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("TAO_Binary_Search_Table:find failed\n")),
                       -1);
@@ -55,7 +55,7 @@ TAO_Binary_Search_OpTable::find (const char *opname,
 
   TAO_operation_db_entry const * const entry = lookup (opname);
 
-  if (entry == 0)
+  if (entry == nullptr)
     TAOLIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("TAO_Binary_Search_Table:find failed\n")),
                       -1);

--- a/TAO/tao/PortableServer/Operation_Table_Linear_Search.cpp
+++ b/TAO/tao/PortableServer/Operation_Table_Linear_Search.cpp
@@ -42,7 +42,7 @@ TAO_Linear_Search_OpTable::find (const char *opname,
   ACE_FUNCTION_TIMEPROBE (TAO_LINEAR_SEARCH_OPTABLE_FIND_START);
 
   TAO_operation_db_entry const * const entry = lookup (opname);
-  if (entry == 0)
+  if (entry == nullptr)
     TAOLIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("TAO_Linear_Search_Table:find failed\n")),
                       -1);
@@ -63,7 +63,7 @@ TAO_Linear_Search_OpTable::find (const char *opname,
   ACE_FUNCTION_TIMEPROBE (TAO_LINEAR_SEARCH_OPTABLE_FIND_START);
 
   TAO_operation_db_entry const * const entry = lookup (opname);
-  if (entry == 0)
+  if (entry == nullptr)
     TAOLIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("TAO_Linear_Search_Table:find failed\n")),
                       -1);

--- a/TAO/tao/PortableServer/Operation_Table_Perfect_Hash.cpp
+++ b/TAO/tao/PortableServer/Operation_Table_Perfect_Hash.cpp
@@ -34,7 +34,7 @@ TAO_Perfect_Hash_OpTable::find (const char *opname,
 
   TAO_operation_db_entry const * const entry = lookup (opname,
                                                        length);
-  if (entry == 0)
+  if (entry == nullptr)
     {
       skelfunc = 0; // insure that somebody can't call a wrong function!
       TAOLIB_ERROR_RETURN ((LM_ERROR,
@@ -59,7 +59,7 @@ TAO_Perfect_Hash_OpTable::find (const char *opname,
   ACE_FUNCTION_TIMEPROBE (TAO_PERFECT_HASH_OPTABLE_FIND_START);
 
   TAO_operation_db_entry const * const entry = lookup (opname, length);
-  if (entry == 0)
+  if (entry == nullptr)
     {
       skelfunc = 0; // insure that somebody can't call a wrong function!
       TAOLIB_ERROR_RETURN ((LM_ERROR,

--- a/TAO/tao/PortableServer/Operation_Table_Perfect_Hash.cpp
+++ b/TAO/tao/PortableServer/Operation_Table_Perfect_Hash.cpp
@@ -36,7 +36,7 @@ TAO_Perfect_Hash_OpTable::find (const char *opname,
                                                        length);
   if (entry == nullptr)
     {
-      skelfunc = 0; // insure that somebody can't call a wrong function!
+      skelfunc = nullptr; // insure that somebody can't call a wrong function!
       TAOLIB_ERROR_RETURN ((LM_ERROR,
                          ACE_TEXT ("TAO_Perfect_Hash_OpTable:find for ")
                          ACE_TEXT ("operation '%C' (length=%d) failed\n"),
@@ -61,7 +61,7 @@ TAO_Perfect_Hash_OpTable::find (const char *opname,
   TAO_operation_db_entry const * const entry = lookup (opname, length);
   if (entry == nullptr)
     {
-      skelfunc = 0; // insure that somebody can't call a wrong function!
+      skelfunc = nullptr; // insure that somebody can't call a wrong function!
       TAOLIB_ERROR_RETURN ((LM_ERROR,
                          ACE_TEXT ("TAO_Perfect_Hash_OpTable:find for ")
                          ACE_TEXT ("operation '%C' (length=%d) failed\n"),

--- a/TAO/tao/PortableServer/POA_Cached_Policies.cpp
+++ b/TAO/tao/PortableServer/POA_Cached_Policies.cpp
@@ -34,11 +34,6 @@ namespace TAO
     {
     }
 
-
-    Cached_Policies::~Cached_Policies ()
-    {
-    }
-
     void
     Cached_Policies::update (TAO_POA_Policy_Set &policy_set)
     {

--- a/TAO/tao/PortableServer/POA_Cached_Policies.h
+++ b/TAO/tao/PortableServer/POA_Cached_Policies.h
@@ -56,7 +56,7 @@ namespace TAO
 
       Cached_Policies ();
 
-      ~Cached_Policies ();
+      ~Cached_Policies () = default;
 
       /// Update the cached policy values.
       void update (TAO_POA_Policy_Set &policy_set);

--- a/TAO/tao/PortableServer/POA_Current.cpp
+++ b/TAO/tao/PortableServer/POA_Current.cpp
@@ -17,7 +17,7 @@ namespace TAO
     {
       POA_Current_Impl *impl = this->implementation ();
 
-      if (impl == 0)
+      if (impl == nullptr)
         throw PortableServer::Current::NoContext ();
       return impl->get_POA ();
     }
@@ -27,7 +27,7 @@ namespace TAO
     {
       POA_Current_Impl *impl = this->implementation ();
 
-      if (impl == 0)
+      if (impl == nullptr)
         throw PortableServer::Current::NoContext ();
       return impl->get_object_id ();
     }
@@ -37,7 +37,7 @@ namespace TAO
     {
       POA_Current_Impl *impl = this->implementation ();
 
-      if (impl == 0)
+      if (impl == nullptr)
         throw PortableServer::Current::NoContext ();
       return impl->get_servant ();
     }
@@ -47,7 +47,7 @@ namespace TAO
     {
       POA_Current_Impl *impl = this->implementation ();
 
-      if (impl == 0)
+      if (impl == nullptr)
         throw PortableServer::Current::NoContext ();
       return impl->get_reference ();
     }

--- a/TAO/tao/PortableServer/POA_Policy_Set.cpp
+++ b/TAO/tao/PortableServer/POA_Policy_Set.cpp
@@ -17,12 +17,7 @@ TAO_POA_Policy_Set::TAO_POA_Policy_Set ()
 }
 
 TAO_POA_Policy_Set::TAO_POA_Policy_Set (const TAO_POA_Policy_Set &rhs)
-  :
-    impl_ (rhs.impl_)
-{
-}
-
-TAO_POA_Policy_Set::~TAO_POA_Policy_Set ()
+  : impl_ (rhs.impl_)
 {
 }
 

--- a/TAO/tao/PortableServer/POA_Policy_Set.h
+++ b/TAO/tao/PortableServer/POA_Policy_Set.h
@@ -33,7 +33,7 @@ public:
 
   TAO_POA_Policy_Set (const TAO_POA_Policy_Set &rhs);
 
-  ~TAO_POA_Policy_Set ();
+  ~TAO_POA_Policy_Set () = default;
 
   /// Returns the policy at the specified index.
   /// CORBA::Policy::_nil () is returned if the policy doesn't exist

--- a/TAO/tao/PortableServer/PortableServer_Functions.cpp
+++ b/TAO/tao/PortableServer/PortableServer_Functions.cpp
@@ -32,13 +32,13 @@ namespace PortableServer
     ACE_OS::memcpy (buffer, string, buffer_size);
 
     // Create and return a new ID
-    PortableServer::ObjectId *id = 0;
+    PortableServer::ObjectId *id {};
     ACE_NEW_RETURN (id,
                     PortableServer::ObjectId (buffer_size,
                                               buffer_size,
                                               buffer,
                                               1),
-                    0);
+                    nullptr);
 
     return id;
   }

--- a/TAO/tao/PortableServer/PortableServer_Functions.cpp
+++ b/TAO/tao/PortableServer/PortableServer_Functions.cpp
@@ -12,7 +12,7 @@ namespace PortableServer
   {
     // Passing in a nil pointer is illegal so throw an exception to
     // indicate that
-    if (string == 0)
+    if (string == nullptr)
     {
       throw ::CORBA::BAD_PARAM ();
     }

--- a/TAO/tao/PortableServer/PortableServer_WFunctions.cpp
+++ b/TAO/tao/PortableServer/PortableServer_WFunctions.cpp
@@ -25,13 +25,13 @@ namespace PortableServer
     ACE_OS::memcpy (buffer, string, buffer_size);
 
     // Create a new ID
-    PortableServer::ObjectId *id = 0;
+    PortableServer::ObjectId *id {};
     ACE_NEW_RETURN (id,
                     PortableServer::ObjectId (buffer_size,
                                               buffer_size,
                                               buffer,
                                               1),
-                    0);
+                    nullptr);
 
     return id;
   }

--- a/TAO/tao/PortableServer/Regular_POA.cpp
+++ b/TAO/tao/PortableServer/Regular_POA.cpp
@@ -45,7 +45,7 @@ TAO_Regular_POA::remove_from_parent_i ()
 CORBA::Boolean
 TAO_Regular_POA::root () const
 {
-  return (parent_ == 0);
+  return (parent_ == nullptr);
 }
 
 char

--- a/TAO/tao/PortableServer/Regular_POA.cpp
+++ b/TAO/tao/PortableServer/Regular_POA.cpp
@@ -32,7 +32,7 @@ void
 TAO_Regular_POA::remove_from_parent_i ()
 {
   // Remove POA from the parent
-  if (this->parent_ != 0)
+  if (this->parent_ != nullptr)
     {
       int const result = this->parent_->delete_child (this->name_);
       if (result != 0)
@@ -51,7 +51,7 @@ TAO_Regular_POA::root () const
 char
 TAO_Regular_POA::root_key_type ()
 {
-  if (this->parent_ != 0)
+  if (this->parent_ != nullptr)
     {
       return TAO_Root_POA::non_root_key_char ();
     }

--- a/TAO/tao/PortableServer/RequestProcessingStrategyDefaultServant.cpp
+++ b/TAO/tao/PortableServer/RequestProcessingStrategyDefaultServant.cpp
@@ -208,7 +208,7 @@ namespace TAO
     {
       PortableServer::Servant default_servant = this->default_servant_.in ();
 
-      if (default_servant != 0 &&
+      if (default_servant != nullptr &&
           default_servant == servant)
         {
           // If they are the same servant, then check if we are in an

--- a/TAO/tao/PortableServer/RequestProcessingStrategyDefaultServant.cpp
+++ b/TAO/tao/PortableServer/RequestProcessingStrategyDefaultServant.cpp
@@ -218,7 +218,7 @@ namespace TAO
                         (TAO_TSS_Resources::instance ()->poa_current_impl_);
           // If we are in an upcall on the default servant, return the
           // ObjectId associated with the current invocation.
-          if (poa_current_impl != 0 &&
+          if (poa_current_impl != nullptr &&
               servant == poa_current_impl->servant ())
             {
               return poa_current_impl->get_object_id ();

--- a/TAO/tao/PortableServer/RequestProcessingStrategyServantActivator.cpp
+++ b/TAO/tao/PortableServer/RequestProcessingStrategyServantActivator.cpp
@@ -84,13 +84,9 @@ namespace TAO
       TAO::Portable_Server::POA_Current_Impl &poa_current_impl,
       bool &wait_occurred_restart_call)
     {
-      PortableServer::Servant servant = 0;
+      PortableServer::Servant servant = this->poa_->find_servant (system_id, servant_upcall, poa_current_impl);
 
-      servant = this->poa_->find_servant (system_id,
-                                          servant_upcall,
-                                          poa_current_impl);
-
-      if (servant != 0)
+      if (servant != nullptr)
         {
           return servant;
         }
@@ -125,8 +121,7 @@ namespace TAO
       // will raise an OBJ_ADAPTER system exception for the
       // request.
       bool may_activate =
-        this->poa_->is_servant_activation_allowed (servant,
-                                                   wait_occurred_restart_call);
+        this->poa_->is_servant_activation_allowed (servant, wait_occurred_restart_call);
 
       if (!may_activate)
         {

--- a/TAO/tao/PortableServer/RequestProcessingStrategyServantLocator.cpp
+++ b/TAO/tao/PortableServer/RequestProcessingStrategyServantLocator.cpp
@@ -86,7 +86,7 @@ namespace TAO
                                                                   servant_upcall,
                                                                   poa_current_impl);
 
-      if (servant != 0)
+      if (servant != nullptr)
         {
           return servant;
         }

--- a/TAO/tao/PortableServer/RequestProcessingStrategyServantLocator.cpp
+++ b/TAO/tao/PortableServer/RequestProcessingStrategyServantLocator.cpp
@@ -139,7 +139,7 @@ namespace TAO
                                            operation,
                                            cookie);
 
-      if (servant == 0)
+      if (servant == nullptr)
         {
           throw ::CORBA::OBJ_ADAPTER (CORBA::OMGVMCID | 7, CORBA::COMPLETED_NO);
         }

--- a/TAO/tao/PortableServer/Root_POA.cpp
+++ b/TAO/tao/PortableServer/Root_POA.cpp
@@ -600,7 +600,7 @@ TAO_Root_POA::find_POA (const char *adapter_name,
                         CORBA::Boolean activate_it)
 {
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   TAO_Root_POA *poa = this->find_POA_i (adapter_name, activate_it);
 
@@ -693,7 +693,7 @@ TAO_Root_POA::create_POA (const char *adapter_name,
                           const CORBA::PolicyList &policies)
 {
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   return this->create_POA_i (adapter_name, poa_manager, policies);
 }
@@ -705,7 +705,7 @@ TAO_Root_POA::servant_to_id (PortableServer::Servant servant)
   // If we had upgradeable locks, this would initially be a read lock
   //
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   return this->servant_to_id_i (servant);
 }
@@ -721,7 +721,7 @@ PortableServer::Servant
 TAO_Root_POA::reference_to_servant (CORBA::Object_ptr reference)
 {
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   return this->reference_to_servant_i (reference);
 }
@@ -740,7 +740,7 @@ PortableServer::POAList *
 TAO_Root_POA::the_children ()
 {
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   return this->the_children_i ();
 }
@@ -750,7 +750,7 @@ PortableServer::Servant
 TAO_Root_POA::id_to_servant (const PortableServer::ObjectId &oid)
 {
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   return this->id_to_servant_i (oid);
 }
@@ -759,7 +759,7 @@ CORBA::Object_ptr
 TAO_Root_POA::id_to_reference (const PortableServer::ObjectId &oid)
 {
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   return this->id_to_reference_i (oid, true);
 }
@@ -1131,7 +1131,7 @@ TAO_Root_POA::activate_object (PortableServer::Servant servant)
       bool wait_occurred_restart_call = false;
 
       // Lock access for the duration of this transaction.
-      TAO_POA_GUARD_RETURN (0);
+      TAO_POA_GUARD_RETURN (nullptr);
 
       PortableServer::ObjectId *result =
         this->activate_object_i (servant,
@@ -1387,7 +1387,7 @@ TAO_Root_POA::reference_to_servant_i (CORBA::Object_ptr reference)
     this->active_policy_strategies_.request_processing_strategy()->
       system_id_to_servant (system_id);
 
-  if (servant != 0)
+  if (servant != nullptr)
     {
       // ATTENTION: Trick locking here, see class header for details
       TAO::Portable_Server::Non_Servant_Upcall non_servant_upcall (*this);
@@ -1465,7 +1465,7 @@ TAO_Root_POA::reference_to_id (CORBA::Object_ptr reference)
     }
 
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   return this->active_policy_strategies_.servant_retention_strategy()->
     system_id_to_object_id (system_id);
@@ -1501,7 +1501,7 @@ TAO_Root_POA::id_to_servant_i (const PortableServer::ObjectId &id)
     this->active_policy_strategies_.request_processing_strategy()->
       id_to_servant (id);
 
-  if (servant != 0)
+  if (servant != nullptr)
     {
       // ATTENTION: Trick locking here, see class header for details
       TAO::Portable_Server::Non_Servant_Upcall non_servant_upcall (*this);
@@ -2316,11 +2316,11 @@ PortableServer::Servant
 TAO_Root_POA::get_servant ()
 {
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   PortableServer::Servant servant = this->get_servant_i ();
 
-  if (servant != 0)
+  if (servant != nullptr)
     {
       // ATTENTION: Trick locking here, see class header for details
       TAO::Portable_Server::Non_Servant_Upcall non_servant_upcall (*this);
@@ -2483,14 +2483,14 @@ TAO_Root_POA::root () const
 TAO::ORT_Adapter *
 TAO_Root_POA::ORT_adapter ()
 {
-  if (this->ort_adapter_ != 0)
+  if (this->ort_adapter_ != nullptr)
     return this->ort_adapter_;
 
   // Lock access for the duration of this transaction.
-  TAO_POA_GUARD_RETURN (0);
+  TAO_POA_GUARD_RETURN (nullptr);
 
   // DCL ..
-  if (this->ort_adapter_ != 0)
+  if (this->ort_adapter_ != nullptr)
     {
       return this->ort_adapter_;
     }
@@ -2501,7 +2501,7 @@ TAO_Root_POA::ORT_adapter ()
 CORBA::Policy *
 TAO_Root_POA::server_protocol ()
 {
-  return 0;
+  return nullptr;
 }
 
 void

--- a/TAO/tao/PortableServer/Root_POA.cpp
+++ b/TAO/tao/PortableServer/Root_POA.cpp
@@ -330,14 +330,13 @@ TAO_Root_POA::complete_destruction_i ()
 
   PortableServer::POA_var poa;
   TAO::ORT_Array my_array_obj_ref_template;
-  TAO::ORT_Adapter *ort_adapter = 0;
+  TAO::ORT_Adapter *ort_adapter = nullptr;
   if (doing_complete_destruction)
     {
-      ort_adapter =
-        this->ORT_adapter_i ();
+      ort_adapter = this->ORT_adapter_i ();
 
       // In case no ORT library is linked we get zero.
-      if (ort_adapter != 0)
+      if (ort_adapter != nullptr)
         {
           // Get the ObjectReferenceTemplate.
           PortableInterceptor::ObjectReferenceTemplate * const ort =
@@ -398,7 +397,7 @@ TAO_Root_POA::complete_destruction_i ()
       this->adapter_state_changed (my_array_obj_ref_template,
                                    this->adapter_state_);
 
-      if (ort_adapter != 0)
+      if (ort_adapter != nullptr)
         {
           ort_adapter->release (my_array_obj_ref_template[0]);
 
@@ -837,7 +836,7 @@ TAO_Root_POA::destroy_i (CORBA::Boolean etherealize_objects,
       TAO::ORT_Adapter * const adapter = child_poa->ORT_adapter_i ();
 
       // In case no ORT library is linked we get zero.
-      if (adapter != 0)
+      if (adapter != nullptr)
         {
           // Get the ObjectReferenceTemplate for the child POA.
           PortableInterceptor::ObjectReferenceTemplate * const ort =
@@ -857,7 +856,7 @@ TAO_Root_POA::destroy_i (CORBA::Boolean etherealize_objects,
       this->adapter_state_changed (array_obj_ref_template,
                                    PortableInterceptor::INACTIVE);
 
-      if (adapter != 0)
+      if (adapter != nullptr)
         adapter->release (array_obj_ref_template[0]);
 
       ++i;
@@ -870,8 +869,7 @@ TAO_Root_POA::destroy_i (CORBA::Boolean etherealize_objects,
     {
       TAO_Root_POA *destroy_child_poa = (*destroy_iterator).int_id_;
 
-      destroy_child_poa->destroy_i (etherealize_objects,
-                                    wait_for_completion);
+      destroy_child_poa->destroy_i (etherealize_objects, wait_for_completion);
     }
 
   // Notify the lifespan strategy of our shutdown
@@ -909,7 +907,7 @@ TAO_Root_POA::destroy_i (CORBA::Boolean etherealize_objects,
         this->ORT_adapter_i ();
 
       // In case no ORT library is linked we get zero.
-      if (ort_adapter != 0)
+      if (ort_adapter != nullptr)
         {
           // Get the ObjectReferenceTemplate.
           PortableInterceptor::ObjectReferenceTemplate * const ort =
@@ -937,7 +935,7 @@ TAO_Root_POA::destroy_i (CORBA::Boolean etherealize_objects,
       this->adapter_state_changed (my_array_obj_ref_template,
                                    this->adapter_state_);
 
-      if (ort_adapter != 0)
+      if (ort_adapter != nullptr)
         {
           ort_adapter->release (my_array_obj_ref_template[0]);
 
@@ -946,7 +944,7 @@ TAO_Root_POA::destroy_i (CORBA::Boolean etherealize_objects,
               this->ort_adapter_factory_->destroy (ort_adapter);
             }
 
-          this->ort_adapter_ = 0;
+          this->ort_adapter_ = nullptr;
         }
     }
   else
@@ -1003,7 +1001,6 @@ TAO_Root_POA::adapter_name_i ()
   // The adapter name is the sequence of names starting from the
   // RootPOA to the one whose name is requested.  The name of the
   // RootPOA is "RootPOA".
-
   PortableServer::POA_var poa = PortableServer::POA::_duplicate (this);
 
   CORBA::ULong len = 0;

--- a/TAO/tao/PortableServer/Servant_Base.cpp
+++ b/TAO/tao/PortableServer/Servant_Base.cpp
@@ -79,10 +79,6 @@ TAO_ServantBase::operator= (const TAO_ServantBase &rhs)
   return *this;
 }
 
-TAO_ServantBase::~TAO_ServantBase ()
-{
-}
-
 PortableServer::POA_ptr
 TAO_ServantBase::_default_POA ()
 {

--- a/TAO/tao/PortableServer/Servant_Base.cpp
+++ b/TAO/tao/PortableServer/Servant_Base.cpp
@@ -446,8 +446,7 @@ TAO_ServantBase::_create_stub ()
 
   CORBA::ORB_ptr servant_orb = nullptr;
 
-  if (poa_current_impl != 0
-      && this == poa_current_impl->servant ())
+  if (poa_current_impl != nullptr && this == poa_current_impl->servant ())
     {
       servant_orb = poa_current_impl->orb_core ().orb () ;
 

--- a/TAO/tao/PortableServer/Servant_Base.cpp
+++ b/TAO/tao/PortableServer/Servant_Base.cpp
@@ -389,7 +389,7 @@ TAO_ServantBase::_get_interface ()
     ACE_Dynamic_Service<TAO_IFR_Client_Adapter>::instance (
         TAO_ORB_Core::ifr_client_adapter_name ());
 
-  if (adapter == 0)
+  if (adapter == nullptr)
     {
       throw ::CORBA::INTF_REPOS ();
     }

--- a/TAO/tao/PortableServer/Servant_Base.h
+++ b/TAO/tao/PortableServer/Servant_Base.h
@@ -65,7 +65,7 @@ public:
   typedef CORBA::Object_var _stub_var_type;
 
   /// Destructor.
-  virtual ~TAO_ServantBase ();
+  virtual ~TAO_ServantBase () = default;
 
   static void _is_a_skel (TAO_ServerRequest & req,
                           TAO::Portable_Server::Servant_Upcall* servant_upcall,


### PR DESCRIPTION
    * TAO/tao/PortableServer/Active_Object_Map.cpp:
    * TAO/tao/PortableServer/Active_Object_Map.inl:
    * TAO/tao/PortableServer/Object_Adapter.cpp:
    * TAO/tao/PortableServer/Object_Adapter.inl:
    * TAO/tao/PortableServer/RequestProcessingStrategyDefaultServant.cpp:
    * TAO/tao/PortableServer/RequestProcessingStrategyServantActivator.cpp:
    * TAO/tao/PortableServer/RequestProcessingStrategyServantLocator.cpp:
    * TAO/tao/PortableServer/Root_POA.cpp:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the codebase by modernizing pointer initialization and null pointer checks for clearer and more maintainable logic.
	- Simplified destructors to use default implementations, improving code clarity and reducing unnecessary complexity.
	- Streamlined copy constructors and destructors, removing unnecessary code while preserving functionality.
- **Style**
	- Improved formatting and consistency across multiple components for a more uniform code structure.
- **Chores**
	- Streamlined initialization routines to promote overall system robustness and readability.

These updates maintain existing functionality while contributing to a more stable and efficient system for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->