### PR TITLE
Updated tao_idl code generation for IDL maps

### DIFF
--- a/TAO/TAO_IDL/be/be_visitor_field/field_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_field/field_ch.cpp
@@ -576,7 +576,7 @@ be_visitor_field_ch::visit_union (be_union *node)
   *os << be_nl_2;
 
   // This was a typedefed array.
-  UTL_Scope *holds_container =\
+  UTL_Scope *holds_container =
     this->ctx_->scope ()->decl ()->defined_in ();
   AST_Decl *hc_decl = ScopeAsDecl (holds_container);
 

--- a/TAO/TAO_IDL/be/be_visitor_map/buffer_type.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_map/buffer_type.cpp
@@ -14,10 +14,8 @@
 // We have to generate the buffer type in the constructor
 // ****************************************************************
 
-be_visitor_map_buffer_type::be_visitor_map_buffer_type (
-      be_visitor_context *ctx
-  )
-  : be_visitor_decl(ctx)
+be_visitor_map_buffer_type::be_visitor_map_buffer_type (be_visitor_context *ctx)
+  : be_visitor_decl (ctx)
 {
 }
 
@@ -26,53 +24,37 @@ be_visitor_map_buffer_type::~be_visitor_map_buffer_type ()
 }
 
 int
-be_visitor_map_buffer_type::visit_node (be_type *node)
+be_visitor_map_buffer_type::visit_node (be_type *node, bool var)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-  be_type *bt = nullptr;
+  TAO_OutStream *const os = this->ctx_->stream ();
 
-  if (this->ctx_->alias ())
-    {
-      bt = this->ctx_->alias ();
-    }
-  else
-    {
-      bt = node;
-    }
+  be_typedef *const td = this->ctx_->alias ();
+  be_type *const bt = td ? static_cast<be_type *> (td) : node;
 
-  if (this->ctx_->state () == TAO_CodeGen::TAO_MAP_BUFFER_TYPE_CH)
-    {
-      *os << bt->nested_type_name (this->ctx_->scope ()->decl ());
-    }
-  else
-    {
-      *os << bt->name ();
-    }
-
+  *os << bt->nested_type_name (this->ctx_->scope ()->decl (), var ? "_var" : nullptr);
   return 0;
 }
 
 int
 be_visitor_map_buffer_type::visit_predefined_type (be_predefined_type *node)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-  AST_PredefinedType::PredefinedType pt = node->pt ();
+  TAO_OutStream *const os = this->ctx_->stream ();
 
-  *os << "::";
+  be_typedef *const td = this->ctx_->alias ();
+  be_type *const bt = td ? static_cast<be_type *> (td) : node;
 
-  if (pt == AST_PredefinedType::PT_pseudo
-      || pt == AST_PredefinedType::PT_object
-      || pt == AST_PredefinedType::PT_abstract)
+  *os << bt->nested_type_name (this->ctx_->scope ()->decl ());
+
+  switch (node->pt ())
     {
-      *os << node->name () << "_ptr";
-    }
-  else if (pt == AST_PredefinedType::PT_value)
-    {
-       *os << node->name () << " *";
-    }
-  else
-    {
-      *os << node->name ();
+      case AST_PredefinedType::PT_object:
+      case AST_PredefinedType::PT_abstract:
+      case AST_PredefinedType::PT_pseudo:
+      case AST_PredefinedType::PT_value:
+        *os << "_var";
+        break;
+      default:
+        break;
     }
 
   return 0;
@@ -82,42 +64,19 @@ be_visitor_map_buffer_type::visit_predefined_type (be_predefined_type *node)
 int
 be_visitor_map_buffer_type::visit_sequence (be_sequence *node)
 {
-  return this->visit_node(node);
+  return this->visit_node (node);
 }
 
 int
 be_visitor_map_buffer_type::visit_interface (be_interface *node)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-
-  if (this->ctx_->state () == TAO_CodeGen::TAO_SEQUENCE_BUFFER_TYPE_CH)
-    {
-      *os << node->nested_type_name (this->ctx_->scope ()->decl (),
-                                     "_ptr");
-    }
-  else
-    {
-      *os << node->name () << "_ptr";
-    }
-
-  return 0;
+  return this->visit_node (node, true);
 }
 
 int
 be_visitor_map_buffer_type::visit_interface_fwd (be_interface_fwd *node)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-
-  if (this->ctx_->state () == TAO_CodeGen::TAO_SEQUENCE_BUFFER_TYPE_CH)
-    {
-      *os << node->nested_type_name (this->ctx_->scope ()->decl (), "_ptr");
-    }
-  else
-    {
-      *os << node->name () << "_ptr";
-    }
-
-  return 0;
+  return this->visit_node (node, true);
 }
 
 int
@@ -135,52 +94,19 @@ be_visitor_map_buffer_type::visit_component_fwd (be_component_fwd *node)
 int
 be_visitor_map_buffer_type::visit_valuebox (be_valuebox *node)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-
-  if (this->ctx_->state () == TAO_CodeGen::TAO_SEQUENCE_BUFFER_TYPE_CH)
-    {
-      *os << node->nested_type_name (this->ctx_->scope ()->decl (), " *");
-    }
-  else
-    {
-      *os << node->name () << " *";
-    }
-
-  return 0;
+  return this->visit_node (node, true);
 }
 
 int
 be_visitor_map_buffer_type::visit_valuetype (be_valuetype *node)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-
-  if (this->ctx_->state () == TAO_CodeGen::TAO_SEQUENCE_BUFFER_TYPE_CH)
-    {
-      *os << node->nested_type_name (this->ctx_->scope ()->decl (), " *");
-    }
-  else
-    {
-      *os << node->name () << " *";
-    }
-
-  return 0;
+  return this->visit_node (node, true);
 }
 
 int
 be_visitor_map_buffer_type::visit_valuetype_fwd (be_valuetype_fwd *node)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-
-  if (this->ctx_->state () == TAO_CodeGen::TAO_SEQUENCE_BUFFER_TYPE_CH)
-    {
-      *os << node->nested_type_name (this->ctx_->scope ()->decl (), " *");
-    }
-  else
-    {
-      *os << node->name () << " *";
-    }
-
-  return 0;
+  return this->visit_node (node, true);
 }
 
 int
@@ -198,16 +124,8 @@ be_visitor_map_buffer_type::visit_eventtype_fwd (be_eventtype_fwd *node)
 int
 be_visitor_map_buffer_type::visit_string (be_string *node)
 {
-  TAO_OutStream *os = this->ctx_->stream ();
-
-  if (node->width () == (long) sizeof (char))
-    {
-      *os << "const ::CORBA::Char *";
-    }
-  else
-    {
-      *os << "const ::CORBA::WChar *";
-    }
+  *this->ctx_->stream () <<
+    (node->width () == 1 ? "::TAO::String_Manager" : "::TAO::WString_Manager");
 
   return 0;
 }
@@ -272,6 +190,7 @@ be_visitor_map_buffer_type::visit_typedef (be_typedef *node)
   return 0;
 }
 
-int be_visitor_map_buffer_type::visit_map (be_map *node) {
-  return this->visit_node(node);
+int be_visitor_map_buffer_type::visit_map (be_map *node)
+{
+  return this->visit_node (node);
 }

--- a/TAO/TAO_IDL/be/be_visitor_map/map_ch.cpp
+++ b/TAO/TAO_IDL/be/be_visitor_map/map_ch.cpp
@@ -45,7 +45,7 @@ int be_visitor_map_ch::visit_map (be_map *node)
 
   *os << be_nl_2;
 
-  *os << "using " << node->local_name () << " = std::map<";
+  *os << "using " << node->local_name () << " = std::map< ";
 
   be_type* kt = node->key_type();
   be_type* vt = node->value_type();

--- a/TAO/TAO_IDL/be_include/be_visitor_map/buffer_type.h
+++ b/TAO/TAO_IDL/be_include/be_visitor_map/buffer_type.h
@@ -13,8 +13,8 @@
 //=============================================================================
 
 
-#ifndef _BE_VISITOR_MAP_BUFFER_TYPE_H_
-#define _BE_VISITOR_MAP_BUFFER_TYPE_H_
+#ifndef BE_VISITOR_MAP_BUFFER_TYPE_H_
+#define BE_VISITOR_MAP_BUFFER_TYPE_H_
 
 /**
  * @class be_visitor_map_buffer_type
@@ -58,7 +58,7 @@ public:
 
 protected:
   /// helper that does the common job
-  int visit_node (be_type *);
+  int visit_node (be_type *node, bool var = false);
 };
 
-#endif /* _BE_VISITOR_MAP_BUFFER_TYPE_H_ */
+#endif

--- a/TAO/tao/String_Manager_T.h
+++ b/TAO/tao/String_Manager_T.h
@@ -24,6 +24,7 @@
 #include "tao/String_Traits_Base_T.h"
 
 #include <algorithm>
+#include <functional>
 
 /****************************************************************/
 
@@ -144,6 +145,29 @@ inline bool operator< (const TAO::WString_Manager &lhs, const TAO::WString_Manag
 }
 
 TAO_END_VERSIONED_NAMESPACE_DECL
+
+namespace std
+{
+
+  template <>
+  struct less<TAO::String_Manager> {
+    bool operator () (TAO::String_Manager const &lhs, TAO::String_Manager const &rhs) const
+    {
+      using ::operator<;
+      return lhs < rhs;
+    }
+  };
+
+  template <>
+  struct less<TAO::WString_Manager> {
+    bool operator () (TAO::WString_Manager const &lhs, TAO::WString_Manager const &rhs) const
+    {
+      using ::operator<;
+      return lhs < rhs;
+    }
+  };
+
+}
 
 #include /**/ "ace/post.h"
 #endif /* TAO_STRING_MANAGER_T */

--- a/TAO/tests/IDLv4/maps/main.cpp
+++ b/TAO/tests/IDLv4/maps/main.cpp
@@ -4,7 +4,20 @@
 #include "ace/OS_main.h"
 #include <string>
 
-int ACE_TMAIN(int, ACE_TCHAR *[])
+template <typename T>
+int check (T const &map)
+{
+  typedef typename T::const_iterator iter_t;
+  iter_t const i = map.find ("abc");
+  if (i != map.begin ())
+    {
+      ACE_DEBUG ((LM_DEBUG, "String-keyed map didn't have 'abc' as first entry\n"));
+      return EXIT_FAILURE;
+    }
+  return EXIT_SUCCESS;
+}
+
+int ACE_TMAIN (int, ACE_TCHAR *[])
 {
   // No need to test the actual map works as it's just a typedef to std::map
   DataStruct testData;
@@ -23,23 +36,33 @@ int ACE_TMAIN(int, ACE_TCHAR *[])
   testIntStringMap[42] = "Hello World!";
 
   TestStructSeq testStructSeq;
-  testStructSeq.length(1);
+  testStructSeq.length (1);
   testStructSeq[0] = testStruct;
 
   testData.intIntMap[4] = 100;
+
   testData.stringStructsMap["test"] = testStruct;
+  testData.stringStructsMap["abc"] = testStruct;
+  int ret = check (testData.stringStructsMap);
+
   testData.stringSequenceMap["test"] = testStructSeq;
+  testData.stringSequenceMap["abc"] = testStructSeq;
+  ret += check (testData.stringSequenceMap);
+
   testData.stringMapMap["test"] = testStructMap;
+  testData.stringMapMap["abc"] = testStructMap;
+  ret += check (testData.stringMapMap);
+
   testData.mapStringMap[testIntStringMap] = "Hello World";
 
   testData.testStructMapArray[0][2] = testStruct;
 
-  testData.testStructMapSeq.length(1);
+  testData.testStructMapSeq.length (1);
   testData.testStructMapSeq[0][1024] = testStruct;
 
   UnionWithMap union_with_map;
-  union_with_map.named_map(testStructMap);
-  union_with_map.anon_map(testData.stringMapMap);
+  union_with_map.named_map (testStructMap);
+  union_with_map.anon_map (testData.stringMapMap);
 
-  return EXIT_SUCCESS;
+  return ret;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Generated code now emits var-aware buffer types and uses TAO-managed string types for string fields.
  * String manager types are now orderable so they can be used as keys in standard containers.

* Refactor
  * Centralized type-resolution logic for map-related code generation to reduce duplication.

* Style
  * Formatting tweaks and include-guard name normalization in generated output.

* Tests
  * Added runtime checks to map tests; failures now return non-zero exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->