### PR TITLE
[ACE 6] Conditional compilation for Windows thread names

### DIFF
--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -4113,10 +4113,12 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
                                                 flags,
                                                 thr_id);
 
+#   ifndef ACE_LACKS_SETTHREADDESCRIPTION
       if (thr_name && *thr_name && *thr_handle)
         {
           SetThreadDescription (*thr_handle, ACE_Ascii_To_Wide (*thr_name).wchar_rep ());
         }
+#   endif
 
       if (priority != ACE_DEFAULT_THREAD_PRIORITY && *thr_handle != 0)
         {


### PR DESCRIPTION
Older versions of Windows don't support SetThreadDescription. When building an ACE library that needs to be compatible with these, set ACE_LACKS_SETTHREADDESCRIPTION in config.h.

This can't be determined from the Windows headers which include SetThreadDescription unconditionally.