### PR TITLE
Fixed compiler warning about misleading indent

### DIFF
--- a/TAO/tests/DynValue_Test/Analyzer.cpp
+++ b/TAO/tests/DynValue_Test/Analyzer.cpp
@@ -136,8 +136,9 @@ DynAnyAnalyzer::get_correct_base_type (
 }
 
 #define CASEE(type,CT,str) case CORBA::tk_##type: {\
-  CORBA::CT b = da->get_##type();\
-  if (!newline) tab(""); \
+  CORBA::CT const b = da->get_##type();\
+  if (!newline) \
+    tab(""); \
   ACE_DEBUG ((LM_DEBUG, str , b));\
 } break;
 


### PR DESCRIPTION
    * TAO/tests/DynValue_Test/Analyzer.cpp: