### PR TITLE
Runtime linking for Windows thread names

### DIFF
--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -3884,7 +3884,20 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
 
       if (thr_name && *thr_name && *thr_handle)
         {
-          SetThreadDescription (*thr_handle, ACE_Ascii_To_Wide (*thr_name).wchar_rep ());
+          // SetThreadDescription is not provided in Kernel32.dll on all Windows versions
+          HINSTANCE const kernelbase = ACE_TEXT_LoadLibrary (ACE_TEXT ("KernelBase.dll"));
+
+          if (kernelbase)
+            {
+              typedef HRESULT (WINAPI *FnPtr) (HANDLE, PCWSTR);
+              FnPtr const SetThreadDescription = (FnPtr) GetProcAddress (kernelbase, "SetThreadDescription");
+
+              if (SetThreadDescription)
+                {
+                  SetThreadDescription (*thr_handle, ACE_Ascii_To_Wide (*thr_name).wchar_rep ());
+                }
+              FreeLibrary (kernelbase);
+            }
         }
 
       if (priority != ACE_DEFAULT_THREAD_PRIORITY && *thr_handle != 0)

--- a/ACE/tests/Thread_Attrs_Test.cpp
+++ b/ACE/tests/Thread_Attrs_Test.cpp
@@ -194,6 +194,7 @@ Stack_Size_Check::svc ()
 int
 Stack_Size_Check::open (void *)
 {
+  const char *names[] = {"Stack_Size_Check"};
   if (this->activate (THR_NEW_LWP | THR_JOINABLE,
                       1,
                       0,
@@ -202,7 +203,9 @@ Stack_Size_Check::open (void *)
                       0,
                       0,
                       0,
-                      &stack_size_) == -1)
+                      &stack_size_,
+                      0,
+                      names) == -1)
     ACE_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("%p\n"),
                        ACE_TEXT ("Stack_Size_Check activate failed")),


### PR DESCRIPTION
Older versions of Windows don't support SetThreadDescription.
When building an ACE library that needs to be compatible with these,
set ACE_LACKS_SETTHREADDESCRIPTION in config.h.

This can't be determined from the Windows headers which
include SetThreadDescription unconditionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved Windows compatibility: thread naming is now applied only when the OS provides the capability, avoiding failures on older systems; public APIs unchanged.

- Tests
  - Extended thread attribute test to supply a thread name and additional activation attributes, increasing coverage without altering public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->