### PR TITLE
[ace6tao2] Fixed building ACE for Android with `uses_wchar=1`

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -3,6 +3,8 @@ USER VISIBLE CHANGES BETWEEN ACE-6.5.22 and ACE-6.5.23
 
 . Backported TTY_IO enhancements from ACE-7.x
 
+. Fixed building ACE for Android with `uses_wchar=1`
+
 USER VISIBLE CHANGES BETWEEN ACE-6.5.21 and ACE-6.5.22
 ======================================================
 

--- a/ACE/ace/Log_Msg_Android_Logcat.cpp
+++ b/ACE/ace/Log_Msg_Android_Logcat.cpp
@@ -72,7 +72,7 @@ ACE_Log_Msg_Android_Logcat::log (ACE_Log_Record &log_record)
   __android_log_write (
     convert_log_priority (static_cast<ACE_Log_Priority> (log_record.type ())),
     "ACE",
-    log_record.msg_data ());
+    ACE_TEXT_ALWAYS_CHAR (log_record.msg_data ()));
   return 0;
 }
 


### PR DESCRIPTION
Backport of https://github.com/DOCGroup/ACE_TAO/pull/2416