### PR TITLE
Use nullptr/default/override in multiple ACE classes

### DIFF
--- a/ACE/ace/Auto_Event.h
+++ b/ACE/ace/Auto_Event.h
@@ -39,19 +39,19 @@ public:
   /// Constructor which will create auto event
   ACE_Auto_Event_T (int initial_state = 0,
                     int type = USYNC_THREAD,
-                    const char *name = 0,
-                    void *arg = 0);
+                    const char *name = nullptr,
+                    void *arg = nullptr);
 
 #if defined (ACE_HAS_WCHAR)
   /// Constructor which will create auto event (wchar_t version)
   ACE_Auto_Event_T (int initial_state,
                     int type,
                     const wchar_t *name,
-                    void *arg = 0);
+                    void *arg = nullptr);
 #endif /* ACE_HAS_WCHAR */
 
   /// Default dtor.
-  virtual ~ACE_Auto_Event_T () = default;
+  ~ACE_Auto_Event_T () override = default;
 
   /// Dump the state of an object.
   void dump () const;
@@ -67,8 +67,8 @@ public:
   /// Constructor which will create auto event
   ACE_Auto_Event (int initial_state = 0,
                   int type = USYNC_THREAD,
-                  const char *name = 0,
-                  void *arg = 0)
+                  const char *name = nullptr,
+                  void *arg = nullptr)
   : ACE_Auto_Event_T<ACE_System_Time_Policy> (initial_state, type, name, arg)
   {
   }
@@ -78,16 +78,14 @@ public:
   ACE_Auto_Event (int initial_state,
                   int type,
                   const wchar_t *name,
-                  void *arg = 0)
+                  void *arg = nullptr)
   : ACE_Auto_Event_T<ACE_System_Time_Policy> (initial_state, type, name, arg)
   {
   }
 #endif /* ACE_HAS_WCHAR */
 
   /// Default dtor.
-  virtual ~ACE_Auto_Event ()
-  {
-  }
+  ~ACE_Auto_Event () override = default;
 };
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Event.h
+++ b/ACE/ace/Event.h
@@ -42,12 +42,12 @@ public:
   ACE_Event_T (int manual_reset = 0,
                int initial_state = 0,
                int type = USYNC_THREAD,
-               const ACE_TCHAR *name = 0,
-               void *arg = 0,
+               const ACE_TCHAR *name = nullptr,
+               void *arg = nullptr,
                LPSECURITY_ATTRIBUTES sa = 0);
 
   /// Implicitly destroy the event variable.
-  virtual ~ACE_Event_T () = default;
+  ~ACE_Event_T () override = default;
 
   /// Get the current time of day according to the queue's TIME_POLICY.
   /// Allows users to initialize timeout values using correct time policy.

--- a/ACE/ace/Manual_Event.cpp
+++ b/ACE/ace/Manual_Event.cpp
@@ -14,11 +14,7 @@ ACE_Manual_Event_T<TIME_POLICY>::ACE_Manual_Event_T (
     int type,
     const char *name,
     void *arg)
-  : ACE_Event_T<TIME_POLICY> (1,
-                              initial_state,
-                              type,
-                              ACE_TEXT_CHAR_TO_TCHAR (name),
-                              arg)
+  : ACE_Event_T<TIME_POLICY> (1, initial_state, type, ACE_TEXT_CHAR_TO_TCHAR (name), arg)
 {
 }
 
@@ -29,11 +25,7 @@ ACE_Manual_Event_T<TIME_POLICY>::ACE_Manual_Event_T (
     int type,
     const wchar_t *name,
     void *arg)
-  : ACE_Event_T<TIME_POLICY> (1,
-                              initial_state,
-                              type,
-                              ACE_TEXT_WCHAR_TO_TCHAR (name),
-                              arg)
+  : ACE_Event_T<TIME_POLICY> (1, initial_state, type, ACE_TEXT_WCHAR_TO_TCHAR (name), arg)
 {
 }
 #endif /* ACE_HAS_WCHAR */

--- a/ACE/ace/Manual_Event.h
+++ b/ACE/ace/Manual_Event.h
@@ -39,19 +39,19 @@ public:
   /// Constructor which will create manual event
   ACE_Manual_Event_T (int initial_state = 0,
                       int type = USYNC_THREAD,
-                      const char *name = 0,
-                      void *arg = 0);
+                      const char *name = nullptr,
+                      void *arg = nullptr);
 
 #if defined (ACE_HAS_WCHAR)
   /// Constructor which will create manual event (wchar_t version)
   ACE_Manual_Event_T (int initial_state,
                       int type,
                       const wchar_t *name,
-                      void *arg = 0);
+                      void *arg = nullptr);
 #endif /* ACE_HAS_WCHAR */
 
   /// Default dtor.
-  ~ACE_Manual_Event_T () = default;
+  ~ACE_Manual_Event_T () override = default;
 
   /// Dump the state of an object.
   void dump () const;
@@ -60,15 +60,14 @@ public:
   ACE_ALLOC_HOOK_DECLARE;
 };
 
-class ACE_Manual_Event :
-  public ACE_Manual_Event_T<ACE_System_Time_Policy>
+class ACE_Manual_Event : public ACE_Manual_Event_T<ACE_System_Time_Policy>
 {
 public:
   /// Constructor which will create auto event
   ACE_Manual_Event (int initial_state = 0,
                     int type = USYNC_THREAD,
-                    const char *name = 0,
-                    void *arg = 0)
+                    const char *name = nullptr,
+                    void *arg = nullptr)
   : ACE_Manual_Event_T<ACE_System_Time_Policy> (initial_state, type, name, arg)
   {}
 
@@ -77,7 +76,7 @@ public:
   ACE_Manual_Event (int initial_state,
                     int type,
                     const wchar_t *name,
-                    void *arg = 0)
+                    void *arg = nullptr)
   : ACE_Manual_Event_T<ACE_System_Time_Policy> (initial_state, type, name, arg)
   {}
 #endif /* ACE_HAS_WCHAR */

--- a/ACE/ace/WFMO_Reactor.h
+++ b/ACE/ace/WFMO_Reactor.h
@@ -297,7 +297,7 @@ public:
   ACE_WFMO_Reactor_Handler_Repository (ACE_WFMO_Reactor &wfmo_reactor);
 
   /// Destructor.
-  virtual ~ACE_WFMO_Reactor_Handler_Repository () = default;
+  virtual ~ACE_WFMO_Reactor_Handler_Repository ();
 
   /// Initialize the repository of the appropriate @a size.
   int open (size_t size);

--- a/ACE/ace/WFMO_Reactor.h
+++ b/ACE/ace/WFMO_Reactor.h
@@ -297,7 +297,7 @@ public:
   ACE_WFMO_Reactor_Handler_Repository (ACE_WFMO_Reactor &wfmo_reactor);
 
   /// Destructor.
-  virtual ~ACE_WFMO_Reactor_Handler_Repository ();
+  virtual ~ACE_WFMO_Reactor_Handler_Repository () = default;
 
   /// Initialize the repository of the appropriate @a size.
   int open (size_t size);

--- a/ACE/ace/WFMO_Reactor.h
+++ b/ACE/ace/WFMO_Reactor.h
@@ -533,7 +533,7 @@ public:
   virtual int is_dispatchable (ACE_Notification_Buffer &buffer);
 
   /// Read one of the notify call on the @a handle into the
-  /// <buffer>. This could be because of a thread trying to unblock
+  /// @a buffer. This could be because of a thread trying to unblock
   /// the <Reactor_Impl>
   virtual int read_notify_pipe (ACE_HANDLE handle,
                                 ACE_Notification_Buffer &buffer);

--- a/ACE/ace/WFMO_Reactor.h
+++ b/ACE/ace/WFMO_Reactor.h
@@ -1240,7 +1240,7 @@ protected:
                                    ACE_HANDLE io_handle,
                                    WSANETWORKEVENTS &events);
 
-  /// Used to caluculate the next timeout
+  /// Used to calculate the next timeout
   virtual int calculate_timeout (ACE_Time_Value *time);
 
   /// Update the state of the handler repository

--- a/ACE/ace/WFMO_Reactor.h
+++ b/ACE/ace/WFMO_Reactor.h
@@ -509,9 +509,9 @@ public:
    * 0, the caller will block until action is possible, else will wait
    * until the relative time specified in @a timeout elapses).
    */
-  virtual int notify (ACE_Event_Handler *event_handler = 0,
+  virtual int notify (ACE_Event_Handler *event_handler = nullptr,
                       ACE_Reactor_Mask mask = ACE_Event_Handler::EXCEPT_MASK,
-                      ACE_Time_Value *timeout = 0);
+                      ACE_Time_Value *timeout = nullptr);
 
   /// No-op.
   virtual int dispatch_notifications (int &number_of_active_handles,

--- a/ACE/ace/WFMO_Reactor.inl
+++ b/ACE/ace/WFMO_Reactor.inl
@@ -5,6 +5,8 @@
 #include "ace/Sig_Handler.h"
 #include "ace/OS_NS_errno.h"
 
+#if defined (ACE_WIN32)
+
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /************************************************************/
@@ -18,10 +20,7 @@ ACE_Wakeup_All_Threads_Handler::handle_signal (int /* signum */, siginfo_t * /* 
   return 0;
 }
 
-#if defined (ACE_WIN32)
-
 /************************************************************/
-
 
 ACE_INLINE void
 ACE_WFMO_Reactor_Handler_Repository::Common_Info::reset ()
@@ -1135,19 +1134,7 @@ ACE_WFMO_Reactor::size () const
   // Size of repository minus the 2 used for internal purposes
   return this->handler_rep_.max_size_ - 2;
 }
-#else
-ACE_INLINE bool
-ACE_WFMO_Reactor_Handler_Repository::changes_required ()
-{
-  return false;
-}
-
-ACE_INLINE int
-ACE_WFMO_Reactor_Handler_Repository::make_changes ()
-{
-  return 0;
-}
-
-#endif /* ACE_WIN32 */
 
 ACE_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* ACE_WIN32 */

--- a/ACE/ace/WFMO_Reactor.inl
+++ b/ACE/ace/WFMO_Reactor.inl
@@ -1148,11 +1148,6 @@ ACE_WFMO_Reactor_Handler_Repository::make_changes ()
   return 0;
 }
 
-ACE_INLINE
-ACE_WFMO_Reactor_Handler_Repository::~ACE_WFMO_Reactor_Handler_Repository ()
-{
-}
-
 #endif /* ACE_WIN32 */
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/examples/Reactor/WFMO_Reactor/Exceptions.cpp
+++ b/ACE/examples/Reactor/WFMO_Reactor/Exceptions.cpp
@@ -39,6 +39,8 @@ public:
 
   int handle_signal (int, siginfo_t * = 0, ucontext_t * = 0)
   {
+    ACE_DEBUG ((LM_DEBUG,
+                "Event_Handler::handle_signal called\n"));
     char *cause_exception = 0;
     char a = *cause_exception;
     ACE_UNUSED_ARG(a);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated initialization defaults for constructors to use `nullptr` instead of `0` for improved type safety.
  - Removed unnecessary methods and destructor from the `ACE_WFMO_Reactor_Handler_Repository` class, simplifying the class structure.
- **Style**
  - Enhanced formatting and comment clarity to streamline internal documentation.
- **Chore**
  - Added diagnostic logging in event handling routines to improve runtime visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->