### PR TITLE
Thread names on Linux are limited to 15 characters

### DIFF
--- a/ACE/tests/Thread_Attrs_Test.cpp
+++ b/ACE/tests/Thread_Attrs_Test.cpp
@@ -194,7 +194,7 @@ Stack_Size_Check::svc ()
 int
 Stack_Size_Check::open (void *)
 {
-  const char *names[] = {"Stack_Size_Check"};
+  const char *names[] = {"StackSizeCheck"};
   if (this->activate (THR_NEW_LWP | THR_JOINABLE,
                       1,
                       0,

--- a/TAO/tao/Thread_Per_Connection_Handler.cpp
+++ b/TAO/tao/Thread_Per_Connection_Handler.cpp
@@ -41,7 +41,7 @@ TAO_Thread_Per_Connection_Handler::activate_ch (long flags,
     {
       ACE_CString buffer = "          ";
       ACE_OS::itoa (static_cast<ACE_INT32> (i), &buffer[0], 10);
-      names.push_back ("TAO_Thread_Per_Connection_Handler " + buffer);
+      names.push_back ("TAO " + buffer);
     }
 
   ACE_Vector<const char *> thread_names (n_threads);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Standardized and shortened thread names to improve readability in logs, dashboards, and monitoring tools. Behavior, performance, and APIs remain unchanged.

* Tests
  * Updated test expectations to align with the new thread naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->