### PR TITLE
Prepare for next release

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN ACE-8.0.5 and ACE-8.0.6
+====================================================
+
 USER VISIBLE CHANGES BETWEEN ACE-8.0.4 and ACE-8.0.5
 ====================================================
 

--- a/ACE/bin/copy-local-script.sh
+++ b/ACE/bin/copy-local-script.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 for i in *.gz *.bz2 *.zip *.md5; do
-  d=`echo $i | sed 's/\.[tz][ai][rp]/-8.0.5&/'`
+  d=`echo $i | sed 's/\.[tz][ai][rp]/-8.0.6&/'`
   echo "Copying $i to $d"
   cp -ip $i $d
 done

--- a/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
+++ b/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
@@ -2,7 +2,7 @@
 
 if test -z $1; then newdate=`date -u +%Y_%m_%d`; else newdate=$1; fi
 if test -z $2; then prefix=`date -u +%Y%m%d%a`; else prefix=$2; fi
-if test -z $3; then olddate=2025_05_04; else olddate=$3; fi
+if test -z $3; then olddate=2025_08_22; else olddate=$3; fi
 if test -z $ACE_ROOT; then ACE_ROOT=..; fi
 if test -z $TAO_ROOT; then TAO_ROOT=${ACE_ROOT}/TAO; fi
 #

--- a/ACE/docs/Download.html
+++ b/ACE/docs/Download.html
@@ -90,80 +90,80 @@ Windows line feeds. For all other platforms download a .gz/.bz2 package.
 </P>
 
 <UL>
-<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 8.0.4 and TAO 4.0.4, please use the links below to download it.<P>
+<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 8.0.5 and TAO 4.0.5, please use the links below to download it.<P>
 
 <TABLE BORDER="4">
   <TR><TH>Filename</TH><TH>Description</TH><TH>Full</TH><TH>Sources only</TH></TR>
   <TR><TD>ACE+TAO.tar.gz</TD>
       <TD>ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE+TAO-8.0.4.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.4.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE+TAO-8.0.5.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.5.tar.gz">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE+TAO-src-8.0.4.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.4.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE+TAO-src-8.0.5.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.5.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE+TAO.tar.bz2</TD>
       <TD>ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE+TAO-8.0.4.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.4.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE+TAO-8.0.5.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.5.tar.bz2">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE+TAO-src-8.0.4.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.4.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE+TAO-src-8.0.5.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.5.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE+TAO.zip</TD>
       <TD>ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE+TAO-8.0.4.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.4.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE+TAO-8.0.5.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.5.zip">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE+TAO-src-8.0.4.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.4.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE+TAO-src-8.0.5.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.5.zip">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.tar.gz</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-html-8.0.4.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.4.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-html-8.0.5.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.5.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.tar.bz2</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-html-8.0.4.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.4.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-html-8.0.5.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.5.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE-html.zip</TD>
       <TD>Doxygen documentation for ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-html-8.0.4.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.4.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-html-8.0.5.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.5.zip">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.tar.gz</TD>
       <TD>ACE only (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-8.0.4.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.4.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-8.0.5.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.5.tar.gz">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-src-8.0.4.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.4.tar.gz">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-src-8.0.5.tar.gz">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.5.tar.gz">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.tar.bz2</TD>
       <TD>ACE only (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-8.0.4.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.4.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-8.0.5.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.5.tar.bz2">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-src-8.0.4.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.4.tar.bz2">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-src-8.0.5.tar.bz2">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.5.tar.bz2">FTP</A>]
       </TD>
   </TR>
   <TR><TD>ACE.zip</TD>
       <TD>ACE only (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-8.0.4.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.4.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-8.0.5.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.5.zip">FTP</A>]
       </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_4/ACE-src-8.0.4.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.4.zip">FTP</A>]
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE-src-8.0.5.zip">HTTP</A>]
+          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.5.zip">FTP</A>]
       </TD>
   </TR>
 </TABLE>

--- a/ACE/etc/index.html
+++ b/ACE/etc/index.html
@@ -30,6 +30,7 @@
     <hr>
     We do have the documentation for previous releases
     <ul>
+      <LI><P><A HREF="8.0.5/html">8.0.5</A></P></LI>
       <LI><P><A HREF="8.0.4/html">8.0.4</A></P></LI>
       <LI><P><A HREF="8.0.3/html">8.0.3</A></P></LI>
       <LI><P><A HREF="8.0.2/html">8.0.2</A></P></LI>

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN TAO-4.0.5 and TAO-4.0.6
+====================================================
+
 USER VISIBLE CHANGES BETWEEN TAO-4.0.4 and TAO-4.0.5
 ====================================================
 


### PR DESCRIPTION
    * ACE/NEWS:
    * ACE/bin/diff-builds-and-group-fixed-tests-only.sh:
    * ACE/docs/Download.html:
    * ACE/etc/index.html:
    * TAO/NEWS:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added new NEWS headers for ACE 8.0.6 and TAO 4.0.6.
  - Updated Download page to point to ACE+TAO 8.0.5/4.0.5 packages across all formats.
  - Added 8.0.5 to the “previous releases” documentation index.

- Chores
  - Adjusted default baseline date in an internal build comparison script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->