### PR TITLE
Fixed test output, use nullptr/delete, fixed typo in comments

### DIFF
--- a/ACE/tests/Time_Value_Test.cpp
+++ b/ACE/tests/Time_Value_Test.cpp
@@ -62,7 +62,7 @@ int test_year_month (const ACE_Time_Value& time, long year, long month)
   if (dt.year () != year)
     {
       ACE_ERROR ((LM_ERROR,
-                  ACE_TEXT ("time year should be %d not %d\n"), dt.year (), year));
+                  ACE_TEXT ("time year should be %d not %d\n"), year, dt.year ()));
       ++ret;
     }
   else
@@ -73,7 +73,7 @@ int test_year_month (const ACE_Time_Value& time, long year, long month)
   if (dt.month () != month)
     {
       ACE_ERROR ((LM_ERROR,
-                  ACE_TEXT ("time month should be %d not %d\n"), dt.month (), month));
+                  ACE_TEXT ("time month should be %d not %d\n"), month, dt.month ()));
       ++ret;
     }
   else

--- a/TAO/tao/DynamicAny/DynAnyUtils_T.cpp
+++ b/TAO/tao/DynamicAny/DynAnyUtils_T.cpp
@@ -113,7 +113,7 @@ namespace TAO
     ANY_TC any_tc,
     CORBA::Boolean allow_truncation)
   {
-    DA_IMPL *p = 0;
+    DA_IMPL *p = nullptr;
     ACE_NEW_THROW_EX (p,
                       DA_IMPL (allow_truncation),
                       CORBA::NO_MEMORY ());
@@ -128,7 +128,7 @@ namespace TAO
         // Currently only TAO_DynValue_i can throw the original (duplicate
         // of a previously found TAO_DynValue_i). The new BLANK one created
         // above on which we called init() will be deleted automatically by
-        // the ACE_Auto_Basic_Ptr.
+        // the std::unique_ptr.
         return original;
       }
 
@@ -142,7 +142,7 @@ namespace TAO
     ANY_TC any_tc,
     CORBA::Boolean allow_truncation)
   {
-    DA_IMPL *p = 0;
+    DA_IMPL *p = nullptr;
     ACE_NEW_THROW_EX (p,
                       DA_IMPL (allow_truncation),
                       CORBA::NO_MEMORY ());
@@ -157,7 +157,7 @@ namespace TAO
         // Currently only TAO_DynValue_i can throw the original (duplicate
         // of a previously found TAO_DynValue_i). The new BLANK one created
         // above on which we called init() will be deleted automatically by
-        // the ACE_Auto_Basic_Ptr.
+        // the std::unique_ptr.
         return original;
       }
 

--- a/TAO/tao/DynamicAny/DynAny_i.h
+++ b/TAO/tao/DynamicAny/DynAny_i.h
@@ -77,8 +77,8 @@ private:
   void init_common ();
 
   // Use copy() or assign() instead of these.
-  TAO_DynAny_i (const TAO_DynAny_i &src);
-  TAO_DynAny_i &operator= (const TAO_DynAny_i &src);
+  TAO_DynAny_i (const TAO_DynAny_i &src) = delete;
+  TAO_DynAny_i &operator= (const TAO_DynAny_i &src) = delete;
 };
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/tao/DynamicAny/DynArray_i.h
+++ b/TAO/tao/DynamicAny/DynArray_i.h
@@ -89,8 +89,8 @@ private:
   void init_common ();
 
   // Use copy() or assign() instead of these.
-  TAO_DynArray_i (const TAO_DynArray_i &src);
-  TAO_DynArray_i &operator= (const TAO_DynArray_i &src);
+  TAO_DynArray_i (const TAO_DynArray_i &src) = delete;
+  TAO_DynArray_i &operator= (const TAO_DynArray_i &src) = delete;
 
 private:
   /// Each component is also a DynAny.

--- a/TAO/tao/DynamicAny/DynEnum_i.h
+++ b/TAO/tao/DynamicAny/DynEnum_i.h
@@ -83,8 +83,8 @@ private:
   void init_common ();
 
   // = Use copy() or assign() instead of these.
-  TAO_DynEnum_i (const TAO_DynEnum_i &src);
-  TAO_DynEnum_i &operator= (const TAO_DynEnum_i &src);
+  TAO_DynEnum_i (const TAO_DynEnum_i &src) = delete;
+  TAO_DynEnum_i &operator= (const TAO_DynEnum_i &src) = delete;
 
 private:
   /// Current numeric value of the enum.

--- a/TAO/tao/DynamicAny/DynStruct_i.h
+++ b/TAO/tao/DynamicAny/DynStruct_i.h
@@ -94,8 +94,8 @@ private:
   void init_common ();
 
   // = Use copy() or assign() instead of these.
-  TAO_DynStruct_i (const TAO_DynStruct_i &src);
-  TAO_DynStruct_i &operator= (const TAO_DynStruct_i &src);
+  TAO_DynStruct_i (const TAO_DynStruct_i &src) = delete;
+  TAO_DynStruct_i &operator= (const TAO_DynStruct_i &src) = delete;
 
 private:
   /// Each component is also a DynAny.

--- a/TAO/tao/DynamicAny/DynUnion_i.h
+++ b/TAO/tao/DynamicAny/DynUnion_i.h
@@ -99,8 +99,8 @@ private:
                               const CORBA::Any &other_any);
 
   /// Use copy() or assign() instead of these.
-  TAO_DynUnion_i (const TAO_DynUnion_i &src);
-  TAO_DynUnion_i &operator= (const TAO_DynUnion_i &src);
+  TAO_DynUnion_i (const TAO_DynUnion_i &src) = delete;
+  TAO_DynUnion_i &operator= (const TAO_DynUnion_i &src) = delete;
 
 private:
   /// Just two components.

--- a/TAO/tao/DynamicAny/DynValueBox_i.h
+++ b/TAO/tao/DynamicAny/DynValueBox_i.h
@@ -82,8 +82,8 @@ private:
   void set_from_any (const CORBA::Any &any);
 
   // = Use copy() or assign() instead of these.
-  TAO_DynValueBox_i (const TAO_DynValueBox_i &src);
-  TAO_DynValueBox_i &operator= (const TAO_DynValueBox_i &src);
+  TAO_DynValueBox_i (const TAO_DynValueBox_i &src) = delete;
+  TAO_DynValueBox_i &operator= (const TAO_DynValueBox_i &src) = delete;
 
   /// The boxed component of DynValueBox is another DynAny.
   DynamicAny::DynAny_var boxed_;

--- a/TAO/tao/DynamicAny/DynValueCommon_i.h
+++ b/TAO/tao/DynamicAny/DynValueCommon_i.h
@@ -36,7 +36,7 @@ class TAO_DynamicAny_Export TAO_DynValueCommon_i
 {
 public:
   /// Constructor.
-  TAO_DynValueCommon_i (CORBA::Boolean allow_truncation=true);
+  TAO_DynValueCommon_i (CORBA::Boolean allow_truncation = true);
 
   /// Destructor.
   ~TAO_DynValueCommon_i ();
@@ -56,8 +56,8 @@ public:
 
 private:
   // = Use copy() or assign() instead of these.
-  TAO_DynValueCommon_i (const TAO_DynValueCommon_i &src);
-  TAO_DynValueCommon_i &operator= (const TAO_DynValueCommon_i &src);
+  TAO_DynValueCommon_i (const TAO_DynValueCommon_i &src) = delete;
+  TAO_DynValueCommon_i &operator= (const TAO_DynValueCommon_i &src) = delete;
 
   /// Check if the typecode is acceptable. Needs to be provided by DynValue or DynValueBox
   virtual void check_typecode (CORBA::TypeCode_ptr tc)=0;

--- a/TAO/tao/DynamicAny/DynValue_i.cpp
+++ b/TAO/tao/DynamicAny/DynValue_i.cpp
@@ -91,7 +91,7 @@ TAO_DynValue_i::init_helper (CORBA::TypeCode_ptr tc)
   this->type_ = CORBA::TypeCode::_duplicate (tc);
 
   // Work out how many total members and types there
-  // are in total in this derived->base hiarchy.
+  // are in total in this derived->base hierarchy.
 
   get_base_types (
     tc,
@@ -1038,7 +1038,7 @@ TAO_DynValue_i::from_inputCDR (TAO_InputCDR &strm)
     }
 
   // Work out how many total types there
-  // are in this derived->base hiarchy.
+  // are in this derived->base hierarchy.
   const CORBA::ULong
     num_fields = static_cast <CORBA::ULong> (this->da_members_.size ()),
     num_ids =    static_cast <CORBA::ULong> (ids.size ());

--- a/TAO/tao/DynamicAny/DynValue_i.h
+++ b/TAO/tao/DynamicAny/DynValue_i.h
@@ -36,7 +36,7 @@ class TAO_DynamicAny_Export TAO_DynValue_i
 {
 public:
   /// Constructor.
-  TAO_DynValue_i (CORBA::Boolean allow_truncation=true);
+  TAO_DynValue_i (CORBA::Boolean allow_truncation = true);
 
   /// Destructor.
   ~TAO_DynValue_i ();
@@ -89,9 +89,9 @@ private:
   /// List of base types.
   typedef ACE_Array_Base<CORBA::TypeCode_var> BaseTypesList_t;
 
-  /// Decompose the given TypeCode into its hiarchical list of
+  /// Decompose the given TypeCode into its hierarchical list of
   /// basetypes. The first element of the list is our actual type,
-  /// each basetype follows in order backwards down the hiarchy.
+  /// each basetype follows in order backwards down the hierarchy.
   /// All types stored in the list are de-aliased. Optionally
   /// return the total_member_count of the fully derived type.
   static void get_base_types (
@@ -100,20 +100,20 @@ private:
     CORBA::ULong *total_member_count = 0);
 
   /// Return the unaliased valuetype typecode that corresponds to
-  /// index (0..total_members-1) from the given hiarchical list of
+  /// index (0..total_members-1) from the given hierarchical list of
   /// the derived type and it basetypes.
   static CORBA::TypeCode_ptr get_correct_base_type (
     const BaseTypesList_t &base_types,
     CORBA::ULong &index);
 
   /// Return the member_type at index (0..total_members-1) from
-  /// the given hiarchical list of the derived type and it basetypes.
+  /// the given hierarchical list of the derived type and it basetypes.
   static CORBA::TypeCode_ptr get_member_type (
     const BaseTypesList_t &,
     CORBA::ULong index);
 
   /// Return the member_name at index (0..total_members-1) from
-  /// the given hiarchical list of the derived type and it basetypes.
+  /// the given hierarchical list of the derived type and it basetypes.
   static const char * get_member_name (
     const BaseTypesList_t &,
     CORBA::ULong index);
@@ -137,14 +137,14 @@ private:
 
   /// These are not implemented!
   /// Use copy() or assign() instead of these.
-  TAO_DynValue_i (const TAO_DynValue_i &src);
-  TAO_DynValue_i &operator= (const TAO_DynValue_i &src);
+  TAO_DynValue_i (const TAO_DynValue_i &src) = delete;
+  TAO_DynValue_i &operator= (const TAO_DynValue_i &src) = delete;
 
   /// Each component of DynValue and DynValueBox is also a DynAny.
   ACE_Array_Base<DynamicAny::DynAny_var> da_members_;
 
   /// First element of this is our type, each basetype follows
-  /// in order backwards down the hiarchy. All types stored are
+  /// in order backwards down the hierarchy. All types stored are
   /// de-aliased.
   BaseTypesList_t da_base_types_;
 };

--- a/TAO/tests/DynValue_Test/Analyzer.h
+++ b/TAO/tests/DynValue_Test/Analyzer.h
@@ -48,7 +48,7 @@ private:
     CORBA::ULong *total_member_count = 0);
 
   /// Return the unaliased valuetype typecode that corresponds to
-  /// index (0..total_members-1) from the given hiarchical list of
+  /// index (0..total_members-1) from the given hierarchical list of
   /// the derived type and it basetypes.
   static CORBA::TypeCode_ptr get_correct_base_type (
     const BaseTypesList_t &base_types,


### PR DESCRIPTION
    * ACE/tests/Time_Value_Test.cpp:
    * TAO/tao/DynamicAny/DynAnyUtils_T.cpp:
    * TAO/tao/DynamicAny/DynAny_i.h:
    * TAO/tao/DynamicAny/DynArray_i.h:
    * TAO/tao/DynamicAny/DynEnum_i.h:
    * TAO/tao/DynamicAny/DynStruct_i.h:
    * TAO/tao/DynamicAny/DynUnion_i.h:
    * TAO/tao/DynamicAny/DynValueBox_i.h:
    * TAO/tao/DynamicAny/DynValueCommon_i.h:
    * TAO/tao/DynamicAny/DynValue_i.cpp:
    * TAO/tao/DynamicAny/DynValue_i.h:
    * TAO/tests/DynValue_Test/Analyzer.h:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the clarity of error messages in tests by correcting the order of expected and actual values.

* **Refactor**
  * Updated class declarations to explicitly prevent copying and assignment, enhancing code safety.
  * Modernized pointer initialization and updated related documentation to reflect current best practices.

* **Style**
  * Corrected multiple spelling and formatting errors in comments and documentation for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->