### PR TITLE
Fixed building ACE for Android with `uses_wchar=1`

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,8 @@
 USER VISIBLE CHANGES BETWEEN ACE-8.0.4 and ACE-8.0.5
 ====================================================
 
+. Fixed building ACE for Android with `uses_wchar=1`
+
 USER VISIBLE CHANGES BETWEEN ACE-8.0.3 and ACE-8.0.4
 ====================================================
 

--- a/ACE/ace/Log_Msg_Android_Logcat.cpp
+++ b/ACE/ace/Log_Msg_Android_Logcat.cpp
@@ -68,7 +68,7 @@ ACE_Log_Msg_Android_Logcat::log (ACE_Log_Record &log_record)
   __android_log_write (
     convert_log_priority (static_cast<ACE_Log_Priority> (log_record.type ())),
     "ACE",
-    log_record.msg_data ());
+    ACE_TEXT_ALWAYS_CHAR (log_record.msg_data ()));
   return 0;
 }
 


### PR DESCRIPTION
Fixes https://github.com/DOCGroup/ACE_TAO/issues/2415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with building on Android platforms when the `uses_wchar` option is enabled, ensuring proper logging output in this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->