### PR TITLE
Removed volatile as it gives compile warnins with C++23

### DIFF
--- a/ACE/tests/Bug_3943_Regression_Test.cpp
+++ b/ACE/tests/Bug_3943_Regression_Test.cpp
@@ -72,7 +72,7 @@ namespace {
   const char START_CHAR = '0';
   bool server_complete = false;
   bool client_complete = false;
-  volatile int expected_num_messages = 0;
+  int expected_num_messages = 0;
 
   char nextChar(const char current)
   {


### PR DESCRIPTION
    * ACE/tests/Bug_3943_Regression_Test.cpp: