### PR TITLE
Use uniform initialization

### DIFF
--- a/TAO/docs/tutorials/Quoter/Event_Service/Stock_Consumer.cpp
+++ b/TAO/docs/tutorials/Quoter/Event_Service/Stock_Consumer.cpp
@@ -30,7 +30,7 @@ Stock_Consumer::disconnect ()
 void
 Stock_Consumer::push (const CORBA::Any& data)
 {
-  const Quoter::Event *event = 0;
+  const Quoter::Event *event {};
   if ((data >>= event) == 0)
     return; // Invalid event
 

--- a/TAO/docs/tutorials/Quoter/Event_Service/index.html
+++ b/TAO/docs/tutorials/Quoter/Event_Service/index.html
@@ -77,7 +77,7 @@ public:
 void
 Stock_Consumer::push (const CORBA::Any& data)
 {
-  const Quoter::Event *event = 0;
+  const Quoter::Event *event {};
   if ((data >>= event) == 0)
     return; // Invalid event
 </PRE>

--- a/TAO/docs/tutorials/Quoter/RT_Event_Service/Stock_Consumer.cpp
+++ b/TAO/docs/tutorials/Quoter/RT_Event_Service/Stock_Consumer.cpp
@@ -35,7 +35,7 @@ Stock_Consumer::push (const RtecEventComm::EventSet &data)
   for (CORBA::ULong i = 0; i != data.length (); ++i) {
     const RtecEventComm::Event &e = data[i];
 
-    const Quoter::Event *event = 0;
+    const Quoter::Event *event {};
     if ((e.data.any_value >>= event) == 0)
       continue; // Invalid event
 

--- a/TAO/docs/tutorials/Quoter/RT_Event_Service/index.html
+++ b/TAO/docs/tutorials/Quoter/RT_Event_Service/index.html
@@ -74,7 +74,7 @@ Stock_Consumer::push (const RtecEventComm::EventSet &data)
   for (CORBA::ULong i = 0; i != data.length (); ++i) {
     RtecEventComm::Event &e = data[i];
 
-    Quoter::Event *event;
+    Quoter::Event *event {};
     if ((e.data.any_value >>= event) == 0)
       continue; // Invalid event
 </PRE>

--- a/TAO/examples/Simulator/Event_Supplier/Event_Con.cpp
+++ b/TAO/examples/Simulator/Event_Supplier/Event_Con.cpp
@@ -168,7 +168,7 @@ Demo_Consumer::push (const RtecEventComm::EventSet &events)
 
               if (ret)
                 {
-                  const Navigation *navigation_ = 0;
+                  const Navigation *navigation_ {};
                   events[i].data.any_value >>= navigation_;
                   ACE_DEBUG ((LM_DEBUG, "Found a Navigation struct in the any: pos_lat = %d\n", navigation_->position_latitude));
                 }
@@ -178,7 +178,7 @@ Demo_Consumer::push (const RtecEventComm::EventSet &events)
 
                   if (ret)
                     {
-                      const Weapons *weapons_ = 0;
+                      const Weapons *weapons_ {};
                       events[i].data.any_value >>= weapons_;
                       ACE_DEBUG ((LM_DEBUG, "Found a Weapons struct in the any: nr_of_weapons = %u\n", weapons_->number_of_weapons));
                     }

--- a/TAO/interop-tests/wchar/client.cpp
+++ b/TAO/interop-tests/wchar/client.cpp
@@ -159,7 +159,7 @@ run_one_test (interop::WChar_Passer_ptr server,
       }
     case ANY_WSTRING_FROM_SERVER:
       {
-        const CORBA::WChar *ws;
+        const CORBA::WChar *ws {};
         CORBA::Any_var test = server->any_from_server (data_set,
                                                        interop::is_wstring);
         if (test >>= ws)
@@ -172,7 +172,7 @@ run_one_test (interop::WChar_Passer_ptr server,
       {
         CORBA::Any a;
         a <<= ref.get_wstring(data_set);
-        const CORBA::WChar *ws;
+        const CORBA::WChar *ws {};
         CORBA::Any_var test = server->any_echo (a);
         if (test >>= ws)
           {

--- a/TAO/orbsvcs/DevGuideExamples/ValueTypes/Notify/consumer.cpp
+++ b/TAO/orbsvcs/DevGuideExamples/ValueTypes/Notify/consumer.cpp
@@ -118,7 +118,7 @@ public:
 
   virtual void push(const CORBA::Any& a)
   {
-    MyEvent* vt;
+    MyEvent* vt {};
     a >>= vt;
 
     std::cout << std::endl

--- a/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.cpp
+++ b/TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.cpp
@@ -26,12 +26,12 @@ Criteria_Evaluator::~Criteria_Evaluator ()
 const LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *
 Criteria_Evaluator::getInitialization ()
 {
-  const LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *sequence_ptr = 0;
+  const LifeCycleService::Criteria_Evaluator::SeqNamedValuePair *sequence_ptr {};
 
   CORBA::Any_ptr any_ptr =
     this->getCriteriaMember ("initialization");
 
-  if (any_ptr == 0)
+  if (any_ptr == nullptr)
     throw LifeCycleService::Criteria_Evaluator::NotAvailable(
       "No initialization member found.\n");
 

--- a/TAO/orbsvcs/orbsvcs/CosEvent/CEC_DynamicImplementation.cpp
+++ b/TAO/orbsvcs/orbsvcs/CosEvent/CEC_DynamicImplementation.cpp
@@ -88,7 +88,7 @@ TAO_CEC_DynamicImplementationServer::is_a (CORBA::ServerRequest_ptr request)
   CORBA::NamedValue_ptr nv = list->item (0);
 
   CORBA::Any_ptr ap = nv->value ();
-  const char *value = 0;
+  const char *value {};
   *ap >>= value;
 
   if (TAO_debug_level >= 10)

--- a/TAO/orbsvcs/orbsvcs/FaultTolerance/FT_ClientPolicy_i.cpp
+++ b/TAO/orbsvcs/orbsvcs/FaultTolerance/FT_ClientPolicy_i.cpp
@@ -102,7 +102,7 @@ TAO_FT_Heart_Beat_Policy::heartbeat_policy_value ()
 CORBA::Policy_ptr
 TAO_FT_Heart_Beat_Policy::create (const CORBA::Any& val)
 {
-  const FT::HeartbeatPolicyValue *value = 0;
+  const FT::HeartbeatPolicyValue *value {};
   if ((val >>= value) == 0)
     throw CORBA::PolicyError (CORBA::BAD_POLICY_VALUE);
 

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/FTEC_Event_Channel_Impl.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/FTEC_Event_Channel_Impl.cpp
@@ -250,17 +250,17 @@ TAO_FTEC_Event_Channel_Impl::connect_push_consumer (
   CORBA::Any_var any
     = Request_Context_Repository().get_cached_result();
 
-  const FtRtecEventChannelAdmin::ObjectId *oid = 0;
+  const FtRtecEventChannelAdmin::ObjectId *oid {};
 
   if (any.in() >>= oid) {
-    FtRtecEventChannelAdmin::ObjectId* result = 0;
+    FtRtecEventChannelAdmin::ObjectId* result {};
     ACE_NEW_THROW_EX(result,
                      FtRtecEventChannelAdmin::ObjectId(*oid),
                      CORBA::NO_MEMORY());
     return result;
   }
 
-  FtRtecEventChannelAdmin::ObjectId* retval = 0;
+  FtRtecEventChannelAdmin::ObjectId* retval {};
   ACE_NEW_THROW_EX(retval, FtRtecEventChannelAdmin::ObjectId, CORBA::NO_MEMORY());
 
   FtRtecEventChannelAdmin::ObjectId_var object_id = retval;

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Request_Context_Repository.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Request_Context_Repository.cpp
@@ -63,12 +63,12 @@ Request_Context_Repository::set_object_id(
 FtRtecEventChannelAdmin::ObjectId_var
 get_object_id(CORBA::Any_var a)
 {
-  const FtRtecEventChannelAdmin::ObjectId *object_id = 0;
+  const FtRtecEventChannelAdmin::ObjectId *object_id {};
 
   if ((a.in() >>= object_id) == 0)
     throw CORBA::NO_MEMORY();
 
-  FtRtecEventChannelAdmin::ObjectId *r = 0;
+  FtRtecEventChannelAdmin::ObjectId *r {};
   ACE_NEW_THROW_EX(r,
                    FtRtecEventChannelAdmin::ObjectId(*object_id),
                    CORBA::NO_MEMORY());

--- a/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Set_Update_Interceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Set_Update_Interceptor.cpp
@@ -45,7 +45,7 @@ TAO_Set_Update_Interceptor::send_request (
     {
       CORBA::Any_var a = Request_Context_Repository().get_ft_request_service_context(ri);
 
-      const IOP::ServiceContext* scp = 0;
+      const IOP::ServiceContext* scp {};
 
       if ((a.in() >>= scp) == 0)
         return;

--- a/TAO/orbsvcs/orbsvcs/Notify/Property_T.cpp
+++ b/TAO/orbsvcs/orbsvcs/Notify/Property_T.cpp
@@ -113,7 +113,7 @@ TAO_Notify_StructProperty_T<TYPE>::set (
 
   if (property_seq.find (this->name_, value) == 0)
     {
-      const TYPE* extract_type = 0;
+      const TYPE* extract_type {};
 
       if ((value >>= extract_type)  && extract_type != 0) // make sure we get something valid.
         {

--- a/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Property_Set_Find.h
+++ b/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Property_Set_Find.h
@@ -37,7 +37,7 @@ namespace TAO
   int find (const PG_Property_Set & decoder, const ACE_CString & key, TYPE & value)
   {
     int result = 0;
-    const PortableGroup::Value * any = nullptr;
+    const PortableGroup::Value * any {};
     if (decoder.find (key, any))
     {
       result = ((*any) >>= value);

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_CredentialsAcquirer.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_CredentialsAcquirer.cpp
@@ -126,7 +126,7 @@ TAO::SSLIOP::CredentialsAcquirer::get_credentials (CORBA::Boolean on_list)
 {
   this->check_validity ();
 
-  const ::SSLIOP::AuthData *data = 0;
+  const ::SSLIOP::AuthData *data {};
 
   if (!(this->acquisition_arguments_ >>= data))
     throw CORBA::BAD_PARAM ();

--- a/TAO/orbsvcs/tests/Event/Mcast/RTEC_MCast_Federated/EchoEventConsumer_i.cpp
+++ b/TAO/orbsvcs/tests/Event/Mcast/RTEC_MCast_Federated/EchoEventConsumer_i.cpp
@@ -23,7 +23,7 @@ void EchoEventConsumer_i::push(const RtecEventComm::EventSet& events)
     {
       //ACE_OS::printf(".");
       // Extract event data from the any.
-      const char* eventData;
+      const char* eventData {};
       std::ostringstream out;
 
 #ifndef ACE_LACKS_GETPID

--- a/TAO/tao/Messaging/ExceptionHolder_i.cpp
+++ b/TAO/tao/Messaging/ExceptionHolder_i.cpp
@@ -75,8 +75,7 @@ namespace TAO
               throw ::CORBA::MARSHAL (TAO::VMCID, CORBA::COMPLETED_MAYBE);
             }
 
-          CORBA::SystemException* exception =
-            TAO::create_system_exception (type_id.in ());
+          CORBA::SystemException* exception = TAO::create_system_exception (type_id.in ());
 
           if (!exception)
             {


### PR DESCRIPTION
    * TAO/docs/tutorials/Quoter/Event_Service/Stock_Consumer.cpp:
    * TAO/docs/tutorials/Quoter/Event_Service/index.html:
    * TAO/docs/tutorials/Quoter/RT_Event_Service/Stock_Consumer.cpp:
    * TAO/docs/tutorials/Quoter/RT_Event_Service/index.html:
    * TAO/examples/Simulator/Event_Supplier/Event_Con.cpp:
    * TAO/interop-tests/wchar/client.cpp:
    * TAO/orbsvcs/DevGuideExamples/ValueTypes/Notify/consumer.cpp:
    * TAO/orbsvcs/LifeCycle_Service/Criteria_Evaluator.cpp:
    * TAO/orbsvcs/orbsvcs/CosEvent/CEC_DynamicImplementation.cpp:
    * TAO/orbsvcs/orbsvcs/FaultTolerance/FT_ClientPolicy_i.cpp:
    * TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/FTEC_Event_Channel_Impl.cpp:
    * TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Request_Context_Repository.cpp:
    * TAO/orbsvcs/orbsvcs/FtRtEvent/EventChannel/Set_Update_Interceptor.cpp:
    * TAO/orbsvcs/orbsvcs/Notify/Property_T.cpp:
    * TAO/orbsvcs/orbsvcs/PortableGroup/PG_Property_Set_Find.h:
    * TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_CredentialsAcquirer.cpp:
    * TAO/orbsvcs/tests/Event/Mcast/RTEC_MCast_Federated/EchoEventConsumer_i.cpp:
    * TAO/tao/Messaging/ExceptionHolder_i.cpp: