### PR TITLE
[ACE6] Time_Value & Floating-point std::chrono::duration

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -7,6 +7,8 @@ USER VISIBLE CHANGES BETWEEN ACE-6.5.22 and ACE-6.5.23
 
 . Updated thread name support to work with older Windows versions
 
+. Support floating-point-based `std::chrono::duration` in `ACE_Time_Value`
+
 USER VISIBLE CHANGES BETWEEN ACE-6.5.21 and ACE-6.5.22
 ======================================================
 

--- a/ACE/ace/Time_Value.h
+++ b/ACE/ace/Time_Value.h
@@ -126,13 +126,13 @@ public:
   template< class Rep, class Period >
   void set (const std::chrono::duration<Rep, Period>& duration)
   {
-    std::chrono::seconds const s {
-      std::chrono::duration_cast<std::chrono::seconds> (duration)};
+    using std::chrono::seconds;
+    using std::chrono::microseconds;
+    using std::chrono::duration_cast;
 
-    std::chrono::microseconds const usec {
-      std::chrono::duration_cast<std::chrono::microseconds>(
-        duration % std::chrono::seconds (1))};
-    this->set (ACE_Utils::truncate_cast<time_t>(s.count ()), ACE_Utils::truncate_cast<suseconds_t>(usec.count ()));
+    auto const sec = duration_cast<seconds> (duration);
+    auto const usec = duration_cast<microseconds> (duration - sec);
+    this->set (ACE_Utils::truncate_cast<time_t> (sec.count ()), ACE_Utils::truncate_cast<suseconds_t> (usec.count ()));
   }
 #endif /* ACE_HAS_CPP11 */
 
@@ -284,11 +284,7 @@ public:
   template< class Rep, class Period >
   ACE_Time_Value &operator += (const std::chrono::duration<Rep, Period>& duration)
   {
-    const ACE_Time_Value tv (duration);
-    this->sec (this->sec () + tv.sec ());
-    this->usec (this->usec () + tv.usec ());
-    this->normalize ();
-    return *this;
+    return *this += ACE_Time_Value (duration);
   }
 
   /// Assign @a std::duration to this
@@ -303,11 +299,7 @@ public:
   template< class Rep, class Period >
   ACE_Time_Value &operator -= (const std::chrono::duration<Rep, Period>& duration)
   {
-    const ACE_Time_Value tv (duration);
-    this->sec (this->sec () - tv.sec ());
-    this->usec (this->usec () - tv.usec ());
-    this->normalize ();
-    return *this;
+    return *this -= ACE_Time_Value (duration);
   }
 #endif /* ACE_HAS_CPP11 */
 

--- a/ACE/tests/.gitignore
+++ b/ACE/tests/.gitignore
@@ -94,6 +94,12 @@
 /Compiler_Features_33_Test
 /Compiler_Features_34_Test
 /Compiler_Features_35_Test
+/Compiler_Features_36_Test
+/Compiler_Features_37_Test
+/Compiler_Features_38_Test
+/Compiler_Features_39_Test
+/Compiler_Features_40_Test
+/Compiler_Features_41_Test
 /Config_Test
 /Conn_Test
 /Date_Time_Test
@@ -110,6 +116,7 @@
 /FlReactor_Test
 /Framework_Component_Test
 /Future_Set_Test
+/Future_Stress_Test
 /Future_Test
 /Get_Opt_Test
 /Handle_Set_Test
@@ -152,6 +159,7 @@
 /MT_Reference_Counted_Event_Handler_Test
 /MT_Reference_Counted_Notify_Test
 /MT_SOCK_Test
+/Multicast_Interfaces_Test
 /Multicast_Test
 /Multicast_Test_IPV6
 /Multihomed_INET_Addr_Test
@@ -216,8 +224,9 @@
 /Signal_Test
 /Sigset_Ops_Test
 /Simple_Message_Block_Test
-/Singleton_Test
 /Singleton_Restart_Test
+/Singleton_Test
+/SOCK_Acceptor_Test
 /SOCK_Connector_Test
 /SOCK_Dgram_Bcast_Test
 /SOCK_Dgram_Test
@@ -256,8 +265,8 @@
 /Token_Strategy_Test
 /Tokens_Test
 /TP_Reactor_Test
-/TSS_Static_Test
 /TSS_Leak_Test
+/TSS_Static_Test
 /TSS_Test
 /Unbounded_Set_Test
 /Unbounded_Set_Test_Ex
@@ -273,8 +282,3 @@
 /XtAthenaReactor_Test
 /XtMotifReactor_Test
 /XtReactor_Test
-/Compiler_Features_36_Test
-/Compiler_Features_37_Test
-/Compiler_Features_38_Test
-/SOCK_Acceptor_Test
-Multicast_Interfaces_Test


### PR DESCRIPTION
This is a backport of https://github.com/DOCGroup/ACE_TAO/pull/2462

`ACE_Time_Value` currently doesn't accept a `std::chrono::duration` with `Rep` that's a floating point type because it's using the modulus operator to separate the microseconds (`duration % seconds(1)`) and trying to use modulus with floating points causes a compile error.

This changes it to use subtraction from the whole number of seconds (`duration - sec`) and adds a test for it.

Also:
- Simplify the `-=` and `+=` ops of `ACE_Time_Value`
- Rewrite some of the testing in `Chrono_Test.cpp`.