### PR TITLE
Add support for Visual Studio 2026

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,6 +27,9 @@ jobs:
           - CC: vs2022
             CXX: vs2022
             os: windows-2022
+          - CC: vs2026
+            CXX: vs2026
+            os: windows-2025
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }}
     env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,6 +84,22 @@ jobs:
             vcpkgarch: x64-windows
             vcpkglibdir: lib
             vcpkgpackages: '"openssl", "xerces-c", "zlib"'
+          - name: VS2026Debug64
+            vmimage: windows-2025
+            mpctype: vs2026
+            BuildPlatform: x64
+            BuildConfiguration: Debug
+            vcpkgarch: x64-windows
+            vcpkglibdir: debug/lib
+            vcpkgpackages: '"openssl", "xerces-c", "zlib"'
+          - name: VS2026Release64
+            vmimage: windows-2025
+            mpctype: vs2026
+            BuildPlatform: x64
+            BuildConfiguration: Release
+            vcpkgarch: x64-windows
+            vcpkglibdir: lib
+            vcpkgpackages: '"openssl", "xerces-c", "zlib"'
     runs-on: ${{ matrix.vmimage }}
     name: ${{ matrix.name }}
     env:

--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,8 @@
 USER VISIBLE CHANGES BETWEEN ACE-8.0.6 and ACE-8.0.7
 ====================================================
 
+. Added support for Visual Studio 2026
+
 USER VISIBLE CHANGES BETWEEN ACE-8.0.5 and ACE-8.0.6
 ====================================================
 

--- a/ACE/ace/config-win32-msvc-145.h
+++ b/ACE/ace/config-win32-msvc-145.h
@@ -1,0 +1,29 @@
+/* -*- C++ -*- */
+//=============================================================================
+/**
+ *  @file   config-win32-msvc-145.h
+ *
+ *  @brief  Microsoft Visual C++ 14.5 configuration file.
+ *
+ *  This file is the ACE configuration file for Microsoft Visual C++ 14.5 (as released with Visual Studio 2026).
+ *
+ *  @note Do not include this file directly, include config-win32.h instead.
+ */
+//=============================================================================
+
+#ifndef ACE_CONFIG_WIN32_MSVC_145_H
+#define ACE_CONFIG_WIN32_MSVC_145_H
+#include /**/ "ace/pre.h"
+
+#ifndef ACE_CONFIG_WIN32_H
+#error Use config-win32.h in config.h instead of this header
+#endif /* ACE_CONFIG_WIN32_H */
+
+#ifndef ACE_WIN32_VC145
+#  define ACE_WIN32_VC145
+#endif
+
+#include "ace/config-win32-msvc-143.h"
+
+#include /**/ "ace/post.h"
+#endif /* ACE_CONFIG_WIN32_MSVC_145_H */

--- a/ACE/ace/config-win32-msvc.h
+++ b/ACE/ace/config-win32-msvc.h
@@ -33,7 +33,9 @@
 #  define ACE_ENDTHREADEX(STATUS) ::_endthreadex ((DWORD) STATUS)
 
 //FUZZ: disable check_for_msc_ver
-#if (_MSC_VER >= 1930)
+#if (_MSC_VER >= 1950)
+# include "ace/config-win32-msvc-145.h"
+#elif (_MSC_VER >= 1930)
 # include "ace/config-win32-msvc-143.h"
 #elif (_MSC_VER >= 1920)
 # include "ace/config-win32-msvc-142.h"

--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -63,6 +63,9 @@ feature(ace_languagestandard2017) {
   specific(vs2017,vs2019,vs2022) {
     LanguageStandard = stdcpp17
   }
+  specific(vs2026) {
+    LanguageStandard = stdcpp20
+  }
   specific(cmake) {
     languagestandard = 17
   }

--- a/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
+++ b/ACE/bin/MakeProjectCreator/config/acedefaults.mpb
@@ -63,10 +63,13 @@ feature(ace_languagestandard2017) {
   specific(vs2017,vs2019,vs2022) {
     LanguageStandard = stdcpp17
   }
-  specific(vs2026) {
-    LanguageStandard = stdcpp20
-  }
   specific(cmake) {
     languagestandard = 17
+  }
+}
+
+feature(ace_languagestandard2020) {
+  specific(vs2026) {
+    LanguageStandard = stdcpp20
   }
 }

--- a/ACE/bin/MakeProjectCreator/config/vs2026.features
+++ b/ACE/bin/MakeProjectCreator/config/vs2026.features
@@ -1,0 +1,4 @@
+ssl=0
+qos=1
+rwho=0
+sctp=0

--- a/ACE/bin/MakeProjectCreator/config/vs2026nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2026nmake.mpb
@@ -29,7 +29,7 @@ feature(vc_avoid_hides_class_member) {
   }
 }
 
-feature(ace_languagestandard2017) {
+feature(ace_languagestandard2020) {
   specific(nmake) {
     compile_flags += /std:c++20
   }

--- a/ACE/bin/MakeProjectCreator/config/vs2026nmake.mpb
+++ b/ACE/bin/MakeProjectCreator/config/vs2026nmake.mpb
@@ -1,0 +1,36 @@
+// -*- MPC -*-
+feature (nmake_avoid_Wp64) {
+  specific(nmake) {
+    add_compile -= /Wp64
+  }
+}
+
+feature (nmake_avoid_Gm) {
+  specific(nmake) {
+    compile_flags -= /Gm
+  }
+}
+
+feature(vc_avoid_hides_local_declaration) {
+  specific(nmake) {
+    DisableSpecificWarnings += 4456
+  }
+}
+
+feature(vc_avoid_hides_global_declaration) {
+  specific(nmake) {
+    DisableSpecificWarnings += 4459
+  }
+}
+
+feature(vc_avoid_hides_class_member) {
+  specific(nmake) {
+    DisableSpecificWarnings += 4458
+  }
+}
+
+feature(ace_languagestandard2017) {
+  specific(nmake) {
+    compile_flags += /std:c++20
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official support added for Visual Studio 2026 across builds and project templates, including language-standard alignment.

* **Chores**
  * Windows CI expanded to include Visual Studio 2026 build configurations.
  * New configuration fragments and project templates added to enable VS2026 builds and related feature flags.

* **Documentation**
  * Release notes updated to announce Visual Studio 2026 support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DOCGroup/ACE_TAO/pull/2509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->