### PR TITLE
Fixed compiler warnings, use default/override

### DIFF
--- a/ACE/protocols/ace/HTBP/HTBP_Addr.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Addr.cpp
@@ -18,12 +18,6 @@ ACE::HTBP::Addr::Addr (const char *htid)
 {
 }
 
-ACE::HTBP::Addr::Addr (const ACE::HTBP::Addr &other)
-  : ACE_INET_Addr (other),
-    htid_(other.htid_)
-{
-}
-
 int
 ACE::HTBP::Addr::set (u_short port,
                       const char host[],

--- a/ACE/protocols/ace/HTBP/HTBP_Addr.h
+++ b/ACE/protocols/ace/HTBP/HTBP_Addr.h
@@ -43,7 +43,10 @@ namespace ACE
       /// Constructor
       Addr () = default;
 
-      Addr (const Addr &other);
+      Addr (const Addr &) = default;
+      Addr (Addr&&) = default;
+      Addr& operator= (const Addr&) = default;
+      Addr& operator= (Addr&&) = default;
 
       /// Create an Addr suitable for use on the inside of a firewall this
       /// take a string used to populate the htid_ member. With this address,
@@ -58,7 +61,7 @@ namespace ACE
             int address_family = AF_UNSPEC);
 
       /// Destructor
-      virtual ~Addr () = default;
+      ~Addr () override = default;
 
       int set (u_short port,
                const char host [],
@@ -68,9 +71,9 @@ namespace ACE
       /// and vice versa
       int addr_to_string (ACE_TCHAR buffer[],
                           size_t size,
-                          int ipaddr_format = 1) const;
+                          int ipaddr_format = 1) const override;
       int string_to_addr (const char address[],
-                          int address_facmily = AF_UNSPEC);
+                          int address_facmily = AF_UNSPEC) override;
 
       int set_htid(const char *htid);
       const char *get_htid () const;

--- a/ACE/protocols/ace/HTBP/HTBP_Addr.h
+++ b/ACE/protocols/ace/HTBP/HTBP_Addr.h
@@ -73,7 +73,7 @@ namespace ACE
                           size_t size,
                           int ipaddr_format = 1) const override;
       int string_to_addr (const char address[],
-                          int address_facmily = AF_UNSPEC) override;
+                          int address_family = AF_UNSPEC) override;
 
       int set_htid(const char *htid);
       const char *get_htid () const;


### PR DESCRIPTION
    * ACE/protocols/ace/HTBP/HTBP_Addr.cpp:
    * ACE/protocols/ace/HTBP/HTBP_Addr.h:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of address-related objects for better consistency and maintainability.
  - Enhanced code clarity by updating method declarations and ensuring proper overrides.
  - Corrected parameter naming for address family in address parsing functions.

- **Style**
  - Standardized special member function declarations and destructor overrides for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->