### PR TITLE
Modernized DefaultValueRefCountBase, use default, uniform init, override, removed TAO specific extensions which are used nowhere

### DIFF
--- a/TAO/tao/Valuetype/ValueBase.cpp
+++ b/TAO/tao/Valuetype/ValueBase.cpp
@@ -1367,45 +1367,14 @@ namespace CORBA
 
 // member functions for CORBA::DefaultValueRefCountBase ============
 
-// destructor
-CORBA::DefaultValueRefCountBase::~DefaultValueRefCountBase ()
-{
-}
-
 void
 CORBA::DefaultValueRefCountBase::_add_ref ()
-{
-  this->_tao_add_ref ();
-}
-
-void
-CORBA::DefaultValueRefCountBase::_remove_ref ()
-{
-  this->_tao_remove_ref ();
-}
-
-CORBA::ULong
-CORBA::DefaultValueRefCountBase::_refcount_value ()
-{
-  return this->_tao_refcount_value ();
-}
-
-// ===========================================================
-
-CORBA::DefaultValueRefCountBase::DefaultValueRefCountBase ()
-  : refcount_ (1)
-{
-}
-
-
-void
-CORBA::DefaultValueRefCountBase::_tao_add_ref ()
 {
   ++this->refcount_;
 }
 
 void
-CORBA::DefaultValueRefCountBase::_tao_remove_ref ()
+CORBA::DefaultValueRefCountBase::_remove_ref ()
 {
   CORBA::ULong const new_count = --this->refcount_;
 
@@ -1414,7 +1383,7 @@ CORBA::DefaultValueRefCountBase::_tao_remove_ref ()
 }
 
 CORBA::ULong
-CORBA::DefaultValueRefCountBase::_tao_refcount_value () const
+CORBA::DefaultValueRefCountBase::_refcount_value ()
 {
   return this->refcount_;
 }

--- a/TAO/tao/Valuetype/ValueBase.h
+++ b/TAO/tao/Valuetype/ValueBase.h
@@ -328,13 +328,13 @@ namespace CORBA
 
   protected:
     DefaultValueRefCountBase () = default;
-    DefaultValueRefCountBase (const DefaultValueRefCountBase &) = delete;
-    DefaultValueRefCountBase (DefaultValueRefCountBase &&) = delete;
     ~DefaultValueRefCountBase () override = default;
 
   private:
     DefaultValueRefCountBase &operator= (const DefaultValueRefCountBase &) = delete;
     DefaultValueRefCountBase &operator= (DefaultValueRefCountBase &&) = delete;
+    DefaultValueRefCountBase (const DefaultValueRefCountBase &) = delete;
+    DefaultValueRefCountBase (DefaultValueRefCountBase &&) = delete;
 
   private: // data
     /// Reference counter.

--- a/TAO/tao/Valuetype/ValueBase.h
+++ b/TAO/tao/Valuetype/ValueBase.h
@@ -319,37 +319,27 @@ namespace CORBA
    *
    * Default mix-in for reference count of a valuetype.
    */
-  class TAO_Valuetype_Export DefaultValueRefCountBase
-    : public virtual ValueBase
+  class TAO_Valuetype_Export DefaultValueRefCountBase : public virtual ValueBase
   {
   public:
-    virtual void _add_ref ();
-    virtual void _remove_ref ();
-    virtual CORBA::ULong _refcount_value ();
-
-    /// The _tao variants are inline for fast access from T_var
-    /// (if valuetype T is compiled with optimization for that.) %! (todo)
-    void _tao_add_ref ();
-    void _tao_remove_ref ();
-    CORBA::ULong _tao_refcount_value () const;
+    void _add_ref () override;
+    void _remove_ref () override;
+    CORBA::ULong _refcount_value () override;
 
   protected:
-    DefaultValueRefCountBase ();
+    DefaultValueRefCountBase () = default;
     DefaultValueRefCountBase (const DefaultValueRefCountBase &) = delete;
-    virtual ~DefaultValueRefCountBase ();
+    DefaultValueRefCountBase (DefaultValueRefCountBase &&) = delete;
+    ~DefaultValueRefCountBase () override = default;
 
   private:
     DefaultValueRefCountBase &operator= (const DefaultValueRefCountBase &) = delete;
+    DefaultValueRefCountBase &operator= (DefaultValueRefCountBase &&) = delete;
 
   private: // data
     /// Reference counter.
-    std::atomic<uint32_t> refcount_;
+    std::atomic<uint32_t> refcount_ { 1 };
   }; // DefaultValueRefCountBase
-
-  //  which lock has the lowest memory overhead ?
-  // %! todo refcountbase w/o locking (now memory overhead)
-  // $! todo: debug aids for refcounts
-
 }  // End CORBA namespace
 
 # if defined (__ACE_INLINE__)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined object lifecycle management for improved performance and maintainability.
  - Simplified internal memory operations by consolidating redundant procedures and clarifying reference management.
  - Updated method signatures to enhance clarity and consistency within the `DefaultValueRefCountBase` class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->