### PR TITLE
Removed operation which generated using a removed macro, operation wa…

### DIFF
--- a/TAO/TAO_IDL/be/be_visitor_operation/operation.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_operation/operation.cpp
@@ -58,39 +58,6 @@ be_visitor_operation::has_param_type (be_operation *node,
   return (node->count_arguments_with_direction (dir) != 0);
 }
 
-size_t
-be_visitor_operation::count_non_out_parameters (be_operation *node)
-{
-  // @@ Once the valuetype issue discussed below is fixed we can
-  //    replace this routine with:
-  //
-  // return node->count_arguments_with_direction (AST_Argument::dir_IN
-  //                                              | AST_Argument::dir_INOUT);
-  //
-  size_t count = 0;
-
-  // Initialize an iterator to iterate thru our scope.
-  for (UTL_ScopeActiveIterator si (node, UTL_Scope::IK_decls);
-       !si.is_done ();
-       si.next ())
-    {
-      be_argument *bd =
-        dynamic_cast<be_argument*> (si.item ());
-
-      // We do not generate insertion operators for valuetypes
-      // yet. Do not include them in the count.
-      be_valuetype *vt =
-        dynamic_cast<be_valuetype*> (bd->field_type ());
-
-      if ((bd->direction () != AST_Argument::dir_OUT) && vt == nullptr)
-        {
-          ++count;
-        }
-    }
-
-  return count;
-}
-
 int
 be_visitor_operation::is_amh_exception_holder (be_interface *node)
 {

--- a/TAO/TAO_IDL/be_include/be_visitor_operation/operation.h
+++ b/TAO/TAO_IDL/be_include/be_visitor_operation/operation.h
@@ -43,9 +43,6 @@ public:
   virtual int has_param_type (be_operation *,
                               AST_Argument::Direction);
 
-  /// Count the number of "in" and "inout" parameters.
-  virtual size_t count_non_out_parameters (be_operation *node);
-
   /// Special generation of throw_spec if it is an AMH ExceptionHolder
   /// 0:false, 1:true
   virtual int is_amh_exception_holder (be_interface *node);


### PR DESCRIPTION
…sn't used anymore

    * TAO/TAO_IDL/be/be_visitor_operation/operation.cpp:
    * TAO/TAO_IDL/be_include/be_visitor_operation/operation.h:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused helper methods related to parameter counting and exception handling from the operation visitor functionality. No visible changes to end-user features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->