### PR TITLE
Set C++17 as C++ level for the preprocessor

### DIFF
--- a/ACE/ace/config-win32-borland.h
+++ b/ACE/ace/config-win32-borland.h
@@ -46,7 +46,7 @@
 
 #define ACE_HAS_BCC64
 
-#define ACE_CC_PREPROCESSOR_ARGS "--precompile -q -o%s"
+#define ACE_CC_PREPROCESSOR_ARGS "--precompile -std=c++17 -q -o%s"
 #define ACE_CC_PREPROCESSOR "BCC64X.EXE"
 
 # include "ace/config-win32-common.h"


### PR DESCRIPTION
    * ACE/ace/config-win32-borland.h:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler configuration to use the C++17 standard for Borland C++ on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->