### PR TITLE
[ACE6-TAO2] Support thread names on Windows; name the threads that TAO creates

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,11 @@
 USER VISIBLE CHANGES BETWEEN ACE-6.5.21 and ACE-6.5.22
 ======================================================
 
+. Support Linux platforms that use musl-libc instead of glibc
+
+. Thread names given to ACE_OS::thr_create are now passed down to the OS
+  on Windows.
+
 USER VISIBLE CHANGES BETWEEN ACE-6.5.20 and ACE-6.5.21
 ======================================================
 

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -3565,7 +3565,7 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
                     void *stack,
                     size_t stacksize,
                     ACE_Base_Thread_Adapter *thread_adapter,
-                    const char** thr_name)
+                    const char **thr_name)
 {
   ACE_OS_TRACE ("ACE_OS::thr_create");
 
@@ -4113,6 +4113,11 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
                                                 flags,
                                                 thr_id);
 
+      if (thr_name && *thr_name && *thr_handle)
+        {
+          SetThreadDescription (*thr_handle, ACE_Ascii_To_Wide (*thr_name).wchar_rep ());
+        }
+
       if (priority != ACE_DEFAULT_THREAD_PRIORITY && *thr_handle != 0)
         {
           // Set the priority of the new thread and then let it
@@ -4168,7 +4173,7 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
       // The call below to ::taskSpawn () causes VxWorks to assign a
       // unique task name of the form: "t" + an integer, because the
       // first argument is 0.
-      tid = ::taskSpawn (thr_name && *thr_name ? const_cast <char*> (*thr_name) : 0,
+      tid = ::taskSpawn (thr_name && *thr_name ? const_cast <char *> (*thr_name) : 0,
                          priority,
                          (int) flags,
                          stacksize,
@@ -4188,7 +4193,7 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
 
       // The TID is defined to be the address of the TCB.
       int status = ::taskInit (tcb,
-                               thr_name && *thr_name ? const_cast <char*>(*thr_name) : 0,
+                               thr_name && *thr_name ? const_cast <char *> (*thr_name) : 0,
                                priority,
                                (int) flags,
                                (char *) stack + sizeof (WIND_TCB),

--- a/ACE/ace/OS_NS_Thread.h
+++ b/ACE/ace/OS_NS_Thread.h
@@ -1620,7 +1620,7 @@ namespace ACE_OS {
                   void *stack = 0,
                   size_t stacksize = ACE_DEFAULT_THREAD_STACKSIZE,
                   ACE_Base_Thread_Adapter *thread_adapter = 0,
-                  const char** thr_name = 0);
+                  const char **thr_name = 0);
 
   ACE_NAMESPACE_INLINE_FUNCTION
   int thr_equal (ACE_thread_t t1, ACE_thread_t t2);

--- a/ACE/ace/OS_NS_Thread.inl
+++ b/ACE/ace/OS_NS_Thread.inl
@@ -2714,6 +2714,8 @@ ACE_OS::sigwait (sigset_t *sset, int *sig)
     *sig = ::sigtimedwait (sset, 0, 0);
     return *sig;
 # endif /* __FreeBSD__ */
+    ACE_UNUSED_ARG (sset);
+    ACE_NOTSUP_RETURN (-1);
 #else
     ACE_UNUSED_ARG (sset);
     ACE_UNUSED_ARG (sig);
@@ -3199,15 +3201,11 @@ ACE_OS::thr_self (void)
 #endif /* ACE_HAS_THREADS */
 }
 
-ACE_INLINE const char*
+ACE_INLINE const char *
 ACE_OS::thr_name (void)
 {
-#if defined (ACE_HAS_THREADS)
-#if defined (ACE_HAS_VXTHREADS)
+#if defined (ACE_HAS_THREADS) && defined (ACE_HAS_VXTHREADS)
   return ::taskName (ACE_OS::thr_self ());
-#else
-  ACE_NOTSUP_RETURN (0);
-#endif
 #else
   ACE_NOTSUP_RETURN (0);
 #endif

--- a/ACE/ace/Sock_Connect.cpp
+++ b/ACE/ace/Sock_Connect.cpp
@@ -1312,10 +1312,10 @@ ACE::count_interfaces (ACE_HANDLE handle, size_t &how_many)
 {
 #if defined (SIOCGIFNUM)
 # if defined (SIOCGLIFNUM) && !defined (ACE_LACKS_STRUCT_LIFNUM)
-  int cmd = SIOCGLIFNUM;
+  ACE_IOCTL_TYPE_ARG2 cmd = SIOCGLIFNUM;
   struct lifnum if_num = {AF_UNSPEC,0,0};
 # else
-  int cmd = SIOCGIFNUM;
+  ACE_IOCTL_TYPE_ARG2 cmd = SIOCGIFNUM;
   int if_num = 0;
 # endif /* SIOCGLIFNUM */
   if (ACE_OS::ioctl (handle, cmd, (caddr_t)&if_num) == -1)

--- a/ACE/ace/Stack_Trace.cpp
+++ b/ACE/ace/Stack_Trace.cpp
@@ -51,8 +51,8 @@ ACE_Stack_Trace::c_str () const
   return &this->buf_[0];
 }
 
-#if defined(__GLIBC__) || defined(ACE_HAS_EXECINFO_H) || defined(VXWORKS) || \
-    (defined(ACE_WIN32) && !defined (__MINGW32__) && !defined(__BORLANDC__))
+#if defined (__GLIBC__) || defined (ACE_HAS_EXECINFO_H) || defined (VXWORKS) || \
+    (defined (ACE_WIN32) && !defined (__MINGW32__) && !defined (__BORLANDC__))
 static inline size_t
 determine_starting_frame (ssize_t initial_frame, ssize_t offset)
 {

--- a/ACE/ace/Stack_Trace.cpp
+++ b/ACE/ace/Stack_Trace.cpp
@@ -51,11 +51,14 @@ ACE_Stack_Trace::c_str () const
   return &this->buf_[0];
 }
 
+#if defined(__GLIBC__) || defined(ACE_HAS_EXECINFO_H) || defined(VXWORKS) || \
+    (defined(ACE_WIN32) && !defined (__MINGW32__) && !defined(__BORLANDC__))
 static inline size_t
 determine_starting_frame (ssize_t initial_frame, ssize_t offset)
 {
   return ACE_MAX( initial_frame + offset, static_cast<ssize_t>(0));
 }
+#endif
 
 #if defined(ACE_FACE_SAFETY_BASE) && !defined(ACE_FACE_DEV)
 void

--- a/ACE/ace/Thread.cpp
+++ b/ACE/ace/Thread.cpp
@@ -17,7 +17,7 @@ ACE_Thread::spawn_n (size_t n,
                      void *stack[],
                      size_t stack_size[],
                      ACE_Thread_Adapter *thread_adapter,
-                     const char* thr_name[])
+                     const char *thr_name[])
 {
   ACE_TRACE ("ACE_Thread::spawn_n");
   size_t i;
@@ -53,7 +53,7 @@ ACE_Thread::spawn_n (ACE_thread_t thread_ids[],
                      size_t stack_size[],
                      ACE_hthread_t thread_handles[],
                      ACE_Thread_Adapter *thread_adapter,
-                     const char* thr_name[])
+                     const char *thr_name[])
 {
   ACE_TRACE ("ACE_Thread::spawn_n");
   size_t i = 0;

--- a/ACE/ace/Thread.h
+++ b/ACE/ace/Thread.h
@@ -88,7 +88,7 @@ public:
                     void *stack = 0,
                     size_t stack_size = ACE_DEFAULT_THREAD_STACKSIZE,
                     ACE_Thread_Adapter *thread_adapter = 0,
-                    const char** thr_name = 0);
+                    const char **thr_name = 0);
 
   /**
    * Spawn N new threads, which execute @a func with argument @a arg (if
@@ -112,7 +112,7 @@ public:
                          void *stack[] = 0,
                          size_t stack_size[] = 0,
                          ACE_Thread_Adapter *thread_adapter = 0,
-                         const char* thr_name[] = 0);
+                         const char *thr_name[] = 0);
 
   /**
    * Spawn @a n new threads, which execute @a func with argument @a arg
@@ -142,7 +142,7 @@ public:
                          size_t stack_size[] = 0,
                          ACE_hthread_t thread_handles[] = 0,
                          ACE_Thread_Adapter *thread_adapter = 0,
-                         const char* thr_name[] = 0);
+                         const char *thr_name[] = 0);
 
   /**
    * Wait for one or more threads to exit and reap their exit status.

--- a/ACE/ace/Thread.inl
+++ b/ACE/ace/Thread.inl
@@ -80,7 +80,7 @@ ACE_Thread::spawn (ACE_THR_FUNC func,
                    void *thr_stack,
                    size_t thr_stack_size,
                    ACE_Thread_Adapter *thread_adapter,
-                   const char** thr_name)
+                   const char **thr_name)
 {
   ACE_TRACE ("ACE_Thread::spawn");
 

--- a/ACE/ace/Thread_Manager.cpp
+++ b/ACE/ace/Thread_Manager.cpp
@@ -579,7 +579,7 @@ ACE_Thread_Manager::spawn_i (ACE_THR_FUNC func,
                              void *stack,
                              size_t stack_size,
                              ACE_Task_Base *task,
-                             const char** thr_name)
+                             const char **thr_name)
 {
   // First, threads created by Thread Manager should not be daemon threads.
   // Using assertion is probably a bit too strong.  However, it helps
@@ -704,7 +704,7 @@ ACE_Thread_Manager::spawn (ACE_THR_FUNC func,
                            int grp_id,
                            void *stack,
                            size_t stack_size,
-                           const char** thr_name)
+                           const char **thr_name)
 {
   ACE_TRACE ("ACE_Thread_Manager::spawn");
 
@@ -745,7 +745,7 @@ ACE_Thread_Manager::spawn_n (size_t n,
                              ACE_hthread_t thread_handles[],
                              void *stack[],
                              size_t stack_size[],
-                             const char* thr_name[])
+                             const char *thr_name[])
 {
   ACE_TRACE ("ACE_Thread_Manager::spawn_n");
   ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, -1));
@@ -788,7 +788,7 @@ ACE_Thread_Manager::spawn_n (ACE_thread_t thread_ids[],
                              size_t stack_size[],
                              ACE_hthread_t thread_handles[],
                              ACE_Task_Base *task,
-                             const char* thr_name[])
+                             const char *thr_name[])
 {
   ACE_TRACE ("ACE_Thread_Manager::spawn_n");
   ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, -1));

--- a/ACE/ace/Thread_Manager.h
+++ b/ACE/ace/Thread_Manager.h
@@ -531,7 +531,7 @@ public:
              int grp_id = -1,
              void *stack = 0,
              size_t stack_size = ACE_DEFAULT_THREAD_STACKSIZE,
-             const char** thr_name = 0);
+             const char **thr_name = 0);
 
   /**
    * Spawn a specified number of threads, all of which execute @a func
@@ -608,7 +608,7 @@ public:
                ACE_hthread_t thread_handles[] = 0,
                void *stack[] = 0,
                size_t stack_size[] = 0,
-               const char* thr_name[] = 0);
+               const char *thr_name[] = 0);
 
   /**
    * Spawn a specified number of threads, all of which execute @a func
@@ -691,7 +691,7 @@ public:
                size_t stack_size[] = 0,
                ACE_hthread_t thread_handles[] = 0,
                ACE_Task_Base *task = 0,
-               const char* thr_name[] = 0);
+               const char *thr_name[] = 0);
 
   /**
    * Called to clean up when a thread exits.
@@ -1110,14 +1110,14 @@ protected:
   int spawn_i (ACE_THR_FUNC func,
                void *arg,
                long flags,
-               ACE_thread_t * = 0,
+               ACE_thread_t *t_id = 0,
                ACE_hthread_t *t_handle = 0,
                long priority = ACE_DEFAULT_THREAD_PRIORITY,
                int grp_id = -1,
                void *stack = 0,
                size_t stack_size = 0,
                ACE_Task_Base *task = 0,
-               const char** thr_name = 0);
+               const char **thr_name = 0);
 
   /// Run the registered hooks when the thread exits.
   void run_thread_exit_hooks (int i);

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,10 +1,12 @@
 USER VISIBLE CHANGES BETWEEN TAO-2.5.21 and TAO-2.5.22
 ======================================================
 
+. Threads created by TAO_Thread_Per_Connection_Handler now have names
+
 USER VISIBLE CHANGES BETWEEN TAO-2.5.20 and TAO-2.5.21
 ======================================================
 
-- TAO_IDL: Added support for the map data type, but this isn't supported in TAO
+. TAO_IDL: Added support for the map data type, but this isn't supported in TAO
   user applications except for local usage
 
 USER VISIBLE CHANGES BETWEEN TAO-2.5.19 and TAO-2.5.20

--- a/TAO/tao/Acceptor_Impl.cpp
+++ b/TAO/tao/Acceptor_Impl.cpp
@@ -126,8 +126,8 @@ TAO_Concurrency_Strategy<SVC_HANDLER>::activate_svc_handler (SVC_HANDLER *sh,
                       -1);
 
       result =
-        tpch->activate (f->server_connection_thread_flags (),
-                        f->server_connection_thread_count ());
+        tpch->activate_ch (f->server_connection_thread_flags (),
+                           f->server_connection_thread_count ());
     }
   else
     {

--- a/TAO/tao/GIOP_Message_Base.cpp
+++ b/TAO/tao/GIOP_Message_Base.cpp
@@ -1375,25 +1375,19 @@ TAO_GIOP_Message_Base::get_parser (
           return
             const_cast<TAO_GIOP_Message_Generator_Parser_10 *> (
                                      &this->tao_giop_impl_.tao_giop_10);
-          break;
         case 1:
           return
             const_cast<TAO_GIOP_Message_Generator_Parser_11 *> (
                                      &this->tao_giop_impl_.tao_giop_11);
-          break;
         case 2:
           return
             const_cast<TAO_GIOP_Message_Generator_Parser_12 *> (
                                      &this->tao_giop_impl_.tao_giop_12);
-          break;
         default:
           throw ::CORBA::INTERNAL (0, CORBA::COMPLETED_NO);
-          break;
         }
-      break;
     default:
       throw ::CORBA::INTERNAL (0, CORBA::COMPLETED_NO);
-      break;
     }
 }
 

--- a/TAO/tao/ORB_Core.cpp
+++ b/TAO/tao/ORB_Core.cpp
@@ -3156,29 +3156,18 @@ TAO_ORB_Core::get_transport_queueing_strategy (TAO_Stub *,
                                                Messaging::SyncScope &scope)
 {
   switch (scope)
-  {
+    {
     case Messaging::SYNC_WITH_TRANSPORT:
     case Messaging::SYNC_WITH_SERVER:
     case Messaging::SYNC_WITH_TARGET:
-    {
       return this->flush_transport_queueing_strategy_;
-    }
-    break;
     case Messaging::SYNC_NONE:
-    {
       return this->eager_transport_queueing_strategy_;
-    }
-    break;
     case TAO::SYNC_DELAYED_BUFFERING:
-    {
       return this->delayed_transport_queueing_strategy_;
-    }
-    break;
     default:
-    {
       return 0;
     }
-  }
 }
 
 #endif /* TAO_HAS_BUFFERING_CONSTRAINT_POLICY == 1 */

--- a/TAO/tao/Stub.inl
+++ b/TAO/tao/Stub.inl
@@ -39,7 +39,7 @@ TAO_Stub::reset_profiles_i (void)
   if (this->forward_profiles_perm_)
     {
       // The *permanent* forward is being kept in the transient
-      // forward queue (??!). We have just nuked it. Put it back the way it was.
+      // forward queue (?). We have just nuked it. Put it back the way it was.
       // reset_base should have reset the profile success.
       // @todo We have knives in the spoon draw - TAO_Stub needs total rewrite.
       this->forward_profiles_ = this->forward_profiles_perm_;

--- a/TAO/tao/Thread_Per_Connection_Handler.cpp
+++ b/TAO/tao/Thread_Per_Connection_Handler.cpp
@@ -4,6 +4,7 @@
 #include "tao/Transport.h"
 #include "tao/ORB_Core.h"
 #include "ace/Flag_Manip.h"
+#include "ace/Vector_T.h"
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -20,6 +21,46 @@ TAO_Thread_Per_Connection_Handler::~TAO_Thread_Per_Connection_Handler (void)
 {
   this->ch_->close_connection ();
   this->ch_->transport ()->remove_reference ();
+}
+
+int
+TAO_Thread_Per_Connection_Handler::activate_ch (long flags,
+                                                int n_threads)
+{
+  if (TAO_debug_level)
+    {
+      TAOLIB_DEBUG ((LM_DEBUG,
+                     ACE_TEXT ("TAO (%P|%t) - Thread_Per_Connection_Handler::")
+                     ACE_TEXT ("activate %d threads, flags = %q\n"),
+                     n_threads,
+                     static_cast<ACE_INT64> (flags)));
+    }
+
+  ACE_Vector<ACE_CString> names (n_threads);
+  for (int i = 0; i < n_threads; ++i)
+    {
+      ACE_CString buffer = "          ";
+      ACE_OS::itoa (static_cast<ACE_INT32> (i), &buffer[0], 10);
+      names.push_back ("TAO_Thread_Per_Connection_Handler " + buffer);
+    }
+
+  ACE_Vector<const char *> thread_names (n_threads);
+  for (int i = 0; i < n_threads; ++i)
+    {
+      thread_names.push_back (names[static_cast<size_t> (i)].c_str ());
+    }
+
+  return this->activate (flags,
+                         n_threads,
+                         0,
+                         ACE_DEFAULT_THREAD_PRIORITY,
+                         -1,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         &thread_names[0]);
 }
 
 int

--- a/TAO/tao/Thread_Per_Connection_Handler.h
+++ b/TAO/tao/Thread_Per_Connection_Handler.h
@@ -46,6 +46,8 @@ public:
 
   ~TAO_Thread_Per_Connection_Handler (void);
 
+  int activate_ch (long flags, int n_threads);
+
   /// Template hook method that the thread uses...
   /**
    * Please see the documentation in ace/Task.h for details.
@@ -55,8 +57,7 @@ public:
   virtual int close (u_long);
 
 private:
-  /// Pointer to protocol specific code that does the bunch of the
-  /// job.
+  /// Pointer to protocol-specific code that does a bunch of the job.
   TAO_Connection_Handler *ch_;
 };
 

--- a/TAO/tao/Transport.cpp
+++ b/TAO/tao/Transport.cpp
@@ -2502,9 +2502,8 @@ TAO_Transport::process_parsed_messages (TAO_Queued_Data *qd,
 #endif /* TAO_HAS_TRANSPORT_CURRENT == 1 */
 
   switch (qd->msg_type ())
-  {
-    case GIOP::CloseConnection:
     {
+    case GIOP::CloseConnection:
       if (TAO_debug_level > 0)
         {
           TAOLIB_DEBUG ((LM_DEBUG,
@@ -2516,11 +2515,8 @@ TAO_Transport::process_parsed_messages (TAO_Queued_Data *qd,
       // Return a "-1" so that the next stage can take care of
       // closing connection and the necessary memory management.
       return -1;
-    }
-    break;
     case GIOP::Request:
     case GIOP::LocateRequest:
-    {
       // Let us resume the handle before we go ahead to process the
       // request. This will open up the handle for other threads.
       rh.resume_handle ();
@@ -2531,32 +2527,29 @@ TAO_Transport::process_parsed_messages (TAO_Queued_Data *qd,
           // closing connection and the necessary memory management.
           return -1;
         }
-    }
-    break;
+      break;
     case GIOP::Reply:
     case GIOP::LocateReply:
-    {
-      rh.resume_handle ();
+      {
+        rh.resume_handle ();
 
-      TAO_Pluggable_Reply_Params params (this);
+        TAO_Pluggable_Reply_Params params (this);
 
-      if (this->messaging_object ()->process_reply_message (params, qd) == -1)
-        {
-          if (TAO_debug_level > 0)
-            {
-              TAOLIB_ERROR ((LM_ERROR,
-                 ACE_TEXT ("TAO (%P|%t) - Transport[%d]::process_parsed_messages, ")
-                 ACE_TEXT ("error in process_reply_message - %m\n"),
-                 this->id ()));
-            }
+        if (this->messaging_object ()->process_reply_message (params, qd) == -1)
+          {
+            if (TAO_debug_level > 0)
+              {
+                TAOLIB_ERROR ((LM_ERROR,
+                  ACE_TEXT ("TAO (%P|%t) - Transport[%d]::process_parsed_messages, ")
+                  ACE_TEXT ("error in process_reply_message - %m\n"),
+                  this->id ()));
+              }
 
-          return -1;
-        }
-
-    }
-    break;
+            return -1;
+          }
+      }
+      break;
     case GIOP::CancelRequest:
-    {
       // The associated request might be incomplete residing
       // fragmented in messaging object. We must make sure the
       // resources allocated by fragments are released.
@@ -2577,10 +2570,8 @@ TAO_Transport::process_parsed_messages (TAO_Queued_Data *qd,
 
       // Just continue processing, CancelRequest does not mean to cut
       // off the connection.
-    }
-    break;
+      break;
     case GIOP::MessageError:
-    {
       if (TAO_debug_level > 0)
         {
           TAOLIB_ERROR ((LM_ERROR,
@@ -2589,14 +2580,9 @@ TAO_Transport::process_parsed_messages (TAO_Queued_Data *qd,
              this->id ()));
         }
       return -1;
-    }
-    break;
     case GIOP::Fragment:
-    {
-      // Nothing to be done.
+      break;
     }
-    break;
-  }
 
   // If not, just return back..
   return 0;


### PR DESCRIPTION
```
Support thread names on Windows; name the threads that TAO creates

Fixed some other warnings / code cleanup along the way

(cherry picked from commit e3b027b753b21daf35682d34a1f0f1f4c7af40ff)

# Conflicts:
#	ACE/NEWS
#	ACE/ace/OS_NS_Thread.cpp
#	ACE/ace/OS_NS_Thread.inl
#	ACE/ace/Sock_Connect.cpp
#	ACE/ace/config-integrity-common.h
#	TAO/NEWS
#	TAO/tao/ORB_Core.cpp
#	TAO/tao/Thread_Per_Connection_Handler.cpp
```