### PR TITLE
Use nullptr, fixed comments

### DIFF
--- a/ACE/ace/Asynch_IO.h
+++ b/ACE/ace/Asynch_IO.h
@@ -1568,7 +1568,7 @@ public:
   /// A do nothing constructor.
   ACE_Handler ();
 
-  /// A do nothing constructor which allows proactor to be set to \<p\>.
+  /// A do nothing constructor which allows proactor to be set to @a p.
   ACE_Handler (ACE_Proactor *p);
 
   /// Virtual destruction.
@@ -1610,8 +1610,7 @@ public:
 
   /// Called when timer expires.  {tv} was the requested time value and
   /// {act} is the ACT passed when scheduling the timer.
-  virtual void handle_time_out (const ACE_Time_Value &tv,
-                                const void *act = 0);
+  virtual void handle_time_out (const ACE_Time_Value &tv, const void *act = nullptr);
 
   /**
    * This is method works with the {run_event_loop} of the
@@ -1649,7 +1648,7 @@ public:
   {
   public:
     Proxy (ACE_Handler *handler) : handler_ (handler) {}
-    void reset () { this->handler_ = 0; }
+    void reset () { this->handler_ = nullptr; }
     ACE_Handler *handler () { return this->handler_; }
   private:
     ACE_Handler *handler_;

--- a/ACE/ace/POSIX_Asynch_IO.cpp
+++ b/ACE/ace/POSIX_Asynch_IO.cpp
@@ -618,7 +618,7 @@ ACE_POSIX_Asynch_Write_File_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_write_file (result);
 }
 

--- a/ACE/examples/Reactor/Proactor/simple_test_proactor.cpp
+++ b/ACE/examples/Reactor/Proactor/simple_test_proactor.cpp
@@ -48,7 +48,7 @@ public:
   int open ();
 
 protected:
-  // = These methods are called by the freamwork.
+  // = These methods are called by the framework.
 
   /// This is called when asynchronous reads from the socket complete.
   virtual void handle_read_file (const ACE_Asynch_Read_File::Result &result);

--- a/ACE/examples/Reactor/Proactor/test_proactor.cpp
+++ b/ACE/examples/Reactor/Proactor/test_proactor.cpp
@@ -287,7 +287,7 @@ public:
   void handle (ACE_HANDLE);
 
 protected:
-  // These methods are called by the freamwork
+  // These methods are called by the framework
 
   /**
    * This is called when asynchronous transmit files complete

--- a/ACE/examples/Reactor/Proactor/test_proactor2.cpp
+++ b/ACE/examples/Reactor/Proactor/test_proactor2.cpp
@@ -371,7 +371,7 @@ public:
   void handle (ACE_HANDLE);
 
 protected:
-// These methods are called by the freamwork
+// These methods are called by the framework
 
 /// This is called when asynchronous reads from the socket complete
 virtual void handle_read_stream (const ACE_Asynch_Read_Stream::Result

--- a/ACE/examples/Reactor/Proactor/test_proactor3.cpp
+++ b/ACE/examples/Reactor/Proactor/test_proactor3.cpp
@@ -425,7 +425,7 @@ public:
   virtual void handle (ACE_HANDLE);
 
 protected:
-  // These methods are called by the freamwork
+  // These methods are called by the framework
 
   /// This is called when asynchronous reads from the socket complete
   virtual void handle_read_stream (const ACE_Asynch_Read_Stream::Result &result);

--- a/ACE/examples/Reactor/Proactor/test_udp_proactor.cpp
+++ b/ACE/examples/Reactor/Proactor/test_udp_proactor.cpp
@@ -226,7 +226,7 @@ public:
   int open (const ACE_TCHAR *host, u_short port);
 
 protected:
-  // These methods are called by the freamwork
+  // These methods are called by the framework
 
   /// This is called when asynchronous writes from the dgram socket
   /// complete

--- a/ACE/tests/Proactor_Timer_Test.cpp
+++ b/ACE/tests/Proactor_Timer_Test.cpp
@@ -114,7 +114,6 @@ Time_Handler::handle_time_out (const ACE_Time_Value &, const void *arg)
     }
 
   counter += (1 + odd);
-  return;
 }
 
 long
@@ -303,7 +302,7 @@ run_main (int argc, ACE_TCHAR *[])
       // precision for a 1 second timer is beyond me ...  I think it
       // is a cut&paste error.
       //
-      // The use of auto_ptr<> is optional, ACE uses dangerous memory
+      // The use of std::unique_ptr<> is optional, ACE uses dangerous memory
       // management idioms everywhere, I thought I could demonstrate how
       // to do it right in at least one test.  Notice the lack of
       // ACE_NEW_RETURN, that monstrosity has no business in proper C++


### PR DESCRIPTION
    * ACE/ace/Asynch_IO.h:
    * ACE/ace/POSIX_Asynch_IO.cpp:
    * ACE/examples/Reactor/Proactor/simple_test_proactor.cpp:
    * ACE/examples/Reactor/Proactor/test_proactor.cpp:
    * ACE/examples/Reactor/Proactor/test_proactor2.cpp:
    * ACE/examples/Reactor/Proactor/test_proactor3.cpp:
    * ACE/examples/Reactor/Proactor/test_udp_proactor.cpp:
    * ACE/tests/Proactor_Timer_Test.cpp:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.

- Refactor
  - Modernized null-pointer usage to C++11 standards for improved clarity and consistency.
  - Removed a redundant return statement in a void function within test logic.

- Documentation
  - Corrected multiple comment typos (e.g., “freamwork” to “framework”).
  - Updated references to modern C++ terminology in comments.

- Tests
  - Minor non-functional updates to test code and comments; behavior and APIs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->