### PR TITLE
Removed workaround for ancient Embarcadero C++ Builder version

### DIFF
--- a/TAO/utils/wxNamingViewer/wxNamingViewer.cpp
+++ b/TAO/utils/wxNamingViewer/wxNamingViewer.cpp
@@ -41,11 +41,6 @@ public:
 
 IMPLEMENT_APP(WxNamingViewer)
 
-// Need this to keep C++Builder 4 happy
-#ifdef __BORLANDC__
-extern WINAPI WinMain( HINSTANCE, HINSTANCE, LPSTR, int);
-#endif
-
 int WxNamingViewer::OnExit()
 {
   ACE::fini();


### PR DESCRIPTION
    * TAO/utils/wxNamingViewer/wxNamingViewer.cpp:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the codebase by removing legacy compatibility workarounds to simplify internal maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->