### PR TITLE
Added more logging, use a code construct which isn't optimized away i…

### DIFF
--- a/ACE/examples/Reactor/WFMO_Reactor/Exceptions.cpp
+++ b/ACE/examples/Reactor/WFMO_Reactor/Exceptions.cpp
@@ -41,9 +41,8 @@ public:
   {
     ACE_DEBUG ((LM_DEBUG,
                 "Event_Handler::handle_signal called\n"));
-    char *cause_exception = 0;
-    char a = *cause_exception;
-    ACE_UNUSED_ARG(a);
+    volatile int* pInt = 0x0000000;
+    *pInt = 20;
     return 0;
   }
 

--- a/ACE/tests/Compiler_Features_41_Test.cpp
+++ b/ACE/tests/Compiler_Features_41_Test.cpp
@@ -8,6 +8,7 @@
 #if defined (ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS)
 void test()
 {
+  ACE_DEBUG ((LM_DEBUG,("In test\n")));
   volatile int* pInt = 0x0000000;
   *pInt = 20;
 }


### PR DESCRIPTION
…n release mode

    * ACE/examples/Reactor/WFMO_Reactor/Exceptions.cpp:
    * ACE/tests/Compiler_Features_41_Test.cpp: