### PR TITLE
Put sockaddr_un in the correct header, fixed #2341

### DIFF
--- a/ACE/ace/os_include/netinet/os_in.h
+++ b/ACE/ace/os_include/netinet/os_in.h
@@ -75,14 +75,6 @@ extern "C"
   };
 # endif /* ACE_LACKS_SOCKADDR_IN */
 
-# if defined (ACE_LACKS_SOCKADDR_UN)
-  struct  sockaddr_un {
-          u_char  sun_len;                /* sockaddr len including null */
-          u_char  sun_family;             /* AF_UNIX */
-          char    sun_path[104];          /* path name (gag) */
-  };
-#endif /* ACE_LACKS_SOCKADDR_UN */
-
 # if defined (ACE_LACKS_IP_MREQ)
   struct ip_mreq
   {

--- a/ACE/ace/os_include/sys/os_un.h
+++ b/ACE/ace/os_include/sys/os_un.h
@@ -36,9 +36,9 @@ extern "C"
 
 #if defined (ACE_LACKS_SOCKADDR_UN)
   struct  sockaddr_un {
-          u_char  sun_len;                /* sockaddr len including null */
-          u_char  sun_family;             /* AF_UNIX */
-          char    sun_path[104];          /* path name (gag) */
+    u_char  sun_len;                /* sockaddr len including null */
+    u_char  sun_family;             /* AF_UNIX */
+    char    sun_path[104];          /* path name (gag) */
   };
 #endif /* ACE_LACKS_SOCKADDR_UN */
 

--- a/ACE/ace/os_include/sys/os_un.h
+++ b/ACE/ace/os_include/sys/os_un.h
@@ -35,12 +35,12 @@ extern "C"
 #endif /* __cplusplus */
 
 #if defined (ACE_LACKS_SOCKADDR_UN)
-struct sockaddr_un {
-  short sun_family;    // AF_UNIX.
-  char  sun_path[108]; // path name.
-};
+  struct  sockaddr_un {
+          u_char  sun_len;                /* sockaddr len including null */
+          u_char  sun_family;             /* AF_UNIX */
+          char    sun_path[104];          /* path name (gag) */
+  };
 #endif /* ACE_LACKS_SOCKADDR_UN */
-
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
    * ACE/ace/os_include/netinet/os_in.h:
    * ACE/ace/os_include/sys/os_un.h:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the definition of the `sockaddr_un` structure for improved compatibility, including changes to field types and sizes.
  * Removed an outdated fallback definition of `sockaddr_un` to streamline system header usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->