### PR TITLE
Add clang 20, with C++20 as default, and with C++23 enabled

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,12 +83,16 @@ jobs:
             os: ubuntu-24.04
           - CC: clang-20
             CXX: clang++-20
+            PackageDeps: clang-20
+            Repo: llvm-toolchain-noble-20
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
             os: ubuntu-24.04
           - feature: c++23
             CC: clang-20
             CXX: clang++-20
             optional_macros: c++std=c++23
+            PackageDeps: clang-20
+            Repo: llvm-toolchain-noble-20
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
             os: ubuntu-24.04
           - feature: CORBA/e micro

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,6 +81,15 @@ jobs:
             CXX: clang++-16
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
             os: ubuntu-24.04
+          - CC: clang-20
+            CXX: clang++-20
+            platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
+            os: ubuntu-24.04
+          - CC: clang-20-c++23
+            CXX: clang++-20
+            optional_macros: c++std=c++23
+            platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
+            os: ubuntu-24.04
           - feature: CORBA/e micro
             CC: gcc-10
             CXX: g++-10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,7 +85,7 @@ jobs:
             CXX: clang++-20
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
             os: ubuntu-24.04
-          - feature: clang-20-c++23
+          - feature: c++23
             CC: clang-20
             CXX: clang++-20
             optional_macros: c++std=c++23

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,7 +85,8 @@ jobs:
             CXX: clang++-20
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU
             os: ubuntu-24.04
-          - CC: clang-20-c++23
+          - feature: clang-20-c++23
+            CC: clang-20
             CXX: clang++-20
             optional_macros: c++std=c++23
             platform_file: include $(ACE_ROOT)/include/makeinclude/platform_linux_clang.GNU


### PR DESCRIPTION
    * .github/workflows/linux.yml:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded Linux CI coverage to include clang-20 on Ubuntu 24.04.
  * Added a C++23 build variant using clang-20 to validate newer language features.
  * Changes only affect continuous integration; existing CI entries remain and no runtime or user-facing behavior is altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->