### PR TITLE
TAO_IDL_FE: fixed a bug where AST_Map would return value annotations as key annotations

### DIFF
--- a/TAO/TAO_IDL/ast/ast_map.cpp
+++ b/TAO/TAO_IDL/ast/ast_map.cpp
@@ -377,7 +377,7 @@ AST_Map::destroy ()
 AST_Annotation_Appls &
 AST_Map::key_type_annotations ()
 {
-  return value_type_annotations_;
+  return key_type_annotations_;
 }
 
 void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the key type annotations accessor to return the appropriate annotations for map key types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->