### PR TITLE
Use clang-tidy to use nullptr

### DIFF
--- a/ACE/ace/ACE.cpp
+++ b/ACE/ace/ACE.cpp
@@ -157,7 +157,7 @@ ACE::debug ()
   //FUZZ: disable check_for_ace_log_categories
   static const char *debug = ACE_OS::getenv ("ACE_DEBUG");
   //FUZZ: enable check_for_ace_log_categories
-  return (ACE::debug_) ? ACE::debug_ : (debug != 0 ? (*debug != '0') : false);
+  return (ACE::debug_) ? ACE::debug_ : (debug != nullptr ? (*debug != '0') : false);
 }
 
 void
@@ -2407,7 +2407,7 @@ ACE::timestamp (const ACE_Time_Value& time_value,
   if (date_and_timelen < 27)
     {
       errno = EINVAL;
-      return 0;
+      return nullptr;
     }
 
   ACE_Time_Value cur_time =
@@ -3305,9 +3305,9 @@ ACE::strend (const wchar_t *s)
 char *
 ACE::strnew (const char *s)
 {
-  if (s == 0)
-    return 0;
-  char *t = 0;
+  if (s == nullptr)
+    return nullptr;
+  char *t = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (t,
                         static_cast<char*> (ACE_Allocator::instance ()->malloc (sizeof (char) * (ACE_OS::strlen (s) + 1))),
@@ -3405,7 +3405,7 @@ ACE::wild_match(const char *str, const char *pat, bool case_sensitive,
 {
   if (str == pat)
     return true;
-  if (pat == 0 || str == 0)
+  if (pat == nullptr || str == nullptr)
     return false;
 
   bool star = false, escape = false;

--- a/ACE/ace/ACE.cpp
+++ b/ACE/ace/ACE.cpp
@@ -174,9 +174,9 @@ ACE::select (int width,
              const ACE_Time_Value *timeout)
 {
   int result = ACE_OS::select (width,
-                               readfds ? readfds->fdset () : 0,
-                               writefds ? writefds->fdset () : 0,
-                               exceptfds ? exceptfds->fdset () : 0,
+                               readfds ? readfds->fdset () : nullptr,
+                               writefds ? writefds->fdset () : nullptr,
+                               exceptfds ? exceptfds->fdset () : nullptr,
                                timeout);
   if (result > 0)
     {
@@ -200,8 +200,8 @@ ACE::select (int width,
 {
   int result = ACE_OS::select (width,
                                readfds.fdset (),
-                               0,
-                               0,
+                               nullptr,
+                               nullptr,
                                timeout);
 
 #if !defined (ACE_WIN32)
@@ -392,7 +392,7 @@ ACE::basename (const ACE_TCHAR *pathname, ACE_TCHAR delim)
   ACE_TRACE ("ACE::basename");
   const ACE_TCHAR *temp = ACE_OS::strrchr (pathname, delim);
 
-  if (temp == 0)
+  if (temp == nullptr)
     return pathname;
   else
     return temp + 1;
@@ -406,7 +406,7 @@ ACE::dirname (const ACE_TCHAR *pathname, ACE_TCHAR delim)
 
   const ACE_TCHAR *temp = ACE_OS::strrchr (pathname, delim);
 
-  if (temp == 0)
+  if (temp == nullptr)
     {
       return_dirname[0] = '.';
       return_dirname[1] = '\0';
@@ -435,7 +435,7 @@ ACE::recv (ACE_HANDLE handle,
            int flags,
            const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::recv (handle, (char *) buf, len, flags);
   else
     {
@@ -486,7 +486,7 @@ ACE::recv (ACE_HANDLE handle,
            size_t n,
            const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE::recv_i (handle, buf, n);
   else
     {
@@ -508,7 +508,7 @@ ACE::recvmsg (ACE_HANDLE handle,
               int flags,
               const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::recvmsg (handle, msg, flags);
   else
     {
@@ -533,7 +533,7 @@ ACE::recvfrom (ACE_HANDLE handle,
                int *addrlen,
                const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::recvfrom (handle, buf, len, flags, addr, addrlen);
   else
     {
@@ -558,7 +558,7 @@ ACE::recv_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
 
   for (bytes_transferred = 0;
@@ -581,7 +581,7 @@ ACE::recv_n_i (ACE_HANDLE handle,
           if (errno == EWOULDBLOCK)
             {
               // Wait for the blocking to subside.
-              int const result = ACE::handle_read_ready (handle, 0);
+              int const result = ACE::handle_read_ready (handle, nullptr);
 
               // Did select() succeed?
               if (result != -1)
@@ -609,7 +609,7 @@ ACE::recv_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
   ssize_t result = 0;
   bool error = false;
@@ -793,7 +793,7 @@ ACE::recv_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
 
   for (bytes_transferred = 0;
@@ -816,7 +816,7 @@ ACE::recv_n_i (ACE_HANDLE handle,
           if (errno == EWOULDBLOCK)
             {
               // Wait for the blocking to subside.
-              int const result = ACE::handle_read_ready (handle, 0);
+              int const result = ACE::handle_read_ready (handle, nullptr);
 
               // Did select() succeed?
               if (result != -1)
@@ -843,7 +843,7 @@ ACE::recv_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
   ssize_t result = 0;
   bool error = false;
@@ -910,7 +910,7 @@ ACE::recv (ACE_HANDLE handle, size_t n, ...)
 {
   va_list argp;
   int const total_tuples = static_cast<int> (n / 2);
-  iovec *iovp = 0;
+  iovec *iovp = nullptr;
 #if defined (ACE_HAS_ALLOCA)
   iovp = (iovec *) alloca (total_tuples * sizeof (iovec));
 #else
@@ -954,7 +954,7 @@ ACE::recvv (ACE_HANDLE handle,
             int iovcnt,
             const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::recvv (handle, iov, iovcnt);
   else
     {
@@ -977,7 +977,7 @@ ACE::recvv_n_i (ACE_HANDLE handle,
                 size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
 
   for (int s = 0; s < iovcnt; )
@@ -995,7 +995,7 @@ ACE::recvv_n_i (ACE_HANDLE handle,
           if (errno == EWOULDBLOCK)
             {
               // Wait for the blocking to subside.
-              int const result = ACE::handle_read_ready (handle, 0);
+              int const result = ACE::handle_read_ready (handle, nullptr);
 
               // Did select() succeed?
               if (result != -1)
@@ -1035,7 +1035,7 @@ ACE::recvv_n_i (ACE_HANDLE handle,
                 size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
   ssize_t result = 0;
   bool error = false;
@@ -1109,18 +1109,18 @@ ACE::recv_n (ACE_HANDLE handle,
              size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
 
   iovec iov[ACE_IOV_MAX];
   int iovcnt = 0;
 
-  while (message_block != 0)
+  while (message_block != nullptr)
     {
       // Our current message block chain.
       const ACE_Message_Block *current_message_block = message_block;
 
-      while (current_message_block != 0)
+      while (current_message_block != nullptr)
         {
           size_t current_message_block_length =
             current_message_block->length ();
@@ -1209,7 +1209,7 @@ ACE::send (ACE_HANDLE handle,
            int flags,
            const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::send (handle, (const char *) buf, n, flags);
   else
     {
@@ -1260,7 +1260,7 @@ ACE::send (ACE_HANDLE handle,
            size_t n,
            const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE::send_i (handle, buf, n);
   else
     {
@@ -1282,7 +1282,7 @@ ACE::sendmsg (ACE_HANDLE handle,
               int flags,
               const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::sendmsg (handle, msg, flags);
   else
     {
@@ -1308,7 +1308,7 @@ ACE::sendto (ACE_HANDLE handle,
              int addrlen,
              const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::sendto (handle, buf, len, flags, addr, addrlen);
   else
     {
@@ -1333,7 +1333,7 @@ ACE::send_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
 
   for (bytes_transferred = 0;
@@ -1360,7 +1360,7 @@ ACE::send_n_i (ACE_HANDLE handle,
 #endif /* ACE_WIN32 */
             {
               // Wait for the blocking to subside.
-              int const result = ACE::handle_write_ready (handle, 0);
+              int const result = ACE::handle_write_ready (handle, nullptr);
 
               // Did select() succeed?
               if (result != -1)
@@ -1388,7 +1388,7 @@ ACE::send_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
   ssize_t result = 0;
   bool error = false;
@@ -1575,7 +1575,7 @@ ACE::send_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
 
   for (bytes_transferred = 0;
@@ -1599,7 +1599,7 @@ ACE::send_n_i (ACE_HANDLE handle,
           if (errno == EWOULDBLOCK || errno == ENOBUFS)
             {
               // Wait for the blocking to subside.
-              int const result = ACE::handle_write_ready (handle, 0);
+              int const result = ACE::handle_write_ready (handle, nullptr);
 
               // Did select() succeed?
               if (result != -1)
@@ -1626,7 +1626,7 @@ ACE::send_n_i (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
   ssize_t result = 0;
   bool error = false;
@@ -1739,7 +1739,7 @@ ACE::sendv (ACE_HANDLE handle,
             int iovcnt,
             const ACE_Time_Value *timeout)
 {
-  if (timeout == 0)
+  if (timeout == nullptr)
     return ACE_OS::sendv (handle, iov, iovcnt);
   else
     {
@@ -1762,7 +1762,7 @@ ACE::sendv_n_i (ACE_HANDLE handle,
                 size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
 
   iovec *iov = const_cast<iovec *> (i);
@@ -1785,7 +1785,7 @@ ACE::sendv_n_i (ACE_HANDLE handle,
           if (errno == EWOULDBLOCK || errno == ENOBUFS)
             {
               // Wait for the blocking to subside.
-              int const result = ACE::handle_write_ready (handle, 0);
+              int const result = ACE::handle_write_ready (handle, nullptr);
 
               // Did select() succeed?
               if (result != -1)
@@ -1825,7 +1825,7 @@ ACE::sendv_n_i (ACE_HANDLE handle,
                 size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
   ssize_t result = 0;
   bool error = false;
@@ -1904,18 +1904,18 @@ ACE::write_n (ACE_HANDLE handle,
               size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
 
   iovec iov[ACE_IOV_MAX];
   int iovcnt = 0;
 
-  while (message_block != 0)
+  while (message_block != nullptr)
     {
       // Our current message block chain.
       const ACE_Message_Block *current_message_block = message_block;
 
-      while (current_message_block != 0)
+      while (current_message_block != nullptr)
         {
           size_t current_message_block_length =
             current_message_block->length ();
@@ -2000,18 +2000,18 @@ ACE::send_n (ACE_HANDLE handle,
              size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
 
   iovec iov[ACE_IOV_MAX];
   int iovcnt = 0;
 
-  while (message_block != 0)
+  while (message_block != nullptr)
     {
       // Our current message block chain.
       const ACE_Message_Block *current_message_block = message_block;
 
-      while (current_message_block != 0)
+      while (current_message_block != nullptr)
         {
           char *this_block_ptr = current_message_block->rd_ptr ();
           size_t current_message_block_length =
@@ -2100,7 +2100,7 @@ ACE::readv_n (ACE_HANDLE handle,
               size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
 
   for (int s = 0;
@@ -2139,7 +2139,7 @@ ACE::writev_n (ACE_HANDLE handle,
                size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   bytes_transferred = 0;
 
   iovec *iov = const_cast<iovec *> (i);
@@ -2519,7 +2519,7 @@ ACE::handle_timed_complete (ACE_HANDLE h,
   // busy to accept our call).
   if (n <= 0)
     {
-      if (n == 0 && timeout != 0)
+      if (n == 0 && timeout != nullptr)
         errno = ETIME;
       return ACE_INVALID_HANDLE;
     }
@@ -2664,7 +2664,7 @@ ACE::handle_timed_accept (ACE_HANDLE listener,
             return -1;
           /* NOTREACHED */
         case 0:
-          if (timeout != 0 && *timeout == ACE_Time_Value::zero)
+          if (timeout != nullptr && *timeout == ACE_Time_Value::zero)
             errno = EWOULDBLOCK;
           else
             errno = ETIMEDOUT;
@@ -2709,7 +2709,7 @@ ACE::daemonize (const ACE_TCHAR pathname[],
 
   // Second child continues.
 
-  if (pathname != 0)
+  if (pathname != nullptr)
     // change working directory.
     ACE_OS::chdir (pathname);
 
@@ -3109,7 +3109,7 @@ ACE::sock_error (int error)
     }
 #else
   ACE_UNUSED_ARG (error);
-  ACE_NOTSUP_RETURN (0);
+  ACE_NOTSUP_RETURN (nullptr);
 #endif /* ACE_WIN32 */
 }
 
@@ -3194,7 +3194,7 @@ ACE::strndup (const char *str, size_t n)
 #else
   ACE_ALLOCATOR_RETURN (s,
                         (char *) ACE_OS::malloc (len + 1),
-                        0);
+                        nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
   return ACE_OS::strsncpy (s, str, len + 1);
 }
@@ -3215,7 +3215,7 @@ ACE::strndup (const wchar_t *str, size_t n)
     continue;
 
   size_t const size = (len + 1) * sizeof (wchar_t);
-  wchar_t *s = 0;
+  wchar_t *s = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (s,
                         static_cast<wchar_t*> (
@@ -3224,7 +3224,7 @@ ACE::strndup (const wchar_t *str, size_t n)
 #else
   ACE_ALLOCATOR_RETURN (s,
                         static_cast<wchar_t*> (ACE_OS::malloc (size)),
-                        0);
+                        nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
   return ACE_OS::strsncpy (s, str, len + 1);
 }
@@ -3253,7 +3253,7 @@ ACE::strnnew (const char *str, size_t n)
 #else
   ACE_NEW_RETURN (s,
                   char[len + 1],
-                  0);
+                  nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
   return ACE_OS::strsncpy (s, str, len + 1);
@@ -3277,7 +3277,7 @@ ACE::strnnew (const wchar_t *str, size_t n)
   wchar_t *s;
   ACE_NEW_RETURN (s,
                   wchar_t[len + 1],
-                  0);
+                  nullptr);
   return ACE_OS::strsncpy (s, str, len + 1);
 }
 #endif /* ACE_HAS_WCHAR */
@@ -3315,7 +3315,7 @@ ACE::strnew (const char *s)
 #else
   ACE_NEW_RETURN (t,
                   char [ACE_OS::strlen (s) + 1],
-                  0);
+                  nullptr);
 #endif  /* ACE_HAS_ALLOC_HOOKS */
 
   return ACE_OS::strcpy (t, s);
@@ -3325,11 +3325,11 @@ ACE::strnew (const char *s)
 wchar_t *
 ACE::strnew (const wchar_t *s)
 {
-  if (s == 0)
-    return 0;
+  if (s == nullptr)
+    return nullptr;
 
   size_t const n = ACE_OS::strlen (s) + 1;
-  wchar_t *t = 0;
+  wchar_t *t = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (t,
                         static_cast<wchar_t*> (
@@ -3337,7 +3337,7 @@ ACE::strnew (const wchar_t *s)
                             sizeof (wchar_t) * (n))),
                         0);
 #else
-  ACE_NEW_RETURN (t, wchar_t[n], 0);
+  ACE_NEW_RETURN (t, wchar_t[n], nullptr);
 #endif  /* ACE_HAS_ALLOC_HOOKS */
 
   return ACE_OS::strcpy (t, s);

--- a/ACE/ace/Abstract_Timer_Queue.h
+++ b/ACE/ace/Abstract_Timer_Queue.h
@@ -154,7 +154,7 @@ public:
    * cancellation succeeded and 0 if the @a timer_id wasn't found.
    */
   virtual int cancel (long timer_id,
-                      const void **act = 0,
+                      const void **act = nullptr,
                       int dont_call_handle_close = 1) = 0;
 
   /**

--- a/ACE/ace/Acceptor.cpp
+++ b/ACE/ace/Acceptor.cpp
@@ -73,7 +73,7 @@ ACE_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::open
 
   // Must supply a valid Reactor to Acceptor::open()...
 
-  if (reactor == 0)
+  if (reactor == nullptr)
     {
       errno = EINVAL;
       return -1;
@@ -187,7 +187,7 @@ ACE_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::info (ACE_TCHAR **strp,
                     addr_str,
                     ACE_TEXT ("# acceptor factory\n"));
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (buf)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (buf)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, buf, length);
@@ -563,18 +563,18 @@ ACE_Strategy_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::open
 {
   ACE_TRACE ("ACE_Strategy_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::open");
 
-  if (this->service_name_ == 0 && service_name != 0)
+  if (this->service_name_ == 0 && service_name != nullptr)
     ACE_ALLOCATOR_RETURN (this->service_name_,
                           ACE_OS::strdup (service_name),
                           -1);
-  if (this->service_description_ == 0 && service_description != 0)
+  if (this->service_description_ == 0 && service_description != nullptr)
     ACE_ALLOCATOR_RETURN (this->service_description_,
                           ACE_OS::strdup (service_description),
                           -1);
   this->reactor (reactor);
 
   // Must supply a valid Reactor to Acceptor::open()...
-  if (reactor == 0)
+  if (reactor == nullptr)
     {
       errno = EINVAL;
       return -1;
@@ -659,15 +659,15 @@ ACE_Strategy_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::ACE_Strategy_Acceptor
       delete_concurrency_strategy_ (false),
       scheduling_strategy_ (0),
       delete_scheduling_strategy_ (false),
-      service_name_ (0),
-      service_description_ (0)
+      service_name_ (nullptr),
+      service_description_ (nullptr)
 {
   ACE_TRACE ("ACE_Strategy_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::ACE_Strategy_Acceptor");
 
-  if (service_name != 0)
+  if (service_name != nullptr)
     ACE_ALLOCATOR (this->service_name_,
                    ACE_OS::strdup (service_name));
-  if (service_description != 0)
+  if (service_description != nullptr)
     ACE_ALLOCATOR (this->service_description_,
                    ACE_OS::strdup (service_description));
   this->use_select_ = use_select;
@@ -694,8 +694,8 @@ ACE_Strategy_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::ACE_Strategy_Acceptor
       delete_concurrency_strategy_ (false),
       scheduling_strategy_ (0),
       delete_scheduling_strategy_ (false),
-      service_name_ (0),
-      service_description_ (0)
+      service_name_ (nullptr),
+      service_description_ (nullptr)
 {
   ACE_TRACE ("ACE_Strategy_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::ACE_Strategy_Acceptor");
 
@@ -859,7 +859,7 @@ ACE_Strategy_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::info (ACE_TCHAR **strp,
                     ? ACE_TEXT ("<unknown>")
                     : this->service_description_);
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (buf)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (buf)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, buf, length);
@@ -1031,7 +1031,7 @@ ACE_Oneshot_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::register_handler
       this->restart_ = restart;
       ACE_Time_Value *tv = (ACE_Time_Value *) synch_options.time_value ();
 
-      if (tv != 0
+      if (tv != nullptr
           && this->reactor ()->schedule_timer (this,
                                                synch_options.arg (),
                                                *tv) == -1)
@@ -1222,7 +1222,7 @@ ACE_Oneshot_Acceptor<SVC_HANDLER, PEER_ACCEPTOR>::info (ACE_TCHAR **strp,
                     addr_str,
                     ACE_TEXT ("#oneshot acceptor factory\n"));
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (buf)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (buf)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, buf, length);

--- a/ACE/ace/Acceptor.h
+++ b/ACE/ace/Acceptor.h
@@ -298,8 +298,8 @@ public:
   typedef ACE_Scheduling_Strategy<SVC_HANDLER> SCHEDULING_STRATEGY;
 
   /// Default constructor.
-  ACE_Strategy_Acceptor (const ACE_TCHAR service_name[] = 0,
-                         const ACE_TCHAR service_description[] = 0,
+  ACE_Strategy_Acceptor (const ACE_TCHAR service_name[] = nullptr,
+                         const ACE_TCHAR service_description[] = nullptr,
                          int use_select = ACE_DEFAULT_ACCEPTOR_USE_SELECT,
                          int reuse_addr = 1);
 
@@ -311,12 +311,12 @@ public:
    */
   ACE_Strategy_Acceptor (const typename PEER_ACCEPTOR::PEER_ADDR &local_addr,
                          ACE_Reactor * = ACE_Reactor::instance (),
-                         ACE_Creation_Strategy<SVC_HANDLER> * = 0,
-                         ACE_Accept_Strategy<SVC_HANDLER, PEER_ACCEPTOR> * = 0,
-                         ACE_Concurrency_Strategy<SVC_HANDLER> * = 0,
-                         ACE_Scheduling_Strategy<SVC_HANDLER> * = 0,
-                         const ACE_TCHAR service_name[] = 0,
-                         const ACE_TCHAR service_description[] = 0,
+                         ACE_Creation_Strategy<SVC_HANDLER> * = nullptr,
+                         ACE_Accept_Strategy<SVC_HANDLER, PEER_ACCEPTOR> * = nullptr,
+                         ACE_Concurrency_Strategy<SVC_HANDLER> * = nullptr,
+                         ACE_Scheduling_Strategy<SVC_HANDLER> * = nullptr,
+                         const ACE_TCHAR service_name[] = nullptr,
+                         const ACE_TCHAR service_description[] = nullptr,
                          int use_select = ACE_DEFAULT_ACCEPTOR_USE_SELECT,
                          int reuse_addr = 1);
 
@@ -368,12 +368,12 @@ public:
    */
   virtual int open (const typename PEER_ACCEPTOR::PEER_ADDR &,
                     ACE_Reactor * = ACE_Reactor::instance (),
-                    ACE_Creation_Strategy<SVC_HANDLER> * = 0,
-                    ACE_Accept_Strategy<SVC_HANDLER, PEER_ACCEPTOR> * =0,
-                    ACE_Concurrency_Strategy<SVC_HANDLER> * = 0,
-                    ACE_Scheduling_Strategy<SVC_HANDLER> * = 0,
-                    const ACE_TCHAR *service_name = 0,
-                    const ACE_TCHAR *service_description = 0,
+                    ACE_Creation_Strategy<SVC_HANDLER> * = nullptr,
+                    ACE_Accept_Strategy<SVC_HANDLER, PEER_ACCEPTOR> * =nullptr,
+                    ACE_Concurrency_Strategy<SVC_HANDLER> * = nullptr,
+                    ACE_Scheduling_Strategy<SVC_HANDLER> * = nullptr,
+                    const ACE_TCHAR *service_name = nullptr,
+                    const ACE_TCHAR *service_description = nullptr,
                     int use_select = ACE_DEFAULT_ACCEPTOR_USE_SELECT,
                     int reuse_addr = 1);
 
@@ -554,7 +554,7 @@ public:
    */
   ACE_Oneshot_Acceptor (const typename PEER_ACCEPTOR::PEER_ADDR &local_addr,
                         ACE_Reactor *reactor = ACE_Reactor::instance (),
-                        ACE_Concurrency_Strategy<SVC_HANDLER> * = 0);
+                        ACE_Concurrency_Strategy<SVC_HANDLER> * = nullptr);
 
   /**
    * Initialize the appropriate strategies for concurrency and then
@@ -566,7 +566,7 @@ public:
    */
   int open (const typename PEER_ACCEPTOR::PEER_ADDR &,
             ACE_Reactor *reactor = ACE_Reactor::instance (),
-            ACE_Concurrency_Strategy<SVC_HANDLER> * = 0);
+            ACE_Concurrency_Strategy<SVC_HANDLER> * = nullptr);
 
   /// Close down the {Oneshot_Acceptor}.
   virtual ~ACE_Oneshot_Acceptor ();

--- a/ACE/ace/Activation_Queue.cpp
+++ b/ACE/ace/Activation_Queue.cpp
@@ -38,7 +38,7 @@ ACE_Activation_Queue::ACE_Activation_Queue (ACE_Message_Queue<ACE_SYNCH> *new_qu
   , allocator_(alloc)
   , data_block_allocator_(db_alloc)
 {
-  if (this->allocator_ == 0)
+  if (this->allocator_ == nullptr)
     this->allocator_ = ACE_Allocator::instance ();
 
   if (new_queue)
@@ -81,7 +81,7 @@ ACE_Activation_Queue::~ACE_Activation_Queue ()
 ACE_Method_Request *
 ACE_Activation_Queue::dequeue (ACE_Time_Value *tv)
 {
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   // Dequeue the message.
   if (this->queue_->dequeue_head (mb, tv) != -1)
@@ -94,14 +94,14 @@ ACE_Activation_Queue::dequeue (ACE_Time_Value *tv)
       return mr;
     }
   else
-    return 0;
+    return nullptr;
 }
 
 int
 ACE_Activation_Queue::enqueue (ACE_Method_Request *mr,
                                ACE_Time_Value *tv)
 {
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   // We pass sizeof (*mr) here so that flow control will work
   // correctly.  Since we also pass <mr> note that no unnecessary
@@ -110,10 +110,10 @@ ACE_Activation_Queue::enqueue (ACE_Method_Request *mr,
                          static_cast<ACE_Message_Block *> (this->allocator_->malloc (sizeof (ACE_Message_Block))),
                          ACE_Message_Block (sizeof (*mr),    // size
                                             ACE_Message_Block::MB_DATA, // type
-                                            0,       // cont
+                                            nullptr,       // cont
                                             (char *) mr,    // data
-                                            0,       // allocator
-                                            0,       // locking strategy
+                                            nullptr,       // allocator
+                                            nullptr,       // locking strategy
                                             mr->priority (), // priority
                                             ACE_Time_Value::zero,     // execution time
                                             ACE_Time_Value::max_time, // absolute time of deadline

--- a/ACE/ace/Addr.cpp
+++ b/ACE/ace/Addr.cpp
@@ -31,7 +31,7 @@ ACE_Addr::ACE_Addr (int type, int size) :
 void *
 ACE_Addr::get_addr () const
 {
-  return 0;
+  return nullptr;
 }
 
 void

--- a/ACE/ace/Array_Base.h
+++ b/ACE/ace/Array_Base.h
@@ -60,12 +60,12 @@ public:
 
   /// Dynamically create an uninitialized array.
   ACE_Array_Base (size_type size = 0,
-                  ACE_Allocator * the_allocator = 0);
+                  ACE_Allocator * the_allocator = nullptr);
 
   /// Dynamically initialize the entire array to the @a default_value.
   ACE_Array_Base (size_type size,
                   T const & default_value,
-                  ACE_Allocator * the_allocator = 0);
+                  ACE_Allocator * the_allocator = nullptr);
 
   /**
    * The copy constructor performs initialization by making an exact

--- a/ACE/ace/Asynch_Acceptor.cpp
+++ b/ACE/ace/Asynch_Acceptor.cpp
@@ -202,7 +202,7 @@ ACE_Asynch_Acceptor<HANDLER>::accept (size_t bytes_to_read, const void *act)
 {
   ACE_TRACE ("ACE_Asynch_Acceptor<>::accept");
 
-  ACE_Message_Block *message_block = 0;
+  ACE_Message_Block *message_block = nullptr;
   // The space_needed calculation is drive by needs of Windows. POSIX doesn't
   // need to extra 16 bytes, but it doesn't hurt.
   size_t space_needed = sizeof (sockaddr_in) + 16;
@@ -307,7 +307,7 @@ ACE_Asynch_Acceptor<HANDLER>::handle_accept (const ACE_Asynch_Accept::Result &re
                                 local_address);
 
       // Pass the ACT
-      if (result.act () != 0)
+      if (result.act () != nullptr)
         new_handler->act (result.act ());
 
       // Set up the handler's new handle value

--- a/ACE/ace/Asynch_Connector.cpp
+++ b/ACE/ace/Asynch_Connector.cpp
@@ -138,7 +138,7 @@ ACE_Asynch_Connector<HANDLER>::handle_connect (const ACE_Asynch_Connect::Result 
                                 local_address);
 
       // Pass the ACT
-      if (result.act () != 0)
+      if (result.act () != nullptr)
         new_handler->act (result.act ());
 
       // Set up the handler's new handle value

--- a/ACE/ace/Asynch_IO.cpp
+++ b/ACE/ace/Asynch_IO.cpp
@@ -105,7 +105,7 @@ ACE_Asynch_Operation::open (ACE_Handler &handler,
 int
 ACE_Asynch_Operation::cancel ()
 {
-  if (0 == this->implementation ())
+  if (nullptr == this->implementation ())
     {
       errno = EFAULT;
       return -1;
@@ -116,10 +116,10 @@ ACE_Asynch_Operation::cancel ()
 ACE_Proactor *
 ACE_Asynch_Operation::proactor () const
 {
-  if (0 == this->implementation ())
+  if (nullptr == this->implementation ())
     {
       errno = EFAULT;
-      return 0;
+      return nullptr;
     }
   return this->implementation ()->proactor ();
 }
@@ -128,11 +128,11 @@ ACE_Proactor *
 ACE_Asynch_Operation::get_proactor (ACE_Proactor *user_proactor,
                                     ACE_Handler &handler) const
 {
-  if (user_proactor == 0)
+  if (user_proactor == nullptr)
     {
       // Grab the singleton proactor if <handler->proactor> is zero
       user_proactor = handler.proactor ();
-      if (user_proactor == 0)
+      if (user_proactor == nullptr)
         user_proactor = ACE_Proactor::instance ();
     }
 
@@ -142,7 +142,7 @@ ACE_Asynch_Operation::get_proactor (ACE_Proactor *user_proactor,
 // ************************************************************
 
 ACE_Asynch_Read_Stream::ACE_Asynch_Read_Stream ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -150,7 +150,7 @@ ACE_Asynch_Read_Stream::~ACE_Asynch_Read_Stream ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -163,7 +163,7 @@ ACE_Asynch_Read_Stream::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_read_stream ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_read_stream ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -180,7 +180,7 @@ ACE_Asynch_Read_Stream::read (ACE_Message_Block &message_block,
                               int priority,
                               int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -260,7 +260,7 @@ ACE_Asynch_Read_Stream::Result::implementation () const
 // ***************************************************
 
 ACE_Asynch_Write_Stream::ACE_Asynch_Write_Stream ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -268,7 +268,7 @@ ACE_Asynch_Write_Stream::~ACE_Asynch_Write_Stream ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -281,7 +281,7 @@ ACE_Asynch_Write_Stream::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_write_stream ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_write_stream ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -298,7 +298,7 @@ ACE_Asynch_Write_Stream::write (ACE_Message_Block &message_block,
                                 int priority,
                                 int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -378,7 +378,7 @@ ACE_Asynch_Write_Stream::Result::implementation () const
 // ************************************************************
 
 ACE_Asynch_Read_File::ACE_Asynch_Read_File ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -386,7 +386,7 @@ ACE_Asynch_Read_File::~ACE_Asynch_Read_File ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -399,7 +399,7 @@ ACE_Asynch_Read_File::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_read_file ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_read_file ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -418,7 +418,7 @@ ACE_Asynch_Read_File::read (ACE_Message_Block &message_block,
                             int priority,
                             int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -486,7 +486,7 @@ ACE_Asynch_Read_File::Result::implementation () const
 // ************************************************************
 
 ACE_Asynch_Write_File::ACE_Asynch_Write_File ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -494,7 +494,7 @@ ACE_Asynch_Write_File::~ACE_Asynch_Write_File ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -507,7 +507,7 @@ ACE_Asynch_Write_File::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_write_file ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_write_file ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -526,7 +526,7 @@ ACE_Asynch_Write_File::write (ACE_Message_Block &message_block,
                               int priority,
                               int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -594,7 +594,7 @@ ACE_Asynch_Write_File::Result::implementation () const
 // *********************************************************************
 
 ACE_Asynch_Accept::ACE_Asynch_Accept ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -602,7 +602,7 @@ ACE_Asynch_Accept::~ACE_Asynch_Accept ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -615,7 +615,7 @@ ACE_Asynch_Accept::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_accept ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_accept ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -634,7 +634,7 @@ ACE_Asynch_Accept::accept (ACE_Message_Block &message_block,
                            int signal_number,
                            int addr_family)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -702,7 +702,7 @@ ACE_Asynch_Accept::Result::implementation () const
 // *********************************************************************
 
 ACE_Asynch_Connect::ACE_Asynch_Connect ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -710,7 +710,7 @@ ACE_Asynch_Connect::~ACE_Asynch_Connect ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -723,7 +723,7 @@ ACE_Asynch_Connect::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_connect ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_connect ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -742,7 +742,7 @@ ACE_Asynch_Connect::connect (ACE_HANDLE connect_handle,
                              int priority,
                              int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -792,7 +792,7 @@ ACE_Asynch_Connect::Result::implementation () const
 // ************************************************************
 
 ACE_Asynch_Transmit_File::ACE_Asynch_Transmit_File ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -800,7 +800,7 @@ ACE_Asynch_Transmit_File::~ACE_Asynch_Transmit_File ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -813,7 +813,7 @@ ACE_Asynch_Transmit_File::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_transmit_file ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_transmit_file ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -835,7 +835,7 @@ ACE_Asynch_Transmit_File::transmit_file (ACE_HANDLE file,
                                          int priority,
                                          int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -993,16 +993,16 @@ ACE_LPTRANSMIT_FILE_BUFFERS
 ACE_Asynch_Transmit_File::Header_And_Trailer::transmit_buffers ()
 {
   // If both are zero, return zero
-  if (this->header_ == 0 && this->trailer_ == 0)
+  if (this->header_ == nullptr && this->trailer_ == nullptr)
     {
-      return 0;
+      return nullptr;
     }
   else
     {
       // Something is valid
 
       // If header is valid, set the fields
-      if (this->header_ != 0)
+      if (this->header_ != nullptr)
         {
           this->transmit_buffers_.Head = this->header_->rd_ptr ();
 #if defined (ACE_WIN64) || defined (ACE_WIN32)
@@ -1014,12 +1014,12 @@ ACE_Asynch_Transmit_File::Header_And_Trailer::transmit_buffers ()
         }
       else
         {
-          this->transmit_buffers_.Head = 0;
+          this->transmit_buffers_.Head = nullptr;
           this->transmit_buffers_.HeadLength = 0;
         }
 
       // If trailer is valid, set the fields
-      if (this->trailer_ != 0)
+      if (this->trailer_ != nullptr)
         {
           this->transmit_buffers_.Tail = this->trailer_->rd_ptr ();
 #if defined(ACE_WIN64) || defined (ACE_WIN32)
@@ -1031,7 +1031,7 @@ ACE_Asynch_Transmit_File::Header_And_Trailer::transmit_buffers ()
         }
       else
         {
-          this->transmit_buffers_.Tail = 0;
+          this->transmit_buffers_.Tail = nullptr;
           this->transmit_buffers_.TailLength = 0;
         }
 
@@ -1043,7 +1043,7 @@ ACE_Asynch_Transmit_File::Header_And_Trailer::transmit_buffers ()
 // *********************************************************************
 
 ACE_Handler::ACE_Handler ()
-  : proactor_ (0), handle_ (ACE_INVALID_HANDLE)
+  : proactor_ (nullptr), handle_ (ACE_INVALID_HANDLE)
 {
   ACE_Handler::Proxy *p;
   ACE_NEW (p, ACE_Handler::Proxy (this));
@@ -1182,7 +1182,7 @@ ACE_Service_Handler::open (ACE_HANDLE,
 // ************************************************************
 
 ACE_Asynch_Read_Dgram::ACE_Asynch_Read_Dgram ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -1190,7 +1190,7 @@ ACE_Asynch_Read_Dgram::~ACE_Asynch_Read_Dgram ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -1203,7 +1203,7 @@ ACE_Asynch_Read_Dgram::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_read_dgram ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_read_dgram ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -1222,7 +1222,7 @@ ACE_Asynch_Read_Dgram::recv (ACE_Message_Block *message_block,
                              int priority,
                              int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;
@@ -1294,7 +1294,7 @@ ACE_Asynch_Read_Dgram::Result::implementation () const
 
 
 ACE_Asynch_Write_Dgram::ACE_Asynch_Write_Dgram ()
-  : implementation_ (0)
+  : implementation_ (nullptr)
 {
 }
 
@@ -1302,7 +1302,7 @@ ACE_Asynch_Write_Dgram::~ACE_Asynch_Write_Dgram ()
 {
   // Delete the implementation.
   delete this->implementation_;
-  this->implementation_ = 0;
+  this->implementation_ = nullptr;
 }
 
 int
@@ -1315,7 +1315,7 @@ ACE_Asynch_Write_Dgram::open (ACE_Handler &handler,
   proactor = this->get_proactor (proactor, handler);
 
   // Now let us get the implementation initialized.
-  if ((this->implementation_ = proactor->create_asynch_write_dgram ()) == 0)
+  if ((this->implementation_ = proactor->create_asynch_write_dgram ()) == nullptr)
     return -1;
 
   // Call the <open> method of the base class.
@@ -1334,7 +1334,7 @@ ACE_Asynch_Write_Dgram::send (ACE_Message_Block *message_block,
                               int priority,
                               int signal_number)
 {
-  if (0 == this->implementation_)
+  if (nullptr == this->implementation_)
     {
       errno = EFAULT;
       return -1;

--- a/ACE/ace/Asynch_Pseudo_Task.cpp
+++ b/ACE/ace/Asynch_Pseudo_Task.cpp
@@ -53,7 +53,7 @@ ACE_Asynch_Pseudo_Task::svc ()
   for (int si = ACE_SIGRTMIN; si <= ACE_SIGRTMAX; si++)
     ACE_OS::sigaddset (&RT_signals, si);
 
-  if (ACE_OS::pthread_sigmask (SIG_BLOCK, &RT_signals, 0) != 0)
+  if (ACE_OS::pthread_sigmask (SIG_BLOCK, &RT_signals, nullptr) != 0)
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("Error:(%P | %t):%p\n"),
                 ACE_TEXT ("pthread_sigmask")));

--- a/ACE/ace/Barrier.cpp
+++ b/ACE/ace/Barrier.cpp
@@ -110,7 +110,7 @@ ACE_Barrier::wait ()
       // We're awake and the count has completed. See if it completed
       // because all threads hit the barrier, or because the barrier
       // was shut down.
-      if (this->sub_barrier_[this->current_generation_] == 0)
+      if (this->sub_barrier_[this->current_generation_] == nullptr)
         {
           errno = ESHUTDOWN;
           retval = -1;

--- a/ACE/ace/Base_Thread_Adapter.cpp
+++ b/ACE/ace/Base_Thread_Adapter.cpp
@@ -12,11 +12,11 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_INIT_LOG_MSG_HOOK     ACE_Base_Thread_Adapter::init_log_msg_hook_ = 0;
-ACE_INHERIT_LOG_MSG_HOOK  ACE_Base_Thread_Adapter::inherit_log_msg_hook_ = 0;
-ACE_CLOSE_LOG_MSG_HOOK    ACE_Base_Thread_Adapter::close_log_msg_hook_ = 0;
-ACE_SYNC_LOG_MSG_HOOK     ACE_Base_Thread_Adapter::sync_log_msg_hook_ = 0;
-ACE_THR_DESC_LOG_MSG_HOOK ACE_Base_Thread_Adapter::thr_desc_log_msg_hook_ = 0;
+ACE_INIT_LOG_MSG_HOOK     ACE_Base_Thread_Adapter::init_log_msg_hook_ = nullptr;
+ACE_INHERIT_LOG_MSG_HOOK  ACE_Base_Thread_Adapter::inherit_log_msg_hook_ = nullptr;
+ACE_CLOSE_LOG_MSG_HOOK    ACE_Base_Thread_Adapter::close_log_msg_hook_ = nullptr;
+ACE_SYNC_LOG_MSG_HOOK     ACE_Base_Thread_Adapter::sync_log_msg_hook_ = nullptr;
+ACE_THR_DESC_LOG_MSG_HOOK ACE_Base_Thread_Adapter::thr_desc_log_msg_hook_ = nullptr;
 
 ACE_Base_Thread_Adapter::ACE_Base_Thread_Adapter (
      ACE_THR_FUNC user_func,
@@ -38,7 +38,7 @@ ACE_Base_Thread_Adapter::ACE_Base_Thread_Adapter (
 {
   ACE_OS_TRACE ("ACE_Base_Thread_Adapter::ACE_Base_Thread_Adapter");
 
-  if (ACE_Base_Thread_Adapter::init_log_msg_hook_ != 0)
+  if (ACE_Base_Thread_Adapter::init_log_msg_hook_ != nullptr)
     (*ACE_Base_Thread_Adapter::init_log_msg_hook_) (
           this->log_msg_attributes_
 # if defined (ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS)
@@ -54,7 +54,7 @@ ACE_Base_Thread_Adapter::ACE_Base_Thread_Adapter (
 void
 ACE_Base_Thread_Adapter::inherit_log_msg ()
 {
-  if (ACE_Base_Thread_Adapter::inherit_log_msg_hook_ != 0)
+  if (ACE_Base_Thread_Adapter::inherit_log_msg_hook_ != nullptr)
     (*ACE_Base_Thread_Adapter::inherit_log_msg_hook_)(
            this->thr_desc_,
            this->log_msg_attributes_);
@@ -68,23 +68,23 @@ ACE_Base_Thread_Adapter::inherit_log_msg ()
 void
 ACE_Base_Thread_Adapter::close_log_msg ()
 {
-  if (ACE_Base_Thread_Adapter::close_log_msg_hook_ != 0)
+  if (ACE_Base_Thread_Adapter::close_log_msg_hook_ != nullptr)
     (*ACE_Base_Thread_Adapter::close_log_msg_hook_) ();
 }
 
 void
 ACE_Base_Thread_Adapter::sync_log_msg (const ACE_TCHAR *prg)
 {
-  if (ACE_Base_Thread_Adapter::sync_log_msg_hook_ != 0)
+  if (ACE_Base_Thread_Adapter::sync_log_msg_hook_ != nullptr)
     (*ACE_Base_Thread_Adapter::sync_log_msg_hook_) (prg);
 }
 
 ACE_OS_Thread_Descriptor *
 ACE_Base_Thread_Adapter::thr_desc_log_msg ()
 {
-  if (ACE_Base_Thread_Adapter::thr_desc_log_msg_hook_ != 0)
+  if (ACE_Base_Thread_Adapter::thr_desc_log_msg_hook_ != nullptr)
     return (*ACE_Base_Thread_Adapter::thr_desc_log_msg_hook_) ();
-  return 0;
+  return nullptr;
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Based_Pointer_Repository.cpp
+++ b/ACE/ace/Based_Pointer_Repository.cpp
@@ -60,7 +60,7 @@ ACE_Based_Pointer_Repository::find (void *addr, void *&base_addr)
 {
   ACE_TRACE ("ACE_Based_Pointer_Repository::find");
   ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, mon, this->rep_->lock_, -1);
-  ACE_Based_Pointer_Repository_Rep::MAP_ENTRY *ce = 0;
+  ACE_Based_Pointer_Repository_Rep::MAP_ENTRY *ce = nullptr;
 
   for (ACE_Based_Pointer_Repository_Rep::MAP_ITERATOR iter (this->rep_->addr_map_);
        iter.next (ce) != 0;
@@ -75,7 +75,7 @@ ACE_Based_Pointer_Repository::find (void *addr, void *&base_addr)
       }
 
   // Assume base address 0 (e.g., if new'ed).
-  base_addr = 0;
+  base_addr = nullptr;
   return 0;
 }
 
@@ -98,7 +98,7 @@ ACE_Based_Pointer_Repository::unbind (void *addr)
 {
   ACE_TRACE ("ACE_Based_Pointer_Repository::unbind");
   ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, mon, this->rep_->lock_, -1);
-  ACE_Based_Pointer_Repository_Rep::MAP_ENTRY *ce = 0;
+  ACE_Based_Pointer_Repository_Rep::MAP_ENTRY *ce = nullptr;
 
   // Search for service handlers that requested notification.
 

--- a/ACE/ace/Based_Pointer_T.cpp
+++ b/ACE/ace/Based_Pointer_T.cpp
@@ -55,7 +55,7 @@ ACE_Based_Pointer_Basic<CONCRETE>::ACE_Based_Pointer_Basic ()
     base_offset_ (0)
 {
   ACE_TRACE ("ACE_Based_Pointer_Basic<CONCRETE>::ACE_Based_Pointer_Basic");
-  void *base_addr = 0;
+  void *base_addr = nullptr;
 
   // Find the base address associated with our <this> pointer.  Note
   // that it's ok for <find> to return 0, which simply indicates that
@@ -86,7 +86,7 @@ ACE_Based_Pointer_Basic<CONCRETE>::ACE_Based_Pointer_Basic (CONCRETE *rhs)
     this->target_ = -1;
   else
     {
-      void *base_addr = 0;
+      void *base_addr = nullptr;
 
       // Find the base address associated with the <addr> pointer.
       // Note that it's ok for <find> to return 0, which simply

--- a/ACE/ace/CDR_Base.cpp
+++ b/ACE/ace/CDR_Base.cpp
@@ -498,7 +498,7 @@ ACE_CDR::grow (ACE_Message_Block *mb, size_t minsize)
   ACE_Data_Block *db =
     mb->data_block ()->clone_nocopy (0, newsize);
 
-  if (db == 0)
+  if (db == nullptr)
     return -1;
 
   // Do the equivalent of ACE_CDR::mb_align() here to avoid having
@@ -540,11 +540,11 @@ int
 ACE_CDR::consolidate (ACE_Message_Block *dst,
                       const ACE_Message_Block *src)
 {
-  if (src == 0)
+  if (src == nullptr)
     return 0;
 
   size_t const newsize =
-    ACE_CDR::first_size (ACE_CDR::total_length (src, 0)
+    ACE_CDR::first_size (ACE_CDR::total_length (src, nullptr)
                          + ACE_CDR::MAX_ALIGNMENT);
 
   if (dst->size (newsize) == -1)
@@ -565,7 +565,7 @@ ACE_CDR::consolidate (ACE_Message_Block *dst,
 #endif /* ACE_CDR_IGNORE_ALIGNMENT */
 
   for (const ACE_Message_Block* i = src;
-       i != 0;
+       i != nullptr;
        i = i->cont ())
     {
       // If the destination and source are the same, do not

--- a/ACE/ace/CDR_Size.cpp
+++ b/ACE/ace/CDR_Size.cpp
@@ -125,7 +125,7 @@ ACE_SizeCDR::write_wstring (ACE_CDR::ULong len,
   if (static_cast<ACE_CDR::Short> (this->major_version_) == 1
       && static_cast<ACE_CDR::Short> (this->minor_version_) == 2)
     {
-      if (x != 0)
+      if (x != nullptr)
         {
           //In GIOP 1.2 the length field contains the number of bytes
           //the wstring occupies rather than number of wchars
@@ -148,7 +148,7 @@ ACE_SizeCDR::write_wstring (ACE_CDR::ULong len,
     }
 
   else
-    if (x != 0)
+    if (x != nullptr)
       {
         if (this->write_ulong (len + 1))
           return this->write_wchar_array (x, len + 1);

--- a/ACE/ace/CDR_Stream.cpp
+++ b/ACE/ace/CDR_Stream.cpp
@@ -23,10 +23,10 @@ ACE_OutputCDR::ACE_OutputCDR (size_t size,
                               ACE_CDR::Octet minor_version)
   :  start_ ((size ? size : (size_t) ACE_CDR::DEFAULT_BUFSIZE) + ACE_CDR::MAX_ALIGNMENT,
              ACE_Message_Block::MB_DATA,
-             0,
-             0,
+             nullptr,
+             nullptr,
              buffer_allocator,
-             0,
+             nullptr,
              0,
              ACE_Time_Value::zero,
              ACE_Time_Value::max_time,
@@ -41,8 +41,8 @@ ACE_OutputCDR::ACE_OutputCDR (size_t size,
      memcpy_tradeoff_ (memcpy_tradeoff),
      major_version_ (major_version),
      minor_version_ (minor_version),
-     char_translator_ (0),
-     wchar_translator_ (0)
+     char_translator_ (nullptr),
+     wchar_translator_ (nullptr)
 
 {
   ACE_CDR::mb_align (&this->start_);
@@ -66,10 +66,10 @@ ACE_OutputCDR::ACE_OutputCDR (char *data,
                               ACE_CDR::Octet minor_version)
   :  start_ (size,
              ACE_Message_Block::MB_DATA,
-             0,
+             nullptr,
              data,
              buffer_allocator,
-             0,
+             nullptr,
              0,
              ACE_Time_Value::zero,
              ACE_Time_Value::max_time,
@@ -84,8 +84,8 @@ ACE_OutputCDR::ACE_OutputCDR (char *data,
      memcpy_tradeoff_ (memcpy_tradeoff),
      major_version_ (major_version),
      minor_version_ (minor_version),
-     char_translator_ (0),
-     wchar_translator_ (0)
+     char_translator_ (nullptr),
+     wchar_translator_ (nullptr)
 {
   // We cannot trust the buffer to be properly aligned
   ACE_CDR::mb_align (&this->start_);
@@ -116,8 +116,8 @@ ACE_OutputCDR::ACE_OutputCDR (ACE_Data_Block *data_block,
      memcpy_tradeoff_ (memcpy_tradeoff),
      major_version_ (major_version),
      minor_version_ (minor_version),
-     char_translator_ (0),
-     wchar_translator_ (0)
+     char_translator_ (nullptr),
+     wchar_translator_ (nullptr)
 {
   // We cannot trust the buffer to be properly aligned
   ACE_CDR::mb_align (&this->start_);
@@ -145,8 +145,8 @@ ACE_OutputCDR::ACE_OutputCDR (ACE_Message_Block *data,
      memcpy_tradeoff_ (memcpy_tradeoff),
      major_version_ (major_version),
      minor_version_ (minor_version),
-     char_translator_ (0),
-     wchar_translator_ (0)
+     char_translator_ (nullptr),
+     wchar_translator_ (nullptr)
 {
   // We cannot trust the buffer to be properly aligned
   ACE_CDR::mb_align (&this->start_);
@@ -177,13 +177,13 @@ ACE_OutputCDR::grow_and_adjust (size_t size,
                                 char*& buf)
 {
   if (!this->current_is_writable_
-      || this->current_->cont () == 0
+      || this->current_->cont () == nullptr
       || this->current_->cont ()->size () < size + ACE_CDR::MAX_ALIGNMENT)
     {
       // Calculate the new buffer's length; if growing for encode, we
       // don't grow in "small" chunks because of the cost.
       size_t cursize = this->current_->size ();
-      if (this->current_->cont () != 0)
+      if (this->current_->cont () != nullptr)
         cursize = this->current_->cont ()->size ();
       size_t minsize = size;
 
@@ -199,14 +199,14 @@ ACE_OutputCDR::grow_and_adjust (size_t size,
       size_t const newsize = ACE_CDR::next_size (minsize);
 
       this->good_bit_ = false;
-      ACE_Message_Block* tmp = 0;
+      ACE_Message_Block* tmp = nullptr;
       ACE_NEW_RETURN (tmp,
                       ACE_Message_Block (newsize,
                                          ACE_Message_Block::MB_DATA,
-                                         0,
-                                         0,
+                                         nullptr,
+                                         nullptr,
                                          this->current_->data_block ()->allocator_strategy (),
-                                         0,
+                                         nullptr,
                                          0,
                                          ACE_Time_Value::zero,
                                          ACE_Time_Value::max_time,
@@ -216,7 +216,7 @@ ACE_OutputCDR::grow_and_adjust (size_t size,
       // Message block initialization may fail while the construction
       // succeds.  Since as a matter of policy, ACE may throw no
       // exceptions, we have to do a separate check like this.
-      if (tmp != 0 && tmp->size () < newsize)
+      if (tmp != nullptr && tmp->size () < newsize)
         {
           delete tmp;
           errno = ENOMEM;
@@ -252,7 +252,7 @@ ACE_OutputCDR::grow_and_adjust (size_t size,
 ACE_CDR::Boolean
 ACE_OutputCDR::write_wchar (ACE_CDR::WChar x)
 {
-  if (this->wchar_translator_ != 0)
+  if (this->wchar_translator_ != nullptr)
     return (this->good_bit_ = this->wchar_translator_->write_wchar (*this, x));
   if (ACE_OutputCDR::wchar_maxbytes_ == 0)
     {
@@ -317,7 +317,7 @@ ACE_OutputCDR::write_string (ACE_CDR::ULong len,
   // @@ This is a slight violation of "Optimize for the common case",
   // i.e. normally the translator will be 0, but OTOH the code is
   // smaller and should be better for the cache ;-) ;-)
-  if (this->char_translator_ != 0)
+  if (this->char_translator_ != nullptr)
     return this->char_translator_->write_string (*this, len, x);
 
   if (len != 0)
@@ -355,7 +355,7 @@ ACE_OutputCDR::write_wstring (ACE_CDR::ULong len,
   // i.e. normally the translator will be 0, but OTOH the code is
   // smaller and should be better for the cache ;-) ;-)
   // What do we do for GIOP 1.2???
-  if (this->wchar_translator_ != 0)
+  if (this->wchar_translator_ != nullptr)
     return this->wchar_translator_->write_wstring (*this, len, x);
   if (ACE_OutputCDR::wchar_maxbytes_ == 0)
     {
@@ -366,7 +366,7 @@ ACE_OutputCDR::write_wstring (ACE_CDR::ULong len,
   if (static_cast<ACE_CDR::Short> (this->major_version_) == 1
       && static_cast<ACE_CDR::Short> (this->minor_version_) == 2)
     {
-      if (x != 0)
+      if (x != nullptr)
         {
           //In GIOP 1.2 the length field contains the number of bytes
           //the wstring occupies rather than number of wchars
@@ -389,7 +389,7 @@ ACE_OutputCDR::write_wstring (ACE_CDR::ULong len,
     }
 
   else
-    if (x != 0)
+    if (x != nullptr)
       {
         if (this->write_ulong (len + 1))
           return this->write_wchar_array (x, len + 1);
@@ -405,7 +405,7 @@ ACE_OutputCDR::write_octet_array_mb (const ACE_Message_Block* mb)
   // If the buffer is small and it fits in the current message
   // block it is be cheaper just to copy the buffer.
   for (const ACE_Message_Block* i = mb;
-       i != 0;
+       i != nullptr;
        i = i->cont ())
     {
       size_t const length = i->length ();
@@ -433,14 +433,14 @@ ACE_OutputCDR::write_octet_array_mb (const ACE_Message_Block* mb)
           continue;
         }
 
-      ACE_Message_Block* cont = 0;
+      ACE_Message_Block* cont = nullptr;
       this->good_bit_ = false;
       ACE_NEW_RETURN (cont,
                       ACE_Message_Block (i->data_block ()->duplicate ()),
                       false);
       this->good_bit_ = true;
 
-      if (this->current_->cont () != 0)
+      if (this->current_->cont () != nullptr)
         ACE_Message_Block::release (this->current_->cont ());
       cont->rd_ptr (i->rd_ptr ());
       cont->wr_ptr (i->wr_ptr ());
@@ -460,7 +460,7 @@ ACE_OutputCDR::write_octet_array_mb (const ACE_Message_Block* mb)
 ACE_CDR::Boolean
 ACE_OutputCDR::write_1 (const ACE_CDR::Octet *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (1, buf) == 0)
     {
       *reinterpret_cast<ACE_CDR::Octet*> (buf) = *x;
@@ -473,7 +473,7 @@ ACE_OutputCDR::write_1 (const ACE_CDR::Octet *x)
 ACE_CDR::Boolean
 ACE_OutputCDR::write_2 (const ACE_CDR::UShort *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::SHORT_SIZE, buf) == 0)
     {
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -499,7 +499,7 @@ ACE_OutputCDR::write_2 (const ACE_CDR::UShort *x)
 ACE_CDR::Boolean
 ACE_OutputCDR::write_4 (const ACE_CDR::ULong *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::LONG_SIZE, buf) == 0)
     {
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -525,7 +525,7 @@ ACE_OutputCDR::write_4 (const ACE_CDR::ULong *x)
 ACE_CDR::Boolean
 ACE_OutputCDR::write_8 (const ACE_CDR::ULongLong *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
 
   if (this->adjust (ACE_CDR::LONGLONG_SIZE, buf) == 0)
     {
@@ -552,7 +552,7 @@ ACE_OutputCDR::write_8 (const ACE_CDR::ULongLong *x)
 ACE_CDR::Boolean
 ACE_OutputCDR::write_16 (const ACE_CDR::LongDouble *x)
 {
-  char* buf = 0;
+  char* buf = nullptr;
   if (this->adjust (ACE_CDR::LONGDOUBLE_SIZE,
                     ACE_CDR::LONGDOUBLE_ALIGN,
                     buf) == 0)
@@ -583,7 +583,7 @@ ACE_OutputCDR::write_wchar_array_i (const ACE_CDR::WChar *x,
 {
   if (length == 0)
     return true;
-  char* buf = 0;
+  char* buf = nullptr;
   size_t const align = (ACE_OutputCDR::wchar_maxbytes_ == 2) ?
     ACE_CDR::SHORT_ALIGN :
     ACE_CDR::OCTET_ALIGN;
@@ -625,7 +625,7 @@ ACE_OutputCDR::write_array (const void *x,
 {
   if (length == 0)
     return true;
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (size * length, align, buf) == 0)
     {
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -689,95 +689,95 @@ ACE_OutputCDR::write_boolean_array (const ACE_CDR::Boolean* x,
 char *
 ACE_OutputCDR::write_long_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::LONG_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::ULong*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 char *
 ACE_OutputCDR::write_short_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::SHORT_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::UShort*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 char *
 ACE_OutputCDR::write_boolean_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::OCTET_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::Boolean*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 char *
 ACE_OutputCDR::write_char_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::OCTET_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::Char*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 char *
 ACE_OutputCDR::write_octet_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::OCTET_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::Octet*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 char *
 ACE_OutputCDR::write_longlong_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::LONGLONG_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::ULongLong*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 char *
 ACE_OutputCDR::write_float_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::LONG_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::ULong*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 char *
 ACE_OutputCDR::write_double_placeholder ()
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::LONGLONG_SIZE, buf) == 0)
     *reinterpret_cast<ACE_CDR::ULongLong*> (buf) = 0;
   else
-    buf = 0;
+    buf = nullptr;
   return buf;
 }
 
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::Long x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -799,7 +799,7 @@ ACE_OutputCDR::replace (ACE_CDR::Long x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::ULong x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -821,7 +821,7 @@ ACE_OutputCDR::replace (ACE_CDR::ULong x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::Short x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -843,7 +843,7 @@ ACE_OutputCDR::replace (ACE_CDR::Short x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::UShort x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -865,7 +865,7 @@ ACE_OutputCDR::replace (ACE_CDR::UShort x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::Boolean x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
   *reinterpret_cast<ACE_CDR::Boolean*> (loc) = x;
@@ -876,7 +876,7 @@ ACE_OutputCDR::replace (ACE_CDR::Boolean x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::Char x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
   *reinterpret_cast<ACE_CDR::Char*> (loc) = x;
@@ -887,7 +887,7 @@ ACE_OutputCDR::replace (ACE_CDR::Char x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::Octet x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
   *reinterpret_cast<ACE_CDR::Octet*> (loc) = x;
@@ -898,7 +898,7 @@ ACE_OutputCDR::replace (ACE_CDR::Octet x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::LongLong x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -920,7 +920,7 @@ ACE_OutputCDR::replace (ACE_CDR::LongLong x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::ULongLong x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -942,7 +942,7 @@ ACE_OutputCDR::replace (ACE_CDR::ULongLong x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::Float x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -964,7 +964,7 @@ ACE_OutputCDR::replace (ACE_CDR::Float x, char* loc)
 ACE_CDR::Boolean
 ACE_OutputCDR::replace (ACE_CDR::Double x, char* loc)
 {
-  if (this->find (loc) == 0)
+  if (this->find (loc) == nullptr)
     return false;
 
 #if !defined (ACE_ENABLE_SWAP_ON_WRITE)
@@ -1011,7 +1011,7 @@ ACE_OutputCDR::consolidate ()
       // above.  There is therefore no reason to check for a 0 continuation
       // field here.
       ACE_Message_Block *cont = this->start_.cont ();
-      for (const ACE_Message_Block* i = cont; i != 0; i = i->cont ())
+      for (const ACE_Message_Block* i = cont; i != nullptr; i = i->cont ())
         {
           this->start_.copy (i->rd_ptr (), i->length ());
         }
@@ -1019,7 +1019,7 @@ ACE_OutputCDR::consolidate ()
       // Release the old blocks that were consolidated and reset the
       // current_ and current_is_writable_ to reflect the single used block.
       ACE_Message_Block::release (cont);
-      this->start_.cont (0);
+      this->start_.cont (nullptr);
       this->current_ = &this->start_;
       this->current_is_writable_ = true;
     }
@@ -1031,8 +1031,8 @@ ACE_OutputCDR::consolidate ()
 ACE_Message_Block*
 ACE_OutputCDR::find (char* loc)
 {
-  ACE_Message_Block* mb = 0;
-  for (mb = &this->start_; mb != 0; mb = mb->cont ())
+  ACE_Message_Block* mb = nullptr;
+  for (mb = &this->start_; mb != nullptr; mb = mb->cont ())
   {
     if (loc <= mb->wr_ptr () && loc >= mb->rd_ptr ())
     {
@@ -1072,8 +1072,8 @@ ACE_InputCDR::ACE_InputCDR (const char *buf,
     good_bit_ (true),
     major_version_ (major_version),
     minor_version_ (minor_version),
-    char_translator_ (0),
-    wchar_translator_ (0)
+    char_translator_ (nullptr),
+    wchar_translator_ (nullptr)
 {
   this->start_.wr_ptr (bufsiz);
 
@@ -1093,8 +1093,8 @@ ACE_InputCDR::ACE_InputCDR (size_t bufsiz,
     good_bit_ (true),
     major_version_ (major_version),
     minor_version_ (minor_version),
-    char_translator_ (0),
-    wchar_translator_ (0)
+    char_translator_ (nullptr),
+    wchar_translator_ (nullptr)
 {
 #if defined (ACE_HAS_MONITOR_POINTS) && (ACE_HAS_MONITOR_POINTS == 1)
   ACE_NEW (this->monitor_,
@@ -1108,12 +1108,12 @@ ACE_InputCDR::ACE_InputCDR (const ACE_Message_Block *data,
                             ACE_CDR::Octet major_version,
                             ACE_CDR::Octet minor_version,
                             ACE_Lock* lock)
-  : start_ (0, ACE_Message_Block::MB_DATA, 0, 0, 0, lock),
+  : start_ (0, ACE_Message_Block::MB_DATA, nullptr, nullptr, nullptr, lock),
     good_bit_ (true),
     major_version_ (major_version),
     minor_version_ (minor_version),
-    char_translator_ (0),
-    wchar_translator_ (0)
+    char_translator_ (nullptr),
+    wchar_translator_ (nullptr)
 {
 #if defined (ACE_HAS_MONITOR_POINTS) && (ACE_HAS_MONITOR_POINTS == 1)
   ACE_NEW (this->monitor_,
@@ -1134,8 +1134,8 @@ ACE_InputCDR::ACE_InputCDR (ACE_Data_Block *data,
     good_bit_ (true),
     major_version_ (major_version),
     minor_version_ (minor_version),
-    char_translator_ (0),
-    wchar_translator_ (0)
+    char_translator_ (nullptr),
+    wchar_translator_ (nullptr)
 {
 #if defined (ACE_HAS_MONITOR_POINTS) && (ACE_HAS_MONITOR_POINTS == 1)
   ACE_NEW (this->monitor_,
@@ -1156,8 +1156,8 @@ ACE_InputCDR::ACE_InputCDR (ACE_Data_Block *data,
     good_bit_ (true),
     major_version_ (major_version),
     minor_version_ (minor_version),
-    char_translator_ (0),
-    wchar_translator_ (0)
+    char_translator_ (nullptr),
+    wchar_translator_ (nullptr)
 {
   // Set the read pointer
   this->start_.rd_ptr (rd_pos);
@@ -1345,10 +1345,10 @@ ACE_InputCDR::ACE_InputCDR (const ACE_OutputCDR& rhs,
                             ACE_Allocator* message_block_allocator)
   : start_ (rhs.total_length () + ACE_CDR::MAX_ALIGNMENT,
             ACE_Message_Block::MB_DATA,
-            0,
-            0,
+            nullptr,
+            nullptr,
             buffer_allocator,
-            0,
+            nullptr,
             0,
             ACE_Time_Value::zero,
             ACE_Time_Value::max_time,
@@ -1402,7 +1402,7 @@ ACE_InputCDR::skip_wchar ()
 ACE_CDR::Boolean
 ACE_InputCDR::read_wchar (ACE_CDR::WChar& x)
 {
-  if (this->wchar_translator_ != 0)
+  if (this->wchar_translator_ != nullptr)
     {
       this->good_bit_ = this->wchar_translator_->read_wchar (*this,x);
       return this->good_bit_;
@@ -1504,7 +1504,7 @@ ACE_InputCDR::read_string (ACE_CDR::Char *&x)
   // @@ This is a slight violation of "Optimize for the common case",
   // i.e. normally the translator will be 0, but OTOH the code is
   // smaller and should be better for the cache ;-) ;-)
-  if (this->char_translator_ != 0)
+  if (this->char_translator_ != nullptr)
     {
       this->good_bit_ = this->char_translator_->read_string (*this, x);
       return this->good_bit_;
@@ -1556,7 +1556,7 @@ ACE_InputCDR::read_string (ACE_CDR::Char *&x)
       return true;
     }
 
-  x = 0;
+  x = nullptr;
   return (this->good_bit_ = false);
 }
 
@@ -1581,7 +1581,7 @@ ACE_InputCDR::read_wstring (ACE_CDR::WChar*& x)
   // @@ This is a slight violation of "Optimize for the common case",
   // i.e. normally the translator will be 0, but OTOH the code is
   // smaller and should be better for the cache ;-) ;-)
-  if (this->wchar_translator_ != 0)
+  if (this->wchar_translator_ != nullptr)
     {
       this->good_bit_ = this->wchar_translator_->read_wstring (*this, x);
       return this->good_bit_;
@@ -1679,7 +1679,7 @@ ACE_InputCDR::read_wstring (ACE_CDR::WChar*& x)
     }
 
   this->good_bit_ = false;
-  x = 0;
+  x = nullptr;
   return false;
 }
 
@@ -1691,7 +1691,7 @@ ACE_InputCDR::read_string (std::string& x)
   // @@ This is a slight violation of "Optimize for the common case",
   // i.e. normally the translator will be 0, but OTOH the code is
   // smaller and should be better for the cache ;-) ;-)
-  if (this->char_translator_ != 0)
+  if (this->char_translator_ != nullptr)
     {
       this->good_bit_ = this->char_translator_->read_string (*this, x);
       return this->good_bit_;
@@ -1738,7 +1738,7 @@ ACE_InputCDR::read_wstring (std::wstring& x)
   // @@ This is a slight violation of "Optimize for the common case",
   // i.e. normally the translator will be 0, but OTOH the code is
   // smaller and should be better for the cache ;-) ;-)
-  if (this->wchar_translator_ != 0)
+  if (this->wchar_translator_ != nullptr)
     {
       this->good_bit_ = this->wchar_translator_->read_wstring (*this, x);
       return this->good_bit_;
@@ -1826,7 +1826,7 @@ ACE_InputCDR::read_array (void* x,
 {
   if (length == 0)
     return true;
-  char* buf = 0;
+  char* buf = nullptr;
 
   if (this->adjust (size * length, align, buf) == 0)
     {
@@ -1870,7 +1870,7 @@ ACE_InputCDR::read_wchar_array_i (ACE_CDR::WChar* x,
 {
   if (length == 0)
     return true;
-  char* buf = 0;
+  char* buf = nullptr;
   size_t const align = (ACE_OutputCDR::wchar_maxbytes_ == 2) ?
     ACE_CDR::SHORT_ALIGN :
     ACE_CDR::OCTET_ALIGN;
@@ -1951,7 +1951,7 @@ ACE_InputCDR::read_1 (ACE_CDR::Octet *x)
 ACE_CDR::Boolean
 ACE_InputCDR::read_2 (ACE_CDR::UShort *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::SHORT_SIZE, buf) == 0)
     {
 #if !defined (ACE_DISABLE_SWAP_ON_READ)
@@ -1971,7 +1971,7 @@ ACE_InputCDR::read_2 (ACE_CDR::UShort *x)
 ACE_CDR::Boolean
 ACE_InputCDR::read_4 (ACE_CDR::ULong *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::LONG_SIZE, buf) == 0)
     {
 #if !defined (ACE_DISABLE_SWAP_ON_READ)
@@ -1991,7 +1991,7 @@ ACE_InputCDR::read_4 (ACE_CDR::ULong *x)
 ACE_CDR::Boolean
 ACE_InputCDR::read_8 (ACE_CDR::ULongLong *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
 
   if (this->adjust (ACE_CDR::LONGLONG_SIZE, buf) == 0)
     {
@@ -2013,7 +2013,7 @@ ACE_InputCDR::read_8 (ACE_CDR::ULongLong *x)
 ACE_CDR::Boolean
 ACE_InputCDR::read_16 (ACE_CDR::LongDouble *x)
 {
-  char *buf = 0;
+  char *buf = nullptr;
   if (this->adjust (ACE_CDR::LONGDOUBLE_SIZE,
                     ACE_CDR::LONGDOUBLE_ALIGN,
                     buf) == 0)
@@ -2269,9 +2269,9 @@ ACE_InputCDR::clone_from (ACE_InputCDR &cdr)
       // block interface to simplify this
       db = cdr.start_.data_block ()->clone_nocopy ();
 
-      if (db == 0 || db->size ((wr_bytes) +
+      if (db == nullptr || db->size ((wr_bytes) +
                                ACE_CDR::MAX_ALIGNMENT) == -1)
-        return 0;
+        return nullptr;
 
       // Replace our data block by using the incoming CDR stream.
       db = this->start_.replace_data_block (db);
@@ -2367,7 +2367,7 @@ ACE_CDR::Boolean
 ACE_Char_Codeset_Translator::read_string (ACE_InputCDR &cdr,
                                           std::string &x)
 {
-  ACE_CDR::Char *buf = 0;
+  ACE_CDR::Char *buf = nullptr;
   ACE_CDR::Boolean const marshal_flag = this->read_string (cdr, buf);
   x.assign (buf);
   ACE::strdelete (buf);
@@ -2381,7 +2381,7 @@ ACE_CDR::Boolean
 ACE_WChar_Codeset_Translator::read_wstring (ACE_InputCDR &cdr,
                                             std::wstring &x)
 {
-  ACE_CDR::WChar *buf = 0;
+  ACE_CDR::WChar *buf = nullptr;
   ACE_CDR::Boolean const marshal_flag = this->read_wstring (cdr, buf);
   x.assign (buf);
   ACE::strdelete (buf);

--- a/ACE/ace/Cached_Connect_Strategy_T.cpp
+++ b/ACE/ace/Cached_Connect_Strategy_T.cpp
@@ -435,7 +435,7 @@ ACE_Cached_Connect_Strategy_Ex<SVC_HANDLER, ACE_PEER_CONNECTOR_2, CACHING_STRATE
   // Reset the <*act_holder> in the confines and protection of the
   // lock.
   if (act_holder)
-    *act_holder = 0;
+    *act_holder = nullptr;
 
   // The wonders and perils of ACT
   CONNECTION_CACHE_ENTRY *entry = (CONNECTION_CACHE_ENTRY *) recycling_act;

--- a/ACE/ace/Cached_Connect_Strategy_T.h
+++ b/ACE/ace/Cached_Connect_Strategy_T.h
@@ -216,9 +216,9 @@ public:
   /// Constructor
   ACE_Bounded_Cached_Connect_Strategy (size_t  max_size,
                                        CACHING_STRATEGY &caching_s,
-                                       ACE_Creation_Strategy<SVC_HANDLER> *cre_s = 0,
-                                       ACE_Concurrency_Strategy<SVC_HANDLER> *con_s = 0,
-                                       ACE_Recycling_Strategy<SVC_HANDLER> *rec_s = 0,
+                                       ACE_Creation_Strategy<SVC_HANDLER> *cre_s = nullptr,
+                                       ACE_Concurrency_Strategy<SVC_HANDLER> *con_s = nullptr,
+                                       ACE_Recycling_Strategy<SVC_HANDLER> *rec_s = nullptr,
                                        MUTEX *lock = 0,
                                        int delete_lock = 0);
 

--- a/ACE/ace/Capabilities.cpp
+++ b/ACE/ace/Capabilities.cpp
@@ -98,7 +98,7 @@ ACE_Capabilities::resetcaps ()
        !iter.done ();
        iter.advance ())
     {
-      CAPABILITIES_MAP::ENTRY *entry = 0;
+      CAPABILITIES_MAP::ENTRY *entry = nullptr;
       iter.next (entry);
       delete entry->int_id_;
     }
@@ -227,7 +227,7 @@ ACE_Capabilities::getline (FILE *fp, ACE_TString &line)
 {
   int ch;
 
-  line.set (0, 0);
+  line.set (nullptr, 0);
 
   while ((ch = ACE_OS::fgetc (fp)) != EOF && ch != ACE_TEXT ('\n'))
     line += (ACE_TCHAR) ch;
@@ -241,13 +241,13 @@ ACE_Capabilities::getline (FILE *fp, ACE_TString &line)
 int
 ACE_Capabilities::getval (const ACE_TCHAR *keyname, ACE_TString &val)
 {
-  ACE_CapEntry* cap = 0;
+  ACE_CapEntry* cap = nullptr;
   if (this->caps_.find (keyname, cap) == -1)
     return -1;
 
   ACE_StringCapEntry *scap =
     dynamic_cast<ACE_StringCapEntry *> (cap);
-  if (scap == 0)
+  if (scap == nullptr)
     return -1;
 
   val = scap->getval ();
@@ -257,13 +257,13 @@ ACE_Capabilities::getval (const ACE_TCHAR *keyname, ACE_TString &val)
 int
 ACE_Capabilities::getval (const ACE_TCHAR *keyname, int &val)
 {
-  ACE_CapEntry *cap = 0;
+  ACE_CapEntry *cap = nullptr;
   if (this->caps_.find (keyname, cap) == -1)
     return -1;
 
   ACE_IntCapEntry *icap =
     dynamic_cast<ACE_IntCapEntry *> (cap);
-  if (icap != 0)
+  if (icap != nullptr)
     {
       val = icap->getval ();
       return 0;
@@ -272,7 +272,7 @@ ACE_Capabilities::getval (const ACE_TCHAR *keyname, int &val)
   ACE_BoolCapEntry *bcap =
     dynamic_cast<ACE_BoolCapEntry *> (cap);
 
-  if (bcap == 0)
+  if (bcap == nullptr)
     return -1;
 
   val = bcap->getval ();
@@ -302,7 +302,7 @@ ACE_Capabilities::getent (const ACE_TCHAR *fname, const ACE_TCHAR *name)
 {
   FILE *fp = ACE_OS::fopen (fname, ACE_TEXT ("r"));
 
-  if (fp == 0)
+  if (fp == nullptr)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("Can't open %s file\n"),
                        fname),

--- a/ACE/ace/Cleanup.cpp
+++ b/ACE/ace/Cleanup.cpp
@@ -31,10 +31,10 @@ ACE_CLEANUP_DESTROYER_NAME (ACE_Cleanup *object, void *param)
 /*****************************************************************************/
 
 ACE_Cleanup_Info_Node::ACE_Cleanup_Info_Node ()
-  : object_ (0),
-    cleanup_hook_ (0),
-    param_ (0),
-    name_ (0)
+  : object_ (nullptr),
+    cleanup_hook_ (nullptr),
+    param_ (nullptr),
+    name_ (nullptr)
 {
 }
 
@@ -45,7 +45,7 @@ ACE_Cleanup_Info_Node::ACE_Cleanup_Info_Node (void *object,
   : object_ (object),
     cleanup_hook_ (cleanup_hook),
     param_ (param),
-    name_ (name ? ACE_OS::strdup (name) : 0)
+    name_ (name ? ACE_OS::strdup (name) : nullptr)
 {
 }
 
@@ -86,7 +86,7 @@ ACE_OS_Exit_Info::at_exit_i (void *object,
 {
   // Return -1 and sets errno if unable to allocate storage.  Enqueue
   // at the head and dequeue from the head to get LIFO ordering.
-  ACE_Cleanup_Info_Node *new_node = 0;
+  ACE_Cleanup_Info_Node *new_node = nullptr;
 
   ACE_NEW_RETURN (new_node,
                   ACE_Cleanup_Info_Node (object, cleanup_hook, param, name),
@@ -101,7 +101,7 @@ bool
 ACE_OS_Exit_Info::find (void *object)
 {
   for (ACE_Cleanup_Info_Node *iter = registered_objects_.head ();
-       iter != 0;
+       iter != nullptr;
        iter = iter->next ())
     {
       if (iter->object () == object)
@@ -117,9 +117,9 @@ ACE_OS_Exit_Info::find (void *object)
 bool
 ACE_OS_Exit_Info::remove (void *object)
 {
-  ACE_Cleanup_Info_Node *node = 0;
+  ACE_Cleanup_Info_Node *node = nullptr;
   for (ACE_Cleanup_Info_Node *iter = registered_objects_.head ();
-       iter != 0;
+       iter != nullptr;
        iter = iter->next ())
     {
       if (iter->object () == object)
@@ -146,7 +146,7 @@ ACE_OS_Exit_Info::call_hooks ()
   // Call all registered cleanup hooks, in reverse order of
   // registration.
   for (ACE_Cleanup_Info_Node *iter = registered_objects_.pop_front ();
-       iter != 0;
+       iter != nullptr;
        iter = registered_objects_.pop_front ())
     {
       if (iter->cleanup_hook () == reinterpret_cast<ACE_CLEANUP_FUNC> (

--- a/ACE/ace/Codecs.cpp
+++ b/ACE/ace/Codecs.cpp
@@ -44,9 +44,9 @@ ACE_Base64::encode (const ACE_Byte* input,
     ACE_Base64::init();
 
   if (!input)
-    return 0;
+    return nullptr;
 
-  ACE_Byte* result = 0;
+  ACE_Byte* result = nullptr;
 
   size_t length = ((input_len + 2) / 3) * 4;
   size_t num_lines = length / max_columns + 1;
@@ -54,7 +54,7 @@ ACE_Base64::encode (const ACE_Byte* input,
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (result, static_cast<ACE_Byte*> (ACE_Allocator::instance()->malloc(sizeof (ACE_Byte) * length)), 0);
 #else
-  ACE_NEW_RETURN (result, ACE_Byte[length], 0);
+  ACE_NEW_RETURN (result, ACE_Byte[length], nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
   int char_count = 0;
@@ -139,15 +139,15 @@ ACE_Base64::decode (const ACE_Byte* input, size_t* output_len)
     ACE_Base64::init();
 
   if (!input)
-    return 0;
+    return nullptr;
 
   size_t result_len = ACE_Base64::length (input);
-  ACE_Byte* result = 0;
+  ACE_Byte* result = nullptr;
 
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (result, static_cast<ACE_Byte*> (ACE_Allocator::instance()->malloc(sizeof (ACE_Byte) * result_len)), 0);
 #else
-  ACE_NEW_RETURN (result, ACE_Byte[result_len], 0);
+  ACE_NEW_RETURN (result, ACE_Byte[result_len], nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
   ACE_Byte* ptr = const_cast<ACE_Byte*> (input);
@@ -222,7 +222,7 @@ ACE_Base64::decode (const ACE_Byte* input, size_t* output_len)
 #else
       delete[] result;
 #endif /* ACE_HAS_ALLOC_HOOKS */
-      return 0;
+      return nullptr;
     }
   result[pos] = 0;
   *output_len = pos;

--- a/ACE/ace/Codeset_Registry.cpp
+++ b/ACE/ace/Codeset_Registry.cpp
@@ -24,16 +24,16 @@ ACE_Codeset_Registry::locale_to_registry_i (const ACE_CString &locale,
                                             ACE_CDR::UShort *num_sets,
                                             ACE_CDR::UShort **char_sets)
 {
-  registry_entry const *element = 0;
-  for (size_t i = 0; element == 0 && i < num_registry_entries_; i++)
+  registry_entry const *element = nullptr;
+  for (size_t i = 0; element == nullptr && i < num_registry_entries_; i++)
     if (ACE_OS::strcmp (registry_db_[i].loc_name_, locale.c_str ()) == 0)
       element = &registry_db_[i];
-  if (element == 0)
+  if (element == nullptr)
     return 0;
   codeset_id = element->codeset_id_;
-  if (num_sets != 0)
+  if (num_sets != nullptr)
     *num_sets = element->num_sets_;
-  if (char_sets != 0)
+  if (char_sets != nullptr)
     {
 #if defined (ACE_HAS_ALLOC_HOOKS)
       ACE_ALLOCATOR_RETURN (*char_sets,static_cast<ACE_CDR::UShort*> (ACE_Allocator::instance()->malloc(sizeof (ACE_CDR::UShort) * (element->num_sets_))),0);
@@ -52,16 +52,16 @@ ACE_Codeset_Registry::registry_to_locale_i (ACE_CDR::ULong codeset_id,
                                             ACE_CDR::UShort *num_sets,
                                             ACE_CDR::UShort **char_sets)
 {
-  registry_entry const *element = 0;
-  for (size_t i = 0; element == 0 && i < num_registry_entries_; i++)
+  registry_entry const *element = nullptr;
+  for (size_t i = 0; element == nullptr && i < num_registry_entries_; i++)
     if (codeset_id == registry_db_[i].codeset_id_)
       element = &registry_db_[i];
-  if (element == 0)
+  if (element == nullptr)
     return 0;
   locale.set (element->loc_name_);
-  if (num_sets != 0)
+  if (num_sets != nullptr)
     *num_sets = element->num_sets_;
-  if (char_sets != 0)
+  if (char_sets != nullptr)
     {
 #if defined (ACE_HAS_ALLOC_HOOKS)
       ACE_ALLOCATOR_RETURN (*char_sets,static_cast<ACE_CDR::UShort*> (ACE_Allocator::instance()->malloc(sizeof (ACE_CDR::UShort) * (element->num_sets_))),0);
@@ -78,9 +78,9 @@ int
 ACE_Codeset_Registry::is_compatible_i (ACE_CDR::ULong codeset_id,
                                        ACE_CDR::ULong other)
 {
-  registry_entry const *lhs = 0;
-  registry_entry const *rhs = 0;
-  for (size_t i = 0; (lhs == 0 || rhs == 0) && i < num_registry_entries_; i++)
+  registry_entry const *lhs = nullptr;
+  registry_entry const *rhs = nullptr;
+  for (size_t i = 0; (lhs == nullptr || rhs == nullptr) && i < num_registry_entries_; i++)
     {
       if (codeset_id == registry_db_[i].codeset_id_)
         lhs = &registry_db_[i];
@@ -88,7 +88,7 @@ ACE_Codeset_Registry::is_compatible_i (ACE_CDR::ULong codeset_id,
         rhs = &registry_db_[i];
     }
 
-  if (lhs == 0 || rhs == 0)
+  if (lhs == nullptr || rhs == nullptr)
     return 0;
 
   for (ACE_CDR::UShort l = 0; l < lhs->num_sets_; l++)

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.cpp
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.cpp
@@ -84,7 +84,7 @@ ACE_Condition<ACE_Recursive_Thread_Mutex>::wait (ACE_Recursive_Thread_Mutex &mut
   // returned with the lock held, but waiters primed and waiting to be
   // released. At cond_wait below, the mutex will be released.
   // On return, it will be reacquired.
-  int const result = abstime == 0
+  int const result = abstime == nullptr
     ? ACE_OS::cond_wait (&this->cond_,
                          &mutex.get_nesting_mutex ())
     : ACE_OS::cond_timedwait (&this->cond_,

--- a/ACE/ace/Condition_T.cpp
+++ b/ACE/ace/Condition_T.cpp
@@ -114,7 +114,7 @@ ACE_Condition<MUTEX>::wait (MUTEX &mutex,
                             const ACE_Time_Value *abstime)
 {
 // ACE_TRACE ("ACE_Condition<MUTEX>::wait");
-  if (abstime == 0)
+  if (abstime == nullptr)
     {
       return ACE_OS::cond_wait (&this->cond_,
                                 &mutex.lock ());

--- a/ACE/ace/Configuration.cpp
+++ b/ACE/ace/Configuration.cpp
@@ -100,7 +100,7 @@ ACE_Configuration::expand_path (const ACE_Configuration_Section_Key& key,
   parser.delimiter_replace ('/', '\0');
 
   for (ACE_TCHAR *temp = parser.next ();
-       temp != 0;
+       temp != nullptr;
        temp = parser.next ())
     {
       // Open the section
@@ -153,7 +153,7 @@ ACE_Configuration::validate_name (const ACE_TCHAR* name, int allow_path)
 int
 ACE_Configuration::validate_value_name (const ACE_TCHAR* name)
 {
-  if (name == 0 || *name == this->NULL_String_)
+  if (name == nullptr || *name == this->NULL_String_)
     return 0;
 
   return this->validate_name (name);
@@ -281,8 +281,8 @@ ACE_Configuration::operator== (const ACE_Configuration& rhs) const
                     }
                   else if (valueType == BINARY)
                     {
-                      void* thisData = 0;
-                      void* rhsData = 0;
+                      void* thisData = nullptr;
+                      void* rhsData = nullptr;
                       size_t thisLength = 0;
                       size_t rhsLength = 0;
                       if (nonconst_this->get_binary_value (thisSection,
@@ -1108,7 +1108,7 @@ ACE_Configuration_ExtId::operator!= (const ACE_Configuration_ExtId& rhs) const
 u_long
 ACE_Configuration_ExtId::hash () const
 {
-  ACE_TString temp (name_, 0, false);
+  ACE_TString temp (name_, nullptr, false);
   return temp.hash ();
 }
 
@@ -1121,8 +1121,8 @@ ACE_Configuration_ExtId::free (ACE_Allocator *alloc)
 ///////////////////////////////////////////////////////////////////////
 
 ACE_Configuration_Section_IntId::ACE_Configuration_Section_IntId ()
-  : value_hash_map_ (0),
-    section_hash_map_ (0)
+  : value_hash_map_ (nullptr),
+    section_hash_map_ (nullptr)
 {
 }
 
@@ -1157,9 +1157,9 @@ ACE_Configuration_Section_IntId::free (ACE_Allocator *alloc)
 }
 
 ACE_Configuration_Section_Key_Heap::ACE_Configuration_Section_Key_Heap (const ACE_TCHAR* path)
-  : path_ (0),
-    value_iter_ (0),
-    section_iter_ (0)
+  : path_ (nullptr),
+    value_iter_ (nullptr),
+    section_iter_ (nullptr)
 {
   path_ = ACE_OS::strdup (path);
 }
@@ -1276,7 +1276,7 @@ ACE_Configuration_Heap::create_index ()
       size_t constexpr index_size = sizeof (SECTION_MAP);
       section_index = this->allocator_->malloc (index_size);
 
-      if (section_index == 0
+      if (section_index == nullptr
           || create_index_helper (section_index) == -1
           || this->allocator_->bind (ACE_CONFIG_SECTION_INDEX,
                                      section_index) == -1)
@@ -1314,7 +1314,7 @@ ACE_Configuration_Heap::load_key (const ACE_Configuration_Section_Key& key,
       return -1;
     }
 
-  ACE_TString temp (pKey->path_, 0, false);
+  ACE_TString temp (pKey->path_, nullptr, false);
   name.assign_nocopy (temp);
   return 0;
 }
@@ -1379,7 +1379,7 @@ ACE_Configuration_Heap::new_section (const ACE_TString& section,
 
   int return_value = -1;
 
-  if (ptr == 0)
+  if (ptr == nullptr)
     return -1;
   else
     {
@@ -1501,7 +1501,7 @@ ACE_Configuration_Heap::open_simple_section (const ACE_Configuration_Section_Key
                                              bool create,
                                              ACE_Configuration_Section_Key& result)
 {
-  ACE_TString section (0, 0, false);
+  ACE_TString section (nullptr, nullptr, false);
 
   if (load_key (base, section))
     {
@@ -1614,7 +1614,7 @@ ACE_Configuration_Heap::remove_section (const ACE_Configuration_Section_Key& key
   VALUE_HASH::ITERATOR value_iter = value_hash_map->begin ();
   while (!value_iter.done ())
     {
-      VALUE_HASH::ENTRY* value_entry = 0;
+      VALUE_HASH::ENTRY* value_entry = nullptr;
       if (!value_iter.next (value_entry))
         return 1;
 
@@ -1674,7 +1674,7 @@ ACE_Configuration_Heap::enumerate_values (const ACE_Configuration_Section_Key& k
     }
 
   // Get the next entry
-  ACE_Hash_Map_Entry<ACE_Configuration_ExtId, ACE_Configuration_Value_IntId>* entry = 0;
+  ACE_Hash_Map_Entry<ACE_Configuration_ExtId, ACE_Configuration_Value_IntId>* entry = nullptr;
 
   if (!pKey->value_iter_->next (entry))
     return 1;
@@ -1717,7 +1717,7 @@ ACE_Configuration_Heap::enumerate_sections (const ACE_Configuration_Section_Key&
     }
 
   // Get the next entry
-  ACE_Hash_Map_Entry<ACE_Configuration_ExtId, int>* entry = 0;
+  ACE_Hash_Map_Entry<ACE_Configuration_ExtId, int>* entry = nullptr;
   if (!pKey->section_iter_->next (entry))
     return 1;
 
@@ -1748,7 +1748,7 @@ ACE_Configuration_Heap::set_string_value (const ACE_Configuration_Section_Key& k
     return -1;
 
   // Get the entry for this item (if it exists)
-  VALUE_HASH::ENTRY* entry = 0;
+  VALUE_HASH::ENTRY* entry = nullptr;
   ACE_Configuration_ExtId item_name (t_name);
   if (section_int.value_hash_map_->VALUE_HASH::find (item_name, entry) == 0)
     {
@@ -1807,7 +1807,7 @@ ACE_Configuration_Heap::set_integer_value (const ACE_Configuration_Section_Key& 
     return -1;  // section does not exist
 
   // Get the entry for this item (if it exists)
-  VALUE_HASH::ENTRY* entry = 0;
+  VALUE_HASH::ENTRY* entry = nullptr;
   ACE_Configuration_ExtId item_name (t_name);
   if (section_int.value_hash_map_->VALUE_HASH::find (item_name, entry) == 0)
     {
@@ -1857,7 +1857,7 @@ ACE_Configuration_Heap::set_binary_value (const ACE_Configuration_Section_Key& k
     return -1;    // section does not exist
 
   // Get the entry for this item (if it exists)
-  VALUE_HASH::ENTRY* entry = 0;
+  VALUE_HASH::ENTRY* entry = nullptr;
   ACE_Configuration_ExtId item_name (t_name);
   if (section_int.value_hash_map_->VALUE_HASH::find (item_name, entry) == 0)
     {
@@ -1943,7 +1943,7 @@ ACE_Configuration_Heap::get_integer_value (const ACE_Configuration_Section_Key& 
     return -1;
 
   // Get the section name from the key
-  ACE_TString section (0, 0, false);
+  ACE_TString section (nullptr, nullptr, false);
 
   if (this->load_key (key, section) != 0)
     {
@@ -2051,7 +2051,7 @@ ACE_Configuration_Heap::find_value (const ACE_Configuration_Section_Key& key,
 
   // Find it
   ACE_Configuration_ExtId ValueExtId (t_name);
-  VALUE_HASH::ENTRY* value_entry = 0;
+  VALUE_HASH::ENTRY* value_entry = nullptr;
   if (((VALUE_HASH *) IntId.value_hash_map_)->find (ValueExtId, value_entry))
     return -1;  // value does not exist
 
@@ -2081,7 +2081,7 @@ ACE_Configuration_Heap::remove_value (const ACE_Configuration_Section_Key& key,
 
   // Find it
   ACE_Configuration_ExtId ValueExtId (t_name);
-  VALUE_HASH::ENTRY* value_entry = 0;
+  VALUE_HASH::ENTRY* value_entry = nullptr;
   if (((VALUE_HASH *) IntId.value_hash_map_)->find (ValueExtId, value_entry))
     return -1;
 

--- a/ACE/ace/Configuration_Import_Export.cpp
+++ b/ACE/ace/Configuration_Import_Export.cpp
@@ -21,7 +21,7 @@ ACE_Registry_ImpExp::ACE_Registry_ImpExp (ACE_Configuration& config)
 int
 ACE_Registry_ImpExp::import_config (const ACE_TCHAR* filename)
 {
-  if (0 == filename)
+  if (nullptr == filename)
     {
       errno = EINVAL;
       return -1;
@@ -32,7 +32,7 @@ ACE_Registry_ImpExp::import_config (const ACE_TCHAR* filename)
 
   u_int buffer_size = 4096;
   u_int read_pos = 0;
-  ACE_TCHAR *buffer = 0;
+  ACE_TCHAR *buffer = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_NORETURN (buffer, static_cast<ACE_TCHAR*> (ACE_Allocator::instance()->malloc(sizeof(ACE_TCHAR) * buffer_size)));
 #else
@@ -45,7 +45,7 @@ ACE_Registry_ImpExp::import_config (const ACE_TCHAR* filename)
       return -1;
     }
   ACE_Configuration_Section_Key section;
-  ACE_TCHAR *end = 0;
+  ACE_TCHAR *end = nullptr;
 
   while (ACE_OS::fgets (buffer+read_pos, buffer_size - read_pos, in))
     {
@@ -154,7 +154,7 @@ ACE_Registry_ImpExp::import_config (const ACE_TCHAR* filename)
           else if (ACE_OS::strncmp (end, ACE_TEXT ("dword:"), 6) == 0)
             {
               // number type
-              ACE_TCHAR* endptr = 0;
+              ACE_TCHAR* endptr = nullptr;
               unsigned long value = ACE_OS::strtoul (end + 6, &endptr, 16);
               if (config_.set_integer_value (section, name,
                                              static_cast<u_int> (value)))
@@ -175,7 +175,7 @@ ACE_Registry_ImpExp::import_config (const ACE_TCHAR* filename)
               // divide by 3 to get the actual buffer length
               size_t length = string_length / 3;
               size_t remaining = length;
-              u_char* data = 0;
+              u_char* data = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
               ACE_ALLOCATOR_RETURN (data,
                                     static_cast<u_char*> (ACE_Allocator::instance()->malloc(sizeof(u_char) * length)),
@@ -187,7 +187,7 @@ ACE_Registry_ImpExp::import_config (const ACE_TCHAR* filename)
 #endif /* ACE_HAS_ALLOC_HOOKS */
               u_char* out = data;
               ACE_TCHAR* inb = end + 4;
-              ACE_TCHAR* endptr = 0;
+              ACE_TCHAR* endptr = nullptr;
               while (remaining)
                 {
                   u_char charin = (u_char) ACE_OS::strtoul (inb, &endptr, 16);
@@ -267,7 +267,7 @@ ACE_Registry_ImpExp::import_config (const ACE_TCHAR* filename)
 int
 ACE_Registry_ImpExp::export_config (const ACE_TCHAR* filename)
 {
-  if (0 == filename)
+  if (nullptr == filename)
     {
       errno = EINVAL;
       return -1;
@@ -426,7 +426,7 @@ ACE_Registry_ImpExp::process_previous_line_format (ACE_TCHAR* buffer,
 {
   // Chop any cr/lf at the end of the line.
   ACE_TCHAR *endp = ACE_OS::strpbrk (buffer, ACE_TEXT ("\r\n"));
-  if (endp != 0)
+  if (endp != nullptr)
     *endp = '\0';
 
   // assume this is a value, read in the value name
@@ -464,7 +464,7 @@ ACE_Ini_ImpExp::ACE_Ini_ImpExp (ACE_Configuration& config)
 int
 ACE_Ini_ImpExp::import_config (const ACE_TCHAR* filename)
 {
-  if (0 == filename)
+  if (nullptr == filename)
     {
       errno = EINVAL;
       return -1;
@@ -510,7 +510,7 @@ ACE_Ini_ImpExp::import_config (const ACE_TCHAR* filename)
 
       // We have a line; name ends at equal sign.
       ACE_TCHAR *end = ACE_OS::strchr (line, ACE_TEXT ('='));
-      if (end == 0)                            // No '='
+      if (end == nullptr)                            // No '='
         {
           ACE_OS::fclose (in);
           return -3;
@@ -564,7 +564,7 @@ ACE_Ini_ImpExp::import_config (const ACE_TCHAR* filename)
 int
 ACE_Ini_ImpExp::export_config (const ACE_TCHAR* filename)
 {
-  if (0 == filename)
+  if (nullptr == filename)
     {
       errno = EINVAL;
       return -1;
@@ -710,10 +710,10 @@ ACE_Ini_ImpExp::export_section (const ACE_Configuration_Section_Key& section,
 ACE_TCHAR *
 ACE_Ini_ImpExp::squish (ACE_TCHAR *src)
 {
-  ACE_TCHAR *cp = 0;
+  ACE_TCHAR *cp = nullptr;
 
-  if (src == 0)
-    return 0;
+  if (src == nullptr)
+    return nullptr;
 
   // Start at the end and work backwards over all whitespace.
   for (cp = src + ACE_OS::strlen (src) - 1;

--- a/ACE/ace/Connector.cpp
+++ b/ACE/ace/Connector.cpp
@@ -406,7 +406,7 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::connect_i
   if (this->make_svc_handler (sh) == -1)
     return -1;
 
-  ACE_Time_Value *timeout = 0;
+  ACE_Time_Value *timeout = nullptr;
   int const use_reactor = synch_options[ACE_Synch_Options::USE_REACTOR];
 
   if (use_reactor)
@@ -492,11 +492,11 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::connect_n
                && errno == EWOULDBLOCK))
         {
           result = -1;
-          if (failed_svc_handlers != 0)
+          if (failed_svc_handlers != nullptr)
             // Mark this entry as having failed.
             failed_svc_handlers[i] = 1;
         }
-      else if (failed_svc_handlers != 0)
+      else if (failed_svc_handlers != nullptr)
         // Mark this entry as having succeeded.
         failed_svc_handlers[i] = 0;
     }
@@ -513,7 +513,7 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::cancel (SVC_HANDLER *sh)
   ACE_Event_Handler *handler =
     this->reactor ()->find_handler (sh->get_handle ());
 
-  if (handler == 0)
+  if (handler == nullptr)
     return -1;
 
   // find_handler() increments handler's refcount; ensure we decrement it.
@@ -549,7 +549,7 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::nonblocking_connect
 
   ACE_HANDLE handle = sh->get_handle ();
   long timer_id = -1;
-  ACE_Time_Value *tv = 0;
+  ACE_Time_Value *tv = nullptr;
   NBCH *nbch = 0;
 
   ACE_NEW_RETURN (nbch,
@@ -576,7 +576,7 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::nonblocking_connect
   // If we're starting connection under timer control then we need to
   // schedule a timeout with the ACE_Reactor.
   tv = const_cast<ACE_Time_Value *> (synch_options.time_value ());
-  if (tv != 0)
+  if (tv != nullptr)
     {
       timer_id =
         this->reactor ()->schedule_timer (nbch,
@@ -687,7 +687,7 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::close ()
   // Go through all the non-blocking handles.  It is necessary to
   // create a new iterator each time because we remove from the handle
   // set when we cancel the Svc_Handler.
-  ACE_HANDLE *handle = 0;
+  ACE_HANDLE *handle = nullptr;
   while (1)
     {
       ACE_Unbounded_Set_Iterator<ACE_HANDLE>
@@ -697,7 +697,7 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::close ()
 
       ACE_Event_Handler *handler =
         this->reactor ()->find_handler (*handle);
-      if (handler == 0)
+      if (handler == nullptr)
         {
           ACELIB_ERROR ((LM_ERROR,
                       ACE_TEXT ("%t: Connector::close h %d, no handler\n"),
@@ -775,7 +775,7 @@ ACE_Connector<SVC_HANDLER, PEER_CONNECTOR>::info (ACE_TCHAR **strp, size_t lengt
                     ACE_TEXT ("ACE_Connector"),
                     ACE_TEXT ("# connector factory\n"));
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (buf)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (buf)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, buf, length);

--- a/ACE/ace/Connector.h
+++ b/ACE/ace/Connector.h
@@ -246,7 +246,7 @@ public:
   virtual int connect_n (size_t n,
                          SVC_HANDLER *svc_handlers[],
                          typename PEER_CONNECTOR::PEER_ADDR remote_addrs[],
-                         ACE_TCHAR *failed_svc_handlers = 0,
+                         ACE_TCHAR *failed_svc_handlers = nullptr,
                          const ACE_Synch_Options &synch_options =
                          ACE_Synch_Options::defaults);
 
@@ -435,9 +435,9 @@ public:
    * non-blocking I/O on the SVC_HANDLER when it is opened.
    */
   ACE_Strategy_Connector (ACE_Reactor *r = ACE_Reactor::instance (),
-                          ACE_Creation_Strategy<SVC_HANDLER> * = 0,
-                          ACE_Connect_Strategy<SVC_HANDLER, PEER_CONNECTOR> * = 0,
-                          ACE_Concurrency_Strategy<SVC_HANDLER> * = 0,
+                          ACE_Creation_Strategy<SVC_HANDLER> * = nullptr,
+                          ACE_Connect_Strategy<SVC_HANDLER, PEER_CONNECTOR> * = nullptr,
+                          ACE_Concurrency_Strategy<SVC_HANDLER> * = nullptr,
                           int flags = 0);
 
   /**
@@ -457,9 +457,9 @@ public:
    * non-blocking I/O on the SVC_HANDLER when it is opened.
    */
   virtual int open (ACE_Reactor *r = ACE_Reactor::instance (),
-                    ACE_Creation_Strategy<SVC_HANDLER> * = 0,
-                    ACE_Connect_Strategy<SVC_HANDLER, PEER_CONNECTOR> * = 0,
-                    ACE_Concurrency_Strategy<SVC_HANDLER> * = 0,
+                    ACE_Creation_Strategy<SVC_HANDLER> * = nullptr,
+                    ACE_Connect_Strategy<SVC_HANDLER, PEER_CONNECTOR> * = nullptr,
+                    ACE_Concurrency_Strategy<SVC_HANDLER> * = nullptr,
                     int flags = 0);
 
   /// Shutdown a connector and release resources.

--- a/ACE/ace/Containers_T.cpp
+++ b/ACE/ace/Containers_T.cpp
@@ -1822,31 +1822,31 @@ ACE_Ordered_MultiSet_Iterator<T>::operator* ()
 template <class T> T *
 ACE_DLList<T>::insert_tail (T *new_item)
 {
-  ACE_DLList_Node *temp1 = 0;
+  ACE_DLList_Node *temp1 = nullptr;
   ACE_NEW_MALLOC_RETURN (temp1,
                          static_cast<ACE_DLList_Node *> (this->allocator_->malloc (sizeof (ACE_DLList_Node))),
                          ACE_DLList_Node (new_item),
                          0);
   ACE_DLList_Node *temp2 = ACE_DLList_Base::insert_tail (temp1);
-  return (T *) (temp2 ? temp2->item_ : 0);
+  return (T *) (temp2 ? temp2->item_ : nullptr);
 }
 
 template <class T> T *
 ACE_DLList<T>::insert_head (T *new_item)
 {
-  ACE_DLList_Node *temp1 = 0;
+  ACE_DLList_Node *temp1 = nullptr;
   ACE_NEW_MALLOC_RETURN (temp1,
                          (ACE_DLList_Node *) this->allocator_->malloc (sizeof (ACE_DLList_Node)),
                          ACE_DLList_Node (new_item), 0);
   ACE_DLList_Node *temp2 = ACE_DLList_Base::insert_head (temp1);
-  return (T *) (temp2 ? temp2->item_ : 0);
+  return (T *) (temp2 ? temp2->item_ : nullptr);
 }
 
 template <class T> T *
 ACE_DLList<T>::delete_head ()
 {
   ACE_DLList_Node *temp1 = ACE_DLList_Base::delete_head ();
-  T *temp2 = (T *) (temp1 ? temp1->item_ : 0);
+  T *temp2 = (T *) (temp1 ? temp1->item_ : nullptr);
   ACE_DES_FREE (temp1,
                 this->allocator_->free,
                 ACE_DLList_Node);
@@ -1858,7 +1858,7 @@ template <class T> T *
 ACE_DLList<T>::delete_tail ()
 {
   ACE_DLList_Node *temp1 = ACE_DLList_Base::delete_tail ();
-  T *temp2 = (T *) (temp1 ? temp1->item_ : 0);
+  T *temp2 = (T *) (temp1 ? temp1->item_ : nullptr);
   ACE_DES_FREE (temp1,
                 this->allocator_->free,
                 ACE_DLList_Node);

--- a/ACE/ace/Containers_T.h
+++ b/ACE/ace/Containers_T.h
@@ -380,7 +380,7 @@ public:
    * Initialize an empty stack using the user specified allocation strategy
    * if provided.
    */
-  ACE_Unbounded_Stack (ACE_Allocator *the_allocator = 0);
+  ACE_Unbounded_Stack (ACE_Allocator *the_allocator = nullptr);
 
   /// The copy constructor (performs initialization).
   /**
@@ -825,7 +825,7 @@ public:
    * Initialize an empy list using the allocation strategy specified by the user.
    * If none is specified, then use default allocation strategy.
    */
-  ACE_Double_Linked_List (ACE_Allocator *the_allocator = 0);
+  ACE_Double_Linked_List (ACE_Allocator *the_allocator = nullptr);
 
   /// Copy constructor.
   /**
@@ -1782,7 +1782,7 @@ public:
    * Initialize the set using the allocation strategy specified.  If none, use the
    * default strategy.
    */
-  ACE_Ordered_MultiSet (ACE_Allocator *the_allocator = 0);
+  ACE_Ordered_MultiSet (ACE_Allocator *the_allocator = nullptr);
 
   /// Copy constructor.
   /**
@@ -1953,7 +1953,7 @@ public:
    * allocation strategy.
    */
   ACE_Array (size_t size = 0,
-             ACE_Allocator* alloc = 0);
+             ACE_Allocator* alloc = nullptr);
 
   /// Dynamically initialize the entire array to the {default_value}.
   /**
@@ -1961,7 +1961,7 @@ public:
    */
   ACE_Array (size_t size,
              const T &default_value,
-             ACE_Allocator* alloc = 0);
+             ACE_Allocator* alloc = nullptr);
 
   ///Copy constructor.
   /**

--- a/ACE/ace/DLL.cpp
+++ b/ACE/ace/DLL.cpp
@@ -16,9 +16,9 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_DLL::ACE_DLL (bool close_handle_on_destruction)
   : open_mode_ (0),
-    dll_name_ (0),
+    dll_name_ (nullptr),
     close_handle_on_destruction_ (close_handle_on_destruction),
-    dll_handle_ (0),
+    dll_handle_ (nullptr),
     error_ (0)
 {
   ACE_TRACE ("ACE_DLL::ACE_DLL (int)");
@@ -26,9 +26,9 @@ ACE_DLL::ACE_DLL (bool close_handle_on_destruction)
 
 ACE_DLL::ACE_DLL (const ACE_DLL &rhs)
   : open_mode_ (0),
-    dll_name_ (0),
+    dll_name_ (nullptr),
     close_handle_on_destruction_ (false),
-    dll_handle_ (0),
+    dll_handle_ (nullptr),
     error_ (0)
 {
   ACE_TRACE ("ACE_DLL::ACE_DLL (const ACE_DLL &)");
@@ -71,9 +71,9 @@ ACE_DLL::ACE_DLL (const ACE_TCHAR *dll_name,
                   int open_mode,
                   bool close_handle_on_destruction)
   : open_mode_ (open_mode),
-    dll_name_ (0),
+    dll_name_ (nullptr),
     close_handle_on_destruction_ (close_handle_on_destruction),
-    dll_handle_ (0),
+    dll_handle_ (nullptr),
     error_ (0)
 {
   ACE_TRACE ("ACE_DLL::ACE_DLL");
@@ -143,7 +143,7 @@ ACE_DLL::open_i (const ACE_TCHAR *dll_filename,
       if (ACE::debug ())
         ACELIB_ERROR ((LM_ERROR,
                     ACE_TEXT ("ACE_DLL::open_i: dll_name is %s\n"),
-                    this->dll_name_ == 0 ? ACE_TEXT ("(null)")
+                    this->dll_name_ == nullptr ? ACE_TEXT ("(null)")
         : this->dll_name_));
       return -1;
     }
@@ -195,7 +195,7 @@ ACE_DLL::symbol (const ACE_TCHAR *sym_name, int ignore_errors)
   this->error_ = 0;
   this->errmsg_.clear (true);
 
-  void *sym = 0;
+  void *sym = nullptr;
   if (this->dll_handle_)
     sym = this->dll_handle_->symbol (sym_name, ignore_errors, this->errmsg_);
 
@@ -222,13 +222,13 @@ ACE_DLL::close ()
     this->error_ = 1;
 
   // Even if close_dll() failed, go ahead and cleanup.
-  this->dll_handle_ = 0;
+  this->dll_handle_ = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_Allocator::instance()->free (this->dll_name_);
 #else
   delete [] this->dll_name_;
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  this->dll_name_ = 0;
+  this->dll_name_ = nullptr;
   this->close_handle_on_destruction_ = false;
 
   return retval;
@@ -245,7 +245,7 @@ ACE_DLL::error () const
       return const_cast<ACE_TCHAR*> (this->errmsg_.c_str ());
     }
 
-  return 0;
+  return nullptr;
 }
 
 // Return the handle to the user either temporarily or forever, thus

--- a/ACE/ace/DLL_Manager.cpp
+++ b/ACE/ace/DLL_Manager.cpp
@@ -19,7 +19,7 @@ sig_atomic_t ACE_DLL_Handle::open_called_ = 0;
 
 ACE_DLL_Handle::ACE_DLL_Handle ()
   : refcount_ (0),
-    dll_name_ (0),
+    dll_name_ (nullptr),
     handle_ (ACE_SHLIB_INVALID_HANDLE)
 {
   ACE_TRACE ("ACE_DLL_Handle::ACE_DLL_Handle");
@@ -117,7 +117,7 @@ ACE_DLL_Handle::open (const ACE_TCHAR *dll_name,
           this->get_dll_names (dll_name, dll_names);
 #endif
 
-          ACE_TString *name = 0;
+          ACE_TString *name = nullptr;
           for (ACE_Array_Iterator<ACE_TString> name_iter (dll_names);
                name_iter.next (name); name_iter.advance ())
             {
@@ -241,7 +241,7 @@ void *
 ACE_DLL_Handle::symbol (const ACE_TCHAR *sym_name, bool ignore_errors, ACE_TString &error)
 {
   ACE_TRACE ("ACE_DLL_Handle::symbol");
-  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
 
   std::unique_ptr <ACE_TCHAR[]> auto_name (ACE::ldname (sym_name));
   // handle_ can be invalid especially when ACE_DLL_Handle resigned ownership
@@ -276,7 +276,7 @@ ACE_SHLIB_HANDLE
 ACE_DLL_Handle::get_handle (bool become_owner)
 {
   ACE_TRACE ("ACE_DLL_Handle::get_handle");
-  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
 
   if (this->refcount_ == 0 && become_owner)
     {
@@ -451,7 +451,7 @@ ACE_DLL_Handle::open_i (const ACE_TCHAR *dll_name, int open_mode, ERROR_STACK* e
 /******************************************************************/
 
 // Pointer to the Singleton instance.
-ACE_DLL_Manager *ACE_DLL_Manager::instance_ = 0;
+ACE_DLL_Manager *ACE_DLL_Manager::instance_ = nullptr;
 
 
 ACE_DLL_Manager *
@@ -459,16 +459,16 @@ ACE_DLL_Manager::instance (int size)
 {
   ACE_TRACE ("ACE_DLL_Manager::instance");
 
-  if (ACE_DLL_Manager::instance_ == 0)
+  if (ACE_DLL_Manager::instance_ == nullptr)
     {
       // Perform Double-Checked Locking Optimization.
       ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                                *ACE_Static_Object_Lock::instance (), 0));
-      if (ACE_DLL_Manager::instance_ == 0)
+                                *ACE_Static_Object_Lock::instance (), nullptr));
+      if (ACE_DLL_Manager::instance_ == nullptr)
         {
           ACE_NEW_RETURN (ACE_DLL_Manager::instance_,
                           ACE_DLL_Manager (size),
-                          0);
+                          nullptr);
         }
     }
 
@@ -484,11 +484,11 @@ ACE_DLL_Manager::close_singleton ()
                      *ACE_Static_Object_Lock::instance ()));
 
   delete ACE_DLL_Manager::instance_;
-  ACE_DLL_Manager::instance_ = 0;
+  ACE_DLL_Manager::instance_ = nullptr;
 }
 
 ACE_DLL_Manager::ACE_DLL_Manager (int size)
-  : handle_vector_ (0),
+  : handle_vector_ (nullptr),
     current_size_ (0),
     total_size_ (0),
     unload_policy_ (ACE_DLL_UNLOAD_POLICY_PER_DLL)
@@ -521,10 +521,10 @@ ACE_DLL_Manager::open_dll (const ACE_TCHAR *dll_name,
 {
   ACE_TRACE ("ACE_DLL_Manager::open_dll");
 
-  ACE_DLL_Handle *temp_handle = 0;
-  ACE_DLL_Handle *dll_handle = 0;
+  ACE_DLL_Handle *temp_handle = nullptr;
+  ACE_DLL_Handle *dll_handle = nullptr;
   {
-    ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
+    ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
     dll_handle = this->find_dll (dll_name);
     if (!dll_handle)
       {
@@ -532,7 +532,7 @@ ACE_DLL_Manager::open_dll (const ACE_TCHAR *dll_name,
           {
             ACE_NEW_RETURN (temp_handle,
                             ACE_DLL_Handle,
-                            0);
+                            nullptr);
 
             dll_handle = temp_handle;
           }
@@ -551,14 +551,14 @@ ACE_DLL_Manager::open_dll (const ACE_TCHAR *dll_name,
                         dll_name));
 
           delete temp_handle;
-          return 0;
+          return nullptr;
         }
 
       // Add the handle to the vector only if the dll is successfully
       // opened.
-      if (temp_handle != 0)
+      if (temp_handle != nullptr)
         {
-          ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
+          ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
           this->handle_vector_[this->current_size_] = dll_handle;
           ++this->current_size_;
         }
@@ -571,7 +571,7 @@ int
 ACE_DLL_Manager::close_dll (const ACE_TCHAR *dll_name)
 {
   ACE_TRACE ("ACE_DLL_Manager::close_dll");
-  ACE_DLL_Handle *handle = 0;
+  ACE_DLL_Handle *handle = nullptr;
 
   {
     ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
@@ -626,7 +626,7 @@ ACE_DLL_Manager::open (int size)
 {
   ACE_TRACE ("ACE_DLL_Manager::open");
 
-  ACE_DLL_Handle **temp = 0;
+  ACE_DLL_Handle **temp = nullptr;
 
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (temp,
@@ -650,7 +650,7 @@ ACE_DLL_Manager::close ()
 
   int force_close = 1;
 
-  if (this->handle_vector_ != 0)
+  if (this->handle_vector_ != nullptr)
     {
       // Delete components in reverse order.
       for (int i = this->current_size_ - 1; i >= 0; i--)
@@ -659,7 +659,7 @@ ACE_DLL_Manager::close ()
             {
               ACE_DLL_Handle *s =
                 const_cast<ACE_DLL_Handle *> (this->handle_vector_[i]);
-              this->handle_vector_[i] = 0;
+              this->handle_vector_[i] = nullptr;
               this->unload_dll (s, force_close);
               delete s;
             }
@@ -671,7 +671,7 @@ ACE_DLL_Manager::close ()
       delete [] this->handle_vector_;
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
-      this->handle_vector_ = 0;
+      this->handle_vector_ = nullptr;
       this->current_size_ = 0;
     }
   return 0;
@@ -689,7 +689,7 @@ ACE_DLL_Manager::find_dll (const ACE_TCHAR *dll_name) const
         return this->handle_vector_[i];
       }
 
-  return 0;
+  return nullptr;
 }
 
 int
@@ -721,7 +721,7 @@ ACE_DLL_Manager::unload_dll (ACE_DLL_Handle *dll_handle, int force_unload)
               dll_unload_policy const the_policy =
                 reinterpret_cast<dll_unload_policy> (temp_p);
 
-              if (the_policy != 0)
+              if (the_policy != nullptr)
                 unload = ACE_BIT_DISABLED (the_policy (),
                                            ACE_DLL_UNLOAD_POLICY_LAZY);
               else

--- a/ACE/ace/Dev_Poll_Reactor.cpp
+++ b/ACE/ace/Dev_Poll_Reactor.cpp
@@ -44,7 +44,7 @@ ACE_ALLOC_HOOK_DEFINE(ACE_Dev_Poll_Reactor::Event_Tuple)
 ACE_ALLOC_HOOK_DEFINE(ACE_Dev_Poll_Reactor_Notify)
 
 ACE_Dev_Poll_Reactor_Notify::ACE_Dev_Poll_Reactor_Notify ()
-  : dp_reactor_ (0)
+  : dp_reactor_ (nullptr)
   , notification_pipe_ ()
   , max_notify_iterations_ (-1)
 #if defined (ACE_HAS_REACTOR_NOTIFICATION_QUEUE)
@@ -64,7 +64,7 @@ ACE_Dev_Poll_Reactor_Notify::open (ACE_Reactor_Impl *r,
     {
       this->dp_reactor_ = dynamic_cast<ACE_Dev_Poll_Reactor *> (r);
 
-      if (this->dp_reactor_ == 0)
+      if (this->dp_reactor_ == nullptr)
         {
           errno = EINVAL;
           return -1;
@@ -128,7 +128,7 @@ ACE_Dev_Poll_Reactor_Notify::notify (ACE_Event_Handler *eh,
 
   // Just consider this method a "no-op" if there's no
   // ACE_Dev_Poll_Reactor configured.
-  if (this->dp_reactor_ == 0)
+  if (this->dp_reactor_ == nullptr)
     return 0;
 
   ACE_Notification_Buffer buffer (eh, mask);
@@ -236,7 +236,7 @@ ACE_Dev_Poll_Reactor_Notify::read_notify_pipe (ACE_HANDLE handle,
         return result;
 
       // If it's just a wake-up, toss it and see if there's anything else.
-      if (buffer.eh_ != 0)
+      if (buffer.eh_ != nullptr)
         break;
     }
 
@@ -314,7 +314,7 @@ ACE_Dev_Poll_Reactor_Notify::dispatch_notify (ACE_Notification_Buffer &buffer)
   // internal structures.  Otherwise, we need to dispatch the
   // appropriate handle_* method on the ACE_Event_Handler
   // pointer we've been passed.
-  if (buffer.eh_ != 0)
+  if (buffer.eh_ != nullptr)
     {
       int result = 0;
 
@@ -404,7 +404,7 @@ ACE_Dev_Poll_Reactor_Notify::dump () const
 int
 ACE_Dev_Poll_Reactor_Notify::dequeue_one (ACE_Notification_Buffer &nb)
 {
-  nb.eh_ = 0;
+  nb.eh_ = nullptr;
   nb.mask_ = 0;
   return this->read_notify_pipe (this->notify_handle (), nb);
 }
@@ -415,7 +415,7 @@ ACE_Dev_Poll_Reactor_Notify::dequeue_one (ACE_Notification_Buffer &nb)
 ACE_Dev_Poll_Reactor::Handler_Repository::Handler_Repository ()
   : size_ (0),
     max_size_ (0),
-    handlers_ (0)
+    handlers_ (nullptr)
 {
   ACE_TRACE ("ACE_Dev_Poll_Reactor::Handler_Repository::Handler_Repository");
 }
@@ -476,7 +476,7 @@ ACE_Dev_Poll_Reactor::Handler_Repository::unbind_all ()
        ++handle)
     {
       Event_Tuple *entry = this->find (handle);
-      if (entry == 0)
+      if (entry == nullptr)
         continue;
 
       // Check for ref counting now - handle_close () may delete eh.
@@ -496,12 +496,12 @@ ACE_Dev_Poll_Reactor::Handler_Repository::close ()
 {
   ACE_TRACE ("ACE_Dev_Poll_Reactor::Handler_Repository::close");
 
-  if (this->handlers_ != 0)
+  if (this->handlers_ != nullptr)
     {
       this->unbind_all ();
 
       delete [] this->handlers_;
-      this->handlers_ = 0;
+      this->handlers_ = nullptr;
     }
 
   return 0;
@@ -512,19 +512,19 @@ ACE_Dev_Poll_Reactor::Handler_Repository::find (ACE_HANDLE handle)
 {
   ACE_TRACE ("ACE_Dev_Poll_Reactor::Handler_Repository::find");
 
-  Event_Tuple *tuple = 0;
+  Event_Tuple *tuple = nullptr;
 
   // Only bother to search for the <handle> if it's in range.
   if (!this->handle_in_range (handle))
     {
-      return 0;
+      return nullptr;
     }
 
   tuple = &(this->handlers_[handle]);
-  if (tuple->event_handler == 0)
+  if (tuple->event_handler == nullptr)
     {
       errno = ENOENT;
-      tuple = 0;
+      tuple = nullptr;
     }
 
   return tuple;
@@ -538,7 +538,7 @@ ACE_Dev_Poll_Reactor::Handler_Repository::bind (
 {
   ACE_TRACE ("ACE_Dev_Poll_Reactor::Handler_Repository::bind");
 
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     return -1;
 
   if (handle == ACE_INVALID_HANDLE)
@@ -562,13 +562,13 @@ ACE_Dev_Poll_Reactor::Handler_Repository::unbind (ACE_HANDLE handle,
   ACE_TRACE ("ACE_Dev_Poll_Reactor::Handler_Repository::unbind");
 
   Event_Tuple *entry = this->find (handle);
-  if (entry == 0)
+  if (entry == nullptr)
     return -1;
 
   if (decr_refcnt)
     entry->event_handler->remove_reference ();
 
-  entry->event_handler = 0;
+  entry->event_handler = nullptr;
   entry->mask = ACE_Event_Handler::NULL_MASK;
   entry->suspended = false;
   entry->controlled = false;
@@ -595,11 +595,11 @@ ACE_Dev_Poll_Reactor::ACE_Dev_Poll_Reactor (ACE_Sig_Handler *sh,
   , token_ (*this, s_queue)
   , lock_adapter_ (token_)
   , deactivated_ (0)
-  , timer_queue_ (0)
+  , timer_queue_ (nullptr)
   , delete_timer_queue_ (false)
-  , signal_handler_ (0)
+  , signal_handler_ (nullptr)
   , delete_signal_handler_ (false)
-  , notify_handler_ (0)
+  , notify_handler_ (nullptr)
   , delete_notify_handler_ (false)
   , mask_signals_ (mask_signals)
   , restart_ (0)
@@ -638,11 +638,11 @@ ACE_Dev_Poll_Reactor::ACE_Dev_Poll_Reactor (size_t size,
   , token_ (*this, s_queue)
   , lock_adapter_ (token_)
   , deactivated_ (0)
-  , timer_queue_ (0)
+  , timer_queue_ (nullptr)
   , delete_timer_queue_ (false)
-  , signal_handler_ (0)
+  , signal_handler_ (nullptr)
   , delete_signal_handler_ (false)
-  , notify_handler_ (0)
+  , notify_handler_ (nullptr)
   , delete_notify_handler_ (false)
   , mask_signals_ (mask_signals)
   , restart_ (0)
@@ -695,39 +695,39 @@ ACE_Dev_Poll_Reactor::open (size_t size,
   int result = 0;
 
   // Allows the signal handler to be overridden.
-  if (this->signal_handler_ == 0)
+  if (this->signal_handler_ == nullptr)
     {
       ACE_NEW_RETURN (this->signal_handler_,
                       ACE_Sig_Handler,
                       -1);
 
-      if (this->signal_handler_ == 0)
+      if (this->signal_handler_ == nullptr)
         result = -1;
       else
         this->delete_signal_handler_ = true;
     }
 
   // Allows the timer queue to be overridden.
-  if (result != -1 && this->timer_queue_ == 0)
+  if (result != -1 && this->timer_queue_ == nullptr)
     {
       ACE_NEW_RETURN (this->timer_queue_,
                       ACE_Timer_Heap,
                       -1);
 
-      if (this->timer_queue_ == 0)
+      if (this->timer_queue_ == nullptr)
         result = -1;
       else
         this->delete_timer_queue_ = true;
     }
 
   // Allows the Notify_Handler to be overridden.
-  if (result != -1 && this->notify_handler_ == 0)
+  if (result != -1 && this->notify_handler_ == nullptr)
     {
       ACE_NEW_RETURN (this->notify_handler_,
                       ACE_Dev_Poll_Reactor_Notify,
                       -1);
 
-      if (this->notify_handler_ == 0)
+      if (this->notify_handler_ == nullptr)
         result = -1;
       else
         this->delete_notify_handler_ = true;
@@ -761,7 +761,7 @@ ACE_Dev_Poll_Reactor::open (size_t size,
   // Registration of the notification handler must be done after the
   // /dev/poll device has been fully initialized.
   else if (this->notify_handler_->open (this,
-                                        0,
+                                        nullptr,
                                         disable_notify_pipe) == -1
            || (disable_notify_pipe == 0
                && this->register_handler_i (
@@ -850,7 +850,7 @@ ACE_Dev_Poll_Reactor::close ()
   if (this->delete_signal_handler_)
     {
       delete this->signal_handler_;
-      this->signal_handler_ = 0;
+      this->signal_handler_ = nullptr;
       this->delete_signal_handler_ = false;
     }
 
@@ -859,22 +859,22 @@ ACE_Dev_Poll_Reactor::close ()
   if (this->delete_timer_queue_)
     {
       delete this->timer_queue_;
-      this->timer_queue_ = 0;
+      this->timer_queue_ = nullptr;
       this->delete_timer_queue_ = false;
     }
   else if (this->timer_queue_)
     {
       this->timer_queue_->close ();
-      this->timer_queue_ = 0;
+      this->timer_queue_ = nullptr;
     }
 
-  if (this->notify_handler_ != 0)
+  if (this->notify_handler_ != nullptr)
     this->notify_handler_->close ();
 
   if (this->delete_notify_handler_)
     {
       delete this->notify_handler_;
-      this->notify_handler_ = 0;
+      this->notify_handler_ = nullptr;
       this->delete_notify_handler_ = false;
     }
 
@@ -932,12 +932,12 @@ ACE_Dev_Poll_Reactor::work_pending_i (ACE_Time_Value * max_wait_time)
 
   // Check if we have timers to fire.
   int const timers_pending =
-    ((this_timeout != 0 && max_wait_time == 0)
-     || (this_timeout != 0 && max_wait_time != 0
+    ((this_timeout != nullptr && max_wait_time == nullptr)
+     || (this_timeout != nullptr && max_wait_time != nullptr
          && *this_timeout != *max_wait_time) ? 1 : 0);
 
   long const timeout =
-    (this_timeout == 0
+    (this_timeout == nullptr
      ? -1 /* Infinity */
      : static_cast<long> (this_timeout->msec ()));
 
@@ -1170,17 +1170,17 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
 
       // Going to access handler repo, so lock it. If the lock is
       // unobtainable, something is very wrong so bail out.
-      Event_Tuple *info = 0;
+      Event_Tuple *info = nullptr;
       ACE_Reactor_Mask disp_mask = 0;
-      ACE_Event_Handler *eh = 0;
-      int (ACE_Event_Handler::*callback)(ACE_HANDLE) = 0;
+      ACE_Event_Handler *eh = nullptr;
+      int (ACE_Event_Handler::*callback)(ACE_HANDLE) = nullptr;
 #ifndef ACE_HAS_DEV_POLL
       bool reactor_resumes_eh = false;
 #endif /* !ACE_HAS_DEV_POLL */
       {
         ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, grd, this->repo_lock_, -1);
         info = this->handler_rep_.find (handle);
-        if (info == 0)   // No registered handler any longer
+        if (info == nullptr)   // No registered handler any longer
           return 0;
 
         // It is possible another thread has changed (and possibly re-armed)
@@ -1310,7 +1310,7 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
               {
                 ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, grd, this->repo_lock_, -1);
                 info = this->handler_rep_.find (handle);
-                if (info != 0 && info->event_handler == eh)
+                if (info != nullptr && info->event_handler == eh)
                   this->resume_handler_i (handle);
               }
 #endif /* ACE_HAS_EVENT_POLL */
@@ -1324,7 +1324,7 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
         // handler.
         ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, grd, this->repo_lock_, 1);
         info = this->handler_rep_.find (handle);
-        if (info != 0 && info->event_handler == eh)
+        if (info != nullptr && info->event_handler == eh)
           {
             if (status < 0)
               {
@@ -1336,7 +1336,7 @@ ACE_Dev_Poll_Reactor::dispatch_io_event (Token_Guard &guard)
                 if (reactor_resumes_eh)
                   {
                     info = this->handler_rep_.find (handle);
-                    if (info != 0 && info->event_handler == eh)
+                    if (info != nullptr && info->event_handler == eh)
                       {
                         this->resume_handler_i (handle);
                       }
@@ -1431,7 +1431,7 @@ ACE_Dev_Poll_Reactor::register_handler_i (ACE_HANDLE handle,
       return -1;
     }
 
- if (this->handler_rep_.find (handle) == 0)
+ if (this->handler_rep_.find (handle) == nullptr)
    {
      // Handler not present in the repository.  Bind it.
      if (this->handler_rep_.bind (handle, event_handler, mask) != 0)
@@ -1612,9 +1612,9 @@ ACE_Dev_Poll_Reactor::remove_handler_i (ACE_HANDLE handle,
   // the mask, but do the proper callback and refcount when needed.
   bool handle_reg_changed = true;
   Event_Tuple *info = this->handler_rep_.find (handle);
-  if (info == 0 && eh == 0)  // Nothing to work with
+  if (info == nullptr && eh == nullptr)  // Nothing to work with
     return -1;
-  if (info != 0 && (eh == 0 || info->event_handler == eh))
+  if (info != nullptr && (eh == nullptr || info->event_handler == eh))
     {
       if (this->mask_ops_i (handle, mask, ACE_Reactor::CLR_MASK) == -1)
         return -1;
@@ -1703,7 +1703,7 @@ ACE_Dev_Poll_Reactor::suspend_handler (ACE_Event_Handler *event_handler)
 {
   ACE_TRACE ("ACE_Dev_Poll_Reactor::suspend_handler");
 
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     {
       errno = EINVAL;
       return -1;
@@ -1755,7 +1755,7 @@ ACE_Dev_Poll_Reactor::suspend_handlers ()
   for (size_t i = 0; i < len; ++i)
     {
       Event_Tuple *info = this->handler_rep_.find (i);
-      if (info != 0 && !info->suspended && this->suspend_handler_i (i) != 0)
+      if (info != nullptr && !info->suspended && this->suspend_handler_i (i) != 0)
         return -1;
     }
   return 0;
@@ -1767,7 +1767,7 @@ ACE_Dev_Poll_Reactor::suspend_handler_i (ACE_HANDLE handle)
   ACE_TRACE ("ACE_Dev_Poll_Reactor::suspend_handler_i");
 
   Event_Tuple *info = this->handler_rep_.find (handle);
-  if (info == 0)
+  if (info == nullptr)
     return -1;
 
   if (info->suspended)
@@ -1814,7 +1814,7 @@ ACE_Dev_Poll_Reactor::resume_handler (ACE_Event_Handler *event_handler)
 {
   ACE_TRACE ("ACE_Dev_Poll_Reactor::resume_handler");
 
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     {
       errno = EINVAL;
       return -1;
@@ -1866,7 +1866,7 @@ ACE_Dev_Poll_Reactor::resume_handlers ()
   for (size_t i = 0; i < len; ++i)
     {
       Event_Tuple *info = this->handler_rep_.find (i);
-      if (info != 0 && info->suspended && this->resume_handler_i (i) != 0)
+      if (info != nullptr && info->suspended && this->resume_handler_i (i) != 0)
         return -1;
     }
 
@@ -1879,7 +1879,7 @@ ACE_Dev_Poll_Reactor::resume_handler_i (ACE_HANDLE handle)
   ACE_TRACE ("ACE_Dev_Poll_Reactor::resume_handler_i");
 
   Event_Tuple *info = this->handler_rep_.find (handle);
-  if (info == 0)
+  if (info == nullptr)
     return -1;
 
   if (!info->suspended)
@@ -1954,7 +1954,7 @@ ACE_Dev_Poll_Reactor::schedule_timer (ACE_Event_Handler *event_handler,
 
   ACE_MT (ACE_GUARD_RETURN (ACE_Dev_Poll_Reactor_Token, mon, this->token_, -1));
 
-  if (0 != this->timer_queue_)
+  if (nullptr != this->timer_queue_)
     return this->timer_queue_->schedule
       (event_handler,
        arg,
@@ -1973,7 +1973,7 @@ ACE_Dev_Poll_Reactor::reset_timer_interval (long timer_id,
 
   ACE_MT (ACE_GUARD_RETURN (ACE_Dev_Poll_Reactor_Token, mon, this->token_, -1));
 
-  if (0 != this->timer_queue_)
+  if (nullptr != this->timer_queue_)
     return this->timer_queue_->reset_interval (timer_id, interval);
 
   errno = ESHUTDOWN;
@@ -1988,7 +1988,7 @@ ACE_Dev_Poll_Reactor::cancel_timer (ACE_Event_Handler *handler,
 
   // Don't bother waking the poll - the worse that will happen is it will
   // wake up for a timer that doesn't exist then go back to waiting.
-  if ((this->timer_queue_ != 0) && (handler != 0))
+  if ((this->timer_queue_ != nullptr) && (handler != nullptr))
     return this->timer_queue_->cancel (handler, dont_call_handle_close);
   else
     return 0;
@@ -2003,7 +2003,7 @@ ACE_Dev_Poll_Reactor::cancel_timer (long timer_id,
 
   // Don't bother waking the poll - the worse that will happen is it will
   // wake up for a timer that doesn't exist then go back to waiting.
-  return (this->timer_queue_ == 0
+  return (this->timer_queue_ == nullptr
           ? 0
           : this->timer_queue_->cancel (timer_id,
                                         arg,
@@ -2088,7 +2088,7 @@ int
 ACE_Dev_Poll_Reactor::purge_pending_notifications (ACE_Event_Handler * eh,
                                                    ACE_Reactor_Mask mask)
 {
-  if (this->notify_handler_ == 0)
+  if (this->notify_handler_ == nullptr)
     return 0;
 
   return this->notify_handler_->purge_pending_notifications (eh, mask);
@@ -2097,7 +2097,7 @@ ACE_Dev_Poll_Reactor::purge_pending_notifications (ACE_Event_Handler * eh,
 ACE_Event_Handler *
 ACE_Dev_Poll_Reactor::find_handler (ACE_HANDLE handle)
 {
-  ACE_MT (ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, grd, this->repo_lock_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, grd, this->repo_lock_, nullptr));
 
   Event_Tuple *info = this->handler_rep_.find (handle);
   if (info)
@@ -2107,7 +2107,7 @@ ACE_Dev_Poll_Reactor::find_handler (ACE_HANDLE handle)
     }
   else
     {
-      return 0;
+      return nullptr;
     }
 }
 
@@ -2122,12 +2122,12 @@ ACE_Dev_Poll_Reactor::handler (ACE_HANDLE handle,
 
   Event_Tuple *info = this->handler_rep_.find (handle);
 
-  if (info != 0
+  if (info != nullptr
       && ACE_BIT_CMP_MASK (info->mask,
                            mask,  // Compare all bits in the mask
                            mask))
     {
-      if (event_handler != 0)
+      if (event_handler != nullptr)
         *event_handler = info->event_handler;
 
       return 0;
@@ -2144,9 +2144,9 @@ ACE_Dev_Poll_Reactor::handler (int signum,
 
   ACE_Event_Handler *handler = this->signal_handler_->handler (signum);
 
-  if (handler == 0)
+  if (handler == nullptr)
     return -1;
-  else if (eh != 0)
+  else if (eh != nullptr)
     *eh = handler;
 
   return 0;
@@ -2183,7 +2183,7 @@ ACE_Dev_Poll_Reactor::wakeup_all_threads ()
 
   // Send a notification, but don't block if there's no one to receive
   // it.
-  this->notify (0,
+  this->notify (nullptr,
                 ACE_Event_Handler::NULL_MASK,
                 (ACE_Time_Value *) &ACE_Time_Value::zero);
 }
@@ -2279,7 +2279,7 @@ ACE_Dev_Poll_Reactor::mask_ops_i (ACE_HANDLE handle,
   ACE_TRACE ("ACE_Dev_Poll_Reactor::mask_ops_i");
 
   Event_Tuple *info = this->handler_rep_.find (handle);
-  if (info == 0)
+  if (info == nullptr)
     return -1;
 
   // Block out all signals until method returns.
@@ -2501,7 +2501,7 @@ ACE_Dev_Poll_Reactor::Token_Guard::acquire_quietly (ACE_Time_Value *max_wait)
       tv += *max_wait;
 
       ACE_MT (result = this->token_.acquire_read (&polite_sleep_hook,
-                                                  0,
+                                                  nullptr,
                                                   &tv));
     }
   else
@@ -2540,7 +2540,7 @@ ACE_Dev_Poll_Reactor::Token_Guard::acquire (ACE_Time_Value *max_wait)
       ACE_Time_Value tv = ACE_OS::gettimeofday ();
       tv += *max_wait;
 
-      ACE_MT (result = this->token_.acquire (0, 0, &tv));
+      ACE_MT (result = this->token_.acquire (nullptr, nullptr, &tv));
     }
   else
     {

--- a/ACE/ace/Dirent_Selector.cpp
+++ b/ACE/ace/Dirent_Selector.cpp
@@ -54,7 +54,7 @@ ACE_Dirent_Selector::close ()
 #else
   ACE_OS::free (this->namelist_);
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  this->namelist_ = 0;
+  this->namelist_ = nullptr;
   return 0;
 }
 

--- a/ACE/ace/Dump.cpp
+++ b/ACE/ace/Dump.cpp
@@ -61,17 +61,17 @@ ACE_ODB::instance ()
 {
   ACE_TRACE ("ACE_ODB::instance");
 
-  if (ACE_ODB::instance_ == 0)
+  if (ACE_ODB::instance_ == nullptr)
     {
       ACE_MT (ACE_Thread_Mutex *lock =
         ACE_Managed_Object<ACE_Thread_Mutex>::get_preallocated_object
           (ACE_Object_Manager::ACE_DUMP_LOCK);
-        ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, *lock, 0));
+        ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, *lock, nullptr));
 
-      if (ACE_ODB::instance_ == 0)
+      if (ACE_ODB::instance_ == nullptr)
         ACE_NEW_RETURN (ACE_ODB::instance_,
                         ACE_ODB,
-                        0);
+                        nullptr);
     }
 
   return ACE_ODB::instance_;
@@ -83,7 +83,7 @@ ACE_ODB::dump_objects ()
   ACE_TRACE ("ACE_ODB::dump_objects");
   for (int i = 0; i < this->current_size_; i++)
     {
-      if (this->object_table_[i].this_ != 0)
+      if (this->object_table_[i].this_ != nullptr)
         // Dump the state of the object.
         this->object_table_[i].dumper_->dump ();
     }
@@ -101,7 +101,7 @@ ACE_ODB::register_object (const ACE_Dumpable *dumper)
 
   for (i = 0; i < this->current_size_; i++)
     {
-      if (this->object_table_[i].this_ == 0)
+      if (this->object_table_[i].this_ == nullptr)
         slot = i;
       else if (this->object_table_[i].this_ == dumper->this_)
         {
@@ -133,11 +133,11 @@ ACE_ODB::remove_object (const void *this_ptr)
 
   if (i < this->current_size_)
     {
-      this->object_table_[i].this_ = 0;
-      this->object_table_[i].dumper_ = 0;
+      this->object_table_[i].this_ = nullptr;
+      this->object_table_[i].dumper_ = nullptr;
     }
 }
 
-ACE_ODB *ACE_ODB::instance_ = 0;
+ACE_ODB *ACE_ODB::instance_ = nullptr;
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Dynamic_Service_Base.cpp
+++ b/ACE/ace/Dynamic_Service_Base.cpp
@@ -39,7 +39,7 @@ ACE_Dynamic_Service_Base::find_i (const ACE_Service_Gestalt* &repo,
                                   bool no_global)
 {
   ACE_TRACE ("ACE_Dynamic_Service_Base::find_i");
-  const ACE_Service_Type *svc_rec = 0;
+  const ACE_Service_Type *svc_rec = nullptr;
 
   ACE_Service_Gestalt* global = ACE_Service_Config::global ();
 
@@ -62,21 +62,21 @@ ACE_Dynamic_Service_Base::instance (const ACE_Service_Gestalt* repo,
 {
   ACE_TRACE ("ACE_Dynamic_Service_Base::instance");
 
-  void *obj = 0;
-  const ACE_Service_Type_Impl *type = 0;
+  void *obj = nullptr;
+  const ACE_Service_Type_Impl *type = nullptr;
 
   const ACE_Service_Gestalt* repo_found = repo;
   const ACE_Service_Type *svc_rec = find_i (repo_found, name, no_global);
-  if (svc_rec != 0)
+  if (svc_rec != nullptr)
     {
       type = svc_rec->type ();
-      if (type != 0)
+      if (type != nullptr)
         obj = type->object ();
     }
 
   if (ACE::debug ())
     {
-      ACE_GUARD_RETURN (ACE_Log_Msg, log_guard, *ACE_Log_Msg::instance (), 0);
+      ACE_GUARD_RETURN (ACE_Log_Msg, log_guard, *ACE_Log_Msg::instance (), nullptr);
 
       if (repo->repo_ != repo_found->repo_)
         {

--- a/ACE/ace/Event_Handler.cpp
+++ b/ACE/ace/Event_Handler.cpp
@@ -231,7 +231,7 @@ ACE_Event_Handler::read_adapter (void *args)
   // cache the reactor pointer and use it here.
   r->notify ();
 
-  return nullptr;
+  return 0;
 }
 
 int

--- a/ACE/ace/Event_Handler.cpp
+++ b/ACE/ace/Event_Handler.cpp
@@ -231,7 +231,7 @@ ACE_Event_Handler::read_adapter (void *args)
   // cache the reactor pointer and use it here.
   r->notify ();
 
-  return 0;
+  return nullptr;
 }
 
 int
@@ -273,7 +273,7 @@ ACE_Event_Handler::remove_stdin_handler (ACE_Reactor *reactor,
 // ---------------------------------------------------------------------
 
 ACE_Event_Handler_var::ACE_Event_Handler_var ()
-  : ptr_ (0)
+  : ptr_ (nullptr)
 {
 }
 
@@ -285,7 +285,7 @@ ACE_Event_Handler_var::ACE_Event_Handler_var (ACE_Event_Handler *p)
 ACE_Event_Handler_var::ACE_Event_Handler_var (const ACE_Event_Handler_var &b)
   : ptr_ (b.ptr_)
 {
-  if (this->ptr_ != 0)
+  if (this->ptr_ != nullptr)
     {
       this->ptr_->add_reference ();
     }
@@ -293,7 +293,7 @@ ACE_Event_Handler_var::ACE_Event_Handler_var (const ACE_Event_Handler_var &b)
 
 ACE_Event_Handler_var::~ACE_Event_Handler_var ()
 {
-  if (this->ptr_ != 0)
+  if (this->ptr_ != nullptr)
     {
       ACE_Errno_Guard eguard (errno);
       this->ptr_->remove_reference ();
@@ -337,7 +337,7 @@ ACE_Event_Handler *
 ACE_Event_Handler_var::release ()
 {
   ACE_Event_Handler * const old = this->ptr_;
-  this->ptr_ = 0;
+  this->ptr_ = nullptr;
   return old;
 }
 
@@ -367,7 +367,7 @@ ACE_Event_Handler_var::operator !=(std::nullptr_t) const
 // ---------------------------------------------------------------------
 
 ACE_Notification_Buffer::ACE_Notification_Buffer ()
-  : eh_ (0),
+  : eh_ (nullptr),
     mask_ (ACE_Event_Handler::NULL_MASK)
 {
   ACE_TRACE ("ACE_Notification_Buffer::ACE_Notification_Buffer");

--- a/ACE/ace/FILE.cpp
+++ b/ACE/ace/FILE.cpp
@@ -108,7 +108,7 @@ ACE_FILE::get_local_addr (ACE_Addr &addr) const
   ACE_FILE_Addr *file_addr =
     dynamic_cast<ACE_FILE_Addr *> (&addr);
 
-  if (file_addr == 0)
+  if (file_addr == nullptr)
     return -1;
   else
     {

--- a/ACE/ace/FILE_Addr.cpp
+++ b/ACE/ace/FILE_Addr.cpp
@@ -49,7 +49,7 @@ ACE_FILE_Addr::set (const ACE_FILE_Addr &sa)
 
 #  endif /* ACE_DEFAULT_TEMP_FILE */
 
-      if (ACE_OS::mktemp (this->filename_) == 0)
+      if (ACE_OS::mktemp (this->filename_) == nullptr)
         return -1;
       this->base_set (AF_FILE,
                       static_cast<int> (ACE_OS::strlen (this->filename_) + 1));

--- a/ACE/ace/FILE_IO.cpp
+++ b/ACE/ace/FILE_IO.cpp
@@ -50,7 +50,7 @@ ACE_FILE_IO::send (size_t n, ...) const
 #else
   va_list argp;
   int total_tuples = ACE_Utils::truncate_cast<int> (n / 2);
-  iovec *iovp = 0;
+  iovec *iovp = nullptr;
 #if defined (ACE_HAS_ALLOCA)
   iovp = (iovec *) alloca (total_tuples * sizeof (iovec));
 #else
@@ -105,7 +105,7 @@ ACE_FILE_IO::recv (size_t n, ...) const
 #else
   va_list argp;
   int total_tuples = ACE_Utils::truncate_cast<int> (n / 2);
-  iovec *iovp = 0;
+  iovec *iovp = nullptr;
 #if defined (ACE_HAS_ALLOCA)
   iovp = (iovec *) alloca (total_tuples * sizeof (iovec));
 #else
@@ -154,7 +154,7 @@ ACE_FILE_IO::recvv (iovec *io_vec)
 {
   ACE_TRACE ("ACE_FILE_IO::recvv");
 
-  io_vec->iov_base = 0;
+  io_vec->iov_base = nullptr;
   ACE_OFF_T const length = ACE_OS::filesize (this->get_handle ());
 
   if (length > 0)

--- a/ACE/ace/Filecache.cpp
+++ b/ACE/ace/Filecache.cpp
@@ -40,24 +40,24 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // static data members
-ACE_Filecache *ACE_Filecache::cvf_ = 0;
+ACE_Filecache *ACE_Filecache::cvf_ = nullptr;
 
 void
 ACE_Filecache_Handle::init ()
 {
-  this->file_ = 0;
+  this->file_ = nullptr;
   this->handle_ = ACE_INVALID_HANDLE;
 }
 
 ACE_Filecache_Handle::ACE_Filecache_Handle ()
-  : file_ (0), handle_ (0)
+  : file_ (nullptr), handle_ (0)
 {
   this->init ();
 }
 
 ACE_Filecache_Handle::ACE_Filecache_Handle (const ACE_TCHAR *filename,
                                             ACE_Filecache_Flag mapit)
-  : file_ (0), handle_ (0)
+  : file_ (nullptr), handle_ (0)
 {
   this->init ();
   // Fetch the file from the Virtual_Filesystem let the
@@ -71,7 +71,7 @@ ACE_Filecache_Handle::ACE_Filecache_Handle (const ACE_TCHAR *filename,
 ACE_Filecache_Handle::ACE_Filecache_Handle (const ACE_TCHAR *filename,
                                             int size,
                                             ACE_Filecache_Flag )
-  : file_ (0), handle_ (0)
+  : file_ (nullptr), handle_ (0)
 {
   this->init ();
 
@@ -101,13 +101,13 @@ ACE_Filecache_Handle::~ACE_Filecache_Handle ()
 void *
 ACE_Filecache_Handle::address () const
 {
-  return this->file_ == 0 ? 0 : this->file_->address ();
+  return this->file_ == nullptr ? nullptr : this->file_->address ();
 }
 
 ACE_HANDLE
 ACE_Filecache_Handle::handle () const
 {
-  if (this->handle_ == ACE_INVALID_HANDLE && this->file_ != 0)
+  if (this->handle_ == ACE_INVALID_HANDLE && this->file_ != nullptr)
     {
       ACE_Filecache_Handle *mutable_this =
         const_cast<ACE_Filecache_Handle *> (this);
@@ -119,7 +119,7 @@ ACE_Filecache_Handle::handle () const
 int
 ACE_Filecache_Handle::error () const
 {
-  if (this->file_ == 0)
+  if (this->file_ == nullptr)
     return -1;
   else
     return this->file_->error ();
@@ -128,7 +128,7 @@ ACE_Filecache_Handle::error () const
 ACE_OFF_T
 ACE_Filecache_Handle::size () const
 {
-  if (this->file_ == 0)
+  if (this->file_ == nullptr)
     return -1;
   else
     return this->file_->size ();
@@ -208,19 +208,19 @@ ACE_Filecache *
 ACE_Filecache::instance ()
 {
   // Double check locking pattern.
-  if (ACE_Filecache::cvf_ == 0)
+  if (ACE_Filecache::cvf_ == nullptr)
     {
       ACE_SYNCH_RW_MUTEX &lock =
         *ACE_Managed_Object<ACE_SYNCH_RW_MUTEX>::get_preallocated_object
           (ACE_Object_Manager::ACE_FILECACHE_LOCK);
-      ACE_GUARD_RETURN (ACE_SYNCH_RW_MUTEX, ace_mon, lock, 0);
+      ACE_GUARD_RETURN (ACE_SYNCH_RW_MUTEX, ace_mon, lock, nullptr);
 
       // @@ James, please check each of the ACE_NEW_RETURN calls to
       // make sure that it is safe to return if allocation fails.
-      if (ACE_Filecache::cvf_ == 0)
+      if (ACE_Filecache::cvf_ == nullptr)
         ACE_NEW_RETURN (ACE_Filecache::cvf_,
                         ACE_Filecache,
-                        0);
+                        nullptr);
     }
 
   return ACE_Filecache::cvf_;
@@ -243,24 +243,24 @@ ACE_Filecache::insert_i (const ACE_TCHAR *filename,
                          ACE_SYNCH_RW_MUTEX &filelock,
                          int mapit)
 {
-  ACE_Filecache_Object *handle = 0;
+  ACE_Filecache_Object *handle = nullptr;
 
   if (this->hash_.find (filename, handle) == -1)
     {
       ACE_NEW_RETURN (handle,
                       ACE_Filecache_Object (filename, filelock, 0, mapit),
-                      0);
+                      nullptr);
 
       //      ACELIB_DEBUG ((LM_DEBUG,  ACE_TEXT ("   (%t) CVF: creating %s\n"), filename));
 
       if (this->hash_.bind (filename, handle) == -1)
         {
           delete handle;
-          handle = 0;
+          handle = nullptr;
         }
     }
   else
-    handle = 0;
+    handle = nullptr;
 
   return handle;
 }
@@ -268,7 +268,7 @@ ACE_Filecache::insert_i (const ACE_TCHAR *filename,
 ACE_Filecache_Object *
 ACE_Filecache::remove_i (const ACE_TCHAR *filename)
 {
-  ACE_Filecache_Object *handle = 0;
+  ACE_Filecache_Object *handle = nullptr;
 
   // Disassociate file from the cache.
   if (this->hash_.unbind (filename, handle) == 0)
@@ -280,11 +280,11 @@ ACE_Filecache::remove_i (const ACE_TCHAR *filename)
       if (handle->lock_.tryacquire_write () == 0)
         {
           delete handle;
-          handle = 0;
+          handle = nullptr;
         }
     }
   else
-    handle = 0;
+    handle = nullptr;
 
   return handle;
 }
@@ -294,7 +294,7 @@ ACE_Filecache::update_i (const ACE_TCHAR *filename,
                          ACE_SYNCH_RW_MUTEX &filelock,
                          int mapit)
 {
-  ACE_Filecache_Object *handle = 0;
+  ACE_Filecache_Object *handle = nullptr;
 
   handle = this->remove_i (filename);
   handle = this->insert_i (filename, filelock, mapit);
@@ -312,7 +312,7 @@ ACE_Filecache::find (const ACE_TCHAR *filename)
 ACE_Filecache_Object *
 ACE_Filecache::remove (const ACE_TCHAR *filename)
 {
-  ACE_Filecache_Object *handle = 0;
+  ACE_Filecache_Object *handle = nullptr;
 
   ACE_OFF_T loc = ACE::hash_pjw (filename) % this->size_;
   ACE_SYNCH_RW_MUTEX &hashlock = this->hash_lock_[loc];
@@ -323,19 +323,19 @@ ACE_Filecache::remove (const ACE_TCHAR *filename)
       ACE_WRITE_GUARD_RETURN (ACE_SYNCH_RW_MUTEX,
                               ace_mon,
                               hashlock,
-                              0);
+                              nullptr);
 
       return this->remove_i (filename);
     }
 
-  return 0;
+  return nullptr;
 }
 
 
 ACE_Filecache_Object *
 ACE_Filecache::fetch (const ACE_TCHAR *filename, int mapit)
 {
-  ACE_Filecache_Object *handle = 0;
+  ACE_Filecache_Object *handle = nullptr;
 
   ACE_OFF_T loc = ACE::hash_pjw (filename) % this->size_;
   ACE_SYNCH_RW_MUTEX &hashlock = this->hash_lock_[loc];
@@ -348,12 +348,12 @@ ACE_Filecache::fetch (const ACE_TCHAR *filename, int mapit)
       ACE_WRITE_GUARD_RETURN (ACE_SYNCH_RW_MUTEX,
                               ace_mon,
                               hashlock,
-                              0);
+                              nullptr);
 
       // Second check in the method call
       handle = this->insert_i (filename, filelock, mapit);
 
-      if (handle == 0)
+      if (handle == nullptr)
         filelock.release ();
     }
   else
@@ -365,12 +365,12 @@ ACE_Filecache::fetch (const ACE_TCHAR *filename, int mapit)
             ACE_WRITE_GUARD_RETURN (ACE_SYNCH_RW_MUTEX,
                                     ace_mon,
                                     hashlock,
-                                    0);
+                                    nullptr);
 
             // Second check in the method call
             handle = this->update_i (filename, filelock, mapit);
 
-            if (handle == 0)
+            if (handle == nullptr)
               filelock.release ();
           }
         }
@@ -383,14 +383,14 @@ ACE_Filecache::fetch (const ACE_TCHAR *filename, int mapit)
 ACE_Filecache_Object *
 ACE_Filecache::create (const ACE_TCHAR *filename, int size)
 {
-  ACE_Filecache_Object *handle = 0;
+  ACE_Filecache_Object *handle = nullptr;
 
   ACE_OFF_T loc = ACE::hash_pjw (filename) % this->size_;
   ACE_SYNCH_RW_MUTEX &filelock = this->file_lock_[loc];
 
   ACE_NEW_RETURN (handle,
                   ACE_Filecache_Object (filename, size, filelock),
-                  0);
+                  nullptr);
   handle->acquire ();
 
   return handle;
@@ -399,13 +399,13 @@ ACE_Filecache::create (const ACE_TCHAR *filename, int size)
 ACE_Filecache_Object *
 ACE_Filecache::finish (ACE_Filecache_Object *&file)
 {
-  if (file == 0)
+  if (file == nullptr)
     return file;
 
   ACE_OFF_T loc = ACE::hash_pjw (file->filename_) % this->size_;
   ACE_SYNCH_RW_MUTEX &hashlock = this->hash_lock_[loc];
 
-  if (file != 0)
+  if (file != nullptr)
     switch (file->action_)
       {
       case ACE_Filecache_Object::ACE_WRITING:
@@ -413,7 +413,7 @@ ACE_Filecache::finish (ACE_Filecache_Object *&file)
           ACE_WRITE_GUARD_RETURN (ACE_SYNCH_RW_MUTEX,
                                   ace_mon,
                                   hashlock,
-                                  0);
+                                  nullptr);
 
           file->release ();
 
@@ -432,7 +432,7 @@ ACE_Filecache::finish (ACE_Filecache_Object *&file)
             if (file->lock_.tryacquire_write () == 0)
               {
                 delete file;
-                file = 0;
+                file = nullptr;
               }
           }
 #endif
@@ -450,7 +450,7 @@ ACE_Filecache::finish (ACE_Filecache_Object *&file)
             if (file->lock_.tryacquire_write () == 0)
               {
                 delete file;
-                file = 0;
+                file = nullptr;
               }
           }
 
@@ -466,14 +466,14 @@ ACE_Filecache_Object::init ()
   this->filename_[0] = '\0';
   this->handle_ = ACE_INVALID_HANDLE;
   this->error_ = ACE_SUCCESS;
-  this->tempname_ = 0;
+  this->tempname_ = nullptr;
   this->size_ = 0;
 
   ACE_OS::memset (&(this->stat_), 0, sizeof (this->stat_));
 }
 
 ACE_Filecache_Object::ACE_Filecache_Object ()
-  : tempname_ (0),
+  : tempname_ (nullptr),
     mmap_ (),
     handle_ (0),
     // stat_ (),
@@ -492,7 +492,7 @@ ACE_Filecache_Object::ACE_Filecache_Object (const ACE_TCHAR *filename,
                                             ACE_SYNCH_RW_MUTEX &lock,
                                             LPSECURITY_ATTRIBUTES sa,
                                             int mapit)
-  : tempname_ (0),
+  : tempname_ (nullptr),
     mmap_ (),
     handle_ (0),
     // stat_ (),
@@ -542,7 +542,7 @@ ACE_Filecache_Object::ACE_Filecache_Object (const ACE_TCHAR *filename,
     {
       // Can we map the file?
       if (this->mmap_.map (this->handle_, static_cast<size_t> (-1),
-                           PROT_READ, ACE_MAP_PRIVATE, 0, 0, this->sa_) != 0)
+                           PROT_READ, ACE_MAP_PRIVATE, nullptr, 0, this->sa_) != 0)
         {
           this->error_i (ACE_Filecache_Object::ACE_MEMMAP_FAILED,
                          ACE_TEXT ("ACE_Filecache_Object::ctor: map"));
@@ -602,7 +602,7 @@ ACE_Filecache_Object::ACE_Filecache_Object (const ACE_TCHAR *filename,
 
   // Can we map?
   if (this->mmap_.map (this->handle_, this->size_, PROT_RDWR, MAP_SHARED,
-                       0, 0, this->sa_) != 0)
+                       nullptr, 0, this->sa_) != 0)
     {
       this->error_i (ACE_Filecache_Object::ACE_MEMMAP_FAILED,
                      ACE_TEXT ("ACE_Filecache_Object::acquire: map"));

--- a/ACE/ace/Framework_Component.cpp
+++ b/ACE/ace/Framework_Component.cpp
@@ -27,7 +27,7 @@ ACE_ALLOC_HOOK_DEFINE(ACE_Framework_Repository)
 sig_atomic_t ACE_Framework_Repository::shutting_down_ = 0;
 
 // Pointer to the Singleton instance.
-ACE_Framework_Repository *ACE_Framework_Repository::repository_ = 0;
+ACE_Framework_Repository *ACE_Framework_Repository::repository_ = nullptr;
 
 ACE_Framework_Repository::~ACE_Framework_Repository ()
 {
@@ -40,7 +40,7 @@ ACE_Framework_Repository::open (int size)
 {
   ACE_TRACE ("ACE_Framework_Repository::open");
 
-  ACE_Framework_Component **temp = 0;
+  ACE_Framework_Component **temp = nullptr;
 
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (temp,
@@ -65,7 +65,7 @@ ACE_Framework_Repository::close ()
 
   this->shutting_down_ = 1;
 
-  if (this->component_vector_ != 0)
+  if (this->component_vector_ != nullptr)
     {
       // Delete components in reverse order.
       for (int i = this->current_size_ - 1; i >= 0; i--)
@@ -75,7 +75,7 @@ ACE_Framework_Repository::close ()
               const_cast<ACE_Framework_Component *> (
                 this->component_vector_[i]);
 
-            this->component_vector_[i] = 0;
+            this->component_vector_[i] = nullptr;
             delete s;
           }
 
@@ -84,7 +84,7 @@ ACE_Framework_Repository::close ()
 #else
       delete [] this->component_vector_;
 #endif /* ACE_HAS_ALLOC_HOOKS */
-      this->component_vector_ = 0;
+      this->component_vector_ = nullptr;
       this->current_size_ = 0;
     }
 
@@ -126,7 +126,7 @@ ACE_Framework_Repository::close_singleton ()
                      *ACE_Static_Object_Lock::instance ()));
 
   delete ACE_Framework_Repository::repository_;
-  ACE_Framework_Repository::repository_ = 0;
+  ACE_Framework_Repository::repository_ = nullptr;
 }
 
 int
@@ -168,7 +168,7 @@ ACE_Framework_Repository::remove_component (const ACE_TCHAR *name)
         ACE_OS::strcmp (this->component_vector_[i]->name_, name) == 0)
       {
         delete this->component_vector_[i];
-        this->component_vector_[i] = 0;
+        this->component_vector_[i] = nullptr;
         this->compact ();
         return 0;
       }
@@ -206,7 +206,7 @@ ACE_Framework_Repository::remove_dll_components_i (const ACE_TCHAR *dll_name)
                         ACE_TEXT ("component \"%s\"\n"),
                         dll_name, this->component_vector_[i]->name_));
         delete this->component_vector_[i];
-        this->component_vector_[i] = 0;
+        this->component_vector_[i] = nullptr;
         ++retval;
       }
 
@@ -232,7 +232,7 @@ ACE_Framework_Repository::compact ()
       // Find hole
       for (i = 0; i < this->current_size_; ++i)
         {
-          if (this->component_vector_[i] == 0)
+          if (this->component_vector_[i] == nullptr)
             {
               if (start_hole == this->current_size_)
                 {

--- a/ACE/ace/Get_Opt.cpp
+++ b/ACE/ace/Get_Opt.cpp
@@ -99,17 +99,17 @@ ACE_Get_Opt::ACE_Get_Opt (int argc,
     argv_ (argv),
     optind (skip),
     opterr (report_errors),
-    optarg (0),
-    optstring_ (0),
+    optarg (nullptr),
+    optstring_ (nullptr),
     long_only_ (long_only),
     has_colon_ (0),
-    last_option_ (0),
-    nextchar_ (0),
+    last_option_ (nullptr),
+    nextchar_ (nullptr),
     optopt_ (0),
     ordering_ (ordering),
     nonopt_start_ (optind),
     nonopt_end_ (optind),
-    long_option_ (0)
+    long_option_ (nullptr)
 #endif
 {
   ACE_TRACE ("ACE_Get_Opt::ACE_Get_Opt");
@@ -124,7 +124,7 @@ ACE_Get_Opt::ACE_Get_Opt (int argc,
 #else
   const char *env_check = "POSIXLY_CORRECT";
 #endif
-  if (ACE_OS::getenv (env_check) != 0)
+  if (ACE_OS::getenv (env_check) != nullptr)
     this->ordering_ = REQUIRE_ORDER;
 
   // Now, check to see if any or the following were passed at
@@ -162,7 +162,7 @@ ACE_Get_Opt::~ACE_Get_Opt ()
 
   size_t i = 0;
   size_t size = this->long_opts_.size ();
-  ACE_Get_Opt_Long_Option *option = 0;
+  ACE_Get_Opt_Long_Option *option = nullptr;
   for (i = 0; i < size; ++i)
     {
       int retval = this->long_opts_.get (option, i);
@@ -175,7 +175,7 @@ ACE_Get_Opt::~ACE_Get_Opt ()
       if (option)
         {
           delete option;
-          option = 0;
+          option = nullptr;
         }
     }
   delete this->optstring_;
@@ -195,7 +195,7 @@ ACE_Get_Opt::nextchar_i ()
   if (this->optind >= this->argc_)
     {
       // We're done...
-      this->nextchar_ = 0;
+      this->nextchar_ = nullptr;
       return EOF;
     }
   else if (*(this->nextchar_ = this->argv_[this->optind]) != '-'
@@ -210,7 +210,7 @@ ACE_Get_Opt::nextchar_i ()
 
       // It must be RETURN_IN_ORDER...
       this->optarg = this->argv_[this->optind++];
-      this->nextchar_ = 0;
+      this->nextchar_ = nullptr;
       return 1;
     }
   else if (this->nextchar_[1] != 0
@@ -219,7 +219,7 @@ ACE_Get_Opt::nextchar_i ()
     {
       // Found "--" so we're done...
       ++this->optind;
-      this->nextchar_ = 0;
+      this->nextchar_ = nullptr;
       return EOF;
     }
 
@@ -239,7 +239,7 @@ ACE_Get_Opt::long_option_i ()
   ACE_TCHAR *s = this->nextchar_;
   int hits = 0;
   int exact = 0;
-  ACE_Get_Opt_Long_Option *pfound = 0;
+  ACE_Get_Opt_Long_Option *pfound = nullptr;
   int indfound = 0;
 
   // Advance to the end of the long option name so we can use
@@ -281,12 +281,12 @@ ACE_Get_Opt::long_option_i ()
         ACELIB_ERROR ((LM_ERROR,
                     ACE_TEXT ("%s: option `%s' is ambiguous\n"),
                     this->argv_[0], this->argv_[this->optind]));
-      this->nextchar_ = 0;
+      this->nextchar_ = nullptr;
       this->optind++;
       return '?';
     }
 
-  if (pfound != 0)
+  if (pfound != nullptr)
     {
       // Okay, we found a good one (either a single hit or an exact match).
       option_index = indfound;
@@ -328,12 +328,12 @@ ACE_Get_Opt::long_option_i ()
                             ACE_TEXT ("%s: long option '--%s' requires ")
                             ACE_TEXT ("an argument\n"),
                             this->argv_[0], pfound->name_));
-              this->nextchar_ = 0;
+              this->nextchar_ = nullptr;
               this->optopt_ = pfound->val_;   // Remember matching short equiv
               return this->has_colon_ ? ':' : '?';
             }
         }
-      this->nextchar_ = 0;
+      this->nextchar_ = nullptr;
       this->long_option_ = pfound;
       // Since val_ has to be either a valid short option or 0, this works
       // great.  If the user really wants to know if a long option was passed.
@@ -351,7 +351,7 @@ ACE_Get_Opt::long_option_i ()
         ACELIB_ERROR ((LM_ERROR,
                     ACE_TEXT ("%s: illegal long option '--%s'\n"),
                     this->argv_[0], this->nextchar_));
-      this->nextchar_ = 0;
+      this->nextchar_ = nullptr;
       this->optind++;
       return '?';
     }
@@ -368,7 +368,7 @@ ACE_Get_Opt::short_option_i ()
   // Set last_option_ to opt
   this->last_option (opt);
 
-  ACE_TCHAR *oli = 0;
+  ACE_TCHAR *oli = nullptr;
   oli =
     const_cast<ACE_TCHAR*> (ACE_OS::strchr (this->optstring_->c_str (), opt));
 
@@ -376,7 +376,7 @@ ACE_Get_Opt::short_option_i ()
   if (*this->nextchar_ == '\0')
     ++this->optind;
 
-  if (oli == 0 || opt == ':')
+  if (oli == nullptr || opt == ':')
     {
       if (this->opterr)
         ACELIB_ERROR ((LM_ERROR,
@@ -404,8 +404,8 @@ ACE_Get_Opt::short_option_i ()
               this->optind++;
             }
           else
-            this->optarg = 0;
-          this->nextchar_ = 0;
+            this->optarg = nullptr;
+          this->nextchar_ = nullptr;
         }
       else
         {
@@ -429,7 +429,7 @@ ACE_Get_Opt::short_option_i ()
           else
             // Use the next argv-element as the argument.
             this->optarg = this->argv_[this->optind++];
-          this->nextchar_ = 0;
+          this->nextchar_ = nullptr;
         }
     }
   return opt;
@@ -441,10 +441,10 @@ ACE_Get_Opt::operator () ()
   ACE_TRACE ("ACE_Get_Opt_Long::operator");
 
   // First of all, make sure we reinitialize any pointers..
-  this->optarg = 0;
-  this->long_option_ = 0;
+  this->optarg = nullptr;
+  this->long_option_ = nullptr;
 
-  if (this->argv_ == 0)
+  if (this->argv_ == nullptr)
     {
       // It can happen, e.g., on VxWorks.
       this->optind = 0;
@@ -453,7 +453,7 @@ ACE_Get_Opt::operator () ()
 
   // We check this because we can string short options together if the
   // preceding one doesn't take an argument.
-  if (this->nextchar_ == 0 || *this->nextchar_ == '\0')
+  if (this->nextchar_ == nullptr || *this->nextchar_ == '\0')
     {
       int retval = this->nextchar_i ();
       if (retval != 0)
@@ -491,10 +491,10 @@ ACE_Get_Opt::long_option (const ACE_TCHAR *name,
     {
       // If the short_option already exists, make sure it matches, otherwise
       // add it.
-      ACE_TCHAR *s = 0;
+      ACE_TCHAR *s = nullptr;
       if ((s = const_cast<ACE_TCHAR*> (
                  ACE_OS::strchr (this->optstring_->c_str (),
-                                 short_option))) != 0)
+                                 short_option))) != nullptr)
         {
           // Short option exists, so verify the argument options
           if (s[1] == ':')
@@ -574,7 +574,7 @@ ACE_Get_Opt::long_option () const
   ACE_TRACE ("ACE_Get_Opt::long_option ()");
   if (this->long_option_)
     return this->long_option_->name_;
-  return 0;
+  return nullptr;
 }
 
 const ACE_TCHAR*
@@ -636,7 +636,7 @@ ACE_Get_Opt::permute_args ()
   u_long cyclelen, i, j, ncycle, nnonopts, nopts;
   u_long opt_end = this->optind;
   int cstart, pos = 0;
-  ACE_TCHAR *swap = 0;
+  ACE_TCHAR *swap = nullptr;
 
   nnonopts = this->nonopt_end_ - this->nonopt_start_;
   nopts = opt_end - this->nonopt_end_;

--- a/ACE/ace/Handle_Ops.cpp
+++ b/ACE/ace/Handle_Ops.cpp
@@ -16,7 +16,7 @@ ACE::handle_timed_open (ACE_Time_Value *timeout,
 {
   ACE_TRACE ("ACE::handle_timed_open");
 
-  if (timeout != 0)
+  if (timeout != nullptr)
     {
 #if !defined (ACE_WIN32)
       // On Win32, ACE_NONBLOCK gets recognized as O_WRONLY so we

--- a/ACE/ace/Hash_Map_Manager_T.cpp
+++ b/ACE/ace/Hash_Map_Manager_T.cpp
@@ -111,7 +111,7 @@ template <class EXT_ID, class INT_ID, class HASH_KEY, class COMPARE_KEYS, class 
 ACE_Hash_Map_Manager_Ex<EXT_ID, INT_ID, HASH_KEY, COMPARE_KEYS, ACE_LOCK>::create_buckets (size_t size)
 {
   size_t bytes = size * sizeof (ACE_Hash_Map_Entry<EXT_ID, INT_ID>);
-  void *ptr = 0;
+  void *ptr = nullptr;
 
   ACE_ALLOCATOR_RETURN (ptr,
                         this->table_allocator_->malloc (bytes),
@@ -141,12 +141,12 @@ ACE_Hash_Map_Manager_Ex<EXT_ID, INT_ID, HASH_KEY, COMPARE_KEYS, ACE_LOCK>::open 
   // memory before allocating new one.
   this->close_i ();
 
-  if (table_alloc == 0)
+  if (table_alloc == nullptr)
     table_alloc = ACE_Allocator::instance ();
 
   this->table_allocator_ = table_alloc;
 
-  if (entry_alloc == 0)
+  if (entry_alloc == nullptr)
     entry_alloc = table_alloc;
 
   this->entry_allocator_ = entry_alloc;
@@ -233,7 +233,7 @@ ACE_Hash_Map_Manager_Ex<EXT_ID, INT_ID, HASH_KEY, COMPARE_KEYS, ACE_LOCK>::bind_
   size_t loc = 0;
   if (this->shared_find (ext_id, entry, loc) == -1)
     {
-      void *ptr = 0;
+      void *ptr = nullptr;
       // Not found.
       ACE_ALLOCATOR_RETURN (ptr,
                             this->entry_allocator_->malloc (sizeof (ACE_Hash_Map_Entry<EXT_ID, INT_ID>)),
@@ -261,7 +261,7 @@ ACE_Hash_Map_Manager_Ex<EXT_ID, INT_ID, HASH_KEY, COMPARE_KEYS, ACE_LOCK>::trybi
   if (this->shared_find (ext_id, entry, loc) == -1)
     {
       // Not found.
-      void *ptr = 0;
+      void *ptr = nullptr;
       ACE_ALLOCATOR_RETURN (ptr,
                             this->entry_allocator_->malloc (sizeof (ACE_Hash_Map_Entry<EXT_ID, INT_ID>)),
                             -1);

--- a/ACE/ace/Hash_Map_Manager_T.h
+++ b/ACE/ace/Hash_Map_Manager_T.h
@@ -185,8 +185,8 @@ public:
    *        If @a entry_alloc is 0 it defaults to the same allocator as
    *        @a table_alloc.
    */
-  ACE_Hash_Map_Manager_Ex (ACE_Allocator *table_alloc = 0,
-                           ACE_Allocator *entry_alloc = 0);
+  ACE_Hash_Map_Manager_Ex (ACE_Allocator *table_alloc = nullptr,
+                           ACE_Allocator *entry_alloc = nullptr);
 
   /**
    * Initialize an ACE_Hash_Map_Manager_Ex with @a size elements.
@@ -201,8 +201,8 @@ public:
    *        @a table_alloc.
    */
   ACE_Hash_Map_Manager_Ex (size_t size,
-                           ACE_Allocator *table_alloc = 0,
-                           ACE_Allocator *entry_alloc = 0);
+                           ACE_Allocator *table_alloc = nullptr,
+                           ACE_Allocator *entry_alloc = nullptr);
 
   /**
    * Initialize an ACE_Hash_Map_Manager_Ex with @a size elements.
@@ -218,8 +218,8 @@ public:
    */
 
   int open (size_t size = ACE_DEFAULT_MAP_SIZE,
-            ACE_Allocator *table_alloc = 0,
-            ACE_Allocator *entry_alloc = 0);
+            ACE_Allocator *table_alloc = nullptr,
+            ACE_Allocator *entry_alloc = nullptr);
 
   /// Close down the ACE_Hash_Map_Manager_Ex and release dynamically allocated
   /// resources.

--- a/ACE/ace/Hash_Multi_Map_Manager_T.cpp
+++ b/ACE/ace/Hash_Multi_Map_Manager_T.cpp
@@ -122,12 +122,12 @@ ACE_Hash_Multi_Map_Manager<EXT_ID, INT_ID, HASH_KEY, COMPARE_KEYS, ACE_LOCK>::op
   // memory before allocating new one.
   this->close_i ();
 
-  if (table_alloc == 0)
+  if (table_alloc == nullptr)
     table_alloc = ACE_Allocator::instance ();
 
   this->table_allocator_ = table_alloc;
 
-  if (entry_alloc == 0)
+  if (entry_alloc == nullptr)
     entry_alloc = table_alloc;
 
   this->entry_allocator_ = entry_alloc;

--- a/ACE/ace/Hash_Multi_Map_Manager_T.h
+++ b/ACE/ace/Hash_Multi_Map_Manager_T.h
@@ -179,8 +179,8 @@ public:
    * If @a entry_alloc is 0 then it defaults to the same allocator as
    * @a table_alloc.
    */
-  ACE_Hash_Multi_Map_Manager (ACE_Allocator *table_alloc = 0,
-                              ACE_Allocator *entry_alloc = 0);
+  ACE_Hash_Multi_Map_Manager (ACE_Allocator *table_alloc = nullptr,
+                              ACE_Allocator *entry_alloc = nullptr);
 
   /**
    * Initialize a @c Hash_Multi_Map_Manager with @a size elements.
@@ -197,8 +197,8 @@ public:
    * @a table_alloc.
    */
   ACE_Hash_Multi_Map_Manager (size_t size,
-                              ACE_Allocator *table_alloc = 0,
-                              ACE_Allocator *entry_alloc = 0);
+                              ACE_Allocator *table_alloc = nullptr,
+                              ACE_Allocator *entry_alloc = nullptr);
 
   /**
    * Initialize a @c Hash_Multi_Map_Manager with @a size elements.
@@ -217,8 +217,8 @@ public:
    */
 
   int open (size_t size = ACE_DEFAULT_MAP_SIZE,
-            ACE_Allocator *table_alloc = 0,
-            ACE_Allocator *entry_alloc = 0);
+            ACE_Allocator *table_alloc = nullptr,
+            ACE_Allocator *entry_alloc = nullptr);
 
   /// Close down a Hash_Multi_Map_Manager and release dynamically allocated
   /// resources.

--- a/ACE/ace/High_Res_Timer.cpp
+++ b/ACE/ace/High_Res_Timer.cpp
@@ -87,7 +87,7 @@ ACE_High_Res_Timer::get_cpuinfo ()
   FILE *cpuinfo = ACE_OS::fopen (ACE_TEXT ("/proc/cpuinfo"),
                                  ACE_TEXT ("r"));
 
-  if (cpuinfo != 0)
+  if (cpuinfo != nullptr)
     {
       char buf[128];
 
@@ -486,10 +486,10 @@ ACE_High_Res_Timer::print_total (const ACE_TCHAR *str,
 int
 ACE_High_Res_Timer::get_env_global_scale_factor (const ACE_TCHAR *env)
 {
-  if (env != 0)
+  if (env != nullptr)
     {
       const char *env_value = ACE_OS::getenv (ACE_TEXT_ALWAYS_CHAR (env));
-      if (env_value != 0)
+      if (env_value != nullptr)
         {
           int const value = ACE_OS::atoi (env_value);
           if (value > 0)

--- a/ACE/ace/INET_Addr.cpp
+++ b/ACE/ace/INET_Addr.cpp
@@ -39,7 +39,7 @@ ACE_INET_Addr::addr_to_string (ACE_TCHAR s[],
   if (ipaddr_format == 0)
     result = (this->get_host_name (hoststr, MAXHOSTNAMELEN+1) == 0);
   else
-    result = (this->get_host_addr (hoststr, MAXHOSTNAMELEN+1) != 0);
+    result = (this->get_host_addr (hoststr, MAXHOSTNAMELEN+1) != nullptr);
 
   if (!result)
     return -1;
@@ -210,8 +210,8 @@ ACE_INET_Addr::string_to_addr (const char s[], int address_family)
 {
   ACE_TRACE ("ACE_INET_Addr::string_to_addr");
   int result;
-  char *ip_buf = 0;
-  char *ip_addr = 0;
+  char *ip_buf = nullptr;
+  char *ip_addr = nullptr;
 
   // Need to make a duplicate since we'll be overwriting the string.
   ACE_ALLOCATOR_RETURN (ip_buf,
@@ -240,9 +240,9 @@ ACE_INET_Addr::string_to_addr (const char s[], int address_family)
     }
 #endif /* ACE_HAS_IPV6 */
 
-  if (port_p == 0) // Assume it's a port number.
+  if (port_p == nullptr) // Assume it's a port number.
     {
-      char *endp = 0;
+      char *endp = nullptr;
       long const port = ACE_OS::strtol (ip_addr, &endp, 10);
 
       if (*endp == '\0')    // strtol scanned the entire string - all digits
@@ -259,7 +259,7 @@ ACE_INET_Addr::string_to_addr (const char s[], int address_family)
     {
       *port_p = '\0'; ++port_p; // skip over ':'
 
-      char *endp = 0;
+      char *endp = nullptr;
       long port = ACE_OS::strtol (port_p, &endp, 10);
 
       if (*endp == '\0')    // strtol scanned the entire string - all digits
@@ -344,7 +344,7 @@ ACE_INET_Addr::set (u_short port_number,
   ACE_TRACE ("ACE_INET_Addr::set");
 
   // Yow, someone gave us a NULL host_name!
-  if (host_name == 0)
+  if (host_name == nullptr)
     {
       errno = EINVAL;
       return -1;
@@ -415,8 +415,8 @@ ACE_INET_Addr::set (u_short port_number,
   // searching this->inet_addrs_ which would slow things down.
   hints.ai_socktype = SOCK_STREAM;
 
-  addrinfo *res = 0;
-  const int error = ACE_OS::getaddrinfo (host_name, 0, &hints, &res);
+  addrinfo *res = nullptr;
+  const int error = ACE_OS::getaddrinfo (host_name, nullptr, &hints, &res);
 
   if (error)
     {
@@ -479,7 +479,7 @@ static int get_port_number_from_name (const char port_name[],
                                          protocol,
                                          &sentry,
                                          buf);
-  if (sp != 0)
+  if (sp != nullptr)
     port_number = sp->s_port;
 #endif /* ACE_LACKS_GETSERVBYNAME */
 
@@ -550,7 +550,7 @@ ACE_INET_Addr::ACE_INET_Addr (u_short port_number,
                  address_family) == -1)
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("ACE_INET_Addr::ACE_INET_Addr: %p\n"),
-                ACE_TEXT_CHAR_TO_TCHAR ((host_name == 0) ?
+                ACE_TEXT_CHAR_TO_TCHAR ((host_name == nullptr) ?
                                         "<unknown>" : host_name)));
 }
 
@@ -568,7 +568,7 @@ ACE_INET_Addr::ACE_INET_Addr (u_short port_number,
                  address_family) == -1)
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("ACE_INET_Addr::ACE_INET_Addr: %p\n"),
-                ACE_TEXT_WCHAR_TO_TCHAR ((host_name == 0) ?
+                ACE_TEXT_WCHAR_TO_TCHAR ((host_name == nullptr) ?
                                          ACE_TEXT_WIDE ("<unknown>") :
                                          host_name)));
 }
@@ -868,7 +868,7 @@ ACE_INET_Addr::get_host_name_i (char hostname[], size_t len) const
   const int res = ACE_OS::getnameinfo ((const sockaddr *) this->get_addr (),
                                        addr_size, hostname,
                                        static_cast<ACE_SOCKET_LEN> (len),
-                                       0, 0, 0);
+                                       nullptr, 0, 0);
   return (res == 0) ? 0 : -1;
 }
 

--- a/ACE/ace/INET_Addr.cpp
+++ b/ACE/ace/INET_Addr.cpp
@@ -449,7 +449,7 @@ static int get_port_number_from_name (const char port_name[],
                                       const char protocol[])
 {
   // Maybe port_name is directly a port number?
-  char *endp = 0;
+  char *endp = nullptr;
   long port_number = ACE_OS::strtol (port_name, &endp, 10);
 
   if (*endp == '\0')

--- a/ACE/ace/LSOCK.cpp
+++ b/ACE/ace/LSOCK.cpp
@@ -49,7 +49,7 @@ ACE_LSOCK::send_handle (const ACE_HANDLE handle) const
   iov.iov_len = sizeof a;
   send_msg.msg_iov = &iov;
   send_msg.msg_iovlen = 1;
-  send_msg.msg_name = 0;
+  send_msg.msg_name = nullptr;
   send_msg.msg_namelen = 0;
 
 #if defined (ACE_LACKS_SENDMSG)
@@ -89,7 +89,7 @@ ACE_LSOCK::recv_handle (ACE_HANDLE &handle, char *pbuf, ssize_t *len) const
   char cmsgbuf[ACE_BSD_CONTROL_MSG_LEN];
 #endif /* ACE_HAS_4_4BSD_SENDMSG_RECVMSG */
 
-  if (pbuf != 0 && len != 0)
+  if (pbuf != nullptr && len != nullptr)
     {
       iov.iov_base = pbuf;
       iov.iov_len  = *len;
@@ -102,7 +102,7 @@ ACE_LSOCK::recv_handle (ACE_HANDLE &handle, char *pbuf, ssize_t *len) const
 
   recv_msg.msg_iov = &iov;
   recv_msg.msg_iovlen = 1;
-  recv_msg.msg_name = 0;
+  recv_msg.msg_name = nullptr;
   recv_msg.msg_namelen = 0;
 
 #ifndef ACE_LACKS_SENDMSG
@@ -176,7 +176,7 @@ ACE_LSOCK::recv_handle (ACE_HANDLE &handle, char *pbuf, ssize_t *len) const
         }
       else
         {
-          if (len != 0)
+          if (len != nullptr)
             *len = nbytes;
           return 0;
         }

--- a/ACE/ace/LSOCK_Acceptor.cpp
+++ b/ACE/ace/LSOCK_Acceptor.cpp
@@ -94,10 +94,10 @@ ACE_LSOCK_Acceptor::accept (ACE_LSOCK_Stream &new_stream,
     return -1;
   else
     {
-      sockaddr *addr = 0;
+      sockaddr *addr = nullptr;
       int len = 0;
 
-      if (remote_addr != 0)
+      if (remote_addr != nullptr)
         {
           len = remote_addr->get_size ();
           addr = (sockaddr *) remote_addr->get_addr ();
@@ -110,12 +110,12 @@ ACE_LSOCK_Acceptor::accept (ACE_LSOCK_Stream &new_stream,
       while (new_stream.get_handle () == ACE_INVALID_HANDLE
              && restart != 0
              && errno == EINTR
-             && timeout == 0);
+             && timeout == nullptr);
 
       // Reset the size of the addr, which is only necessary for UNIX
       // domain sockets.
       if (new_stream.get_handle () != ACE_INVALID_HANDLE
-          && remote_addr != 0)
+          && remote_addr != nullptr)
         remote_addr->set_size (len);
     }
 

--- a/ACE/ace/LSOCK_Stream.cpp
+++ b/ACE/ace/LSOCK_Stream.cpp
@@ -25,7 +25,7 @@ ACE_LSOCK_Stream::get_local_addr (ACE_Addr &addr) const
   ACE_UNIX_Addr *rhs_unix_addr = dynamic_cast<ACE_UNIX_Addr *> (&addr);
   ACE_UNIX_Addr lhs_unix_addr;
 
-  if (rhs_unix_addr == 0)
+  if (rhs_unix_addr == nullptr)
     return -1;
   else if (ACE_SOCK::get_local_addr (lhs_unix_addr) == -1)
     return -1;
@@ -74,7 +74,7 @@ ACE_LSOCK_Stream::send_msg (const iovec iov[],
 
   send_msg.msg_iov = const_cast <iovec *> (iov);
   send_msg.msg_iovlen = n;
-  send_msg.msg_name = 0;
+  send_msg.msg_name = nullptr;
   send_msg.msg_namelen = 0;
 
 #if defined (ACE_LACKS_SENDMSG)
@@ -115,7 +115,7 @@ ACE_LSOCK_Stream::recv_msg (iovec iov[],
 
   recv_msg.msg_iov = (iovec *) iov;
   recv_msg.msg_iovlen = n;
-  recv_msg.msg_name = 0;
+  recv_msg.msg_name = nullptr;
   recv_msg.msg_namelen = 0;
 
 #if defined (ACE_LACKS_SENDMSG)

--- a/ACE/ace/Lib_Find.cpp
+++ b/ACE/ace/Lib_Find.cpp
@@ -66,7 +66,7 @@ ACE::ldfind (const ACE_TCHAR* filename,
   separator_ptr = ACE_OS::strrchr (tempcopy, '/');
 
   // This is a relative path.
-  if (separator_ptr == 0)
+  if (separator_ptr == nullptr)
     {
       searchpathname[0] = '\0';
       ACE_OS::strcpy (searchfilename, tempcopy);
@@ -86,7 +86,7 @@ ACE::ldfind (const ACE_TCHAR* filename,
 
   const ACE_TCHAR *dll_suffix = ACE_DLL_SUFFIX;
 
-  if (s != 0)
+  if (s != nullptr)
     {
       // If we have a dot, we have a suffix
       has_suffix = true;
@@ -208,7 +208,7 @@ ACE::ldfind (const ACE_TCHAR* filename,
           else if (pathlen > 0)
             return 0;
 #else
-          ACE_TCHAR *ld_path = 0;
+          ACE_TCHAR *ld_path = nullptr;
 #  if defined ACE_DEFAULT_LD_SEARCH_PATH
           ld_path = const_cast<ACE_TCHAR*> (ACE_DEFAULT_LD_SEARCH_PATH);
 #  else
@@ -223,8 +223,8 @@ ACE::ldfind (const ACE_TCHAR* filename,
 #    endif /* ACE_WIN32 || !ACE_USES_WCHAR */
 #  endif /* ACE_DEFAULT_LD_SEARCH_PATH */
 
-          if (ld_path != 0
-              && (ld_path = ACE_OS::strdup (ld_path)) != 0)
+          if (ld_path != nullptr
+              && (ld_path = ACE_OS::strdup (ld_path)) != nullptr)
             {
               // strtok has the strange behavior of not separating the
               // string ":/foo:/bar" into THREE tokens.  One would expect
@@ -241,7 +241,7 @@ ACE::ldfind (const ACE_TCHAR* filename,
 
               // Look at each dynamic lib directory in the search path.
 
-              ACE_TCHAR *nextholder = 0;
+              ACE_TCHAR *nextholder = nullptr;
               const ACE_TCHAR *path_entry =
                 ACE::strsplit_r (ld_path,
                                  ACE_LD_SEARCH_PATH_SEPARATOR_STR,
@@ -251,7 +251,7 @@ ACE::ldfind (const ACE_TCHAR* filename,
               for (;;)
                 {
                   // Check if at end of search path.
-                  if (path_entry == 0)
+                  if (path_entry == nullptr)
                     {
                       errno = ENOENT;
                       result = -1;
@@ -298,7 +298,7 @@ ACE::ldfind (const ACE_TCHAR* filename,
 
                   // Fetch the next item in the path
                   path_entry =
-                    ACE::strsplit_r (0,
+                    ACE::strsplit_r (nullptr,
                                      ACE_LD_SEARCH_PATH_SEPARATOR_STR,
                                      nextholder);
                 }
@@ -333,7 +333,7 @@ ACE::ldopen (const ACE_TCHAR *filename,
   if (ACE::ldfind (filename,
                    buf,
                    sizeof (buf) /sizeof (ACE_TCHAR)) == -1)
-    return 0;
+    return nullptr;
   else
     return ACE_OS::fopen (buf, type);
 }
@@ -371,7 +371,7 @@ ACE::ldname (const ACE_TCHAR *entry_point)
 #else
   ACE_NEW_RETURN (new_name,
                   ACE_TCHAR[size],
-                  0);
+                  nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
   ACE_OS::strcpy (new_name, entry_point);
@@ -402,7 +402,7 @@ ACE::get_temp_dir (ACE_TCHAR *buffer, size_t buffer_len)
   // variable is defined to be.  If it doesn't exist, just use /tmp
   const char *tmpdir = ACE_OS::getenv ("TMPDIR");
 
-  if (tmpdir == 0)
+  if (tmpdir == nullptr)
     {
 #if defined (ACE_DEFAULT_TEMP_DIR)
       tmpdir = ACE_DEFAULT_TEMP_DIR;
@@ -489,16 +489,16 @@ ACE::strsplit_r (char *str,
                  const char *token,
                  char *&next_start)
 {
-  char *result = 0;
+  char *result = nullptr;
 
-  if (str != 0)
+  if (str != nullptr)
     next_start = str;
 
-  if (next_start != 0)
+  if (next_start != nullptr)
     {
       char *tok_loc = ACE_OS::strstr (next_start, token);
 
-      if (tok_loc != 0)
+      if (tok_loc != nullptr)
         {
           // Return the beginning of the string.
           result = next_start;
@@ -510,7 +510,7 @@ ACE::strsplit_r (char *str,
       else
         {
           result = next_start;
-          next_start = (char *) 0;
+          next_start = (char *) nullptr;
         }
     }
 
@@ -523,16 +523,16 @@ ACE::strsplit_r (wchar_t *str,
                  const wchar_t *token,
                  wchar_t *&next_start)
 {
-  wchar_t *result = 0;
+  wchar_t *result = nullptr;
 
-  if (str != 0)
+  if (str != nullptr)
     next_start = str;
 
-  if (next_start != 0)
+  if (next_start != nullptr)
     {
       wchar_t *tok_loc = ACE_OS::strstr (next_start, token);
 
-      if (tok_loc != 0)
+      if (tok_loc != nullptr)
         {
           // Return the beginning of the string.
           result = next_start;
@@ -544,7 +544,7 @@ ACE::strsplit_r (wchar_t *str,
       else
         {
           result = next_start;
-          next_start = (wchar_t *) 0;
+          next_start = (wchar_t *) nullptr;
         }
     }
 

--- a/ACE/ace/Local_Memory_Pool.cpp
+++ b/ACE/ace/Local_Memory_Pool.cpp
@@ -49,7 +49,7 @@ ACE_Local_Memory_Pool::acquire (size_t nbytes,
   ACE_TRACE ("ACE_Local_Memory_Pool::acquire");
   rounded_bytes = this->round_up (nbytes);
 
-  char *temp = 0;
+  char *temp = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (temp,
                         static_cast<char*>(ACE_Allocator::instance()->malloc(sizeof(char) * rounded_bytes)),
@@ -57,7 +57,7 @@ ACE_Local_Memory_Pool::acquire (size_t nbytes,
 #else
   ACE_NEW_RETURN (temp,
                   char[rounded_bytes],
-                  0);
+                  nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
   std::unique_ptr<char[]> cp (temp);
@@ -136,7 +136,7 @@ ACE_Local_Memory_Pool::remap (void *)
 void *
 ACE_Local_Memory_Pool::base_addr () const
 {
-  return 0;
+  return nullptr;
 }
 
 // Let the underlying new operator figure out the alignment...

--- a/ACE/ace/Local_Name_Space.cpp
+++ b/ACE/ace/Local_Name_Space.cpp
@@ -49,7 +49,7 @@ ACE_NS_String::char_rep () const
 
 ACE_NS_String::ACE_NS_String ()
   : len_ (0),
-    rep_ (0),
+    rep_ (nullptr),
     delete_rep_ (false)
 {
   ACE_TRACE ("ACE_NS_String::ACE_NS_String");

--- a/ACE/ace/Local_Name_Space_T.cpp
+++ b/ACE/ace/Local_Name_Space_T.cpp
@@ -146,7 +146,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::shared_bind_i (
   const size_t total_len = name_len + value_len + type_len;
   char *ptr = (char *) this->allocator_->malloc (total_len);
 
-  if (ptr == 0)
+  if (ptr == nullptr)
     return -1;
   else
     {
@@ -331,7 +331,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::resolve_i (
   size_t len = ACE_OS::strlen (ns_internal.type ());
   // Makes a copy here. Caller needs to call delete to free up
   // memory.
-  char *new_type = 0;
+  char *new_type = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_ALLOCATOR_RETURN (new_type,
                         static_cast<char*>(ACE_Allocator::instance()->malloc(sizeof(char) * (len + 1))),
@@ -361,7 +361,7 @@ template <ACE_MEM_POOL_1, class ACE_LOCK>
 ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::ACE_Local_Name_Space ()
   : allocator_ (0),
     name_space_map_ (0),
-    name_options_ (0)
+    name_options_ (nullptr)
 {
   ACE_TRACE ("ACE_Local_Name_Space::ACE_Local_Name_Space");
 }
@@ -491,7 +491,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::create_manager_i ()
                       -1);
 #endif /* ACE_LACKS_ACCESS */
 
-  void *ns_map = 0;
+  void *ns_map = nullptr;
 
   // This is the easy case since if we find the Name Server Map
   // Manager we know it's already initialized.
@@ -556,7 +556,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_names_i (
 
   int result = 1;
 
-  for (map_entry = 0;
+  for (map_entry = nullptr;
        map_iterator.next (map_entry) != 0;
        map_iterator.advance())
     {
@@ -590,7 +590,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_values_i (
 
   int result = 1;
 
-  for (map_entry = 0;
+  for (map_entry = nullptr;
        map_iterator.next (map_entry) != 0;
        map_iterator.advance ())
     {
@@ -622,7 +622,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_types_i (
   MAP_MANAGER::ITERATOR map_iterator (*this->name_space_map_);
   MAP_MANAGER::ENTRY *map_entry;
 
-  char *compiled_regexp = 0;
+  char *compiled_regexp = nullptr;
 
   // Note that char_rep() allocates memory so we need to delete it
   char *pattern_rep = pattern.char_rep ();
@@ -645,7 +645,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_types_i (
 
   int result = 1;
 
-  for (map_entry = 0;
+  for (map_entry = nullptr;
        map_iterator.next (map_entry) != 0;
        map_iterator.advance ())
     {
@@ -659,7 +659,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_types_i (
 #else
         // If we don't have regular expressions just use strstr() for
         // substring matching.
-        || ACE_OS::strstr (type, compiled_regexp) != 0)
+        || ACE_OS::strstr (type, compiled_regexp) != nullptr)
 #endif /* ACE_HAS_REGEX */
 
         {
@@ -697,7 +697,7 @@ ACE_Local_Name_Space <ACE_MEM_POOL_2, ACE_LOCK>::list_name_entries_i (
   MAP_MANAGER::ITERATOR map_iterator (*this->name_space_map_);
   MAP_MANAGER::ENTRY *map_entry;
 
-  for (map_entry = 0;
+  for (map_entry = nullptr;
        map_iterator.next (map_entry) != 0;
        map_iterator.advance())
     {
@@ -726,7 +726,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_value_entries_i (
   MAP_MANAGER::ITERATOR map_iterator (*this->name_space_map_);
   MAP_MANAGER::ENTRY *map_entry;
 
-  for (map_entry = 0;
+  for (map_entry = nullptr;
        map_iterator.next (map_entry) != 0;
        map_iterator.advance ())
     {
@@ -754,7 +754,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_type_entries_i (
   MAP_MANAGER::ITERATOR map_iterator (*this->name_space_map_);
   MAP_MANAGER::ENTRY *map_entry;
 
-  char *compiled_regexp = 0;
+  char *compiled_regexp = nullptr;
   // Note that char_rep() allocates memory so we need to delete it
   char *pattern_rep = pattern.char_rep ();
 
@@ -771,7 +771,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_type_entries_i (
   compiled_regexp = pattern_rep;
 #endif /* ACE_HAS_REGEX */
 
-  for (map_entry = 0;
+  for (map_entry = nullptr;
        map_iterator.next (map_entry) != 0;
        map_iterator.advance ())
     {
@@ -784,7 +784,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::list_type_entries_i (
           || ACE_OS::step (type, compiled_regexp) != 0)
 #else /* If we don't have regular expressions just use strstr() for
          substring matching. */
-        || ACE_OS::strstr (type, compiled_regexp) != 0)
+        || ACE_OS::strstr (type, compiled_regexp) != nullptr)
 #endif /* ACE_HAS_REGEX */
         {
           ACE_Name_Binding entry (map_entry->ext_id_,
@@ -817,7 +817,7 @@ ACE_Local_Name_Space<ACE_MEM_POOL_2, ACE_LOCK>::dump_i () const
   MAP_MANAGER::ITERATOR map_iterator (*this->name_space_map_);
   MAP_MANAGER::ENTRY *map_entry;
 
-  for (map_entry = 0;
+  for (map_entry = nullptr;
        map_iterator.next (map_entry) != 0;
        map_iterator.advance())
     {

--- a/ACE/ace/Log_Category.cpp
+++ b/ACE/ace/Log_Category.cpp
@@ -48,14 +48,14 @@ ACE_Log_Category::~ACE_Log_Category()
 
   if (this->id_ > 0)
     {
-      void *temp = 0;
+      void *temp = nullptr;
       if (ACE_OS::thr_getspecific (this->key_, &temp) == -1)
         {
           return; // This should not happen!
         }
-      if (temp != 0) {
+      if (temp != nullptr) {
         delete static_cast <ACE_Log_Category_TSS *> (temp);
-        ACE_OS::thr_setspecific (this->key_, 0);
+        ACE_OS::thr_setspecific (this->key_, nullptr);
       }
       ACE_OS::thr_keyfree (this->key_);
     }
@@ -77,7 +77,7 @@ ACE_Log_Category::per_thr_obj()
 #if defined (ACE_HAS_THREADS)
   {
     // Ensure that we are serialized!
-    ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->keylock_, 0);
+    ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->keylock_, nullptr);
 
     // make sure we only create the key once!
     if (this->id_ == 0)
@@ -87,28 +87,28 @@ ACE_Log_Category::per_thr_obj()
 
         if (ACE_OS::thr_keycreate (&this->key_,
                                    &ACE_Log_Category_tss_destroy) != 0)
-          return 0; // Major problems, this should *never* happen!
+          return nullptr; // Major problems, this should *never* happen!
       }
   }
 
-  void *temp = 0;
+  void *temp = nullptr;
   if (ACE_OS::thr_getspecific (this->key_, &temp) == -1)
     {
-      return 0; // This should not happen!
+      return nullptr; // This should not happen!
     }
-  if (temp != 0)
+  if (temp != nullptr)
     return static_cast <ACE_Log_Category_TSS *> (temp);
 
   ACE_Log_Category_TSS * result;
 
   ACE_NEW_RETURN(result,
                  ACE_Log_Category_TSS(this, ACE_Log_Msg::instance()),
-                 0);
+                 nullptr);
 
  if (ACE_OS::thr_setspecific (this->key_,
                               result) != 0)
    {
-     return 0;
+     return nullptr;
    }
 
   return result;

--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -121,7 +121,7 @@ public:
 
   static u_long log_backend_flags_;
 
-  static int init_backend (const u_long *flags = 0);
+  static int init_backend (const u_long *flags = nullptr);
 
 #if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
   //FUZZ: disable check_for_lack_ACE_OS

--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -135,8 +135,8 @@ private:
 #endif /* ! ACE_MT_SAFE */
 };
 
-ACE_Log_Msg_Backend *ACE_Log_Msg_Manager::log_backend_ = 0;
-ACE_Log_Msg_Backend *ACE_Log_Msg_Manager::custom_backend_ = 0;
+ACE_Log_Msg_Backend *ACE_Log_Msg_Manager::log_backend_ = nullptr;
+ACE_Log_Msg_Backend *ACE_Log_Msg_Manager::custom_backend_ = nullptr;
 
 #ifndef ACE_DEFAULT_LOG_BACKEND_FLAGS
 #  ifdef ACE_ANDROID
@@ -157,7 +157,7 @@ int ACE_Log_Msg_Manager::init_backend (const u_long *flags)
     {
       // Sanity check for custom backend.
       if (ACE_BIT_ENABLED (*flags, ACE_Log_Msg::CUSTOM) &&
-          ACE_Log_Msg_Manager::custom_backend_ == 0)
+          ACE_Log_Msg_Manager::custom_backend_ == nullptr)
         {
           return -1;
         }
@@ -168,13 +168,13 @@ int ACE_Log_Msg_Manager::init_backend (const u_long *flags)
             && ACE_BIT_ENABLED (ACE_Log_Msg_Manager::log_backend_flags_, ACE_Log_Msg::SYSLOG)))
         {
           delete ACE_Log_Msg_Manager::log_backend_;
-          ACE_Log_Msg_Manager::log_backend_ = 0;
+          ACE_Log_Msg_Manager::log_backend_ = nullptr;
         }
 
       ACE_Log_Msg_Manager::log_backend_flags_ = *flags;
     }
 
-  if (ACE_Log_Msg_Manager::log_backend_ == 0)
+  if (ACE_Log_Msg_Manager::log_backend_ == nullptr)
     {
 #ifdef ACE_LOG_MSG_SYSLOG_BACKEND
       // Allocate the ACE_Log_Msg_Backend instance.
@@ -193,7 +193,7 @@ int ACE_Log_Msg_Manager::init_backend (const u_long *flags)
 }
 
 #if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
-ACE_Recursive_Thread_Mutex *ACE_Log_Msg_Manager::lock_ = 0;
+ACE_Recursive_Thread_Mutex *ACE_Log_Msg_Manager::lock_ = nullptr;
 
 ACE_Recursive_Thread_Mutex *
 ACE_Log_Msg_Manager::get_lock ()
@@ -201,15 +201,15 @@ ACE_Log_Msg_Manager::get_lock ()
   // This function is called by the first thread to create an ACE_Log_Msg
   // instance.  It makes the call while holding a mutex, so we don't have
   // to grab another one here.
-  if (ACE_Log_Msg_Manager::lock_ == 0)
+  if (ACE_Log_Msg_Manager::lock_ == nullptr)
     {
       ACE_NEW_RETURN (ACE_Log_Msg_Manager::lock_,
                       ACE_Recursive_Thread_Mutex,
-                      0);
+                      nullptr);
     }
 
   if (init_backend () == -1)
-    return 0;
+    return nullptr;
 
   return ACE_Log_Msg_Manager::lock_;
 }
@@ -219,13 +219,13 @@ ACE_Log_Msg_Manager::close ()
 {
   // Ugly, ugly, but don't know a better way.
   delete ACE_Log_Msg_Manager::lock_;
-  ACE_Log_Msg_Manager::lock_ = 0;
+  ACE_Log_Msg_Manager::lock_ = nullptr;
 
   delete ACE_Log_Msg_Manager::log_backend_;
-  ACE_Log_Msg_Manager::log_backend_ = 0;
+  ACE_Log_Msg_Manager::log_backend_ = nullptr;
 
   // we are never responsible for custom backend
-  ACE_Log_Msg_Manager::custom_backend_ = 0;
+  ACE_Log_Msg_Manager::custom_backend_ = nullptr;
 }
 
 # if defined (ACE_HAS_THREAD_SPECIFIC_STORAGE) || \
@@ -240,11 +240,11 @@ LOCAL_EXTERN_PREFIX
 void
 ACE_TSS_CLEANUP_NAME (void *ptr)
 {
-  if (ptr != 0)
+  if (ptr != nullptr)
     {
       // Delegate to thr_desc if this not has terminated
       ACE_Log_Msg *log_msg = (ACE_Log_Msg *) ptr;
-      if (log_msg->thr_desc () != 0)
+      if (log_msg->thr_desc () != nullptr)
         log_msg->thr_desc ()->log_msg_cleanup (log_msg);
       else
         delete log_msg;
@@ -260,13 +260,13 @@ ACE_Log_Msg::exists ()
 #if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
 # if defined (ACE_HAS_THREAD_SPECIFIC_STORAGE) || \
      defined (ACE_HAS_TSS_EMULATION)
-  void *tss_log_msg = 0; // The actual type is ACE_Log_Msg*, but we need this
+  void *tss_log_msg = nullptr; // The actual type is ACE_Log_Msg*, but we need this
                          // void to keep G++ from complaining.
 
   // Get the tss_log_msg from thread-specific storage.
   return ACE_Log_Msg::key_created_
     && ACE_Thread::getspecific (*(log_msg_tss_key ()), &tss_log_msg) != -1
-    && tss_log_msg != 0;
+    && tss_log_msg != nullptr;
 # else
 #   error "Platform must support thread-specific storage if threads are used."
 # endif /* ACE_HAS_THREAD_SPECIFIC_STORAGE || ACE_HAS_TSS_EMULATION */
@@ -313,7 +313,7 @@ ACE_Log_Msg::instance ()
                 ;
               else
                 ACE_OS::thread_mutex_unlock (lock);
-              return 0; // Major problems, this should *never* happen!
+              return nullptr; // Major problems, this should *never* happen!
             }
 
           ACE_Log_Msg::key_created_ = true;
@@ -328,17 +328,17 @@ ACE_Log_Msg::instance ()
         ACE_OS::thread_mutex_unlock (lock);
     }
 
-  ACE_Log_Msg *tss_log_msg = 0;
-  void *temp = 0;
+  ACE_Log_Msg *tss_log_msg = nullptr;
+  void *temp = nullptr;
 
   // Get the tss_log_msg from thread-specific storage.
   if (ACE_Thread::getspecific (*(log_msg_tss_key ()), &temp) == -1)
-    return 0; // This should not happen!
+    return nullptr; // This should not happen!
 
   tss_log_msg = static_cast <ACE_Log_Msg *> (temp);
 
   // Check to see if this is the first time in for this thread.
-  if (tss_log_msg == 0)
+  if (tss_log_msg == nullptr)
     {
       // Allocate memory off the heap and store it in a pointer in
       // thread-specific storage (on the stack...).  The memory will
@@ -346,7 +346,7 @@ ACE_Log_Msg::instance ()
       // callback set up when the key was created.
       ACE_NEW_RETURN (tss_log_msg,
                       ACE_Log_Msg,
-                      0);
+                      nullptr);
       // Store the dynamically allocated pointer in thread-specific
       // storage.  It gets deleted via the ACE_TSS_cleanup function
       // when the thread terminates.
@@ -354,7 +354,7 @@ ACE_Log_Msg::instance ()
       if (ACE_Thread::setspecific (*(log_msg_tss_key()),
                                     reinterpret_cast<void *> (tss_log_msg))
           != 0)
-        return 0; // Major problems, this should *never* happen!
+        return nullptr; // Major problems, this should *never* happen!
     }
 
   return tss_log_msg;
@@ -420,10 +420,10 @@ ACE_Log_Msg::program_name ()
 }
 
 /// Name of the local host.
-const ACE_TCHAR *ACE_Log_Msg::local_host_ = 0;
+const ACE_TCHAR *ACE_Log_Msg::local_host_ = nullptr;
 
 /// Records the program name.
-const ACE_TCHAR *ACE_Log_Msg::program_name_ = 0;
+const ACE_TCHAR *ACE_Log_Msg::program_name_ = nullptr;
 
 /// Default is to use stderr.
 u_long ACE_Log_Msg::flags_ = ACE_DEFAULT_LOG_FLAGS;
@@ -480,7 +480,7 @@ ACE_Log_Msg::close ()
          // unload of libACE, by a program not linked with libACE,
          // ACE_TSS_cleanup will be invoked after libACE has been unloaded.
          // See Bugzilla 2980 for lots of details.
-         void *temp = 0;
+         void *temp = nullptr;
 
          // Get the tss_log_msg from thread-specific storage.
          if (ACE_Thread::getspecific (*(log_msg_tss_key ()), &temp) != -1
@@ -619,15 +619,15 @@ ACE_Log_Msg::ACE_Log_Msg ()
   : status_ (0),
     errnum_ (0),
     linenum_ (0),
-    msg_ (0),
+    msg_ (nullptr),
     restart_ (1),  // Restart by default...
     ostream_ (nullptr),
-    ostream_refcount_ (0),
-    msg_callback_ (0),
+    ostream_refcount_ (nullptr),
+    msg_callback_ (nullptr),
     trace_depth_ (0),
     trace_active_ (false),
     tracing_enabled_ (true), // On by default?
-    thr_desc_ (0),
+    thr_desc_ (nullptr),
     priority_mask_ (default_priority_mask_),
     timestamp_ (0)
 {
@@ -647,7 +647,7 @@ ACE_Log_Msg::ACE_Log_Msg ()
   this->conditional_values_.is_set_ = false;
 
   char *timestamp = ACE_OS::getenv ("ACE_LOG_TIMESTAMP");
-  if (timestamp != 0)
+  if (timestamp != nullptr)
     {
       // If variable is set or is set to date tag so we print date and time.
       if (ACE_OS::strcmp (timestamp, "TIME") == 0)
@@ -693,11 +693,11 @@ ACE_Log_Msg::~ACE_Log_Msg ()
   if (instance_count == 0)
     {
       // Destroy the message queue instance.
-      if (ACE_Log_Msg_Manager::log_backend_ != 0)
+      if (ACE_Log_Msg_Manager::log_backend_ != nullptr)
         ACE_Log_Msg_Manager::log_backend_->close ();
 
       // Close down custom backend
-      if (ACE_Log_Msg_Manager::custom_backend_ != 0)
+      if (ACE_Log_Msg_Manager::custom_backend_ != nullptr)
         ACE_Log_Msg_Manager::custom_backend_->close ();
 
 #     if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
@@ -713,7 +713,7 @@ ACE_Log_Msg::~ACE_Log_Msg ()
 #else
           ACE_OS::free ((void *) ACE_Log_Msg::program_name_);
 #endif /* ACE_HAS_ALLOC_HOOKS */
-          ACE_Log_Msg::program_name_ = 0;
+          ACE_Log_Msg::program_name_ = nullptr;
         }
 
       if (ACE_Log_Msg::local_host_)
@@ -723,7 +723,7 @@ ACE_Log_Msg::~ACE_Log_Msg ()
 #else
           ACE_OS::free ((void *) ACE_Log_Msg::local_host_);
 #endif /* ACE_HAS_ALLOC_HOOKS */
-          ACE_Log_Msg::local_host_ = 0;
+          ACE_Log_Msg::local_host_ = nullptr;
         }
     }
 
@@ -756,7 +756,7 @@ ACE_Log_Msg::cleanup_ostream ()
 #endif
           this->ostream_ = nullptr;
         }
-      this->ostream_refcount_ = 0;
+      this->ostream_refcount_ = nullptr;
     }
 }
 
@@ -782,7 +782,7 @@ ACE_Log_Msg::open (const ACE_TCHAR *prog_name,
                             ACE_OS::strdup (prog_name),
                             -1);
     }
-  else if (ACE_Log_Msg::program_name_ == 0)
+  else if (ACE_Log_Msg::program_name_ == nullptr)
     {
       ACE_ALLOCATOR_RETURN (ACE_Log_Msg::program_name_,
                             ACE_OS::strdup (ACE_TEXT ("<unknown>")),
@@ -795,10 +795,10 @@ ACE_Log_Msg::open (const ACE_TCHAR *prog_name,
   ACE_MT (ACE_Log_Msg_Manager::init_backend (&flags));
 
   // Always close the current handle before doing anything else.
-  if (ACE_Log_Msg_Manager::log_backend_ != 0)
+  if (ACE_Log_Msg_Manager::log_backend_ != nullptr)
     ACE_Log_Msg_Manager::log_backend_->reset ();
 
-  if (ACE_Log_Msg_Manager::custom_backend_ != 0)
+  if (ACE_Log_Msg_Manager::custom_backend_ != nullptr)
     ACE_Log_Msg_Manager::custom_backend_->reset ();
 
   // Note that if we fail to open the message queue the default action
@@ -811,7 +811,7 @@ ACE_Log_Msg::open (const ACE_TCHAR *prog_name,
       // The SYSLOG backends (both NT and UNIX) can get along fine
       // without the logger_key - they will default to prog_name if
       // logger key is 0.
-      if (logger_key == 0 && ACE_BIT_ENABLED (flags, ACE_Log_Msg::LOGGER))
+      if (logger_key == nullptr && ACE_BIT_ENABLED (flags, ACE_Log_Msg::LOGGER))
         status = -1;
       else
         status = ACE_Log_Msg_Manager::log_backend_->open (logger_key);
@@ -867,7 +867,7 @@ ACE_Log_Msg::open (const ACE_TCHAR *prog_name,
       ACE_SET_BITS (ACE_Log_Msg::flags_,
                     ACE_Log_Msg::OSTREAM);
       // Only set this to cerr if it hasn't already been set.
-      if (this->msg_ostream () == 0)
+      if (this->msg_ostream () == nullptr)
         this->msg_ostream (ACE_DEFAULT_LOG_STREAM);
     }
 
@@ -1051,7 +1051,7 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
   if (ACE_BIT_ENABLED (flags, ACE_Log_Msg::VERBOSE))
     {
       // Prepend the program name onto this message
-      if (ACE_Log_Msg::program_name_ != 0)
+      if (ACE_Log_Msg::program_name_ != nullptr)
         {
           for (const ACE_TCHAR *s = ACE_Log_Msg::program_name_;
                bspace > 1 && (*bp = *s) != '\0';
@@ -1066,7 +1066,7 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
   if (timestamp_ > 0)
     {
       ACE_TCHAR day_and_time[27];
-      const ACE_TCHAR *s = 0;
+      const ACE_TCHAR *s = nullptr;
       if (timestamp_ == 1)
         {
           // Print just the time
@@ -1124,7 +1124,7 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
           size_t fspace = 128;
           ACE_TCHAR format[128]; // Converted format string
           ACE_OS::memset (format, '\0', 128); // Set this string to known values.
-          ACE_TCHAR *fp = 0;         // Current format pointer
+          ACE_TCHAR *fp = nullptr;         // Current format pointer
           int       wp = 0;      // Width/precision extracted from args
           bool      done = false;
           bool      skip_nul_locate = false;
@@ -1884,15 +1884,15 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
                  case 'Z':              // ACE_OS::WChar character string
                   {
                     ACE_OS::WChar *wchar_str = va_arg (argp, ACE_OS::WChar*);
-                    if (wchar_str == 0)
+                    if (wchar_str == nullptr)
                       break;
 
-                    wchar_t *wchar_t_str = 0;
+                    wchar_t *wchar_t_str = nullptr;
                     if (sizeof (ACE_OS::WChar) != sizeof (wchar_t))
                       {
                         size_t len = ACE_OS::wslen (wchar_str) + 1;
                         ACE_NEW_NORETURN(wchar_t_str, wchar_t[len]);
-                        if (wchar_t_str == 0)
+                        if (wchar_t_str == nullptr)
                           break;
 
                         for (size_t i = 0; i < len; ++i)
@@ -1901,7 +1901,7 @@ ACE_Log_Msg::log (const ACE_TCHAR *format_str,
                           }
                       }
 
-                    if (wchar_t_str == 0)
+                    if (wchar_t_str == nullptr)
                       {
                         wchar_t_str = reinterpret_cast<wchar_t*> (wchar_str);
                       }
@@ -2780,7 +2780,7 @@ ACE_Log_Msg_Sig_Guard::~ACE_Log_Msg_Sig_Guard ()
 # else
   ACE_OS::thr_sigsetmask (SIG_SETMASK,
                           &this->omask_,
-                          0);
+                          nullptr);
 # endif /* ACE_LACKS_PTHREAD_THR_SIGSETMASK */
 #endif /* ! ACE_LACKS_UNIX_SIGNALS */
 }
@@ -2814,7 +2814,7 @@ ACE_Log_Msg::log (ACE_Log_Record &log_record,
       // to avoid holding the lock during the callback so we don't
       // have deadlock if the callback uses the logger.
       if (ACE_BIT_ENABLED (flags, ACE_Log_Msg::MSG_CALLBACK)
-          && this->msg_callback () != 0)
+          && this->msg_callback () != nullptr)
         {
           this->msg_callback ()->log (log_record);
         }
@@ -2851,7 +2851,7 @@ ACE_Log_Msg::log (ACE_Log_Record &log_record,
         }
 
       if (ACE_BIT_ENABLED (flags, ACE_Log_Msg::CUSTOM) &&
-          ACE_Log_Msg_Manager::custom_backend_ != 0)
+          ACE_Log_Msg_Manager::custom_backend_ != nullptr)
         {
           result =
             ACE_Log_Msg_Manager::custom_backend_->log (log_record);
@@ -2861,7 +2861,7 @@ ACE_Log_Msg::log (ACE_Log_Record &log_record,
       // (see the <ACE_Log_Record::print> method for details).
       if (ACE_BIT_ENABLED (flags,
                            ACE_Log_Msg::OSTREAM)
-          && this->msg_ostream () != 0)
+          && this->msg_ostream () != nullptr)
         log_record.print (ACE_Log_Msg::local_host_,
                           flags,
 #if defined (ACE_LACKS_IOSTREAM_TOTALLY)
@@ -3034,7 +3034,7 @@ ACE_Log_Msg::thr_desc (ACE_Thread_Descriptor *td)
 {
   this->thr_desc_ = td;
 
-  if (td != 0)
+  if (td != nullptr)
     td->acquire_release ();
 }
 
@@ -3043,7 +3043,7 @@ ACE_Log_Msg::msg_backend (ACE_Log_Msg_Backend *b)
 {
   ACE_TRACE ("ACE_Log_Msg::msg_backend");
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Log_Msg_Manager::get_lock (), 0));
+                            *ACE_Log_Msg_Manager::get_lock (), nullptr));
 
   ACE_Log_Msg_Backend *tmp  = ACE_Log_Msg_Manager::custom_backend_;
   ACE_Log_Msg_Manager::custom_backend_ = b;
@@ -3055,7 +3055,7 @@ ACE_Log_Msg::msg_backend ()
 {
   ACE_TRACE ("ACE_Log_Msg::msg_backend");
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Log_Msg_Manager::get_lock (), 0));
+                            *ACE_Log_Msg_Manager::get_lock (), nullptr));
 
   return ACE_Log_Msg_Manager::custom_backend_;
 }
@@ -3085,7 +3085,7 @@ ACE_Log_Msg::msg_ostream (ACE_OSTREAM_TYPE *m, bool delete_ostream)
               delete this->ostream_refcount_;
 #endif /* ACE_HAS_ALLOC_HOOKS */
             }
-          this->ostream_refcount_ = 0;
+          this->ostream_refcount_ = nullptr;
         }
       // The other two cases are no-ops, the user has requested the same
       // state that's already present.
@@ -3167,7 +3167,7 @@ ACE_Log_Msg::init_hook (ACE_OS_Log_Msg_Attributes &attributes
         }
       else
         {
-          attributes.ostream_refcount_ = 0;
+          attributes.ostream_refcount_ = nullptr;
         }
       attributes.priority_mask_ = inherit_log->priority_mask ();
       attributes.tracing_enabled_ = inherit_log->tracing_enabled ();
@@ -3209,7 +3209,7 @@ ACE_Log_Msg::inherit_hook (ACE_OS_Thread_Descriptor *thr_desc,
   // @@ Now the TSS Log_Msg has been created, cache my thread
   // descriptor in.
 
-  if (thr_desc != 0)
+  if (thr_desc != nullptr)
     // This downcast is safe.  We do it to avoid having to #include
     // ace/Thread_Manager.h.
     new_log->thr_desc (static_cast<ACE_Thread_Descriptor *> (thr_desc));

--- a/ACE/ace/Log_Msg_UNIX_Syslog.cpp
+++ b/ACE/ace/Log_Msg_UNIX_Syslog.cpp
@@ -30,7 +30,7 @@ ACE_Log_Msg_UNIX_Syslog::~ACE_Log_Msg_UNIX_Syslog ()
 int
 ACE_Log_Msg_UNIX_Syslog::open (const ACE_TCHAR * logger_key)
 {
-  if (logger_key == 0)
+  if (logger_key == nullptr)
     logger_key = ACE_Log_Msg::program_name ();
 
   // Initialize the UNIX syslog facility.  Default the syslog log
@@ -90,13 +90,13 @@ ACE_Log_Msg_UNIX_Syslog::log (ACE_Log_Record &log_record)
 
   ACE_TCHAR message[ACE_Log_Record::MAXVERBOSELOGMSGLEN];
   ACE_OS::strcpy (message, log_record.msg_data ());
-  ACE_TCHAR *strtokp = 0;
+  ACE_TCHAR *strtokp = nullptr;
 
   for (ACE_TCHAR *line = ACE_OS::strtok_r (message,
                                            ACE_TEXT ("\n"),
                                            &strtokp);
-       line != 0;
-       line = ACE_OS::strtok_r (0,
+       line != nullptr;
+       line = ACE_OS::strtok_r (nullptr,
                                 ACE_TEXT ("\n"),
                                 &strtokp))
     {
@@ -110,7 +110,7 @@ ACE_Log_Msg_UNIX_Syslog::log (ACE_Log_Record &log_record)
           || ACE_BIT_ENABLED (flags, ACE_Log_Msg::VERBOSE_LITE))
         {
           ACE_TCHAR date_and_time[27];
-          if (0 == ACE::timestamp (date_and_time, sizeof (date_and_time), 1))
+          if (nullptr == ACE::timestamp (date_and_time, sizeof (date_and_time), 1))
             ACE_OS::strcpy (date_and_time, ACE_TEXT ("<time error>"));
           const ACE_TCHAR *prio_name =
             ACE_Log_Record::priority_name(ACE_Log_Priority(log_record.type()));

--- a/ACE/ace/Log_Record.cpp
+++ b/ACE/ace/Log_Record.cpp
@@ -148,9 +148,9 @@ ACE_Log_Record::ACE_Log_Record (ACE_Log_Priority lp,
     secs_ (ts_sec),
     usecs_ (0),
     pid_ (ACE_UINT32 (p)),
-    msg_data_ (0),
+    msg_data_ (nullptr),
     msg_data_size_ (0),
-    category_(0)
+    category_(nullptr)
 {
   // ACE_TRACE ("ACE_Log_Record::ACE_Log_Record");
 #if defined (ACE_HAS_ALLOC_HOOKS)
@@ -158,7 +158,7 @@ ACE_Log_Record::ACE_Log_Record (ACE_Log_Priority lp,
 #else
   ACE_NEW_NORETURN (this->msg_data_, ACE_TCHAR[MAXLOGMSGLEN]);
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  if (0 != this->msg_data_)
+  if (nullptr != this->msg_data_)
     {
       this->msg_data_size_ = MAXLOGMSGLEN;
       this->msg_data_[0] = '\0';
@@ -173,9 +173,9 @@ ACE_Log_Record::ACE_Log_Record (ACE_Log_Priority lp,
     secs_ (ts.sec ()),
     usecs_ ((ACE_UINT32) ts.usec ()),
     pid_ (ACE_UINT32 (p)),
-    msg_data_ (0),
+    msg_data_ (nullptr),
     msg_data_size_ (0),
-    category_(0)
+    category_(nullptr)
 {
   // ACE_TRACE ("ACE_Log_Record::ACE_Log_Record");
 #if defined (ACE_HAS_ALLOC_HOOKS)
@@ -183,7 +183,7 @@ ACE_Log_Record::ACE_Log_Record (ACE_Log_Priority lp,
 #else
   ACE_NEW_NORETURN (this->msg_data_, ACE_TCHAR[MAXLOGMSGLEN]);
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  if (0 != this->msg_data_)
+  if (nullptr != this->msg_data_)
     {
       this->msg_data_size_ = MAXLOGMSGLEN;
       this->msg_data_[0] = '\0';
@@ -209,9 +209,9 @@ ACE_Log_Record::ACE_Log_Record ()
     secs_ (0),
     usecs_ (0),
     pid_ (0),
-    msg_data_ (0),
+    msg_data_ (nullptr),
     msg_data_size_ (0),
-    category_(0)
+    category_(nullptr)
 {
   // ACE_TRACE ("ACE_Log_Record::ACE_Log_Record");
 #if defined (ACE_HAS_ALLOC_HOOKS)
@@ -219,7 +219,7 @@ ACE_Log_Record::ACE_Log_Record ()
 #else
   ACE_NEW_NORETURN (this->msg_data_, ACE_TCHAR[MAXLOGMSGLEN]);
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  if (0 != this->msg_data_)
+  if (nullptr != this->msg_data_)
     {
       this->msg_data_size_ = MAXLOGMSGLEN;
       this->msg_data_[0] = '\0';
@@ -241,7 +241,7 @@ ACE_Log_Record::format_msg (const ACE_TCHAR host_name[],
                           ACE_Log_Msg::VERBOSE_LITE))
     {
       ACE_Time_Value reftime (this->secs_, this->usecs_);
-      if (0 == ACE::timestamp (reftime,
+      if (nullptr == ACE::timestamp (reftime,
                                timestamp,
                                sizeof (timestamp) / sizeof (ACE_TCHAR)))
         return -1;
@@ -255,7 +255,7 @@ ACE_Log_Record::format_msg (const ACE_TCHAR host_name[],
   if (ACE_BIT_ENABLED (verbose_flag,
                        ACE_Log_Msg::VERBOSE))
     {
-      const ACE_TCHAR *lhost_name = ((host_name == 0)
+      const ACE_TCHAR *lhost_name = ((host_name == nullptr)
                                       ? ACE_TEXT ("<local_host>")
                                       : host_name);
       ACE_OS::snprintf (verbose_msg, verbose_msg_size,
@@ -297,7 +297,7 @@ ACE_Log_Record::print (const ACE_TCHAR host_name[],
 {
   if ( log_priority_enabled(this->category(), ACE_Log_Priority (this->type_)) )
     {
-      ACE_TCHAR *verbose_msg = 0;
+      ACE_TCHAR *verbose_msg = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
       ACE_ALLOCATOR_RETURN (verbose_msg, static_cast<ACE_TCHAR *>(ACE_Allocator::instance()->malloc(sizeof(ACE_TCHAR) * MAXVERBOSELOGMSGLEN)), -1);
 #else
@@ -309,7 +309,7 @@ ACE_Log_Record::print (const ACE_TCHAR host_name[],
 
       if (result == 0)
         {
-          if (fp != 0)
+          if (fp != nullptr)
             {
               int const verbose_msg_len =
                 static_cast<int> (ACE_OS::strlen (verbose_msg));
@@ -404,7 +404,7 @@ ACE_Log_Record::print (const ACE_TCHAR host_name[],
 {
   if ( log_priority_enabled(this->category(), ACE_Log_Priority (this->type_)) )
     {
-      ACE_TCHAR* verbose_msg = 0;
+      ACE_TCHAR* verbose_msg = nullptr;
       ACE_NEW_RETURN (verbose_msg, ACE_TCHAR[MAXVERBOSELOGMSGLEN], -1);
 
       int const result = this->format_msg (host_name, verbose_flag, verbose_msg,

--- a/ACE/ace/Logging_Strategy.cpp
+++ b/ACE/ace/Logging_Strategy.cpp
@@ -37,8 +37,8 @@ ACE_Logging_Strategy::priorities (ACE_TCHAR *priority_string, ACE_Log_Msg::MASK_
   for (ACE_TCHAR *priority = ACE_OS::strtok_r (priority_string,
                                                ACE_TEXT ("|"),
                                                &strtokp);
-       priority != 0;
-       priority = ACE_OS::strtok_r (0,
+       priority != nullptr;
+       priority = ACE_OS::strtok_r (nullptr,
                                     ACE_TEXT ("|"),
                                     &strtokp))
     {
@@ -106,8 +106,8 @@ ACE_Logging_Strategy::tokenize (ACE_TCHAR *flag_string)
   for (ACE_TCHAR *flag = ACE_OS::strtok_r (flag_string,
                                            ACE_TEXT ("|"),
                                            &strtokp);
-       flag != 0;
-       flag = ACE_OS::strtok_r (0, ACE_TEXT ("|"), &strtokp))
+       flag != nullptr;
+       flag = ACE_OS::strtok_r (nullptr, ACE_TEXT ("|"), &strtokp))
     {
       if (ACE_OS::strcmp (flag, ACE_TEXT ("STDERR")) == 0)
         ACE_SET_BITS (this->flags_, ACE_Log_Msg::STDERR);
@@ -160,12 +160,12 @@ ACE_Logging_Strategy::parse_args (int argc, ACE_TCHAR *argv[])
           // The key can be changed by the -k option also, so if it's
           // been set already, don't set it.
           if (ACE_BIT_ENABLED (this->flags_, ACE_Log_Msg::LOGGER) &&
-              this->logger_key_ == 0)
+              this->logger_key_ == nullptr)
             this->logger_key_ = ACE::strnew (ACE_DEFAULT_LOGGER_KEY);
           break;
         case 'i':
           // Interval (in secs) at which logfile size is sampled.
-          this->interval_ = ACE_OS::strtoul (get_opt.opt_arg (), 0, 10);
+          this->interval_ = ACE_OS::strtoul (get_opt.opt_arg (), nullptr, 10);
           break;
         case 'k':
           // Ensure that the LOGGER flag is set
@@ -179,7 +179,7 @@ ACE_Logging_Strategy::parse_args (int argc, ACE_TCHAR *argv[])
           break;
         case 'm':
           // Maximum logfile size (in KB).  Must be a non-zero value.
-          this->max_size_ = ACE_OS::strtoul (get_opt.opt_arg (), 0, 10);
+          this->max_size_ = ACE_OS::strtoul (get_opt.opt_arg (), nullptr, 10);
           this->max_size_ <<= 10;       // convert from KB to bytes.
           break;
         case 'n':
@@ -277,7 +277,7 @@ ACE_Logging_Strategy::fini ()
 #else
   delete [] this->filename_;
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  this->filename_ = 0; // Avoid double deletions.
+  this->filename_ = nullptr; // Avoid double deletions.
 
 #if defined (ACE_HAS_ALLOC_HOOKS)
   ACE_Allocator::instance()->free(this->logger_key_);
@@ -355,7 +355,7 @@ ACE_Logging_Strategy::init (int argc, ACE_TCHAR *argv[])
                  -1);
               delete_ostream = 1;
             }
-          else if (output_file == 0)
+          else if (output_file == nullptr)
             {
               ACE_NEW_RETURN
                 (output_file,
@@ -557,7 +557,7 @@ ACE_Logging_Strategy::reactor (ACE_Reactor *r)
       if (this->reactor ())
         {
           this->reactor ()->schedule_timer
-            (this, 0,
+            (this, nullptr,
              ACE_Time_Value (this->interval_),
              ACE_Time_Value (this->interval_));
         }

--- a/ACE/ace/MEM_Acceptor.cpp
+++ b/ACE/ace/MEM_Acceptor.cpp
@@ -27,7 +27,7 @@ ACE_MEM_Acceptor::dump () const
 // Do nothing routine for constructor.
 
 ACE_MEM_Acceptor::ACE_MEM_Acceptor ()
-  : mmap_prefix_ (0),
+  : mmap_prefix_ (nullptr),
     malloc_options_ (ACE_DEFAULT_BASE_ADDR, 0),
     preferred_strategy_ (ACE_MEM_IO::Reactive)
 {
@@ -50,7 +50,7 @@ ACE_MEM_Acceptor::ACE_MEM_Acceptor (const ACE_MEM_Addr &remote_sap,
                                     int reuse_addr,
                                     int backlog,
                                     int protocol)
-  : mmap_prefix_ (0),
+  : mmap_prefix_ (nullptr),
     malloc_options_ (ACE_DEFAULT_BASE_ADDR, 0),
     preferred_strategy_ (ACE_MEM_IO::Reactive)
 {
@@ -95,12 +95,12 @@ ACE_MEM_Acceptor::accept (ACE_MEM_Stream &new_stream,
     return -1;
   else
     {
-      sockaddr *addr = 0;
+      sockaddr *addr = nullptr;
       struct sockaddr_in inet_addr;
-      int *len_ptr = 0;
+      int *len_ptr = nullptr;
       int len = 0;
 
-      if (remote_sap != 0)
+      if (remote_sap != nullptr)
         {
           addr = reinterpret_cast<sockaddr *> (&inet_addr);
           len = sizeof (inet_addr);
@@ -116,9 +116,9 @@ ACE_MEM_Acceptor::accept (ACE_MEM_Stream &new_stream,
       while (new_stream.get_handle () == ACE_INVALID_HANDLE
              && restart != 0
              && errno == EINTR
-             && timeout == 0);
+             && timeout == nullptr);
 
-      if (remote_sap != 0)
+      if (remote_sap != nullptr)
         {
           ACE_INET_Addr temp (&inet_addr, len);
           remote_sap->set_port_number (temp.get_port_number ());
@@ -138,7 +138,7 @@ ACE_MEM_Acceptor::accept (ACE_MEM_Stream &new_stream,
   if (new_stream.get_local_addr (local_addr) == -1)
     return -1;
 
-  if (this->mmap_prefix_ != 0)
+  if (this->mmap_prefix_ != nullptr)
     {
       ACE_OS::snprintf (buf, sizeof buf / sizeof buf[0],
                         ACE_TEXT ("%s_%d_"),

--- a/ACE/ace/MEM_Addr.cpp
+++ b/ACE/ace/MEM_Addr.cpp
@@ -40,7 +40,7 @@ ACE_MEM_Addr::ACE_MEM_Addr (const ACE_TCHAR port_number[])
   : ACE_Addr (AF_INET, sizeof (ACE_MEM_Addr))
 {
   ACE_TRACE ("ACE_MEM_Addr::ACE_MEM_Addr");
-  u_short const pn = static_cast<u_short> (ACE_OS::strtoul (port_number, 0, 10));
+  u_short const pn = static_cast<u_short> (ACE_OS::strtoul (port_number, nullptr, 10));
   this->initialize_local (pn);
 }
 
@@ -93,7 +93,7 @@ ACE_MEM_Addr::string_to_addr (const ACE_TCHAR s[])
 {
   ACE_TRACE ("ACE_MEM_Addr::string_to_addr");
 
-  u_short pn = static_cast<u_short> (ACE_OS::strtoul (s, 0, 10));
+  u_short pn = static_cast<u_short> (ACE_OS::strtoul (s, nullptr, 10));
   return this->set (pn);
 }
 

--- a/ACE/ace/MEM_IO.cpp
+++ b/ACE/ace/MEM_IO.cpp
@@ -34,7 +34,7 @@ ACE_Reactive_MEM_IO::recv_buf (ACE_MEM_SAP_Node *&buf,
 {
   ACE_TRACE ("ACE_Reactive_MEM_IO::recv_buf");
 
-  if (this->shm_malloc_ == 0 || this->handle_ == ACE_INVALID_HANDLE)
+  if (this->shm_malloc_ == nullptr || this->handle_ == ACE_INVALID_HANDLE)
     return -1;
 
   ACE_OFF_T new_offset = 0;
@@ -47,13 +47,13 @@ ACE_Reactive_MEM_IO::recv_buf (ACE_MEM_SAP_Node *&buf,
   if (retv == 0)
     {
       //      ACELIB_DEBUG ((LM_INFO, "MEM_Stream closed\n"));
-      buf = 0;
+      buf = nullptr;
       return 0;
     }
   else if (retv != static_cast <ssize_t> (sizeof (ACE_OFF_T)))
     {
       //  Nothing available or we are really screwed.
-      buf = 0;
+      buf = nullptr;
       return -1;
     }
 
@@ -67,7 +67,7 @@ ACE_Reactive_MEM_IO::send_buf (ACE_MEM_SAP_Node *buf,
 {
   ACE_TRACE ("ACE_Reactive_MEM_IO::send_buf");
 
-  if (this->shm_malloc_ == 0 || this->handle_ == ACE_INVALID_HANDLE)
+  if (this->shm_malloc_ == nullptr || this->handle_ == ACE_INVALID_HANDLE)
     {
       return -1;
     }
@@ -347,7 +347,7 @@ ACE_MEM_IO::init (const ACE_TCHAR *name,
   ACE_UNUSED_ARG (type);
 
   delete this->deliver_strategy_;
-  this->deliver_strategy_ = 0;
+  this->deliver_strategy_ = nullptr;
   switch (type)
     {
     case ACE_MEM_IO::Reactive:
@@ -374,7 +374,7 @@ ACE_MEM_IO::init (const ACE_TCHAR *name,
 int
 ACE_MEM_IO::fini ()
 {
-  if (this->deliver_strategy_ != 0)
+  if (this->deliver_strategy_ != nullptr)
     {
       return this->deliver_strategy_->fini ();
     }
@@ -395,7 +395,7 @@ ACE_MEM_IO::send (const ACE_Message_Block *message_block,
 {
   ACE_TRACE ("ACE_MEM_IO::send");
 
-  if (this->deliver_strategy_ == 0)
+  if (this->deliver_strategy_ == nullptr)
     {
       return -1;                  // Something went seriously wrong.
     }
@@ -411,7 +411,7 @@ ACE_MEM_IO::send (const ACE_Message_Block *message_block,
 
       size_t n = 0;
 
-      while (message_block != 0)
+      while (message_block != nullptr)
         {
           ACE_OS::memcpy (static_cast<char *> (buf->data ()) + n,
                           message_block->rd_ptr (),

--- a/ACE/ace/MEM_SAP.cpp
+++ b/ACE/ace/MEM_SAP.cpp
@@ -27,7 +27,7 @@ ACE_MEM_SAP::dump () const
 
 ACE_MEM_SAP::ACE_MEM_SAP ()
   : handle_ (ACE_INVALID_HANDLE),
-    shm_malloc_ (0)
+    shm_malloc_ (nullptr)
 {
   // ACE_TRACE ("ACE_MEM_SAP::ACE_MEM_SAP");
 }
@@ -52,12 +52,12 @@ ACE_MEM_SAP::create_shm_malloc (const ACE_TCHAR *name,
 {
   ACE_TRACE ("ACE_MEM_SAP::create_shm_malloc");
 
-  if (this->shm_malloc_ != 0)
+  if (this->shm_malloc_ != nullptr)
     return -1;                  // already initialized.
 
   ACE_NEW_RETURN (this->shm_malloc_,
                   MALLOC_TYPE (name,
-                               0,
+                               nullptr,
                                options),
                   -1);
 
@@ -65,7 +65,7 @@ ACE_MEM_SAP::create_shm_malloc (const ACE_TCHAR *name,
     {
       this->shm_malloc_->remove (); // Cleanup OS resources
       delete this->shm_malloc_;
-      this->shm_malloc_ = 0;
+      this->shm_malloc_ = nullptr;
       return -1;
     }
 
@@ -79,13 +79,13 @@ ACE_MEM_SAP::close_shm_malloc ()
 
   int retv = -1;
 
-  if (this->shm_malloc_ != 0)
+  if (this->shm_malloc_ != nullptr)
     if (this->shm_malloc_->release (1) == 0)
       ACE_Process_Mutex::unlink (this->shm_malloc_->memory_pool ().
                                  mmap ().filename ());
 
   delete this->shm_malloc_;
-  this->shm_malloc_ = 0;
+  this->shm_malloc_ = nullptr;
 
   return retv;
 }

--- a/ACE/ace/MEM_Stream.cpp
+++ b/ACE/ace/MEM_Stream.cpp
@@ -21,7 +21,7 @@ ACE_MEM_Stream::dump () const
 int
 ACE_MEM_Stream::close ()
 {
-  this->send ((char *)0, 0);
+  this->send ((char *)nullptr, 0);
 
   this->fini ();
 

--- a/ACE/ace/MMAP_Memory_Pool.cpp
+++ b/ACE/ace/MMAP_Memory_Pool.cpp
@@ -110,7 +110,7 @@ ACE_MMAP_Memory_Pool::protect (void *addr, size_t len, int prot)
 ACE_MMAP_Memory_Pool::ACE_MMAP_Memory_Pool (
   const ACE_TCHAR *backing_store_name,
   const OPTIONS *options)
-  : base_addr_ (0),
+  : base_addr_ (nullptr),
     use_fixed_addr_(0),
     flags_ (MAP_SHARED),
     write_each_page_ (false),
@@ -154,7 +154,7 @@ ACE_MMAP_Memory_Pool::ACE_MMAP_Memory_Pool (
       this->install_signal_handler_ = options->install_signal_handler_;
     }
 
-  if (backing_store_name == 0)
+  if (backing_store_name == nullptr)
     {
       // Only create a new unique filename for the backing store file
       // if the user didn't supply one...
@@ -276,7 +276,7 @@ ACE_MMAP_Memory_Pool::map_file (size_t map_size)
 
 #if (ACE_HAS_POSITION_INDEPENDENT_POINTERS == 1)
   if (use_fixed_addr_ == ACE_MMAP_Memory_Pool_Options::NEVER_FIXED)
-    this->base_addr_ = 0;
+    this->base_addr_ = nullptr;
 #endif /* ACE_HAS_POSITION_INDEPENDENT_POINTERS == 1 */
 
   // Remap the file; try to stay at the same location as a previous mapping
@@ -289,7 +289,7 @@ ACE_MMAP_Memory_Pool::map_file (size_t map_size)
                        this->base_addr_,
                        0,
                        this->sa_) == -1
-      || (this->base_addr_ != 0
+      || (this->base_addr_ != nullptr
       && this->mmap_.addr () != this->base_addr_))
     {
 #if 0
@@ -336,9 +336,9 @@ ACE_MMAP_Memory_Pool::acquire (size_t nbytes,
 
   if (this->commit_backing_store_name (rounded_bytes,
                                        map_size) == -1)
-    return 0;
+    return nullptr;
   else if (this->map_file (map_size) == -1)
-    return 0;
+    return nullptr;
 
   // ACELIB_DEBUG ((LM_DEBUG, "(%P|%t) acquired more chunks, nbytes = %B,
   // rounded_bytes = %B, map_size = %B\n", nbytes, rounded_bytes,
@@ -475,7 +475,7 @@ ACE_MMAP_Memory_Pool_Options::ACE_MMAP_Memory_Pool_Options (
 {
   ACE_TRACE ("ACE_MMAP_Memory_Pool_Options::ACE_MMAP_Memory_Pool_Options");
   // for backwards compatibility
-  if (base_addr_ == 0 && use_fixed_addr_ == ALWAYS_FIXED)
+  if (base_addr_ == nullptr && use_fixed_addr_ == ALWAYS_FIXED)
     use_fixed_addr_ = FIRSTCALL_FIXED;
 }
 
@@ -495,7 +495,7 @@ ACE_MMAP_Memory_Pool::handle_signal (int signum, siginfo_t *siginfo, ucontext_t 
   // Make sure that the pointer causing the problem is within the
   // range of the backing store.
 
-  if (siginfo != 0)
+  if (siginfo != nullptr)
     {
       // ACELIB_DEBUG ((LM_DEBUG,  ACE_TEXT ("(%P|%t) si_signo = %d, si_code = %d, addr = %@\n"), siginfo->si_signo, siginfo->si_code, siginfo->si_addr));
       if (this->remap ((void *) siginfo->si_addr) == -1)

--- a/ACE/ace/Malloc.cpp
+++ b/ACE/ace/Malloc.cpp
@@ -11,7 +11,7 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // Process-wide ACE_Allocator.
-ACE_Allocator *ACE_Allocator::allocator_ = 0;
+ACE_Allocator *ACE_Allocator::allocator_ = nullptr;
 
 void
 ACE_Control_Block::ACE_Malloc_Header::dump () const
@@ -90,10 +90,10 @@ ACE_Control_Block::dump () const
 }
 
 ACE_Control_Block::ACE_Name_Node::ACE_Name_Node ()
-  : name_ (0),
-    pointer_ (0),
-    next_ (0),
-    prev_ (0)
+  : name_ (nullptr),
+    pointer_ (nullptr),
+    next_ (nullptr),
+    prev_ (nullptr)
 {
   ACE_TRACE ("ACE_Control_Block::ACE_Name_Node::ACE_Name_Node");
 }
@@ -105,12 +105,12 @@ ACE_Control_Block::ACE_Name_Node::ACE_Name_Node (const char *name,
   : name_ (name_ptr),
     pointer_ (pointer),
     next_ (next),
-    prev_ (0)
+    prev_ (nullptr)
 {
   ACE_TRACE ("ACE_Control_Block::ACE_Name_Node::ACE_Name_Node");
   char *n = this->name_;
   ACE_OS::strcpy (n, name);
-  if (next != 0)
+  if (next != nullptr)
     next->prev_ = this;
 }
 
@@ -121,7 +121,7 @@ ACE_Control_Block::ACE_Name_Node::name () const
 }
 
 ACE_Control_Block::ACE_Malloc_Header::ACE_Malloc_Header ()
-  : next_block_ (0),
+  : next_block_ (nullptr),
     size_ (0)
 {
 }

--- a/ACE/ace/Malloc_Allocator.cpp
+++ b/ACE/ace/Malloc_Allocator.cpp
@@ -17,13 +17,13 @@ ACE_Allocator::instance ()
 {
   //  ACE_TRACE ("ACE_Allocator::instance");
 
-  if (ACE_Allocator::allocator_ == 0)
+  if (ACE_Allocator::allocator_ == nullptr)
     {
       // Perform Double-Checked Locking Optimization.
       ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                                *ACE_Static_Object_Lock::instance (), 0));
+                                *ACE_Static_Object_Lock::instance (), nullptr));
 
-      if (ACE_Allocator::allocator_ == 0)
+      if (ACE_Allocator::allocator_ == nullptr)
         {
           // Have a seat.  We want to avoid ever having to delete the
           // ACE_Allocator instance, to avoid shutdown order
@@ -39,7 +39,7 @@ ACE_Allocator::instance ()
           // that of a pointer, we allocate it as a pointer so that it
           // doesn't get constructed statically.  We never bother to
           // destroy it.
-          static void *allocator_instance = 0;
+          static void *allocator_instance = nullptr;
 
           // Check this critical assumption.  We put it in a variable
           // first to avoid stupid compiler warnings that the
@@ -65,7 +65,7 @@ ACE_Allocator::instance (ACE_Allocator *r)
 {
   ACE_TRACE ("ACE_Allocator::instance");
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Static_Object_Lock::instance (), 0));
+                            *ACE_Static_Object_Lock::instance (), nullptr));
   ACE_Allocator *t = ACE_Allocator::allocator_;
 
   ACE_Allocator::allocator_ = r;
@@ -94,9 +94,9 @@ ACE_Allocator::ACE_Allocator ()
 void *
 ACE_New_Allocator::malloc (size_t nbytes)
 {
-  char *ptr = 0;
+  char *ptr = nullptr;
   if (nbytes > 0)
-    ACE_NEW_RETURN (ptr, char[nbytes], 0);
+    ACE_NEW_RETURN (ptr, char[nbytes], nullptr);
   return (void *) ptr;
 }
 
@@ -104,9 +104,9 @@ void *
 ACE_New_Allocator::calloc (size_t nbytes,
                            char initial_value)
 {
-  char *ptr = 0;
+  char *ptr = nullptr;
 
-  ACE_NEW_RETURN (ptr, char[nbytes], 0);
+  ACE_NEW_RETURN (ptr, char[nbytes], nullptr);
 
   ACE_OS::memset (ptr, initial_value, nbytes);
   return (void *) ptr;
@@ -216,7 +216,7 @@ ACE_Static_Allocator_Base::malloc (size_t nbytes)
   if (this->offset_ + nbytes > this->size_)
     {
       errno = ENOMEM;
-      return 0;
+      return nullptr;
     }
   else
     {

--- a/ACE/ace/Malloc_T.cpp
+++ b/ACE/ace/Malloc_T.cpp
@@ -19,7 +19,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 template <class T, class ACE_LOCK>
 ACE_Cached_Allocator<T, ACE_LOCK>::ACE_Cached_Allocator (size_t n_chunks)
-  : pool_ (0),
+  : pool_ (nullptr),
     free_list_ (ACE_PURE_FREE_LIST)
 {
   // To maintain alignment requirements, make sure that each element
@@ -71,7 +71,7 @@ ACE_Cached_Allocator<T, ACE_LOCK>::malloc (size_t nbytes)
 {
   // Check if size requested fits within pre-determined size.
   if (nbytes > sizeof (T))
-    return 0;
+    return nullptr;
 
   ACE_Cached_Mem_Pool_Node<T> *allocated = this->free_list_.remove ();
   return allocated == 0 ? 0 : allocated->addr();
@@ -83,11 +83,11 @@ ACE_Cached_Allocator<T, ACE_LOCK>::calloc (size_t nbytes,
 {
   // Check if size requested fits within pre-determined size.
   if (nbytes > sizeof (T))
-    return 0;
+    return nullptr;
 
   ACE_Cached_Mem_Pool_Node<T> *allocated = this->free_list_.remove ();
   void *ptr = allocated == 0 ? 0 : allocated->addr();
-  if (ptr != 0)
+  if (ptr != nullptr)
     ACE_OS::memset (ptr, initial_value, sizeof (T));
   return ptr;
 }
@@ -97,20 +97,20 @@ ACE_Cached_Allocator<T, ACE_LOCK>::calloc (size_t,
                                            size_t,
                                            char)
 {
-  ACE_NOTSUP_RETURN (0);
+  ACE_NOTSUP_RETURN (nullptr);
 }
 
 template <class T, class ACE_LOCK> void
 ACE_Cached_Allocator<T, ACE_LOCK>::free (void * ptr)
 {
-  if (ptr != 0)
+  if (ptr != nullptr)
     this->free_list_.add ((ACE_Cached_Mem_Pool_Node<T> *) ptr) ;
 }
 
 template <class ACE_LOCK>
 ACE_Dynamic_Cached_Allocator<ACE_LOCK>::ACE_Dynamic_Cached_Allocator
   (size_t n_chunks, size_t chunk_size)
-    : pool_ (0),
+    : pool_ (nullptr),
       free_list_ (ACE_PURE_FREE_LIST),
       chunk_size_ (chunk_size)
 {
@@ -143,10 +143,10 @@ ACE_Dynamic_Cached_Allocator<ACE_LOCK>::malloc (size_t nbytes)
 {
   // Check if size requested fits within pre-determined size.
   if (nbytes > chunk_size_)
-    return 0;
+    return nullptr;
 
   ACE_Cached_Mem_Pool_Node<char> *allocated = this->free_list_.remove ();
-  return allocated == 0 ? 0 : allocated->addr();
+  return allocated == nullptr ? nullptr : allocated->addr();
 }
 
 template <class ACE_LOCK> void *
@@ -155,11 +155,11 @@ ACE_Dynamic_Cached_Allocator<ACE_LOCK>::calloc (size_t nbytes,
 {
   // Check if size requested fits within pre-determined size.
   if (nbytes > chunk_size_)
-    return 0;
+    return nullptr;
 
   ACE_Cached_Mem_Pool_Node<char> *allocated = this->free_list_.remove ();
-  void *ptr = allocated == 0 ? 0 : allocated->addr();
-  if (ptr != 0)
+  void *ptr = allocated == nullptr ? nullptr : allocated->addr();
+  if (ptr != nullptr)
     ACE_OS::memset (ptr, initial_value, chunk_size_);
   return ptr;
 }
@@ -167,13 +167,13 @@ ACE_Dynamic_Cached_Allocator<ACE_LOCK>::calloc (size_t nbytes,
 template <class ACE_LOCK> void *
 ACE_Dynamic_Cached_Allocator<ACE_LOCK>::calloc (size_t, size_t, char)
 {
-  ACE_NOTSUP_RETURN (0);
+  ACE_NOTSUP_RETURN (nullptr);
 }
 
 template <class ACE_LOCK> void
 ACE_Dynamic_Cached_Allocator<ACE_LOCK>::free (void * ptr)
 {
-  if (ptr != 0)
+  if (ptr != nullptr)
     this->free_list_.add ((ACE_Cached_Mem_Pool_Node<char> *) ptr);
 }
 
@@ -615,7 +615,7 @@ ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::shared_malloc (size_t nbytes)
 #endif /* !ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS */
 
   if (this->cb_ptr_ == 0)
-    return 0;
+    return nullptr;
 
   // Round up request to a multiple of the MALLOC_HEADER size.
   size_t const nunits =
@@ -683,7 +683,7 @@ ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::shared_malloc (size_t nbytes)
                 this->memory_pool_.acquire (nunits * sizeof (MALLOC_HEADER),
                                             chunk_bytes);
               void *remap_addr = this->memory_pool_.base_addr ();
-              if (remap_addr != 0)
+              if (remap_addr != nullptr)
                 this->cb_ptr_ = (ACE_CB *) remap_addr;
 
               if (currp != 0)
@@ -707,7 +707,7 @@ ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::shared_malloc (size_t nbytes)
                   currp = this->cb_ptr_->freep_;
                 }
               else
-                return 0;
+                return nullptr;
                 // Shouldn't do this here because of errors with the wchar ver
                 // This is because ACELIB_ERROR_RETURN converts the __FILE__ to
                 // wchar before printing out.  The compiler will complain
@@ -724,7 +724,7 @@ ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::shared_malloc (size_t nbytes)
         {
         }
     }
-  ACE_NOTREACHED (return 0;)
+  ACE_NOTREACHED (return nullptr;)
 }
 
 // General-purpose memory allocator.
@@ -733,7 +733,7 @@ template <ACE_MEM_POOL_1, class ACE_LOCK, class ACE_CB> void *
 ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::malloc (size_t nbytes)
 {
   ACE_TRACE ("ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::malloc");
-  ACE_GUARD_RETURN (ACE_LOCK, ace_mon, *this->lock_, 0);
+  ACE_GUARD_RETURN (ACE_LOCK, ace_mon, *this->lock_, nullptr);
 
   return this->shared_malloc (nbytes);
 }
@@ -747,7 +747,7 @@ ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::calloc (size_t nbytes,
   ACE_TRACE ("ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::calloc");
   void *ptr = this->malloc (nbytes);
 
-  if (ptr != 0)
+  if (ptr != nullptr)
     ACE_OS::memset (ptr, initial_value, nbytes);
 
   return ptr;
@@ -772,7 +772,7 @@ ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::shared_free (void *ap)
   ACE_TRACE ("ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::shared_free");
 #endif /* ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS */
 
-  if (ap == 0 || this->cb_ptr_ == 0)
+  if (ap == nullptr || this->cb_ptr_ == 0)
     return;
 
   // Adjust AP to point to the block MALLOC_HEADER
@@ -846,7 +846,7 @@ ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::shared_find (const char *name)
   ACE_SEH_EXCEPT (this->memory_pool_.seh_selector (GetExceptionInformation ()))
     {
     }
-  return 0;
+  return nullptr;
 }
 
 template <ACE_MEM_POOL_1, class ACE_LOCK, class ACE_CB> int
@@ -1017,7 +1017,7 @@ template <ACE_MEM_POOL_1, class ACE_LOCK, class ACE_CB> int
 ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::unbind (const char *name)
 {
   ACE_TRACE ("ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::unbind");
-  void *temp = 0;
+  void *temp = nullptr;
   return this->unbind (name, temp);
 }
 
@@ -1027,7 +1027,7 @@ template <class ACE_LOCK> ACE_LOCK *
 ACE_Malloc_Lock_Adapter_T<ACE_LOCK>::operator () (const ACE_TCHAR *name)
 {
   ACE_LOCK *p = 0;
-  if (name == 0)
+  if (name == nullptr)
     ACE_NEW_RETURN (p, ACE_LOCK (name), 0);
   else
     ACE_NEW_RETURN (p, ACE_LOCK (ACE::basename (name,
@@ -1058,7 +1058,7 @@ ACE_Malloc_LIFO_Iterator_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::ACE_Malloc_LIFO_It
   : malloc_ (malloc),
     curr_ (0),
     guard_ (*malloc_.lock_),
-    name_ (name != 0 ? ACE_OS::strdup (name) : 0)
+    name_ (name != nullptr ? ACE_OS::strdup (name) : nullptr)
 {
   ACE_TRACE ("ACE_Malloc_LIFO_Iterator_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::ACE_Malloc_LIFO_Iterator_T");
   // Cheap trick to make code simple.
@@ -1151,7 +1151,7 @@ ACE_Malloc_FIFO_Iterator_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::ACE_Malloc_FIFO_It
   : malloc_ (malloc),
     curr_ (0),
     guard_ (*malloc_.lock_),
-    name_ (name != 0 ? ACE_OS::strdup (name) : 0)
+    name_ (name != nullptr ? ACE_OS::strdup (name) : nullptr)
 {
   ACE_TRACE ("ACE_Malloc_FIFO_Iterator_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB>::ACE_Malloc_FIFO_Iterator");
   // Cheap trick to make code simple.

--- a/ACE/ace/Malloc_T.h
+++ b/ACE/ace/Malloc_T.h
@@ -222,7 +222,7 @@ public:
    * Note that @a pool_name should be located in
    * a directory with the appropriate visibility and protection so
    * that all processes that need to access it can do so. */
-  ACE_Allocator_Adapter (const char *pool_name = 0);
+  ACE_Allocator_Adapter (const char *pool_name = nullptr);
 
   /**
    * Note that @a pool_name should be located in
@@ -452,7 +452,7 @@ public:
    * a directory with the appropriate visibility and protection so
    * that all processes that need to access it can do so.
    */
-  ACE_Malloc_T (const ACE_TCHAR *pool_name = 0);
+  ACE_Malloc_T (const ACE_TCHAR *pool_name = nullptr);
 
   /**
    * Initialize ACE_Malloc.  This constructor passes @a pool_name to
@@ -467,7 +467,7 @@ public:
    */
   ACE_Malloc_T (const ACE_TCHAR *pool_name,
                 const ACE_TCHAR *lock_name,
-                const ACE_MEM_POOL_OPTIONS *options = 0);
+                const ACE_MEM_POOL_OPTIONS *options = nullptr);
 
   /**
    * Initialize an ACE_Malloc with an external ACE_LOCK.
@@ -703,7 +703,7 @@ public:
   /// If @a name = 0 it will iterate through everything else only
   /// through those entries whose @a name match.
   ACE_Malloc_LIFO_Iterator_T (ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB> &malloc,
-                              const char *name = 0);
+                              const char *name = nullptr);
 
   /// Destructor.
   ~ACE_Malloc_LIFO_Iterator_T ();
@@ -771,7 +771,7 @@ public:
   /// If @a name = 0 it will iterate through everything else only
   /// through those entries whose @a name match.
   ACE_Malloc_FIFO_Iterator_T (ACE_Malloc_T<ACE_MEM_POOL_2, ACE_LOCK, ACE_CB> &malloc,
-                              const char *name = 0);
+                              const char *name = nullptr);
 
   /// Destructor.
   ~ACE_Malloc_FIFO_Iterator_T ();
@@ -834,7 +834,7 @@ public:
    * a directory with the appropriate visibility and protection so
    * that all processes that need to access it can do so.
    */
-  ACE_Malloc (const ACE_TCHAR *pool_name = 0);
+  ACE_Malloc (const ACE_TCHAR *pool_name = nullptr);
 
   /**
    * Initialize ACE_Malloc.  This constructor passes @a pool_name to
@@ -848,7 +848,7 @@ public:
    */
   ACE_Malloc (const ACE_TCHAR *pool_name,
               const ACE_TCHAR *lock_name,
-              const ACE_MEM_POOL_OPTIONS *options = 0);
+              const ACE_MEM_POOL_OPTIONS *options = nullptr);
 };
 
 template <ACE_MEM_POOL_1, class ACE_LOCK>
@@ -858,7 +858,7 @@ public:
   /// If @a name = 0 it will iterate through everything else only
   /// through those entries whose @a name match.
   ACE_Malloc_LIFO_Iterator (ACE_Malloc<ACE_MEM_POOL_2, ACE_LOCK> &malloc,
-                            const char *name = 0);
+                            const char *name = nullptr);
 };
 
 template <ACE_MEM_POOL_1, class ACE_LOCK>
@@ -868,7 +868,7 @@ public:
   /// If @a name = 0 it will iterate through everything else only
   /// through those entries whose @a name match.
   ACE_Malloc_FIFO_Iterator (ACE_Malloc<ACE_MEM_POOL_2, ACE_LOCK> &malloc,
-                            const char *name = 0);
+                            const char *name = nullptr);
 };
 
 template <class ACE_LOCK>

--- a/ACE/ace/Map_Manager.cpp
+++ b/ACE/ace/Map_Manager.cpp
@@ -33,7 +33,7 @@ ACE_Map_Manager<EXT_ID, INT_ID, ACE_LOCK>::open (size_t size,
   this->close_i ();
 
   // Use the user specified allocator or the default singleton one.
-  if (alloc == 0)
+  if (alloc == nullptr)
     alloc = ACE_Allocator::instance ();
 
   this->allocator_ = alloc;

--- a/ACE/ace/Message_Block.cpp
+++ b/ACE/ace/Message_Block.cpp
@@ -59,7 +59,7 @@ ACE_Message_Block::data_block (ACE_Data_Block *db)
   ACE_TRACE ("ACE_Message_Block::data_block");
   if (ACE_BIT_DISABLED (this->flags_,
                         ACE_Message_Block::DONT_DELETE)
-      && this->data_block_ != 0)
+      && this->data_block_ != nullptr)
     this->data_block_->release ();
 
   this->data_block_ = db;
@@ -216,7 +216,7 @@ ACE_Data_Block::size (size_t length)
   else
     {
       // We need to resize!
-      char *buf = 0;
+      char *buf = nullptr;
       ACE_ALLOCATOR_RETURN (buf,
                             (char *) this->allocator_strategy_->malloc (length),
                             -1);
@@ -257,7 +257,7 @@ ACE_Message_Block::total_size_and_length (size_t &mb_size,
   ACE_TRACE ("ACE_Message_Block::total_size_and_length");
 
   for (const ACE_Message_Block *i = this;
-       i != 0;
+       i != nullptr;
        i = i->cont ())
     {
       mb_size += i->size ();
@@ -272,7 +272,7 @@ ACE_Message_Block::total_size () const
 
   size_t size = 0;
   for (const ACE_Message_Block *i = this;
-       i != 0;
+       i != nullptr;
        i = i->cont ())
     size += i->size ();
 
@@ -286,7 +286,7 @@ ACE_Message_Block::total_length () const
 
   size_t length = 0;
   for (const ACE_Message_Block *i = this;
-       i != 0;
+       i != nullptr;
        i = i->cont ())
     length += i->length ();
 
@@ -301,7 +301,7 @@ ACE_Message_Block::total_capacity () const
   size_t size = 0;
 
   for (const ACE_Message_Block *i = this;
-       i != 0;
+       i != nullptr;
        i = i->cont ())
     size += i->capacity ();
 
@@ -313,11 +313,11 @@ ACE_Data_Block::ACE_Data_Block ()
     cur_size_ (0),
     max_size_ (0),
     flags_ (ACE_Message_Block::DONT_DELETE),
-    base_ (0),
-    allocator_strategy_ (0),
-    locking_strategy_ (0),
+    base_ (nullptr),
+    allocator_strategy_ (nullptr),
+    locking_strategy_ (nullptr),
     reference_count_ (1),
-    data_block_allocator_ (0)
+    data_block_allocator_ (nullptr)
 {
   ACE_TRACE ("ACE_Data_Block::ACE_Data_Block");
   ACE_FUNCTION_TIMEPROBE (ACE_DATA_BLOCK_CTOR1_ENTER);
@@ -351,15 +351,15 @@ ACE_Data_Block::ACE_Data_Block (size_t size,
 
   // If the user didn't pass one in, let's use the
   // <ACE_Allocator::instance>.
-  if (this->allocator_strategy_ == 0)
+  if (this->allocator_strategy_ == nullptr)
     ACE_ALLOCATOR (this->allocator_strategy_,
                    ACE_Allocator::instance ());
 
-  if (this->data_block_allocator_ == 0)
+  if (this->data_block_allocator_ == nullptr)
     ACE_ALLOCATOR (this->data_block_allocator_,
                    ACE_Allocator::instance ());
 
-  if (msg_data == 0)
+  if (msg_data == nullptr)
     {
       ACE_ALLOCATOR (this->base_,
                      (char *) this->allocator_strategy_->malloc (size));
@@ -372,7 +372,7 @@ ACE_Data_Block::ACE_Data_Block (size_t size,
 
   // ACE_ALLOCATOR returns on alloc failure but we cant throw, so setting
   // the size to 0 (i.e. "bad bit") ...
-  if (this->base_ == 0)
+  if (this->base_ == nullptr)
     {
       size = 0;
     }
@@ -386,7 +386,7 @@ ACE_Message_Block::ACE_Message_Block (const char *data,
                                       size_t size,
                                       unsigned long priority)
   : flags_ (0),
-    data_block_ (0)
+    data_block_ (nullptr)
 {
   ACE_TRACE ("ACE_Message_Block::ACE_Message_Block");
 
@@ -395,21 +395,21 @@ ACE_Message_Block::ACE_Message_Block (const char *data,
                     nullptr, // cont
                     data,    // data
                     nullptr, // allocator
-                    0,       // locking strategy
+                    nullptr,       // locking strategy
                     ACE_Message_Block::DONT_DELETE, // flags
                     priority, // priority
                     ACE_Time_Value::zero,     // execution time
                     ACE_Time_Value::max_time, // absolute time of deadline
                     nullptr,  // data block
                     nullptr,  // data_block allocator
-                    0) == -1) // message_block allocator
+                    nullptr) == -1) // message_block allocator
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("ACE_Message_Block")));
 }
 
 ACE_Message_Block::ACE_Message_Block (ACE_Allocator *message_block_allocator)
   : flags_ (0),
-    data_block_ (0)
+    data_block_ (nullptr)
 {
   ACE_TRACE ("ACE_Message_Block::ACE_Message_Block");
 
@@ -418,7 +418,7 @@ ACE_Message_Block::ACE_Message_Block (ACE_Allocator *message_block_allocator)
                     nullptr, // cont
                     nullptr, // data
                     nullptr, // allocator
-                    0,       // locking strategy
+                    nullptr,       // locking strategy
                     ACE_Message_Block::DONT_DELETE, // flags
                     0, // priority
                     ACE_Time_Value::zero,     // execution time
@@ -442,7 +442,7 @@ ACE_Message_Block::ACE_Message_Block (size_t size,
                                       ACE_Allocator *data_block_allocator,
                                       ACE_Allocator *message_block_allocator)
   :flags_ (0),
-   data_block_ (0)
+   data_block_ (nullptr)
 {
   ACE_TRACE ("ACE_Message_Block::ACE_Message_Block");
 
@@ -456,7 +456,7 @@ ACE_Message_Block::ACE_Message_Block (size_t size,
                     priority,
                     execution_time,
                     deadline_time,
-                    0, // data block
+                    nullptr, // data block
                     data_block_allocator,
                     message_block_allocator) == -1)
     ACELIB_ERROR ((LM_ERROR,
@@ -488,7 +488,7 @@ ACE_Message_Block::init (size_t size,
                        priority,
                        execution_time,
                        deadline_time,
-                       0,  // data block
+                       nullptr,  // data block
                        data_block_allocator,
                        message_block_allocator);
 }
@@ -504,7 +504,7 @@ ACE_Message_Block::init (const char *data, size_t size)
                        nullptr, // cont
                        data,    // data
                        nullptr, // allocator
-                       0,       // locking strategy
+                       nullptr,       // locking strategy
                        ACE_Message_Block::DONT_DELETE,  // flags
                        0,  // priority
                        ACE_Time_Value::zero,     // execution time
@@ -559,10 +559,10 @@ ACE_Message_Block::ACE_Message_Block (ACE_Data_Block *data_block,
 
   if (this->init_i (0,         // size
                     MB_NORMAL, // type
-                    0,         // cont
-                    0,         // data
-                    0,         // allocator
-                    0,         // locking strategy
+                    nullptr,         // cont
+                    nullptr,         // data
+                    nullptr,         // allocator
+                    nullptr,         // locking strategy
                     0,         // flags
                     0,         // priority
                     ACE_Time_Value::zero,     // execution time
@@ -699,15 +699,15 @@ ACE_Message_Block::init_i (size_t size,
 
   this->message_block_allocator_ = message_block_allocator;
 
-  if (this->data_block_ != 0)
+  if (this->data_block_ != nullptr)
     {
       this->data_block_->release ();
-      this->data_block_ = 0;
+      this->data_block_ = nullptr;
     }
 
-  if (db == 0)
+  if (db == nullptr)
     {
-      if (data_block_allocator == 0)
+      if (data_block_allocator == nullptr)
         ACE_ALLOCATOR_RETURN (data_block_allocator,
                               ACE_Allocator::instance (),
                               -1);
@@ -732,7 +732,7 @@ ACE_Message_Block::init_i (size_t size,
       // Message block initialization may fail, while the construction
       // succeeds.  Since ACE may throw no exceptions, we have to do a
       // separate check and clean up, like this:
-      if (db != 0 && db->size () < size)
+      if (db != nullptr && db->size () < size)
         {
           db->ACE_Data_Block::~ACE_Data_Block();  // placement destructor ...
           data_block_allocator->free (db); // free ...
@@ -793,12 +793,12 @@ ACE_Data_Block::release_no_delete (ACE_Lock *lock)
   ACE_Lock *lock_to_be_used = nullptr;
 
   // Check if we were passed in a lock
-  if (lock != 0)
+  if (lock != nullptr)
     {
       // Make sure that the lock passed in and our lock are the same
       if (lock == this->locking_strategy_)
         // In this case no locking is required.
-        lock_to_be_used = 0;
+        lock_to_be_used = nullptr;
 
       // The lock passed in does not match our lock
       else
@@ -814,9 +814,9 @@ ACE_Data_Block::release_no_delete (ACE_Lock *lock)
 
   // If there's a locking strategy then we need to acquire the lock
   // before decrementing the count.
-  if (lock_to_be_used != 0)
+  if (lock_to_be_used != nullptr)
     {
-      ACE_GUARD_RETURN (ACE_Lock, ace_mon, *lock_to_be_used, 0);
+      ACE_GUARD_RETURN (ACE_Lock, ace_mon, *lock_to_be_used, nullptr);
 
       result = this->release_i ();
     }
@@ -859,7 +859,7 @@ ACE_Message_Block::release ()
   // This flag is set to 1 when we have to destroy the data_block
   int destroy_dblock = 0;
 
-  ACE_Lock *lock = 0;
+  ACE_Lock *lock = nullptr;
 
   // Do we have a valid data block
   if (this->data_block ())
@@ -868,10 +868,10 @@ ACE_Message_Block::release ()
       lock = this->data_block ()->locking_strategy ();
 
       // if we have a lock
-      if (lock != 0)
+      if (lock != nullptr)
         {
           // One guard for all
-          ACE_GUARD_RETURN (ACE_Lock, ace_mon, *lock, 0);
+          ACE_GUARD_RETURN (ACE_Lock, ace_mon, *lock, nullptr);
 
           // Call non-guarded release with @a lock
           destroy_dblock = this->release_i (lock);
@@ -879,11 +879,11 @@ ACE_Message_Block::release ()
       // This is the case when we have a valid data block but no lock
       else
         // Call non-guarded release with no lock
-        destroy_dblock = this->release_i (0);
+        destroy_dblock = this->release_i (nullptr);
     }
   else
     // This is the case when we don't even have a valid data block
-    destroy_dblock = this->release_i (0);
+    destroy_dblock = this->release_i (nullptr);
 
   if (destroy_dblock != 0)
     {
@@ -893,7 +893,7 @@ ACE_Message_Block::release ()
                     ACE_Data_Block);
     }
 
-  return 0;
+  return nullptr;
 }
 
 int
@@ -911,7 +911,7 @@ ACE_Message_Block::release_i (ACE_Lock *lock)
         {
           tmp = mb;
           mb = mb->cont_;
-          tmp->cont_ = 0;
+          tmp->cont_ = nullptr;
 
           ACE_Data_Block *db = tmp->data_block ();
           if (tmp->release_i (lock) != 0)
@@ -924,7 +924,7 @@ ACE_Message_Block::release_i (ACE_Lock *lock)
         }
       while (mb);
 
-      this->cont_ = 0;
+      this->cont_ = nullptr;
     }
 
   int result = 0;
@@ -933,7 +933,7 @@ ACE_Message_Block::release_i (ACE_Lock *lock)
                         ACE_Message_Block::DONT_DELETE) &&
       this->data_block ())
     {
-      if (this->data_block ()->release_no_delete (lock) == 0)
+      if (this->data_block ()->release_no_delete (lock) == nullptr)
         result = 1;
       this->data_block_ = nullptr;
     }
@@ -988,7 +988,7 @@ ACE_Data_Block::duplicate ()
   if (this->locking_strategy_)
     {
       // We need to acquire the lock before incrementing the count.
-      ACE_GUARD_RETURN (ACE_Lock, ace_mon, *this->locking_strategy_, 0);
+      ACE_GUARD_RETURN (ACE_Lock, ace_mon, *this->locking_strategy_, nullptr);
       ++this->reference_count_;
     }
   else
@@ -1017,14 +1017,14 @@ ACE_Message_Block::duplicate () const
   // Increment the reference counts of all the continuation messages.
   while (current)
     {
-      ACE_Message_Block* cur_dup = 0;
+      ACE_Message_Block* cur_dup = nullptr;
 
       // Create a new <ACE_Message_Block> that contains unique copies of
       // the message block fields, but a reference counted duplicate of
       // the <ACE_Data_Block>.
 
       // If there is no allocator, use the standard new and delete calls.
-      if (current->message_block_allocator_ == 0)
+      if (current->message_block_allocator_ == nullptr)
         ACE_NEW_NORETURN (cur_dup,
                           ACE_Message_Block (0, // size
                                              ACE_Message_Type (0), // type
@@ -1067,13 +1067,13 @@ ACE_Message_Block::duplicate () const
 
 
       // If allocation failed above, release everything done so far and return NULL
-      if (cur_dup == 0)
+      if (cur_dup == nullptr)
         {
-          if (nb_top != 0)
+          if (nb_top != nullptr)
             {
               nb_top->release ();
             }
-          return 0;
+          return nullptr;
         }
 
       // Set the read and write pointers in the new <Message_Block> to the
@@ -1151,22 +1151,22 @@ ACE_Data_Block::clone_nocopy (ACE_Message_Block::Message_Flags mask,
                            this->data_block_allocator_->malloc (sizeof (ACE_Data_Block))),
                          ACE_Data_Block (newsize, // size
                                          this->type_,     // type
-                                         0,               // data
+                                         nullptr,               // data
                                          this->allocator_strategy_, // allocator
                                          this->locking_strategy_, // locking strategy
                                          this->flags_,  // flags
                                          this->data_block_allocator_),
-                         0);
+                         nullptr);
 
   // Message block initialization may fail while the construction
   // succeeds.  Since as a matter of policy, ACE may throw no
   // exceptions, we have to do a separate check like this.
-  if (nb != 0 && nb->size () < newsize)
+  if (nb != nullptr && nb->size () < newsize)
     {
       nb->ACE_Data_Block::~ACE_Data_Block();  // placement destructor ...
       this->data_block_allocator_->free (nb); // free ...
       errno = ENOMEM;
-      return 0;
+      return nullptr;
     }
 
   // Set new flags minus the mask...

--- a/ACE/ace/Message_Queue_T.cpp
+++ b/ACE/ace/Message_Queue_T.cpp
@@ -120,7 +120,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::peek_dequeue
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::peek_dequeue_head");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   int const cur_count = this->queue_.peek_dequeue_head (mb, timeout);
 
@@ -136,7 +136,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_head
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_head");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   ACE_NEW_RETURN (mb,
                   ACE_Message_Block ((char *) new_item,
@@ -171,7 +171,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_prio
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_prio");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   ACE_NEW_RETURN (mb,
                   ACE_Message_Block ((char *) new_item,
@@ -193,7 +193,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_dead
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_deadline");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   ACE_NEW_RETURN (mb,
                   ACE_Message_Block ((char *) new_item,
@@ -218,7 +218,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   ACE_NEW_RETURN (mb,
                   ACE_Message_Block ((char *) new_item,
@@ -243,7 +243,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_head
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_head");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   int const cur_count = this->queue_.dequeue_head (mb, timeout);
 
@@ -268,7 +268,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_prio
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_prio");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   int const cur_count = this->queue_.dequeue_prio (mb, timeout);
 
@@ -293,7 +293,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_tail
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_tail");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   int const cur_count = this->queue_.dequeue_tail (mb, timeout);
 
@@ -318,7 +318,7 @@ ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_dead
 {
   ACE_TRACE ("ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::dequeue_deadline");
 
-  ACE_Message_Block *mb = 0;
+  ACE_Message_Block *mb = nullptr;
 
   int const cur_count = this->queue_.dequeue_deadline (mb, timeout);
 
@@ -352,7 +352,7 @@ template <class ACE_MESSAGE_TYPE, ACE_SYNCH_DECL, class TIME_POLICY> int
 ACE_Message_Queue_Ex_Iterator<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::
 next (ACE_MESSAGE_TYPE *&entry)
 {
-  ACE_Message_Block * mb = 0;
+  ACE_Message_Block * mb = nullptr;
   int retval = this->iter_.next (mb);
 
   if (retval == 1)
@@ -392,7 +392,7 @@ template <class ACE_MESSAGE_TYPE, ACE_SYNCH_DECL, class TIME_POLICY> int
 ACE_Message_Queue_Ex_Reverse_Iterator<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::
 next (ACE_MESSAGE_TYPE *&entry)
 {
-  ACE_Message_Block * mb = 0;
+  ACE_Message_Block * mb = nullptr;
   int retval = this->iter_.next (mb);
 
   if (retval == 1)
@@ -449,7 +449,7 @@ ACE_Message_Queue_Ex_N<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_he
   // Create a chained ACE_Message_Blocks wrappers around the 'chained'
   // ACE_MESSAGE_TYPES.
   ACE_Message_Block *mb = this->wrap_with_mbs_i (new_item);
-  if (0 == mb)
+  if (nullptr == mb)
     {
       return -1;
     }
@@ -473,7 +473,7 @@ ACE_Message_Queue_Ex_N<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::enqueue_ta
   // Create a chained ACE_Message_Blocks wrappers around the 'chained'
   // ACE_MESSAGE_TYPES.
   ACE_Message_Block *mb = this->wrap_with_mbs_i (new_item);
-  if (0 == mb)
+  if (nullptr == mb)
     {
       return -1;
     }
@@ -494,13 +494,13 @@ ACE_Message_Queue_Ex_N<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::wrap_with_
   ACE_TRACE ("ACE_Message_Queue_Ex_N<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::wrap_with_mbs_i");
 
   // We need to keep a reference to the head of the chain
-  ACE_Message_Block *mb_head = 0;
+  ACE_Message_Block *mb_head = nullptr;
 
   ACE_NEW_RETURN (mb_head,
                   ACE_Message_Block ((char *) new_item,
                                      sizeof (*new_item),
                                      ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::DEFAULT_PRIORITY),
-                  0);
+                  nullptr);
 
   // mb_tail will point to the last ACE_Message_Block
   ACE_Message_Block *mb_tail = mb_head;
@@ -508,15 +508,15 @@ ACE_Message_Queue_Ex_N<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::wrap_with_
   // Run through rest of the messages and wrap them
   for (ACE_MESSAGE_TYPE *pobj = new_item->next (); pobj; pobj = pobj->next ())
     {
-      ACE_Message_Block *mb_temp = 0;
+      ACE_Message_Block *mb_temp = nullptr;
       ACE_NEW_NORETURN (mb_temp,
                         ACE_Message_Block ((char *) pobj,
                                            sizeof (*pobj),
                                            ACE_Message_Queue_Ex<ACE_MESSAGE_TYPE, ACE_SYNCH_USE, TIME_POLICY>::DEFAULT_PRIORITY));
-      if (mb_temp == 0)
+      if (mb_temp == nullptr)
         {
           mb_head->release ();
-          mb_head = 0;
+          mb_head = nullptr;
           break;
         }
 
@@ -1243,7 +1243,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail_i (ACE_Message_Block
 {
   ACE_TRACE ("ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail_i");
 
-  if (new_item == 0)
+  if (new_item == nullptr)
     return -1;
 
   // Update the queued size and length, taking into account any chained
@@ -1255,7 +1255,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail_i (ACE_Message_Block
   ++this->cur_count_;
   new_item->total_size_and_length (this->cur_bytes_,
                                    this->cur_length_);
-  while (seq_tail->next () != 0)
+  while (seq_tail->next () != nullptr)
     {
       seq_tail->next ()->prev (seq_tail);
       seq_tail = seq_tail->next ();
@@ -1270,7 +1270,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail_i (ACE_Message_Block
       this->head_ = new_item;
       this->tail_ = seq_tail;
       // seq_tail->next (0);   This is a condition of the while() loop above.
-      new_item->prev (0);
+      new_item->prev (nullptr);
     }
   // Link at the end.
   else
@@ -1294,7 +1294,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_head_i (ACE_Message_Block
 {
   ACE_TRACE ("ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_head_i");
 
-  if (new_item == 0)
+  if (new_item == nullptr)
     return -1;
 
   // Update the queued size and length, taking into account any chained
@@ -1306,7 +1306,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_head_i (ACE_Message_Block
   ++this->cur_count_;
   new_item->total_size_and_length (this->cur_bytes_,
                                    this->cur_length_);
-  while (seq_tail->next () != 0)
+  while (seq_tail->next () != nullptr)
     {
       seq_tail->next ()->prev (seq_tail);
       seq_tail = seq_tail->next ();
@@ -1315,7 +1315,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_head_i (ACE_Message_Block
                                        this->cur_length_);
     }
 
-  new_item->prev (0);
+  new_item->prev (nullptr);
   seq_tail->next (this->head_);
 
   if (this->head_ != 0)
@@ -1339,14 +1339,14 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_i (ACE_Message_Block *new
 {
   ACE_TRACE ("ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_i");
 
-  if (new_item == 0)
+  if (new_item == nullptr)
     return -1;
 
   // Since this method uses enqueue_head_i() and enqueue_tail_i() for
   // special situations, and this method doesn't support enqueueing
   // chains of blocks off the 'next' pointer, make sure the new_item's
   // next pointer is 0.
-  new_item->next (0);
+  new_item->next (nullptr);
 
   if (this->head_ == 0)
     // Check for simple case of an empty queue, where all we need to
@@ -1354,26 +1354,26 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_i (ACE_Message_Block *new
     return this->enqueue_head_i (new_item);
   else
     {
-      ACE_Message_Block *temp = 0;
+      ACE_Message_Block *temp = nullptr;
 
       // Figure out where the new item goes relative to its priority.
       // We start looking from the lowest priority (at the tail) to
       // the highest priority (at the head).
 
       for (temp = this->tail_;
-           temp != 0;
+           temp != nullptr;
            temp = temp->prev ())
         if (temp->msg_priority () >= new_item->msg_priority ())
           // Break out when we've located an item that has
           // greater or equal priority.
           break;
 
-      if (temp == 0)
+      if (temp == nullptr)
         // Check for simple case of inserting at the head of the queue,
         // where all we need to do is insert <new_item> before the
         // current head.
         return this->enqueue_head_i (new_item);
-      else if (temp->next () == 0)
+      else if (temp->next () == nullptr)
         // Check for simple case of inserting at the tail of the
         // queue, where all we need to do is insert <new_item> after
         // the current tail.
@@ -1506,8 +1506,8 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_head_i (ACE_Message_Block
     this->head_ = this->tail_ = 0;
 
   // Make sure that the prev and next fields are 0!
-  first_item->prev (0);
-  first_item->next (0);
+  first_item->prev (nullptr);
+  first_item->next (nullptr);
 
 #if defined (ACE_HAS_MONITOR_POINTS) && (ACE_HAS_MONITOR_POINTS == 1)
   this->monitor_->receive (this->cur_length_);
@@ -1537,11 +1537,11 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_prio_i (ACE_Message_Block
 
   // Find the earliest (i.e., FIFO) message enqueued with the lowest
   // priority.
-  ACE_Message_Block *chosen = 0;
+  ACE_Message_Block *chosen = nullptr;
   u_long priority = ULONG_MAX;
 
   for (ACE_Message_Block *temp = this->tail_;
-       temp != 0;
+       temp != nullptr;
        temp = temp->prev ())
     {
       // Find the first version of the earliest message (i.e.,
@@ -1555,17 +1555,17 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_prio_i (ACE_Message_Block
 
   // If every message block is the same priority, pass back the first
   // one.
-  if (chosen == 0)
+  if (chosen == nullptr)
     chosen = this->head_;
 
   // Patch up the queue.  If we don't have a previous then we are at
   // the head of the queue.
-  if (chosen->prev () == 0)
+  if (chosen->prev () == nullptr)
     this->head_ = chosen->next ();
   else
     chosen->prev ()->next (chosen->next ());
 
-  if (chosen->next () == 0)
+  if (chosen->next () == nullptr)
     this->tail_ = chosen->prev ();
   else
     chosen->next ()->prev (chosen->prev ());
@@ -1586,8 +1586,8 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_prio_i (ACE_Message_Block
     this->head_ = this->tail_ = 0;
 
   // Make sure that the prev and next fields are 0!
-  dequeued->prev (0);
-  dequeued->next (0);
+  dequeued->prev (nullptr);
+  dequeued->next (nullptr);
 
   // Only signal enqueueing threads if we've fallen below the low
   // water mark.
@@ -1635,8 +1635,8 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_tail_i (ACE_Message_Block
     this->head_ = this->tail_ = 0;
 
   // Make sure that the prev and next fields are 0!
-  dequeued->prev (0);
-  dequeued->next (0);
+  dequeued->prev (nullptr);
+  dequeued->next (nullptr);
 
   // Only signal enqueueing threads if we've fallen below the low
   // water mark.
@@ -1803,7 +1803,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_head (ACE_Message_Block *
 {
   ACE_TRACE ("ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_head");
   int queue_count = 0;
-  ACE_Notification_Strategy *notifier = 0;
+  ACE_Notification_Strategy *notifier = nullptr;
   {
     ACE_GUARD_RETURN (ACE_SYNCH_MUTEX_T, ace_mon, this->lock_, -1);
 
@@ -1826,7 +1826,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_head (ACE_Message_Block *
     notifier = this->notification_strategy_;
   }
 
-  if (0 != notifier)
+  if (nullptr != notifier)
     notifier->notify();
   return queue_count;
 }
@@ -1841,7 +1841,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_prio (ACE_Message_Block *
 {
   ACE_TRACE ("ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_prio");
   int queue_count = 0;
-  ACE_Notification_Strategy *notifier = 0;
+  ACE_Notification_Strategy *notifier = nullptr;
   {
     ACE_GUARD_RETURN (ACE_SYNCH_MUTEX_T, ace_mon, this->lock_, -1);
 
@@ -1864,7 +1864,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_prio (ACE_Message_Block *
 #endif
     notifier = this->notification_strategy_;
   }
-  if (0 != notifier)
+  if (nullptr != notifier)
     notifier->notify ();
   return queue_count;
 }
@@ -1879,7 +1879,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_deadline (ACE_Message_Blo
 {
   ACE_TRACE ("ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_deadline");
   int queue_count = 0;
-  ACE_Notification_Strategy *notifier = 0;
+  ACE_Notification_Strategy *notifier = nullptr;
   {
     ACE_GUARD_RETURN (ACE_SYNCH_MUTEX_T, ace_mon, this->lock_, -1);
 
@@ -1902,7 +1902,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_deadline (ACE_Message_Blo
 #endif
     notifier = this->notification_strategy_;
   }
-  if (0 != notifier)
+  if (nullptr != notifier)
     notifier->notify ();
   return queue_count;
 }
@@ -1924,7 +1924,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail (ACE_Message_Block *
 {
   ACE_TRACE ("ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail");
   int queue_count = 0;
-  ACE_Notification_Strategy *notifier = 0;
+  ACE_Notification_Strategy *notifier = nullptr;
   {
     ACE_GUARD_RETURN (ACE_SYNCH_MUTEX_T, ace_mon, this->lock_, -1);
 
@@ -1947,7 +1947,7 @@ ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_tail (ACE_Message_Block *
 #endif
     notifier = this->notification_strategy_;
   }
-  if (0 != notifier)
+  if (nullptr != notifier)
     notifier->notify ();
   return queue_count;
 }
@@ -2062,12 +2062,12 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::ACE_Dynamic_Message_Queue
                                                                      size_t lwm,
                                                                      ACE_Notification_Strategy *ns)
   : ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> (hwm, lwm, ns),
-    pending_head_ (0),
-    pending_tail_ (0),
-    late_head_ (0),
-    late_tail_ (0),
-    beyond_late_head_ (0),
-    beyond_late_tail_ (0),
+    pending_head_ (nullptr),
+    pending_tail_ (nullptr),
+    late_head_ (nullptr),
+    late_tail_ (nullptr),
+    beyond_late_head_ (nullptr),
+    beyond_late_tail_ (nullptr),
     message_strategy_ (message_strategy)
 {
   // Note, the ACE_Dynamic_Message_Queue assumes full responsibility
@@ -2089,8 +2089,8 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::remove_messages (ACE_Mess
                                                            u_int status_flags)
 {
   // start with an empty list
-  list_head = 0;
-  list_tail = 0;
+  list_head = nullptr;
+  list_tail = nullptr;
 
   // Get the current time
   ACE_Time_Value current_time = ACE_OS::gettimeofday ();
@@ -2198,7 +2198,7 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::remove_messages (ACE_Mess
   ACE_Message_Block *temp1;
 
   for (temp1 = list_head;
-       temp1 != 0;
+       temp1 != nullptr;
        temp1 = temp1->next ())
     {
       --this->cur_count_;
@@ -2300,7 +2300,7 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_i (ACE_Message_Bl
 {
   ACE_TRACE ("ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::enqueue_i");
 
-  if (new_item == 0)
+  if (new_item == nullptr)
     {
       return -1;
     }
@@ -2458,7 +2458,7 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::sublist_enqueue_i (ACE_Me
                                                              ACE_Dynamic_Message_Strategy::Priority_Status status)
 {
   int result = 0;
-  ACE_Message_Block *current_item = 0;
+  ACE_Message_Block *current_item = nullptr;
 
   // Find message after which to enqueue new item, based on message
   // priority and priority status.
@@ -2478,11 +2478,11 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::sublist_enqueue_i (ACE_Me
         }
     }
 
-  if (current_item == 0)
+  if (current_item == nullptr)
     {
       // If the new message has highest priority of any, put it at the
       // head of the list (and sublist).
-      new_item->prev (0);
+      new_item->prev (nullptr);
       new_item->next (this->head_);
       if (this->head_ != 0)
         this->head_->prev (new_item);
@@ -2549,8 +2549,8 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_head_i (ACE_Messa
           this->pending_head_ = this->pending_head_->next ();
         }
 
-      first_item->prev (0);
-      first_item->next (0);
+      first_item->prev (nullptr);
+      first_item->next (nullptr);
     }
 
   // Second, try to dequeue from the head of the late list
@@ -2579,8 +2579,8 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_head_i (ACE_Messa
           this->late_tail_ = 0;
         }
 
-      first_item->prev (0);
-      first_item->next (0);
+      first_item->prev (nullptr);
+      first_item->next (nullptr);
     }
   // finally, try to dequeue from the head of the beyond late list
   else if (this->beyond_late_head_)
@@ -2607,13 +2607,13 @@ ACE_Dynamic_Message_Queue<ACE_SYNCH_USE, TIME_POLICY>::dequeue_head_i (ACE_Messa
           this->beyond_late_tail_ = 0;
         }
 
-      first_item->prev (0);
-      first_item->next (0);
+      first_item->prev (nullptr);
+      first_item->next (nullptr);
     }
   else
     {
       // nothing to dequeue: set the pointer to zero and return an error code
-      first_item = 0;
+      first_item = nullptr;
       result = -1;
     }
 
@@ -2938,7 +2938,7 @@ ACE_Message_Queue_Factory<ACE_SYNCH_USE, TIME_POLICY>::create_deadline_message_q
                                                                          u_long dynamic_priority_max,
                                                                          u_long dynamic_priority_offset)
 {
-  ACE_Deadline_Message_Strategy *adms = 0;
+  ACE_Deadline_Message_Strategy *adms = nullptr;
 
   ACE_NEW_RETURN (adms,
                   ACE_Deadline_Message_Strategy (static_bit_field_mask,
@@ -2968,7 +2968,7 @@ ACE_Message_Queue_Factory<ACE_SYNCH_USE, TIME_POLICY>::create_laxity_message_que
                                                                        u_long dynamic_priority_max,
                                                                        u_long dynamic_priority_offset)
 {
-  ACE_Laxity_Message_Strategy *alms = 0;
+  ACE_Laxity_Message_Strategy *alms = nullptr;
 
   ACE_NEW_RETURN (alms,
                   ACE_Laxity_Message_Strategy (static_bit_field_mask,

--- a/ACE/ace/Message_Queue_T.h
+++ b/ACE/ace/Message_Queue_T.h
@@ -785,7 +785,7 @@ public:
   ACE_Dynamic_Message_Queue (ACE_Dynamic_Message_Strategy & message_strategy,
                              size_t hwm = ACE_Message_Queue_Base::DEFAULT_HWM,
                              size_t lwm = ACE_Message_Queue_Base::DEFAULT_LWM,
-                             ACE_Notification_Strategy * = 0);
+                             ACE_Notification_Strategy * = nullptr);
 
   /// Close down the message queue and release all resources.
   virtual ~ACE_Dynamic_Message_Queue ();
@@ -809,7 +809,7 @@ public:
    * the queue.
    */
   virtual int dequeue_head (ACE_Message_Block *&first_item,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
   /// Dump the state of the queue.
   virtual void dump () const;
@@ -821,7 +821,7 @@ public:
    * enqueue or dequeue operation.
    */
   virtual int enqueue_tail (ACE_Message_Block *new_item,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
   /**
    * Just call priority enqueue method: head enqueue semantics for dynamic
@@ -830,7 +830,7 @@ public:
    * enqueue or dequeue operation.
    */
   virtual int enqueue_head (ACE_Message_Block *new_item,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
 
   /// Declare the dynamic allocation hooks.
@@ -906,7 +906,7 @@ private:
 
   /// Private method to hide public base class method: just calls base class method
   virtual int peek_dequeue_head (ACE_Message_Block *&first_item,
-                                 ACE_Time_Value *timeout = 0);
+                                 ACE_Time_Value *timeout = nullptr);
 };
 
 /**
@@ -1037,10 +1037,10 @@ public:
    */
   ACE_Message_Queue_Ex (size_t high_water_mark = ACE_Message_Queue_Base::DEFAULT_HWM,
                         size_t low_water_mark = ACE_Message_Queue_Base::DEFAULT_LWM,
-                        ACE_Notification_Strategy * ns = 0);
+                        ACE_Notification_Strategy * ns = nullptr);
   virtual int open (size_t hwm = ACE_Message_Queue_Base::DEFAULT_HWM,
                     size_t lwm = ACE_Message_Queue_Base::DEFAULT_LWM,
-                    ACE_Notification_Strategy * = 0);
+                    ACE_Notification_Strategy * = nullptr);
   //@}
 
   /// Releases all resources from the message queue and marks it deactivated.
@@ -1113,7 +1113,7 @@ public:
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
   virtual int peek_dequeue_head (ACE_MESSAGE_TYPE *&first_item,
-                                 ACE_Time_Value *timeout = 0);
+                                 ACE_Time_Value *timeout = nullptr);
 
   /**
    * Enqueue an ACE_MESSAGE TYPE into the queue in accordance with
@@ -1133,7 +1133,7 @@ public:
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
   virtual int enqueue_prio (ACE_MESSAGE_TYPE *new_item,
-                            ACE_Time_Value *timeout = 0,
+                            ACE_Time_Value *timeout = nullptr,
                             unsigned long priority = DEFAULT_PRIORITY);
 
   /**
@@ -1141,7 +1141,7 @@ public:
    * time associated with items.
    */
   virtual int enqueue_deadline (ACE_MESSAGE_TYPE *new_item,
-                                ACE_Time_Value *timeout = 0);
+                                ACE_Time_Value *timeout = nullptr);
 
   /**
    * @deprecated This is an alias for enqueue_prio().  It's only here for
@@ -1149,7 +1149,7 @@ public:
    * Please use enqueue_prio() instead.
    */
   virtual int enqueue (ACE_MESSAGE_TYPE *new_item,
-                       ACE_Time_Value *timeout = 0);
+                       ACE_Time_Value *timeout = nullptr);
 
   /**
    * Enqueue an item at the tail of the queue.
@@ -1165,7 +1165,7 @@ public:
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
   virtual int enqueue_tail (ACE_MESSAGE_TYPE *new_item,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
   /**
    * Enqueue an item at the head of the queue.
@@ -1181,11 +1181,11 @@ public:
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
   virtual int enqueue_head (ACE_MESSAGE_TYPE *new_item,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
   /// This method is an alias for the following <dequeue_head> method.
   virtual int dequeue (ACE_MESSAGE_TYPE *&first_item,
-                       ACE_Time_Value *timeout = 0);
+                       ACE_Time_Value *timeout = nullptr);
 
   /**
    * Dequeue the item at the head of the queue and return a pointer to it.
@@ -1201,7 +1201,7 @@ public:
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
   virtual int dequeue_head (ACE_MESSAGE_TYPE *&first_item,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
   /**
    * Dequeue the item that has the lowest priority (preserves
@@ -1219,7 +1219,7 @@ public:
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
   virtual int dequeue_prio (ACE_MESSAGE_TYPE *&dequeued,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
   /**
    * Dequeue the item at the tail of the queue and return a pointer to it.
@@ -1235,14 +1235,14 @@ public:
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
   virtual int dequeue_tail (ACE_MESSAGE_TYPE *&dequeued,
-                            ACE_Time_Value *timeout = 0);
+                            ACE_Time_Value *timeout = nullptr);
 
   /**
    * Because there's deadline associated with enqueue_deadline(), this
    * method will behave just as dequeue_head().
    */
   virtual int dequeue_deadline (ACE_MESSAGE_TYPE *&dequeued,
-                                ACE_Time_Value *timeout = 0);
+                                ACE_Time_Value *timeout = nullptr);
   //@}
 
   /** @name Queue statistics methods
@@ -1504,7 +1504,7 @@ public:
    */
   ACE_Message_Queue_Ex_N (size_t high_water_mark = ACE_Message_Queue_Base::DEFAULT_HWM,
                           size_t low_water_mark = ACE_Message_Queue_Base::DEFAULT_LWM,
-                          ACE_Notification_Strategy * ns = 0);
+                          ACE_Notification_Strategy * ns = nullptr);
 
   /// Close down the message queue and release all resources.
   virtual ~ACE_Message_Queue_Ex_N ();
@@ -1529,7 +1529,7 @@ public:
    *            - EWOULDBLOCK: the timeout elapsed
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
-  virtual int enqueue_head (ACE_MESSAGE_TYPE *new_item, ACE_Time_Value *tv = 0);
+  virtual int enqueue_head (ACE_MESSAGE_TYPE *new_item, ACE_Time_Value *tv = nullptr);
 
   /**
    * Enqueue one or more @c ACE_MESSAGE_TYPE objects at the tail of the queue.
@@ -1551,7 +1551,7 @@ public:
    *            - EWOULDBLOCK: the timeout elapsed
    *            - ESHUTDOWN: the queue was deactivated or pulsed
    */
-  virtual int enqueue_tail (ACE_MESSAGE_TYPE *new_item, ACE_Time_Value *tv = 0);
+  virtual int enqueue_tail (ACE_MESSAGE_TYPE *new_item, ACE_Time_Value *tv = nullptr);
 
   /// Declare the dynamic allocation hooks.
   ACE_ALLOC_HOOK_DECLARE;

--- a/ACE/ace/Module.cpp
+++ b/ACE/ace/Module.cpp
@@ -161,7 +161,7 @@ ACE_Module<ACE_SYNCH_USE, TIME_POLICY>::sibling (ACE_Task<ACE_SYNCH_USE, TIME_PO
 template <ACE_SYNCH_DECL, class TIME_POLICY>
 ACE_Module<ACE_SYNCH_USE, TIME_POLICY>::ACE_Module ()
   : next_ (0)
-  , arg_ (0)
+  , arg_ (nullptr)
   , flags_ (M_FLAGS_NOT_SET)
 {
   ACE_TRACE ("ACE_Module<ACE_SYNCH_USE, TIME_POLICY>::ACE_Module");

--- a/ACE/ace/Module.h
+++ b/ACE/ace/Module.h
@@ -87,9 +87,9 @@ public:
   /// Create an initialized module with @a module_name as its identity
   /// and @a reader and @a writer as its tasks.
   ACE_Module (const ACE_TCHAR *module_name,
-              ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *writer = 0,
-              ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *reader = 0,
-              void *args = 0,
+              ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *writer = nullptr,
+              ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *reader = nullptr,
+              void *args = nullptr,
               int flags = M_DELETE);
 
   /**
@@ -100,9 +100,9 @@ public:
    * <ACE_Task::module_closed>.
    */
   int open (const ACE_TCHAR *module_name,
-            ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *writer = 0,
-            ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *reader = 0,
-            void *a = 0,
+            ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *writer = nullptr,
+            ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *reader = nullptr,
+            void *a = nullptr,
             int flags = M_DELETE);
 
   /**

--- a/ACE/ace/Monitor_Admin.cpp
+++ b/ACE/ace/Monitor_Admin.cpp
@@ -75,7 +75,7 @@ namespace ACE
     Monitor_Base*
     Monitor_Admin::monitor_point (const char* name)
     {
-      ACE_CString name_str (name, 0, false);
+      ACE_CString name_str (name, nullptr, false);
       return Monitor_Point_Registry::instance ()->get (name_str);
     }
 

--- a/ACE/ace/Monitor_Base.cpp
+++ b/ACE/ace/Monitor_Base.cpp
@@ -164,10 +164,10 @@ namespace ACE
     Control_Action*
     Monitor_Base::remove_constraint (const long constraint_id)
     {
-      Control_Action* retval = 0;
+      Control_Action* retval = nullptr;
 
       {
-        ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, guard, this->mutex_, 0);
+        ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, guard, this->mutex_, nullptr);
 
         CONSTRAINT_ITERATOR i = this->constraints_.find (constraint_id);
 

--- a/ACE/ace/Monitor_Control_Types.cpp
+++ b/ACE/ace/Monitor_Control_Types.cpp
@@ -30,7 +30,7 @@ namespace ACE
       : expr (rhs.expr),
         control_action (rhs.control_action)
     {
-      if (control_action != 0)
+      if (control_action != nullptr)
         {
           control_action->add_ref ();
         }
@@ -38,7 +38,7 @@ namespace ACE
 
     Monitor_Control_Types::Constraint::~Constraint ()
     {
-      if (this->control_action != 0)
+      if (this->control_action != nullptr)
         {
           this->control_action->remove_ref ();
         }
@@ -49,7 +49,7 @@ namespace ACE
     {
       if (this != &rhs)
         {
-          if (this->control_action != 0)
+          if (this->control_action != nullptr)
             {
               this->control_action->remove_ref ();
             }
@@ -57,7 +57,7 @@ namespace ACE
           this->expr = rhs.expr;
           this->control_action = rhs.control_action;
 
-          if (this->control_action != 0)
+          if (this->control_action != nullptr)
             {
               this->control_action->add_ref ();
             }

--- a/ACE/ace/Monitor_Point_Registry.cpp
+++ b/ACE/ace/Monitor_Point_Registry.cpp
@@ -21,7 +21,7 @@ namespace ACE
     bool
     Monitor_Point_Registry::add (Monitor_Base* type)
     {
-      if (type == 0)
+      if (type == nullptr)
         {
           ACELIB_ERROR_RETURN ((LM_ERROR,
                              "registry add: null type\n"),
@@ -51,7 +51,7 @@ namespace ACE
     bool
     Monitor_Point_Registry::remove (const char* name)
     {
-      if (name == 0)
+      if (name == nullptr)
         {
           ACELIB_ERROR_RETURN ((LM_ERROR,
                              "registry remove: null name\n"),
@@ -59,12 +59,12 @@ namespace ACE
         }
 
       int status = 0;
-      Map::data_type mp = 0;
+      Map::data_type mp = nullptr;
 
       {
         ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, guard, this->mutex_, false);
 
-        ACE_CString name_str (name, 0, false);
+        ACE_CString name_str (name, nullptr, false);
         status = this->map_.unbind (name_str, mp);
       }
 
@@ -109,15 +109,15 @@ namespace ACE
     Monitor_Base*
     Monitor_Point_Registry::get (const ACE_CString& name) const
     {
-      Map::data_type mp = 0;
+      Map::data_type mp = nullptr;
 
       {
-        ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, guard, this->mutex_, 0);
+        ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, guard, this->mutex_, nullptr);
 
         this->map_.find (name, mp);
       }
 
-      if (mp != 0)
+      if (mp != nullptr)
         {
           mp->add_ref ();
         }
@@ -146,7 +146,7 @@ namespace ACE
            i != this->map_.end ();
            i.advance ())
         {
-          Map::ENTRY* entry = 0;
+          Map::ENTRY* entry = nullptr;
           i.next (entry);
           entry->int_id_->remove_ref ();
         }

--- a/ACE/ace/Mutex.cpp
+++ b/ACE/ace/Mutex.cpp
@@ -46,8 +46,8 @@ ACE_Mutex::ACE_Mutex (int type, const ACE_TCHAR *name,
                       ACE_mutexattr_t *arg, mode_t mode)
   :
 #ifdef ACE_MUTEX_USE_PROCESS_LOCK
-    process_lock_ (0),
-    lockname_ (0),
+    process_lock_ (nullptr),
+    lockname_ (nullptr),
 #endif /* ACE_MUTEX_USE_PROCESS_LOCK */
     removed_ (false)
 {
@@ -76,7 +76,7 @@ ACE_Mutex::ACE_Mutex (int type, const ACE_TCHAR *name,
               return;
             }
           this->lockname_ = ACE_OS::strdup (name);
-          if (this->lockname_ == 0)
+          if (this->lockname_ == nullptr)
             {
               ACE_OS::close (fd);
               return;
@@ -84,7 +84,7 @@ ACE_Mutex::ACE_Mutex (int type, const ACE_TCHAR *name,
         }
 
       this->process_lock_ =
-        (ACE_mutex_t *) ACE_OS::mmap (0,
+        (ACE_mutex_t *) ACE_OS::mmap (nullptr,
                                       sizeof (ACE_mutex_t),
                                       PROT_RDWR,
                                       MAP_SHARED,

--- a/ACE/ace/Name_Request_Reply.cpp
+++ b/ACE/ace/Name_Request_Reply.cpp
@@ -33,7 +33,7 @@ ACE_Name_Request::ACE_Name_Request (
   this->type_len (type_length);
 
   // If timeout is a NULL pointer, then block forever...
-  if (timeout == 0)
+  if (timeout == nullptr)
     {
       this->transfer_.block_forever_ = 1;
       this->transfer_.sec_timeout_   = 0;

--- a/ACE/ace/Name_Space.cpp
+++ b/ACE/ace/Name_Space.cpp
@@ -30,7 +30,7 @@ ACE_Name_Binding::ACE_Name_Binding (const ACE_NS_WString &name,
                                     const char *type)
   : name_ (name),
     value_ (value),
-    type_ (type == 0 ? ACE_OS::strdup ("") : ACE_OS::strdup (type))
+    type_ (type == nullptr ? ACE_OS::strdup ("") : ACE_OS::strdup (type))
 {
   ACE_TRACE ("ACE_Name_Binding::ACE_Name_Binding");
 }

--- a/ACE/ace/Naming_Context.cpp
+++ b/ACE/ace/Naming_Context.cpp
@@ -40,7 +40,7 @@ ACE_Naming_Context::info (ACE_TCHAR **strp,
                     ACE_TEXT ("ACE_Naming_Context"),
                     ACE_TEXT ("Proxy for making calls to a Name Server"));
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (buf)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (buf)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, buf, length);
@@ -106,7 +106,7 @@ ACE_Naming_Context::open (Context_Scope_Type scope_in, int lite)
         }
     }
 
-  if (ACE_LOG_MSG->op_status () != 0 || this->name_space_ == 0)
+  if (ACE_LOG_MSG->op_status () != 0 || this->name_space_ == nullptr)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("NAME_SPACE::NAME_SPACE\n")),
                       -1);
@@ -119,7 +119,7 @@ ACE_Naming_Context::close_down ()
   ACE_TRACE ("ACE_Naming_Context::close_down");
 
   delete this->name_options_;
-  this->name_options_ = 0;
+  this->name_options_ = nullptr;
 
   return this->close ();
 }
@@ -130,15 +130,15 @@ ACE_Naming_Context::close ()
   ACE_TRACE ("ACE_Naming_Context::close");
 
   delete this->name_space_;
-  this->name_space_ = 0;
+  this->name_space_ = nullptr;
 
   return 0;
 }
 
 ACE_Naming_Context::ACE_Naming_Context ()
-  : name_options_ (0),
-    name_space_ (0),
-    netnameserver_host_ (0),
+  : name_options_ (nullptr),
+    name_space_ (nullptr),
+    netnameserver_host_ (nullptr),
     netnameserver_port_ (0)
 {
   ACE_TRACE ("ACE_Naming_Context::ACE_Naming_Context");
@@ -149,9 +149,9 @@ ACE_Naming_Context::ACE_Naming_Context ()
 
 ACE_Naming_Context::ACE_Naming_Context (Context_Scope_Type scope_in,
                                         int lite)
-  : name_options_ (0),
-    name_space_ (0),
-    netnameserver_host_ (0)
+  : name_options_ (nullptr),
+    name_space_ (nullptr),
+    netnameserver_host_ (nullptr)
 {
   ACE_TRACE ("ACE_Naming_Context::ACE_Naming_Context");
 
@@ -252,7 +252,7 @@ ACE_Naming_Context::resolve (const char *name_in,
   // responsible for deleting it!
   value_out = val_str.char_rep ();
 
-  return value_out == 0 ? -1 : 0;
+  return value_out == nullptr ? -1 : 0;
 }
 
 int
@@ -419,7 +419,7 @@ ACE_Name_Options::ACE_Name_Options ()
     use_registry_ (false),
     nameserver_port_ (ACE_DEFAULT_SERVER_PORT),
     nameserver_host_ (ACE_OS::strdup (ACE_DEFAULT_SERVER_HOST)),
-    process_name_ (0),
+    process_name_ (nullptr),
     database_ (ACE_OS::strdup (ACE_DEFAULT_LOCALNAME)),
     base_address_ (ACE_DEFAULT_BASE_ADDR)
 {
@@ -575,7 +575,7 @@ ACE_Name_Options::parse_args (int argc, ACE_TCHAR *argv[])
 {
   ACE_TRACE ("ACE_Name_Options::parse_args");
 
-  const ACE_TCHAR* program_name = 0;
+  const ACE_TCHAR* program_name = nullptr;
 
   // Argc can be 0 on some platforms like VxWorks.
   if (argc > 0)

--- a/ACE/ace/Notification_Queue.cpp
+++ b/ACE/ace/Notification_Queue.cpp
@@ -42,10 +42,10 @@ ACE_Notification_Queue::reset()
 
   // Release all the event handlers still in the queue ...
   for (ACE_Notification_Queue_Node * node = notify_queue_.head();
-       node != 0;
+       node != nullptr;
        node = node->next())
     {
-      if (node->get().eh_ == 0)
+      if (node->get().eh_ == nullptr)
         {
           continue;
         }
@@ -53,13 +53,13 @@ ACE_Notification_Queue::reset()
     }
 
   // ... free up the dynamically allocated resources ...
-  ACE_Notification_Queue_Node **b = 0;
+  ACE_Notification_Queue_Node **b = nullptr;
   for (ACE_Unbounded_Queue_Iterator<ACE_Notification_Queue_Node *> alloc_iter (this->alloc_queue_);
        alloc_iter.next (b) != 0;
        alloc_iter.advance ())
     {
       delete [] *b;
-      *b = 0;
+      *b = nullptr;
     }
 
   // ... cleanup the list of allocated blocks ...
@@ -75,7 +75,7 @@ ACE_Notification_Queue::allocate_more_buffers()
 {
   ACE_TRACE ("ACE_Notification_Queue::allocate_more_buffers");
 
-  ACE_Notification_Queue_Node *temp = 0;
+  ACE_Notification_Queue_Node *temp = nullptr;
 
   ACE_NEW_RETURN (temp,
                   ACE_Notification_Queue_Node[ACE_REACTOR_NOTIFICATION_ARRAY_SIZE],
@@ -109,7 +109,7 @@ ACE_Notification_Queue::purge_pending_notifications(
 
   int number_purged = 0;
   ACE_Notification_Queue_Node * node = notify_queue_.head();
-  while(node != 0)
+  while(node != nullptr)
     {
       if (!node->matches_for_purging(eh))
         {
@@ -175,7 +175,7 @@ ACE_Notification_Queue::push_new_notification(
   ACE_Notification_Queue_Node * node =
     free_queue_.pop_front();
 
-  ACE_ASSERT (node != 0);
+  ACE_ASSERT (node != nullptr);
   node->set(buffer);
 
   notify_queue_.push_back(node);

--- a/ACE/ace/Null_Barrier.h
+++ b/ACE/ace/Null_Barrier.h
@@ -24,8 +24,8 @@ class ACE_Null_Barrier
 public:
   /// Initialize the barrier to synchronize <count> threads.
   ACE_Null_Barrier (unsigned int,
-                    const char * = 0,
-                    void * = 0) {}
+                    const char * = nullptr,
+                    void * = nullptr) {}
 
   /// Default dtor.
   ~ACE_Null_Barrier () = default;

--- a/ACE/ace/Null_Semaphore.h
+++ b/ACE/ace/Null_Semaphore.h
@@ -46,8 +46,8 @@ class ACE_Null_Semaphore
 public:
   ACE_Null_Semaphore (unsigned int = 1,
                        int = 0,
-                       const ACE_TCHAR * = 0,
-                       void * = 0,
+                       const ACE_TCHAR * = nullptr,
+                       void * = nullptr,
                        int = 0x7fffffff) {}
   ~ACE_Null_Semaphore () = default;
   /// Return 0.

--- a/ACE/ace/OS_NS_Thread.cpp
+++ b/ACE/ace/OS_NS_Thread.cpp
@@ -1825,7 +1825,7 @@ ACE_OS::mutex_init (ACE_mutex_t *m,
   pthread_mutexattr_t l_attributes;
 # endif
 
-  if (attributes == 0)
+  if (attributes == nullptr)
     attributes = &l_attributes;
   int result = 0;
   int attr_init = 0;  // have we initialized the local attributes.
@@ -2588,8 +2588,8 @@ ACE_OS::event_init (ACE_event_t *event,
     }
 #elif defined (ACE_HAS_THREADS)
   ACE_UNUSED_ARG (sa);
-  event->name_ = 0;
-  event->eventdata_ = 0;
+  event->name_ = nullptr;
+  event->eventdata_ = nullptr;
 
   if (type == USYNC_PROCESS)
     {
@@ -2619,7 +2619,7 @@ ACE_OS::event_init (ACE_event_t *event,
           owner = true;
         }
 
-      void *const mapped = ACE_OS::mmap (0, sizeof (ACE_eventdata_t),
+      void *const mapped = ACE_OS::mmap (nullptr, sizeof (ACE_eventdata_t),
                                          PROT_RDWR, MAP_SHARED, fd);
       ACE_eventdata_t *evtdata = reinterpret_cast<ACE_eventdata_t *> (mapped);
       ACE_OS::close (fd);
@@ -2635,7 +2635,7 @@ ACE_OS::event_init (ACE_event_t *event,
       if (owner)
         {
           event->name_ = ACE_OS::strdup (name_p);
-          if (event->name_ == 0 ||
+          if (event->name_ == nullptr ||
               eventdata_init (event->eventdata_, USYNC_PROCESS, manual_reset,
                               initial_state, attributes, name, arg,
                               ACE_EVENT_USE_COND_PSHARED,
@@ -3471,8 +3471,8 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
 # define  ACE_THREAD_ARGUMENT  thread_args
 #endif /* ! defined (ACE_NO_THREAD_ADAPTER) */
 
-  ACE_Base_Thread_Adapter *thread_args = 0;
-  if (thread_adapter == 0)
+  ACE_Base_Thread_Adapter *thread_args = nullptr;
+  if (thread_adapter == nullptr)
 #if defined (ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS)
     ACE_NEW_RETURN (thread_args,
                     ACE_OS_Thread_Adapter (func, args,
@@ -3494,7 +3494,7 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
 
   std::unique_ptr <ACE_Base_Thread_Adapter> auto_thread_args;
 
-  if (thread_adapter == 0)
+  if (thread_adapter == nullptr)
     auto_thread_args.reset (thread_args);
 
 #if defined (ACE_HAS_THREADS)
@@ -3506,11 +3506,11 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
 # endif /* ACE_NEEDS_HUGE_THREAD_STACKSIZE */
 
   ACE_thread_t tmp_thr;
-  if (thr_id == 0)
+  if (thr_id == nullptr)
     thr_id = &tmp_thr;
 
   ACE_hthread_t tmp_handle;
-  if (thr_handle == 0)
+  if (thr_handle == nullptr)
     thr_handle = &tmp_handle;
 
 # if defined (ACE_HAS_PTHREADS)
@@ -3539,7 +3539,7 @@ ACE_OS::thr_create (ACE_THR_FUNC func,
 #   if !defined (ACE_LACKS_PTHREAD_ATTR_SETSTACKSIZE)
 #     if !defined (ACE_LACKS_PTHREAD_ATTR_SETSTACK)
       int result;
-      if (stack != 0)
+      if (stack != nullptr)
         result = ACE_ADAPT_RETVAL (pthread_attr_setstack (&attr, stack, size), result);
       else
         result = ACE_ADAPT_RETVAL (pthread_attr_setstacksize (&attr, size), result);

--- a/ACE/ace/OS_NS_Thread.h
+++ b/ACE/ace/OS_NS_Thread.h
@@ -1161,8 +1161,8 @@ namespace ACE_OS {
   extern ACE_Export
   int cond_init (ACE_cond_t *cv,
                  short type = ACE_DEFAULT_SYNCH_TYPE,
-                 const char *name = 0,
-                 void *arg = 0);
+                 const char *name = nullptr,
+                 void *arg = nullptr);
 
 #if defined (ACE_LACKS_COND_T)
   extern ACE_Export
@@ -1251,8 +1251,8 @@ namespace ACE_OS {
                   ACE_condattr_t *attributes,
                   int manual_reset = 0,
                   int initial_state = 0,
-                  const char *name = 0,
-                  void *arg = 0,
+                  const char *name = nullptr,
+                  void *arg = nullptr,
                   LPSECURITY_ATTRIBUTES sa = 0);
 
 # if defined (ACE_HAS_WCHAR)
@@ -1310,8 +1310,8 @@ namespace ACE_OS {
   extern ACE_Export
   int mutex_init (ACE_mutex_t *m,
                   int lock_scope = ACE_DEFAULT_SYNCH_TYPE,
-                  const char *name = 0,
-                  ACE_mutexattr_t *arg = 0,
+                  const char *name = nullptr,
+                  ACE_mutexattr_t *arg = nullptr,
                   LPSECURITY_ATTRIBUTES sa = 0,
                   int lock_type = 0);
 
@@ -1459,8 +1459,8 @@ namespace ACE_OS {
   extern ACE_Export
   int rwlock_init (ACE_rwlock_t *rw,
                    int type = ACE_DEFAULT_SYNCH_TYPE,
-                   const ACE_TCHAR *name = 0,
-                   void *arg = 0);
+                   const ACE_TCHAR *name = nullptr,
+                   void *arg = nullptr);
 
   //@}
 
@@ -1635,12 +1635,12 @@ namespace ACE_OS {
                   void *args,
                   long flags,
                   ACE_thread_t *thr_id,
-                  ACE_hthread_t *t_handle = 0,
+                  ACE_hthread_t *t_handle = nullptr,
                   long priority = ACE_DEFAULT_THREAD_PRIORITY,
-                  void *stack = 0,
+                  void *stack = nullptr,
                   size_t stacksize = ACE_DEFAULT_THREAD_STACKSIZE,
-                  ACE_Base_Thread_Adapter *thread_adapter = 0,
-                  const char **thr_name = 0);
+                  ACE_Base_Thread_Adapter *thread_adapter = nullptr,
+                  const char **thr_name = nullptr);
 
   ACE_NAMESPACE_INLINE_FUNCTION
   int thr_equal (ACE_thread_t t1, ACE_thread_t t2);

--- a/ACE/ace/OS_NS_netdb.cpp
+++ b/ACE/ace/OS_NS_netdb.cpp
@@ -95,15 +95,15 @@ ACE_OS::getmacaddress (struct macaddr_node_t *node)
 
   // It's easiest to know the first MAC-using interface. Use the BSD
   // getifaddrs function that simplifies access to connected interfaces.
-  struct ifaddrs *ifap = 0;
-  struct ifaddrs *p_if = 0;
+  struct ifaddrs *ifap = nullptr;
+  struct ifaddrs *p_if = nullptr;
 
   if (::getifaddrs (&ifap) != 0)
     return -1;
 
-  for (p_if = ifap; p_if != 0; p_if = p_if->ifa_next)
+  for (p_if = ifap; p_if != nullptr; p_if = p_if->ifa_next)
     {
-      if (p_if->ifa_addr == 0)
+      if (p_if->ifa_addr == nullptr)
         continue;
 
       // Check to see if it's up and is not either PPP or loopback
@@ -111,7 +111,7 @@ ACE_OS::getmacaddress (struct macaddr_node_t *node)
           (p_if->ifa_flags & (IFF_LOOPBACK | IFF_POINTOPOINT)) == 0)
         break;
     }
-  if (p_if == 0)
+  if (p_if == nullptr)
     {
       errno = ENODEV;
       ::freeifaddrs (ifap);

--- a/ACE/ace/OS_NS_stdio.cpp
+++ b/ACE/ace/OS_NS_stdio.cpp
@@ -475,7 +475,7 @@ ACE_OS::vaswprintf_emulation(wchar_t **bufp, const wchar_t *format, va_list argp
 {
   va_list ap;
   va_copy (ap, argptr);
-  int size = ACE_OS::vsnprintf(0, 0, format, ap);
+  int size = ACE_OS::vsnprintf(nullptr, 0, format, ap);
   va_end (ap);
 
   if (size != -1)

--- a/ACE/ace/OS_NS_stdlib.cpp
+++ b/ACE/ace/OS_NS_stdlib.cpp
@@ -32,7 +32,7 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_EXIT_HOOK ACE_OS::exit_hook_ = 0;
+ACE_EXIT_HOOK ACE_OS::exit_hook_ = nullptr;
 
 void *
 ACE_OS::calloc (size_t elements, size_t sizeof_elements)
@@ -91,7 +91,7 @@ ACE_OS::getenvstrings ()
   return ::GetEnvironmentStrings ();
 # endif /* ACE_USES_WCHAR */
 #else /* ACE_WIN32 */
-  ACE_NOTSUP_RETURN (0);
+  ACE_NOTSUP_RETURN (nullptr);
 #endif /* ACE_WIN32 */
 }
 
@@ -102,8 +102,8 @@ ACE_OS::getenvstrings ()
 ACE_TCHAR *
 ACE_OS::strenvdup (const ACE_TCHAR *str)
 {
-  const ACE_TCHAR * start = 0;
-  if ((start = ACE_OS::strchr (str, ACE_TEXT ('$'))) != 0)
+  const ACE_TCHAR * start = nullptr;
+  if ((start = ACE_OS::strchr (str, ACE_TEXT ('$'))) != nullptr)
     {
       ACE_TCHAR buf[ACE_DEFAULT_ARGV_BUFSIZ];
       size_t var_len = ACE_OS::strcspn (&start[1],
@@ -118,7 +118,7 @@ ACE_OS::strenvdup (const ACE_TCHAR *str)
       char *temp = ACE_OS::getenv (ACE_TEXT_ALWAYS_CHAR (buf));
 #  endif /* ACE_WIN32 */
       size_t buf_len = ACE_OS::strlen (str) + 1;
-      if (temp != 0)
+      if (temp != nullptr)
         buf_len += ACE_OS::strlen (temp) - var_len;
       ACE_TCHAR * buf_p =
 #if defined (ACE_HAS_ALLOC_HOOKS)
@@ -127,16 +127,16 @@ ACE_OS::strenvdup (const ACE_TCHAR *str)
         (ACE_TCHAR *) ACE_OS::malloc (buf_len * sizeof (ACE_TCHAR));
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
-      if (buf_p == 0)
+      if (buf_p == nullptr)
         {
           errno = ENOMEM;
-          return 0;
+          return nullptr;
         }
       ACE_TCHAR * p = buf_p;
       size_t const len = static_cast<size_t> (start - str);
       ACE_OS::strncpy (p, str, len);
       p += len;
-      if (temp != 0)
+      if (temp != nullptr)
         {
 #  if defined (ACE_WIN32)
           p = ACE_OS::strecpy (p, temp) - 1;
@@ -1218,7 +1218,7 @@ void
 ACE_OS::setprogname_emulation (const char* progname)
 {
   const char *p = ACE_OS::strrchr (progname, '/');
-  if (p != 0)
+  if (p != nullptr)
 #  if defined (ACE_INTEGRITY)
     __progname = const_cast<char*> (p + 1);
 #  else

--- a/ACE/ace/OS_NS_string.cpp
+++ b/ACE/ace/OS_NS_string.cpp
@@ -41,8 +41,8 @@ ACE_OS::strdup_emulation (const wchar_t *s)
   wchar_t *buffer =
     (wchar_t *) ACE_OS::malloc ((ACE_OS::strlen (s) + 1)
                                 * sizeof (wchar_t));
-  if (buffer == 0)
-    return 0;
+  if (buffer == nullptr)
+    return nullptr;
 
   return ACE_OS::strcpy (buffer, s);
 }
@@ -99,7 +99,7 @@ ACE_OS::strerror (int errnum)
   // and set errno to EINVAL.
   ACE_Errno_Guard g (errno);
   errno = 0;
-  char *errmsg = 0;
+  char *errmsg = nullptr;
 
 # if defined (ACE_HAS_TR24731_2005_CRT)
   errmsg = ret_errortext;
@@ -116,7 +116,7 @@ ACE_OS::strerror (int errnum)
 #  endif /* ACE_WIN32 */
   errmsg = ::strerror (errnum);
 
-  if (errno == EINVAL || errmsg == 0 || errmsg[0] == 0)
+  if (errno == EINVAL || errmsg == nullptr || errmsg[0] == 0)
     {
       ACE_OS::snprintf (ret_errortext, 128, "Unknown error %d", errnum);
       errmsg = ret_errortext;
@@ -143,7 +143,7 @@ ACE_OS::strsignal (int signum)
 {
   static char signal_text[128];
 #if defined (ACE_HAS_STRSIGNAL)
-  char *ret_val = 0;
+  char *ret_val = nullptr;
 
 # if defined (ACE_NEEDS_STRSIGNAL_RANGE_CHECK)
   if (signum < 0 || signum >= ACE_NSIG)
@@ -196,7 +196,7 @@ ACE_OS::strnchr (const char *s, int c, size_t len)
     if (s[i] == c)
       return s + i;
 
-  return 0;
+  return nullptr;
 }
 
 const ACE_WCHAR_T *
@@ -210,7 +210,7 @@ ACE_OS::strnchr (const ACE_WCHAR_T *s, ACE_WCHAR_T c, size_t len)
         }
     }
 
-  return 0;
+  return nullptr;
 }
 
 const char *
@@ -221,7 +221,7 @@ ACE_OS::strnstr (const char *s1, const char *s2, size_t len2)
 
   // Check if the substring is longer than the string being searched.
   if (len2 > len1)
-    return 0;
+    return nullptr;
 
   // Go upto <len>
   size_t const len = len1 - len2;
@@ -235,7 +235,7 @@ ACE_OS::strnstr (const char *s1, const char *s2, size_t len2)
         }
     }
 
-  return 0;
+  return nullptr;
 }
 
 const ACE_WCHAR_T *
@@ -246,7 +246,7 @@ ACE_OS::strnstr (const ACE_WCHAR_T *s1, const ACE_WCHAR_T *s2, size_t len2)
 
   // Check if the substring is longer than the string being searched.
   if (len2 > len1)
-    return 0;
+    return nullptr;
 
   // Go upto <len>
   size_t const len = len1 - len2;
@@ -260,7 +260,7 @@ ACE_OS::strnstr (const ACE_WCHAR_T *s1, const ACE_WCHAR_T *s2, size_t len2)
         }
     }
 
-  return 0;
+  return nullptr;
 }
 
 char *
@@ -275,7 +275,7 @@ ACE_OS::strsncpy (char *dst, const char *src, size_t maxlen)
       if (rdst!=rsrc)
         {
           *rdst = '\0';
-          if (rsrc != 0)
+          if (rsrc != nullptr)
             {
               ACE_OS::strncat (rdst, rsrc, --rmaxlen);
             }
@@ -301,7 +301,7 @@ ACE_OS::strsncpy (ACE_WCHAR_T *dst, const ACE_WCHAR_T *src, size_t maxlen)
       if (rdst!= rsrc)
         {
           *rdst = ACE_TEXT_WIDE ('\0');
-          if (rsrc != 0)
+          if (rsrc != nullptr)
             {
               ACE_OS::strncat (rdst, rsrc, --rmaxlen);
             }

--- a/ACE/ace/OS_NS_stropts.h
+++ b/ACE/ace/OS_NS_stropts.h
@@ -127,10 +127,10 @@ namespace ACE_OS {
              unsigned long io_control_code,
              ACE_QoS &ace_qos,
              unsigned long *bytes_returned,
-             void *buffer_p = 0,
+             void *buffer_p = nullptr,
              unsigned long buffer = 0,
-             ACE_OVERLAPPED *overlapped = 0,
-             ACE_OVERLAPPED_COMPLETION_FUNC func = 0);
+             ACE_OVERLAPPED *overlapped = nullptr,
+             ACE_OVERLAPPED_COMPLETION_FUNC func = nullptr);
 
   ACE_NAMESPACE_INLINE_FUNCTION
   int isastream (ACE_HANDLE handle);

--- a/ACE/ace/OS_NS_unistd.cpp
+++ b/ACE/ace/OS_NS_unistd.cpp
@@ -30,11 +30,11 @@ ACE_OS::argv_to_string (ACE_TCHAR **argv,
                         bool substitute_env_args,
                         bool quote_args)
 {
-  if (argv == 0 || argv[0] == 0)
+  if (argv == nullptr || argv[0] == nullptr)
     return 0;
 
   int argc;
-  for (argc = 0; argv[argc] != 0; ++argc)
+  for (argc = 0; argv[argc] != nullptr; ++argc)
     continue;
 
   return argv_to_string (argc,
@@ -51,7 +51,7 @@ ACE_OS::argv_to_string (int argc,
                         bool substitute_env_args,
                         bool quote_args)
 {
-  if (argc <= 0 || argv == 0 || argv[0] == 0)
+  if (argc <= 0 || argv == nullptr || argv[0] == nullptr)
     return 0;
 
   size_t buf_len = 0;
@@ -64,7 +64,7 @@ ACE_OS::argv_to_string (int argc,
     {
       // Account for environment variables.
       if (substitute_env_args
-          && ACE_OS::strchr (argv[i], ACE_TEXT ('$')) != 0)
+          && ACE_OS::strchr (argv[i], ACE_TEXT ('$')) != nullptr)
         {
           if (argv_p == argv)
             {
@@ -73,7 +73,7 @@ ACE_OS::argv_to_string (int argc,
 #else
               argv_p = (ACE_TCHAR **) ACE_OS::malloc (argc * sizeof (ACE_TCHAR *));
 #endif /* ACE_HAS_ALLOC_HOOKS */
-              if (argv_p == 0)
+              if (argv_p == nullptr)
                 {
                   errno = ENOMEM;
                   return 0;
@@ -81,7 +81,7 @@ ACE_OS::argv_to_string (int argc,
               ACE_OS::memcpy (argv_p, argv, argc * sizeof (ACE_TCHAR *));
             }
           argv_p[i] = ACE_OS::strenvdup (argv[i]);
-          if (argv_p[i] == 0)
+          if (argv_p[i] == nullptr)
             {
 #if defined (ACE_HAS_ALLOC_HOOKS)
               ACE_Allocator::instance()->free (argv_p);
@@ -96,9 +96,9 @@ ACE_OS::argv_to_string (int argc,
       // is empty. Perhaps a check for other c | ord(c) <= 32 is in
       // order?
       if (quote_args
-          && (ACE_OS::strchr (argv_p[i], ACE_TEXT (' ')) != 0
-              || ACE_OS::strchr (argv_p[i], ACE_TEXT ('\t')) != 0
-              || ACE_OS::strchr (argv_p[i], ACE_TEXT ('\n')) != 0
+          && (ACE_OS::strchr (argv_p[i], ACE_TEXT (' ')) != nullptr
+              || ACE_OS::strchr (argv_p[i], ACE_TEXT ('\t')) != nullptr
+              || ACE_OS::strchr (argv_p[i], ACE_TEXT ('\n')) != nullptr
               || *argv_p[i] == 0))
         {
           if (argv_p == argv)
@@ -108,7 +108,7 @@ ACE_OS::argv_to_string (int argc,
 #else
               argv_p = (ACE_TCHAR **) ACE_OS::malloc (argc * sizeof (ACE_TCHAR *));
 #endif /* ACE_HAS_ALLOC_HOOKS */
-              if (argv_p == 0)
+              if (argv_p == nullptr)
                 {
                   errno = ENOMEM;
                   return 0;
@@ -117,7 +117,7 @@ ACE_OS::argv_to_string (int argc,
             }
           int quotes = 0;
           ACE_TCHAR *temp = argv_p[i];
-          if (ACE_OS::strchr (temp, ACE_TEXT ('"')) != 0)
+          if (ACE_OS::strchr (temp, ACE_TEXT ('"')) != nullptr)
             {
               for (int j = 0; temp[j] != 0; ++j)
                 if (temp[j] == ACE_TEXT ('"'))
@@ -131,7 +131,7 @@ ACE_OS::argv_to_string (int argc,
             (ACE_TCHAR *) ACE_OS::malloc ((ACE_OS::strlen (temp) + quotes + 3)
                                           * sizeof (ACE_TCHAR));
 #endif /* ACE_HAS_ALLOC_HOOKS */
-          if (argv_p[i] == 0)
+          if (argv_p[i] == nullptr)
             {
 #if defined (ACE_HAS_ALLOC_HOOKS)
               ACE_Allocator::instance()->free (argv_p);
@@ -453,7 +453,7 @@ ACE_OS::read_n (ACE_HANDLE handle,
                 size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n = 0;
 
   for (bytes_transferred = 0;
@@ -754,7 +754,7 @@ ACE_OS::string_to_argv (ACE_TCHAR *buf,
   // Reset the number of arguments
   argc = 0;
 
-  if (buf == 0)
+  if (buf == nullptr)
     return -1;
 
   ACE_TCHAR *cp = buf;
@@ -860,7 +860,7 @@ ACE_OS::string_to_argv (ACE_TCHAR *buf,
       if (substitute_env_args) {
           argv[i] = ACE_OS::strenvdup (argp);
 
-          if (argv[i] == 0)
+          if (argv[i] == nullptr)
             {
               if (argp != arg)
 #if defined (ACE_HAS_ALLOC_HOOKS)
@@ -876,7 +876,7 @@ ACE_OS::string_to_argv (ACE_TCHAR *buf,
         {
           argv[i] = ACE_OS::strdup (argp);
 
-          if (argv[i] == 0)
+          if (argv[i] == nullptr)
             {
               if (argp != arg)
                 {
@@ -902,7 +902,7 @@ ACE_OS::string_to_argv (ACE_TCHAR *buf,
 #endif /* ACE_HAS_ALLOC_HOOKS */
     }
 
-  argv[argc] = 0;
+  argv[argc] = nullptr;
   return 0;
 }
 
@@ -916,7 +916,7 @@ ACE_OS::write_n (ACE_HANDLE handle,
                  size_t *bt)
 {
   size_t temp;
-  size_t &bytes_transferred = bt == 0 ? temp : *bt;
+  size_t &bytes_transferred = bt == nullptr ? temp : *bt;
   ssize_t n;
 
   for (bytes_transferred = 0;

--- a/ACE/ace/OS_QoS.cpp
+++ b/ACE/ace/OS_QoS.cpp
@@ -303,8 +303,8 @@ ACE_Flow_Spec::priority (int p)
 ACE_QoS::ACE_QoS ()
 #if defined (ACE_HAS_WINSOCK2) && (ACE_HAS_WINSOCK2 != 0)
 #else
-  : sending_flowspec_ (0),
-    receiving_flowspec_ (0)
+  : sending_flowspec_ (nullptr),
+    receiving_flowspec_ (nullptr)
 #endif /* ACE_HAS_WINSOCK2 */
 {
 }

--- a/ACE/ace/OS_Thread_Adapter.cpp
+++ b/ACE/ace/OS_Thread_Adapter.cpp
@@ -22,7 +22,7 @@ ACE_OS_Thread_Adapter::ACE_OS_Thread_Adapter (
      , long cancel_flags
      )
   : ACE_Base_Thread_Adapter (user_func, arg, entry_point
-                             , 0
+                             , nullptr
 #if defined (ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS)
                              , selector
                              , handler
@@ -69,7 +69,7 @@ ACE_OS_Thread_Adapter::invoke ()
         ACE_OS::thr_setcanceltype (val, &old);
     }
 
-  ACE_THR_FUNC_RETURN status = 0;
+  ACE_THR_FUNC_RETURN status = nullptr;
 
   ACE_SEH_TRY
     {

--- a/ACE/ace/OS_Thread_Adapter.cpp
+++ b/ACE/ace/OS_Thread_Adapter.cpp
@@ -69,7 +69,7 @@ ACE_OS_Thread_Adapter::invoke ()
         ACE_OS::thr_setcanceltype (val, &old);
     }
 
-  ACE_THR_FUNC_RETURN status = nullptr;
+  ACE_THR_FUNC_RETURN status = 0;
 
   ACE_SEH_TRY
     {

--- a/ACE/ace/Obchunk.cpp
+++ b/ACE/ace/Obchunk.cpp
@@ -24,7 +24,7 @@ ACE_Obchunk::ACE_Obchunk (size_t size)
   : end_ (contents_ + size),
     block_ (contents_),
     cur_ (contents_),
-    next_ (0)
+    next_ (nullptr)
 {
 }
 

--- a/ACE/ace/Object_Manager.cpp
+++ b/ACE/ace/Object_Manager.cpp
@@ -62,13 +62,13 @@ LPTOP_LEVEL_EXCEPTION_FILTER WINAPI ACEdisableSetUnhandledExceptionFilter (
 #endif // ACE_DISABLE_WIN32_ERROR_WINDOWS
 
 // Singleton pointer.
-ACE_Object_Manager *ACE_Object_Manager::instance_ = 0;
+ACE_Object_Manager *ACE_Object_Manager::instance_ = nullptr;
 
 void *ACE_Object_Manager::preallocated_object[
-  ACE_Object_Manager::ACE_PREALLOCATED_OBJECTS] = { 0 };
+  ACE_Object_Manager::ACE_PREALLOCATED_OBJECTS] = { nullptr };
 
 void *ACE_Object_Manager::preallocated_array[
-  ACE_Object_Manager::ACE_PREALLOCATED_ARRAYS] = { 0 };
+  ACE_Object_Manager::ACE_PREALLOCATED_ARRAYS] = { nullptr };
 
 // Handy macros for use by ACE_Object_Manager constructor to
 // preallocate or delete an object or array, either statically (in
@@ -324,7 +324,7 @@ ACE_Object_Manager::init ()
 #     endif /* ! ACE_LACKS_ACE_SVCCONF */
 
           // Open the main thread's ACE_Log_Msg.
-          if (0 == ACE_LOG_MSG)
+          if (nullptr == ACE_LOG_MSG)
             return -1;
         }
 
@@ -373,12 +373,12 @@ ACE_Object_Manager::ACE_Object_Manager ()
   // ACE_OS::tss_open () in the function body.
   : exit_info_ ()
 #if !defined (ACE_LACKS_ACE_SVCCONF)
-  , preallocations_ (0)
-  , ace_service_config_sig_handler_ (0)
+  , preallocations_ (nullptr)
+  , ace_service_config_sig_handler_ (nullptr)
 #endif /* ! ACE_LACKS_ACE_SVCCONF */
 #if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
-  , singleton_null_lock_ (0)
-  , singleton_recursive_lock_ (0)
+  , singleton_null_lock_ (nullptr)
+  , singleton_recursive_lock_ (nullptr)
 #endif /* ACE_MT_SAFE */
 #if defined (ACE_HAS_TSS_EMULATION)
   , ts_storage_initialized_ (false)
@@ -398,7 +398,7 @@ ACE_Object_Manager::ACE_Object_Manager ()
   // from calls to ACE_Object_Manager::instance().
 
   // Be sure that no further instances are created via instance ().
-  if (instance_ == 0)
+  if (instance_ == nullptr)
     instance_ = this;
 
   init ();
@@ -419,13 +419,13 @@ ACE_Object_Manager::instance ()
   // instances, or before any other threads have been created in
   // the process.  So, it's not thread safe.
 
-  if (instance_ == 0)
+  if (instance_ == nullptr)
     {
-      ACE_Object_Manager *instance_pointer = 0;
+      ACE_Object_Manager *instance_pointer = nullptr;
 
       ACE_NEW_RETURN (instance_pointer,
                       ACE_Object_Manager,
-                      0);
+                      nullptr);
       ACE_ASSERT (instance_pointer == instance_);
 
       instance_pointer->dynamically_allocated_ = true;
@@ -489,7 +489,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Null_Mutex *&lock)
       // preallocated lock is not available.  Allocate a lock to use,
       // for interface compatibility, though there should be no
       // contention on it.
-      if (ACE_Object_Manager::instance ()->singleton_null_lock_ == 0)
+      if (ACE_Object_Manager::instance ()->singleton_null_lock_ == nullptr)
         {
           ACE_NEW_RETURN (ACE_Object_Manager::instance ()->
                             singleton_null_lock_,
@@ -501,7 +501,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Null_Mutex *&lock)
           // destructor, so it will clean it up as a special case.
         }
 
-      if (ACE_Object_Manager::instance ()->singleton_null_lock_ != 0)
+      if (ACE_Object_Manager::instance ()->singleton_null_lock_ != nullptr)
         lock = &ACE_Object_Manager::instance ()->singleton_null_lock_->
           object ();
     }
@@ -516,7 +516,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Null_Mutex *&lock)
 int
 ACE_Object_Manager::get_singleton_lock (ACE_Thread_Mutex *&lock)
 {
-  if (lock == 0)
+  if (lock == nullptr)
     {
       if (starting_up () || shutting_down ())
         {
@@ -540,9 +540,9 @@ ACE_Object_Manager::get_singleton_lock (ACE_Thread_Mutex *&lock)
                                     internal_lock_,
                                     -1));
 
-          if (lock == 0)
+          if (lock == nullptr)
             {
-              ACE_Cleanup_Adapter<ACE_Thread_Mutex> *lock_adapter = 0;
+              ACE_Cleanup_Adapter<ACE_Thread_Mutex> *lock_adapter = nullptr;
               ACE_NEW_RETURN (lock_adapter,
                               ACE_Cleanup_Adapter<ACE_Thread_Mutex>,
                               -1);
@@ -553,7 +553,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Thread_Mutex *&lock)
               // ACE_Object_Manager::instance ()->internal_lock_
               // again; that's why it is a recursive lock.
               ACE_Object_Manager::at_exit (lock_adapter,
-                                           0,
+                                           nullptr,
                                            typeid (*lock_adapter).name ());
             }
         }
@@ -565,7 +565,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Thread_Mutex *&lock)
 int
 ACE_Object_Manager::get_singleton_lock (ACE_Mutex *&lock)
 {
-  if (lock == 0)
+  if (lock == nullptr)
     {
       if (starting_up ()  ||  shutting_down ())
         {
@@ -590,9 +590,9 @@ ACE_Object_Manager::get_singleton_lock (ACE_Mutex *&lock)
                                       internal_lock_,
                                     -1));
 
-          if (lock == 0)
+          if (lock == nullptr)
             {
-              ACE_Cleanup_Adapter<ACE_Mutex> *lock_adapter = 0;
+              ACE_Cleanup_Adapter<ACE_Mutex> *lock_adapter = nullptr;
               ACE_NEW_RETURN (lock_adapter,
                               ACE_Cleanup_Adapter<ACE_Mutex>,
                               -1);
@@ -621,7 +621,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Recursive_Thread_Mutex *&lock)
       // preallocated lock is not available.  Allocate a lock to use,
       // for interface compatibility, though there should be no
       // contention on it.
-      if (ACE_Object_Manager::instance ()->singleton_recursive_lock_ == 0)
+      if (ACE_Object_Manager::instance ()->singleton_recursive_lock_ == nullptr)
         ACE_NEW_RETURN (ACE_Object_Manager::instance ()->
                           singleton_recursive_lock_,
                         ACE_Cleanup_Adapter<ACE_Recursive_Thread_Mutex>,
@@ -631,7 +631,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Recursive_Thread_Mutex *&lock)
       // declaration is visible to the ACE_Object_Manager destructor,
       // so it will clean it up as a special case.
 
-      if (ACE_Object_Manager::instance ()->singleton_recursive_lock_ != 0)
+      if (ACE_Object_Manager::instance ()->singleton_recursive_lock_ != nullptr)
         lock = &ACE_Object_Manager::instance ()->singleton_recursive_lock_->
           object ();
     }
@@ -649,7 +649,7 @@ ACE_Object_Manager::get_singleton_lock (ACE_Recursive_Thread_Mutex *&lock)
 int
 ACE_Object_Manager::get_singleton_lock (ACE_RW_Thread_Mutex *&lock)
 {
-  if (lock == 0)
+  if (lock == nullptr)
     {
       if (starting_up () || shutting_down ())
         {
@@ -674,9 +674,9 @@ ACE_Object_Manager::get_singleton_lock (ACE_RW_Thread_Mutex *&lock)
                                     internal_lock_,
                                     -1));
 
-          if (lock == 0)
+          if (lock == nullptr)
             {
-              ACE_Cleanup_Adapter<ACE_RW_Thread_Mutex> *lock_adapter = 0;
+              ACE_Cleanup_Adapter<ACE_RW_Thread_Mutex> *lock_adapter = nullptr;
               ACE_NEW_RETURN (lock_adapter,
                               ACE_Cleanup_Adapter<ACE_RW_Thread_Mutex>,
                               -1);
@@ -724,7 +724,7 @@ ACE_Object_Manager::fini ()
     {
 #if !defined (ACE_LACKS_ACE_SVCCONF)
       delete preallocations_;
-      preallocations_ = 0;
+      preallocations_ = nullptr;
 #endif /* ! ACE_LACKS_ACE_SVCCONF */
 
 #if defined (ACE_HAS_TRACE)
@@ -804,18 +804,18 @@ ACE_Object_Manager::fini ()
 
 #if !defined (ACE_LACKS_ACE_SVCCONF)
   delete ace_service_config_sig_handler_;
-  ace_service_config_sig_handler_ = 0;
+  ace_service_config_sig_handler_ = nullptr;
 #endif /* ! ACE_LACKS_ACE_SVCCONF */
 
 #if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
   delete internal_lock_;
-  internal_lock_ = 0;
+  internal_lock_ = nullptr;
 
   delete singleton_null_lock_;
-  singleton_null_lock_ = 0;
+  singleton_null_lock_ = nullptr;
 
   delete singleton_recursive_lock_;
-  singleton_recursive_lock_ = 0;
+  singleton_recursive_lock_ = nullptr;
 #endif /* ACE_MT_SAFE */
 
   // Indicate that this ACE_Object_Manager instance has been shut down.
@@ -831,7 +831,7 @@ ACE_Object_Manager::fini ()
     }
 
   if (this == instance_)
-    instance_ = 0;
+    instance_ = nullptr;
 
   return 0;
 }
@@ -875,7 +875,7 @@ ACE_Object_Manager_Manager::~ACE_Object_Manager_Manager ()
                          saved_main_thread_id_))
     {
       delete ACE_Object_Manager::instance_;
-      ACE_Object_Manager::instance_ = 0;
+      ACE_Object_Manager::instance_ = nullptr;
     }
   // else if this destructor is not called by the main thread, then do
   // not delete the ACE_Object_Manager.  That causes problems, on
@@ -890,7 +890,7 @@ static ACE_Object_Manager_Manager ACE_Object_Manager_Manager_instance;
 // This is global so that it doesn't have to be declared in the header
 // file.  That would cause nasty circular include problems.
 using ACE_Static_Object_Lock_Type = ACE_Cleanup_Adapter<ACE_Recursive_Thread_Mutex>;
-static ACE_Static_Object_Lock_Type *ACE_Static_Object_Lock_lock = 0;
+static ACE_Static_Object_Lock_Type *ACE_Static_Object_Lock_lock = nullptr;
 
 // ACE_SHOULD_MALLOC_STATIC_OBJECT_LOCK isn't (currently) used by ACE.
 // But, applications may find it useful for avoiding recursive calls
@@ -909,7 +909,7 @@ ACE_Static_Object_Lock::instance ()
       // destroyed, so the preallocated lock is not available.
       // Allocate a lock to use, for interface compatibility, though
       // there should be no contention on it.
-      if (ACE_Static_Object_Lock_lock == 0)
+      if (ACE_Static_Object_Lock_lock == nullptr)
         {
 #     if defined (ACE_SHOULD_MALLOC_STATIC_OBJECT_LOCK)
         // Allocate a buffer with malloc, and then use placement
@@ -956,7 +956,7 @@ ACE_Static_Object_Lock::cleanup_lock ()
 # else  /* ! ACE_SHOULD_MALLOC_STATIC_OBJECT_LOCK */
     delete ACE_Static_Object_Lock_lock;
 # endif /* ! ACE_SHOULD_MALLOC_STATIC_OBJECT_LOCK */
-    ACE_Static_Object_Lock_lock = 0;
+    ACE_Static_Object_Lock_lock = nullptr;
 }
 #endif /* ACE_HAS_THREADS */
 

--- a/ACE/ace/Object_Manager_Base.cpp
+++ b/ACE/ace/Object_Manager_Base.cpp
@@ -87,11 +87,11 @@ ACE_OS_Object_Manager_Internal_Exit_Hook ()
 ACE_OS_Object_Manager *ACE_OS_Object_Manager::instance_ {};
 
 void *ACE_OS_Object_Manager::preallocated_object[
-  ACE_OS_Object_Manager::ACE_OS_PREALLOCATED_OBJECTS] = { 0 };
+  ACE_OS_Object_Manager::ACE_OS_PREALLOCATED_OBJECTS] = { nullptr };
 
 ACE_OS_Object_Manager::ACE_OS_Object_Manager ()
-  : default_mask_ (0)
-  , thread_hook_ (0)
+  : default_mask_ (nullptr)
+  , thread_hook_ (nullptr)
   , exit_info_ ()
 #if defined (ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS)
   , seh_except_selector_ (ACE_SEH_Default_Exception_Selector)
@@ -391,7 +391,7 @@ ACE_OS_Object_Manager::fini ()
 #else
   delete default_mask_;
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  default_mask_ = 0;
+  default_mask_ = nullptr;
 
   // Indicate that this ACE_OS_Object_Manager instance has been shut down.
   object_manager_state_ = OBJ_MAN_SHUT_DOWN;
@@ -414,7 +414,7 @@ ACE_OS_Object_Manager::at_exit (ACE_EXIT_HOOK func, const char* name)
 {
   return exit_info_.at_exit_i (&ace_exit_hook_marker,
                                reinterpret_cast <ACE_CLEANUP_FUNC> (func),
-                               0,
+                               nullptr,
                                name);
 }
 

--- a/ACE/ace/Obstack_T.cpp
+++ b/ACE/ace/Obstack_T.cpp
@@ -108,13 +108,13 @@ ACE_Obstack_T<ACE_CHAR_T>::new_chunk ()
 {
   ACE_TRACE ("ACE_Obstack_T<ACE_CHAR_T>::new_chunk");
 
-  ACE_Obchunk *temp = 0;
+  ACE_Obchunk *temp = nullptr;
 
   ACE_NEW_MALLOC_RETURN (temp,
                          static_cast<ACE_Obchunk *> (this->allocator_strategy_->malloc
                              (sizeof (class ACE_Obchunk) + this->size_)),
                          ACE_Obchunk (this->size_),
-                         0);
+                         nullptr);
   return temp;
 }
 
@@ -123,8 +123,8 @@ ACE_Obstack_T<ACE_CHAR_T>::ACE_Obstack_T (size_t size,
                                           ACE_Allocator *allocator_strategy)
   : allocator_strategy_ (allocator_strategy),
     size_ (size),
-    head_ (0),
-    curr_ (0)
+    head_ (nullptr),
+    curr_ (nullptr)
 {
   ACE_TRACE ("ACE_Obstack_T<ACE_CHAR_T>::ACE_Obstack");
 
@@ -143,10 +143,10 @@ ACE_Obstack_T<ACE_CHAR_T>::~ACE_Obstack_T ()
 
   ACE_Obchunk *temp = this->head_;
 
-  while (temp != 0)
+  while (temp != nullptr)
     {
       ACE_Obchunk *next = temp->next_;
-      temp->next_  = 0;
+      temp->next_  = nullptr;
       this->allocator_strategy_->free (temp);
       temp = next;
     }
@@ -180,14 +180,14 @@ template <class ACE_CHAR_T> void
 ACE_Obstack_T<ACE_CHAR_T>::unwind_i (void* obj)
 {
   ACE_Obchunk* curr = this->head_;
-  while (curr != 0 && (curr->contents_ > obj || curr->end_ < obj))
+  while (curr != nullptr && (curr->contents_ > obj || curr->end_ < obj))
       curr = curr->next_;
   if (curr)
     {
       this->curr_ = curr;
       this->curr_->block_ = this->curr_->cur_ = reinterpret_cast<char*> (obj);
     }
-  else if (obj != 0)
+  else if (obj != nullptr)
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("Deletion of non-existent object.\n%a")));
 }

--- a/ACE/ace/Obstack_T.h
+++ b/ACE/ace/Obstack_T.h
@@ -37,7 +37,7 @@ class ACE_Obstack_T
 {
 public:
   ACE_Obstack_T (size_t size = (4096 * sizeof (ACE_CHAR_T)) - sizeof (ACE_Obchunk),
-                 ACE_Allocator *allocator_strategy = 0);
+                 ACE_Allocator *allocator_strategy = nullptr);
   ~ACE_Obstack_T ();
 
   /// Request Obstack to prepare a block at least @a len long for building

--- a/ACE/ace/PI_Malloc.cpp
+++ b/ACE/ace/PI_Malloc.cpp
@@ -103,12 +103,12 @@ ACE_PI_Control_Block::ACE_Name_Node::ACE_Name_Node (const char *name,
   : name_ (name_ptr),
     pointer_ (pointer),
     next_ (next),
-    prev_ (0)
+    prev_ (nullptr)
 {
   ACE_TRACE ("ACE_PI_Control_Block::ACE_Name_Node::ACE_Name_Node");
   char *n = this->name_;
   ACE_OS::strcpy (n, name);
-  if (next != 0)
+  if (next != nullptr)
     next->prev_ = this;
 }
 
@@ -131,7 +131,7 @@ ACE_PI_Control_Block::ACE_Name_Node::name (const char *)
 }
 
 ACE_PI_Control_Block::ACE_Malloc_Header::ACE_Malloc_Header ()
-  : next_block_ (0),
+  : next_block_ (nullptr),
     size_ (0)
 {
 }

--- a/ACE/ace/POSIX_Asynch_IO.cpp
+++ b/ACE/ace/POSIX_Asynch_IO.cpp
@@ -94,7 +94,7 @@ ACE_POSIX_Asynch_Result::post_completion (ACE_Proactor_Impl *proactor_impl)
   // Get to the platform specific implementation.
   ACE_POSIX_Proactor *posix_proactor = dynamic_cast<ACE_POSIX_Proactor *> (proactor_impl);
 
-  if (posix_proactor == 0)
+  if (posix_proactor == nullptr)
     ACELIB_ERROR_RETURN ((LM_ERROR, "Dynamic cast to POSIX Proactor failed\n"), -1);
 
   // Post myself.
@@ -117,7 +117,7 @@ ACE_POSIX_Asynch_Result::ACE_POSIX_Asynch_Result
     act_ (act),
     bytes_transferred_ (0),
     success_ (0),
-    completion_key_ (0),
+    completion_key_ (nullptr),
     error_ (0)
 {
   aio_offset = offset;
@@ -149,7 +149,7 @@ ACE_POSIX_Asynch_Operation::open (const ACE_Handler::Proxy_Ptr &handler_proxy,
   if (this->handle_ == ACE_INVALID_HANDLE)
     {
       ACE_Handler *handler = handler_proxy.get ()->handler ();
-      if (handler != 0)
+      if (handler != nullptr)
         this->handle_ = handler->handle ();
     }
   if (this->handle_ == ACE_INVALID_HANDLE)
@@ -264,7 +264,7 @@ ACE_POSIX_Asynch_Read_Stream_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_read_stream (result);
 }
 
@@ -297,7 +297,7 @@ ACE_POSIX_Asynch_Read_Stream::read (ACE_Message_Block &message_block,
     }
 
   // Create the Asynch_Result.
-  ACE_POSIX_Asynch_Read_Stream_Result *result = 0;
+  ACE_POSIX_Asynch_Read_Stream_Result *result = nullptr;
   ACE_POSIX_Proactor *proactor = this->posix_proactor ();
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Read_Stream_Result (this->handler_proxy_,
@@ -382,7 +382,7 @@ ACE_POSIX_Asynch_Write_Stream_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_write_stream (result);
 }
 
@@ -415,7 +415,7 @@ ACE_POSIX_Asynch_Write_Stream::write (ACE_Message_Block &message_block,
         ACE_TEXT ("Attempt to write 0 bytes\n")),
       -1);
 
-  ACE_POSIX_Asynch_Write_Stream_Result *result = 0;
+  ACE_POSIX_Asynch_Write_Stream_Result *result = nullptr;
   ACE_POSIX_Proactor *proactor = this->posix_proactor ();
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Write_Stream_Result (this->handler_proxy_,
@@ -491,7 +491,7 @@ ACE_POSIX_Asynch_Read_File_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_read_file (result);
 }
 
@@ -526,7 +526,7 @@ ACE_POSIX_Asynch_Read_File::read (ACE_Message_Block &message_block,
         ACE_TEXT ("Attempt to read 0 bytes or no space in the message block\n")),
        -1);
 
-  ACE_POSIX_Asynch_Read_File_Result *result = 0;
+  ACE_POSIX_Asynch_Read_File_Result *result = nullptr;
   ACE_POSIX_Proactor *proactor = this->posix_proactor ();
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Read_File_Result (this->handler_proxy_,
@@ -653,7 +653,7 @@ ACE_POSIX_Asynch_Write_File::write (ACE_Message_Block &message_block,
         ACE_TEXT ("Attempt to write 0 bytes\n")),
       -1);
 
-  ACE_POSIX_Asynch_Write_File_Result *result = 0;
+  ACE_POSIX_Asynch_Write_File_Result *result = nullptr;
   ACE_POSIX_Proactor *proactor = this->posix_proactor ();
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Write_File_Result (this->handler_proxy_,
@@ -760,7 +760,7 @@ ACE_POSIX_Asynch_Accept_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_accept (result);
 }
 
@@ -779,7 +779,7 @@ ACE_POSIX_Asynch_Accept::ACE_POSIX_Asynch_Accept (ACE_POSIX_Proactor * posix_pro
 ACE_POSIX_Asynch_Accept::~ACE_POSIX_Asynch_Accept ()
 {
   this->close ();
-  this->reactor (0); // to avoid purge_pending_notifications
+  this->reactor (nullptr); // to avoid purge_pending_notifications
 }
 
 ACE_HANDLE
@@ -872,7 +872,7 @@ ACE_POSIX_Asynch_Accept::accept (ACE_Message_Block &message_block,
 
   // Common code for both WIN and POSIX.
   // Create future Asynch_Accept_Result
-  ACE_POSIX_Asynch_Accept_Result *result = 0;
+  ACE_POSIX_Asynch_Accept_Result *result = nullptr;
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Accept_Result (this->handler_proxy_,
                                                   this->handle_,
@@ -931,11 +931,11 @@ ACE_POSIX_Asynch_Accept::cancel_uncompleted (int flg_notify)
 
   for (; ; retval++)
     {
-      ACE_POSIX_Asynch_Accept_Result* result = 0;
+      ACE_POSIX_Asynch_Accept_Result* result = nullptr;
 
       this->result_queue_.dequeue_head (result);
 
-      if (result == 0)
+      if (result == nullptr)
         break;
 
       if (this->flg_open_ == 0 || flg_notify == 0) //if we should not notify
@@ -1068,7 +1068,7 @@ ACE_POSIX_Asynch_Accept::handle_input (ACE_HANDLE /* fd */)
   // able to just go ahead and do the <accept> now on this <fd>. This
   // should be the same as the <listen_handle>.
 
-  ACE_POSIX_Asynch_Accept_Result* result = 0;
+  ACE_POSIX_Asynch_Accept_Result* result = nullptr;
 
   {
     ACE_MT (ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, ace_mon, this->lock_, 0));
@@ -1094,9 +1094,9 @@ ACE_POSIX_Asynch_Accept::handle_input (ACE_HANDLE /* fd */)
   // @@ We shouldnt block here since we have already done poll/select
   // thru reactor. But are we sure?
 
-  ACE_HANDLE new_handle = ACE_OS::accept (this->handle_, 0, 0);
+  ACE_HANDLE new_handle = ACE_OS::accept (this->handle_, nullptr, nullptr);
 
-  if (result == 0) // there is nobody to notify
+  if (result == nullptr) // there is nobody to notify
     {
       ACE_OS::closesocket (new_handle);
       return 0;
@@ -1172,7 +1172,7 @@ ACE_POSIX_Asynch_Connect_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_connect (result);
 }
 
@@ -1191,7 +1191,7 @@ ACE_POSIX_Asynch_Connect::ACE_POSIX_Asynch_Connect (ACE_POSIX_Proactor * posix_p
 ACE_POSIX_Asynch_Connect::~ACE_POSIX_Asynch_Connect ()
 {
   this->close ();
-  this->reactor(0); // to avoid purge_pending_notifications
+  this->reactor(nullptr); // to avoid purge_pending_notifications
 }
 
 ACE_HANDLE
@@ -1252,7 +1252,7 @@ ACE_POSIX_Asynch_Connect::connect (ACE_HANDLE connect_handle,
 
   // Common code for both WIN and POSIX.
   // Create future Asynch_Connect_Result
-  ACE_POSIX_Asynch_Connect_Result *result = 0;
+  ACE_POSIX_Asynch_Connect_Result *result = nullptr;
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Connect_Result (this->handler_proxy_,
                                                    connect_handle,
@@ -1303,7 +1303,7 @@ ACE_POSIX_Asynch_Connect::connect (ACE_HANDLE connect_handle,
 
         this->result_map_.unbind (connect_handle, result);
       }
-      if (result != 0)
+      if (result != nullptr)
         {
           result->set_error (EFAULT);
           this->post_result (result, true);
@@ -1311,7 +1311,7 @@ ACE_POSIX_Asynch_Connect::connect (ACE_HANDLE connect_handle,
       return -1;
     }
   else
-    result = 0;
+    result = nullptr;
 
 
   return 0;
@@ -1467,7 +1467,7 @@ ACE_POSIX_Asynch_Connect::cancel_uncompleted (bool flg_notify,
   int retval = 0;
 
   MAP_MANAGER::ITERATOR  iter (result_map_);
-  MAP_MANAGER::ENTRY *   me = 0;
+  MAP_MANAGER::ENTRY *   me = nullptr;
 
   set.reset ();
 
@@ -1552,7 +1552,7 @@ ACE_POSIX_Asynch_Connect::handle_output (ACE_HANDLE fd)
 {
   ACE_TRACE ("ACE_POSIX_Asynch_Connect::handle_output");
 
-  ACE_POSIX_Asynch_Connect_Result* result = 0;
+  ACE_POSIX_Asynch_Connect_Result* result = nullptr;
 
   {
     ACE_MT (ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, ace_mon, this->lock_, 0));
@@ -1593,7 +1593,7 @@ ACE_POSIX_Asynch_Connect::handle_close (ACE_HANDLE fd, ACE_Reactor_Mask)
 
   task.remove_io_handler (fd);
 
-  ACE_POSIX_Asynch_Connect_Result* result = 0;
+  ACE_POSIX_Asynch_Connect_Result* result = nullptr;
 
   {
     ACE_MT (ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, ace_mon, this->lock_, 0));
@@ -1704,7 +1704,7 @@ ACE_POSIX_Asynch_Transmit_File_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_transmit_file (result);
 }
 
@@ -1796,7 +1796,7 @@ ACE_POSIX_Asynch_Transmit_Handler::ACE_POSIX_Asynch_Transmit_Handler
       (ACE_POSIX_Proactor *posix_proactor,
        ACE_POSIX_Asynch_Transmit_File_Result *result)
   : result_ (result),
-    mb_ (0),
+    mb_ (nullptr),
     header_act_ (this->HEADER_ACT),
     data_act_ (this->DATA_ACT),
     trailer_act_ (this->TRAILER_ACT),
@@ -1836,8 +1836,8 @@ ACE_POSIX_Asynch_Transmit_Handler::transmit ()
   // Open Asynch_Read_File.
   if (this->rf_.open (this->proxy (),
                       this->result_->file (),
-                      0,
-                      0) == -1)
+                      nullptr,
+                      nullptr) == -1)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        "ACE_Asynch_Transmit_Handler:read_file open failed\n"),
                       -1);
@@ -1845,8 +1845,8 @@ ACE_POSIX_Asynch_Transmit_Handler::transmit ()
   // Open Asynch_Write_Stream.
   if (this->ws_.open (this->proxy (),
                       this->result_->socket (),
-                      0,
-                      0) == -1)
+                      nullptr,
+                      nullptr) == -1)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        "ACE_Asynch_Transmit_Handler:write_stream open failed\n"),
                       -1);
@@ -1880,7 +1880,7 @@ ACE_POSIX_Asynch_Transmit_Handler::handle_write_stream (const ACE_Asynch_Write_S
         {
           this->result_->complete (this->bytes_transferred_,
                                    0,      // Failure.
-                                   0,      // @@ Completion key.
+                                   nullptr,      // @@ Completion key.
                                    0);     // @@ Error no.
         }
       ACE_SEH_FINALLY
@@ -1936,7 +1936,7 @@ ACE_POSIX_Asynch_Transmit_Handler::handle_write_stream (const ACE_Asynch_Write_S
         {
           this->result_->complete (this->bytes_transferred_,
                                    1,      // @@ Success.
-                                   0,      // @@ Completion key.
+                                   nullptr,      // @@ Completion key.
                                    0);     // @@ Errno.
         }
       ACE_SEH_FINALLY
@@ -1971,7 +1971,7 @@ ACE_POSIX_Asynch_Transmit_Handler::handle_read_file (const ACE_Asynch_Read_File:
         {
           this->result_->complete (this->bytes_transferred_,
                                    0,      // Failure.
-                                   0,      // @@ Completion key.
+                                   nullptr,      // @@ Completion key.
                                    errno); // Error no.
         }
       ACE_SEH_FINALLY
@@ -2032,7 +2032,7 @@ ACE_POSIX_Asynch_Transmit_Handler::initiate_read_file ()
                           this->mb_->size () - 1,
                           this->file_offset_,
                           0, // @@ offset_high !!! if aiocb64 is used.
-                          0, // Act
+                          nullptr, // Act
                           this->result_->priority (),
                           this->result_->signal_number ()) == -1)
         ACELIB_ERROR_RETURN ((LM_ERROR,
@@ -2086,7 +2086,7 @@ ACE_POSIX_Asynch_Transmit_File::transmit_file (ACE_HANDLE file,
     bytes_per_send = bytes_to_write;
 
   // Configure the result parameter.
-  ACE_POSIX_Asynch_Transmit_File_Result *result = 0;
+  ACE_POSIX_Asynch_Transmit_File_Result *result = nullptr;
 
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Transmit_File_Result (this->handler_proxy_,
@@ -2105,7 +2105,7 @@ ACE_POSIX_Asynch_Transmit_File::transmit_file (ACE_HANDLE file,
                   -1);
 
   // Make the auxillary handler and initiate transmit.
-  ACE_POSIX_Asynch_Transmit_Handler *transmit_handler = 0;
+  ACE_POSIX_Asynch_Transmit_Handler *transmit_handler = nullptr;
 
   ACE_NEW_RETURN (transmit_handler,
                   ACE_POSIX_Asynch_Transmit_Handler (this->posix_proactor (),
@@ -2188,7 +2188,7 @@ ACE_POSIX_Asynch_Read_Dgram_Result::ACE_POSIX_Asynch_Read_Dgram_Result
       (handler_proxy, act, event, 0, 0, priority, signal_number),
     bytes_to_read_ (bytes_to_read),
     message_block_ (message_block),
-    remote_address_ (0),
+    remote_address_ (nullptr),
     addr_len_ (0),
     flags_ (flags),
     handle_ (handle)
@@ -2225,7 +2225,7 @@ ACE_POSIX_Asynch_Read_Dgram_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_read_dgram (result);
 }
 
@@ -2306,7 +2306,7 @@ ACE_POSIX_Asynch_Write_Dgram_Result::complete (size_t bytes_transferred,
 
   // Call the application handler.
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_write_dgram (result);
 }
 
@@ -2330,7 +2330,7 @@ ACE_POSIX_Asynch_Read_Dgram::recv (ACE_Message_Block *message_block,
 {
   size_t space = message_block->space ();
   // Create the Asynch_Result.
-  ACE_POSIX_Asynch_Read_Dgram_Result *result = 0;
+  ACE_POSIX_Asynch_Read_Dgram_Result *result = nullptr;
   ACE_POSIX_Proactor *proactor = this->posix_proactor ();
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Read_Dgram_Result (this->handler_proxy_,
@@ -2380,7 +2380,7 @@ ACE_POSIX_Asynch_Write_Dgram::send (ACE_Message_Block *message_block,
         ACE_TEXT ("Attempt to write 0 bytes\n")),
       -1);
 
-  ACE_POSIX_Asynch_Write_Dgram_Result *result = 0;
+  ACE_POSIX_Asynch_Write_Dgram_Result *result = nullptr;
   ACE_POSIX_Proactor *proactor = this->posix_proactor ();
   ACE_NEW_RETURN (result,
                   ACE_POSIX_Asynch_Write_Dgram_Result (this->handler_proxy_,

--- a/ACE/ace/POSIX_CB_Proactor.cpp
+++ b/ACE/ace/POSIX_CB_Proactor.cpp
@@ -35,7 +35,7 @@ ACE_POSIX_CB_Proactor::get_impl_type ()
 void ACE_POSIX_CB_Proactor::aio_completion_func (sigval cb_data)
 {
   ACE_POSIX_CB_Proactor * impl = static_cast<ACE_POSIX_CB_Proactor *> (cb_data.sival_ptr);
-  if ( impl != 0 )
+  if ( impl != nullptr )
     impl->notify_completion (0);
 }
 
@@ -87,7 +87,7 @@ ACE_POSIX_CB_Proactor::allocate_aio_slot (ACE_POSIX_Asynch_Result *result)
 #  else
   result->aio_sigevent.sigev_notify_function = aio_completion_func;
 #  endif /* ACE_HAS_SIG_C_FUNC */
-  result->aio_sigevent.sigev_notify_attributes = 0;
+  result->aio_sigevent.sigev_notify_attributes = nullptr;
 
   result->aio_sigevent.sigev_value.sival_ptr = this ;
 
@@ -145,13 +145,13 @@ ACE_POSIX_CB_Proactor::handle_events_i (u_long milli_seconds)
                                     index,
                                     count);
 
-      if (asynch_result == 0)
+      if (asynch_result == nullptr)
           break;
 
       // Call the application code.
       this->application_specific_code (asynch_result,
                                        return_status, // Bytes transferred.
-                                       0,             // No completion key.
+                                       nullptr,             // No completion key.
                                        error_status); // Error
      }
 

--- a/ACE/ace/POSIX_Proactor.cpp
+++ b/ACE/ace/POSIX_Proactor.cpp
@@ -31,7 +31,7 @@ class ACE_POSIX_Wakeup_Completion : public ACE_POSIX_Asynch_Result
 public:
   /// Constructor.
   ACE_POSIX_Wakeup_Completion (const ACE_Handler::Proxy_Ptr &handler_proxy,
-                               const void *act = 0,
+                               const void *act = nullptr,
                                ACE_HANDLE event = ACE_INVALID_HANDLE,
                                int priority = 0,
                                int signal_number = ACE_SIGRTMIN);
@@ -43,7 +43,7 @@ public:
   /// This method calls the <handler>'s <handle_wakeup> method.
   void complete (size_t bytes_transferred = 0,
                          int success = 1,
-                         const void *completion_key = 0,
+                         const void *completion_key = nullptr,
                          u_long error = 0) override;
 };
 
@@ -115,10 +115,10 @@ ACE_POSIX_Proactor::get_handle () const
 ACE_Asynch_Read_Stream_Impl *
 ACE_POSIX_Proactor::create_asynch_read_stream ()
 {
-  ACE_Asynch_Read_Stream_Impl *implementation = 0;
+  ACE_Asynch_Read_Stream_Impl *implementation = nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Read_Stream (this),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -143,7 +143,7 @@ ACE_POSIX_Proactor::create_asynch_read_stream_result
                                                        event,
                                                        priority,
                                                        signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -151,10 +151,10 @@ ACE_POSIX_Proactor::create_asynch_read_stream_result
 ACE_Asynch_Write_Stream_Impl *
 ACE_POSIX_Proactor::create_asynch_write_stream ()
 {
-  ACE_Asynch_Write_Stream_Impl *implementation = 0;
+  ACE_Asynch_Write_Stream_Impl *implementation = nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Write_Stream (this),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -179,7 +179,7 @@ ACE_POSIX_Proactor::create_asynch_write_stream_result
                                                         event,
                                                         priority,
                                                         signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -187,10 +187,10 @@ ACE_POSIX_Proactor::create_asynch_write_stream_result
 ACE_Asynch_Read_File_Impl *
 ACE_POSIX_Proactor::create_asynch_read_file ()
 {
-  ACE_Asynch_Read_File_Impl *implementation = 0;
+  ACE_Asynch_Read_File_Impl *implementation = nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Read_File (this),
-                  0);
+                  nullptr);
   return  implementation;
 }
 
@@ -219,7 +219,7 @@ ACE_POSIX_Proactor::create_asynch_read_file_result
                                                      event,
                                                      priority,
                                                      signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -227,10 +227,10 @@ ACE_POSIX_Proactor::create_asynch_read_file_result
 ACE_Asynch_Write_File_Impl *
 ACE_POSIX_Proactor::create_asynch_write_file ()
 {
-  ACE_Asynch_Write_File_Impl *implementation = 0;
+  ACE_Asynch_Write_File_Impl *implementation = nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Write_File (this),
-                  0);
+                  nullptr);
   return  implementation;
 }
 
@@ -259,7 +259,7 @@ ACE_POSIX_Proactor::create_asynch_write_file_result
                                                       event,
                                                       priority,
                                                       signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -267,10 +267,10 @@ ACE_POSIX_Proactor::create_asynch_write_file_result
 ACE_Asynch_Read_Dgram_Impl *
 ACE_POSIX_Proactor::create_asynch_read_dgram ()
 {
-    ACE_Asynch_Read_Dgram_Impl *implementation = 0;
+    ACE_Asynch_Read_Dgram_Impl *implementation = nullptr;
     ACE_NEW_RETURN (implementation,
                     ACE_POSIX_Asynch_Read_Dgram (this),
-                    0);
+                    nullptr);
     return implementation;
 }
 
@@ -287,7 +287,7 @@ ACE_POSIX_Proactor::create_asynch_read_dgram_result
    int priority ,
    int signal_number)
 {
-  ACE_Asynch_Read_Dgram_Result_Impl *implementation=0;
+  ACE_Asynch_Read_Dgram_Result_Impl *implementation=nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Read_Dgram_Result(handler_proxy,
                                                      handle,
@@ -299,7 +299,7 @@ ACE_POSIX_Proactor::create_asynch_read_dgram_result
                                                      event,
                                                      priority,
                                                      signal_number),
-                  0);
+                  nullptr);
 
   return implementation;
 }
@@ -308,10 +308,10 @@ ACE_POSIX_Proactor::create_asynch_read_dgram_result
 ACE_Asynch_Write_Dgram_Impl *
 ACE_POSIX_Proactor::create_asynch_write_dgram ()
 {
-        ACE_Asynch_Write_Dgram_Impl *implementation = 0;
+        ACE_Asynch_Write_Dgram_Impl *implementation = nullptr;
         ACE_NEW_RETURN (implementation,
                         ACE_POSIX_Asynch_Write_Dgram (this),
-                        0);
+                        nullptr);
 
     return implementation;
 }
@@ -328,7 +328,7 @@ ACE_POSIX_Proactor::create_asynch_write_dgram_result
    int priority ,
    int signal_number)
 {
-  ACE_Asynch_Write_Dgram_Result_Impl *implementation=0;
+  ACE_Asynch_Write_Dgram_Result_Impl *implementation=nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Write_Dgram_Result(handler_proxy,
                                                       handle,
@@ -339,7 +339,7 @@ ACE_POSIX_Proactor::create_asynch_write_dgram_result
                                                       event,
                                                       priority,
                                                       signal_number),
-                  0);
+                  nullptr);
 
   return implementation;
 }
@@ -348,10 +348,10 @@ ACE_POSIX_Proactor::create_asynch_write_dgram_result
 ACE_Asynch_Accept_Impl *
 ACE_POSIX_Proactor::create_asynch_accept ()
 {
-  ACE_Asynch_Accept_Impl *implementation = 0;
+  ACE_Asynch_Accept_Impl *implementation = nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Accept (this),
-                  0);
+                  nullptr);
 
   return implementation;
 }
@@ -379,7 +379,7 @@ ACE_POSIX_Proactor::create_asynch_accept_result
                                                   event,
                                                   priority,
                                                   signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -387,10 +387,10 @@ ACE_POSIX_Proactor::create_asynch_accept_result
 ACE_Asynch_Connect_Impl *
 ACE_POSIX_Proactor::create_asynch_connect ()
 {
-  ACE_Asynch_Connect_Impl *implementation = 0;
+  ACE_Asynch_Connect_Impl *implementation = nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Connect (this),
-                  0);
+                  nullptr);
 
   return implementation;
 }
@@ -412,7 +412,7 @@ ACE_POSIX_Proactor::create_asynch_connect_result
                                                    event,
                                                    priority,
                                                    signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -420,10 +420,10 @@ ACE_POSIX_Proactor::create_asynch_connect_result
 ACE_Asynch_Transmit_File_Impl *
 ACE_POSIX_Proactor::create_asynch_transmit_file ()
 {
-  ACE_Asynch_Transmit_File_Impl *implementation = 0;
+  ACE_Asynch_Transmit_File_Impl *implementation = nullptr;
   ACE_NEW_RETURN (implementation,
                   ACE_POSIX_Asynch_Transmit_File (this),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -458,7 +458,7 @@ ACE_POSIX_Proactor::create_asynch_transmit_file_result
                                                          event,
                                                          priority,
                                                          signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -479,7 +479,7 @@ ACE_POSIX_Proactor::create_asynch_timer
                                           event,
                                           priority,
                                           signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -494,7 +494,7 @@ ACE_POSIX_Proactor::application_specific_code (ACE_POSIX_Asynch_Result *asynch_r
       // Call completion hook
       asynch_result->complete (bytes_transferred,
                                error ? 0 : 1,
-                               0, // No completion key.
+                               nullptr, // No completion key.
                                error);
     }
   ACE_SEH_FINALLY
@@ -507,7 +507,7 @@ ACE_POSIX_Proactor::application_specific_code (ACE_POSIX_Asynch_Result *asynch_r
 int
 ACE_POSIX_Proactor::post_wakeup_completions (int how_many)
 {
-  ACE_POSIX_Wakeup_Completion *wakeup_completion = 0;
+  ACE_POSIX_Wakeup_Completion *wakeup_completion = nullptr;
 
   for (int ci = 0; ci < how_many; ci++)
     {
@@ -615,8 +615,8 @@ ACE_AIOCB_Notify_Pipe_Manager::ACE_AIOCB_Notify_Pipe_Manager (ACE_POSIX_AIOCB_Pr
   // Open the read stream.
   if (this->read_stream_.open (this->proxy (),
                                this->pipe_.read_handle (),
-                               0, // Completion Key
-                               0) // Proactor
+                               nullptr, // Completion Key
+                               nullptr) // Proactor
       == -1)
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT("%N:%l:%p\n"),
@@ -626,7 +626,7 @@ ACE_AIOCB_Notify_Pipe_Manager::ACE_AIOCB_Notify_Pipe_Manager (ACE_POSIX_AIOCB_Pr
   // Issue an asynch_read on the read_stream of the notify pipe.
   if (this->read_stream_.read (this->message_block_,
                                1, // enough to read 1 byte
-                               0, // ACT
+                               nullptr, // ACT
                                0) // Priority
       == -1)
     ACELIB_ERROR ((LM_ERROR,
@@ -699,7 +699,7 @@ ACE_AIOCB_Notify_Pipe_Manager::handle_read_stream
   // <post_completion>s in the future.
   if (-1 == this->read_stream_.read (this->message_block_,
                                      1,   // enough to read 1 byte
-                                     0,   // ACT
+                                     nullptr,   // ACT
                                      0))  // Priority
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("%N:%l:(%P | %t):%p\n"),
@@ -713,9 +713,9 @@ ACE_AIOCB_Notify_Pipe_Manager::handle_read_stream
 
 // Public constructor for common use.
 ACE_POSIX_AIOCB_Proactor::ACE_POSIX_AIOCB_Proactor (size_t max_aio_operations)
-  : aiocb_notify_pipe_manager_ (0),
-    aiocb_list_ (0),
-    result_list_ (0),
+  : aiocb_notify_pipe_manager_ (nullptr),
+    aiocb_list_ (nullptr),
+    result_list_ (nullptr),
     aiocb_list_max_size_ (max_aio_operations),
     aiocb_list_cur_size_ (0),
     notify_pipe_read_handle_ (ACE_INVALID_HANDLE),
@@ -737,9 +737,9 @@ ACE_POSIX_AIOCB_Proactor::ACE_POSIX_AIOCB_Proactor (size_t max_aio_operations)
 // Special protected constructor for ACE_SUN_Proactor
 ACE_POSIX_AIOCB_Proactor::ACE_POSIX_AIOCB_Proactor (size_t max_aio_operations,
                                                     ACE_POSIX_Proactor::Proactor_Type)
-  : aiocb_notify_pipe_manager_ (0),
-    aiocb_list_ (0),
-    result_list_ (0),
+  : aiocb_notify_pipe_manager_ (nullptr),
+    aiocb_list_ (nullptr),
+    result_list_ (nullptr),
     aiocb_list_max_size_ (max_aio_operations),
     aiocb_list_cur_size_ (0),
     notify_pipe_read_handle_ (ACE_INVALID_HANDLE),
@@ -788,7 +788,7 @@ void ACE_POSIX_AIOCB_Proactor::set_notify_handle (ACE_HANDLE h)
 
 int ACE_POSIX_AIOCB_Proactor::create_result_aiocb_list ()
 {
-  if (aiocb_list_ != 0)
+  if (aiocb_list_ != nullptr)
     return 0;
 
   ACE_NEW_RETURN (aiocb_list_, aiocb *[aiocb_list_max_size_], -1);
@@ -800,8 +800,8 @@ int ACE_POSIX_AIOCB_Proactor::create_result_aiocb_list ()
   // Initialize the array.
   for (size_t ai = 0; ai < this->aiocb_list_max_size_; ai++)
     {
-      aiocb_list_[ai] = 0;
-      result_list_[ai] = 0;
+      aiocb_list_[ai] = nullptr;
+      result_list_[ai] = nullptr;
     }
 
   return 0;
@@ -809,7 +809,7 @@ int ACE_POSIX_AIOCB_Proactor::create_result_aiocb_list ()
 
 int ACE_POSIX_AIOCB_Proactor::delete_result_aiocb_list ()
 {
-  if (aiocb_list_ == 0)  // already deleted
+  if (aiocb_list_ == nullptr)  // already deleted
     return 0;
 
   size_t ai;
@@ -817,14 +817,14 @@ int ACE_POSIX_AIOCB_Proactor::delete_result_aiocb_list ()
   // Try to cancel all uncompleted operations; POSIX systems may have
   // hidden system threads that still can work with our aiocbs!
   for (ai = 0; ai < aiocb_list_max_size_; ai++)
-    if (this->aiocb_list_[ai] != 0)  // active operation
+    if (this->aiocb_list_[ai] != nullptr)  // active operation
       this->cancel_aiocb (result_list_[ai]);
 
   int num_pending = 0;
 
   for (ai = 0; ai < aiocb_list_max_size_; ai++)
     {
-      if (this->aiocb_list_[ai] == 0 ) //  not active operation
+      if (this->aiocb_list_[ai] == nullptr ) //  not active operation
         continue;
 
       // Get the error and return status of the aio_ operation.
@@ -859,8 +859,8 @@ int ACE_POSIX_AIOCB_Proactor::delete_result_aiocb_list ()
       else // completed , OK
         {
           delete this->result_list_[ai];
-          this->result_list_[ai] = 0;
-          this->aiocb_list_[ai] = 0;
+          this->result_list_[ai] = nullptr;
+          this->aiocb_list_[ai] = nullptr;
         }
     }
 
@@ -876,10 +876,10 @@ int ACE_POSIX_AIOCB_Proactor::delete_result_aiocb_list ()
       num_pending));
 
   delete [] this->aiocb_list_;
-  this->aiocb_list_ = 0;
+  this->aiocb_list_ = nullptr;
 
   delete [] this->result_list_;
-  this->result_list_ = 0;
+  this->result_list_ = nullptr;
 
   return (num_pending == 0 ? 0 : -1);
   // ?? or just always return 0;
@@ -945,7 +945,7 @@ ACE_POSIX_AIOCB_Proactor::create_notify_manager ()
   // Remember! this issues a Asynch_Read
   // on the notify pipe for doing the Asynch_Accept/Connect.
 
-  if (aiocb_notify_pipe_manager_ == 0)
+  if (aiocb_notify_pipe_manager_ == nullptr)
     ACE_NEW (aiocb_notify_pipe_manager_,
              ACE_AIOCB_Notify_Pipe_Manager (this));
 }
@@ -956,7 +956,7 @@ ACE_POSIX_AIOCB_Proactor::delete_notify_manager ()
   // We are responsible for delete as all pointers set to 0 after
   // delete, it is save to delete twice
   delete aiocb_notify_pipe_manager_;
-  aiocb_notify_pipe_manager_ = 0;
+  aiocb_notify_pipe_manager_ = nullptr;
 }
 
 int
@@ -1015,13 +1015,13 @@ ACE_POSIX_AIOCB_Proactor::putq_result (ACE_POSIX_Asynch_Result *result)
 
 ACE_POSIX_Asynch_Result * ACE_POSIX_AIOCB_Proactor::getq_result ()
 {
-  ACE_MT (ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, ace_mon, this->mutex_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, ace_mon, this->mutex_, nullptr));
 
 
-  ACE_POSIX_Asynch_Result* result = 0;
+  ACE_POSIX_Asynch_Result* result = nullptr;
 
   if (this->result_queue_.dequeue_head (result) != 0)
-    return 0;
+    return nullptr;
 
 //  don't waste time if queue is empty - it is normal
 //  or check queue size before dequeue_head
@@ -1036,9 +1036,9 @@ ACE_POSIX_Asynch_Result * ACE_POSIX_AIOCB_Proactor::getq_result ()
 int ACE_POSIX_AIOCB_Proactor::clear_result_queue ()
 {
   int ret_val = 0;
-  ACE_POSIX_Asynch_Result* result = 0;
+  ACE_POSIX_Asynch_Result* result = nullptr;
 
-  while ((result = this->getq_result ()) != 0)
+  while ((result = this->getq_result ()) != nullptr)
     {
       delete result;
       ret_val++;
@@ -1050,14 +1050,14 @@ int ACE_POSIX_AIOCB_Proactor::clear_result_queue ()
 int ACE_POSIX_AIOCB_Proactor::process_result_queue ()
 {
   int ret_val = 0;
-  ACE_POSIX_Asynch_Result* result = 0;
+  ACE_POSIX_Asynch_Result* result = nullptr;
 
-  while ((result = this->getq_result ()) != 0)
+  while ((result = this->getq_result ()) != nullptr)
     {
       this->application_specific_code
             (result,
              result->bytes_transferred(), // 0, No bytes transferred.
-             0,  // No completion key.
+             nullptr,  // No completion key.
              result->error());   //0, No error.
 
       ret_val++;
@@ -1076,7 +1076,7 @@ ACE_POSIX_AIOCB_Proactor::handle_events_i (u_long milli_seconds)
     // Indefinite blocking.
     result_suspend = aio_suspend (aiocb_list_,
                                   aiocb_list_max_size_,
-                                  0);
+                                  nullptr);
   else
     {
       // Block on <aio_suspend> for <milli_seconds>
@@ -1114,13 +1114,13 @@ ACE_POSIX_AIOCB_Proactor::handle_events_i (u_long milli_seconds)
                                 index,
                                 count);
 
-          if (asynch_result == 0)
+          if (asynch_result == nullptr)
             break;
 
           // Call the application code.
           this->application_specific_code (asynch_result,
                                            transfer_count,
-                                           0,             // No completion key.
+                                           nullptr,             // No completion key.
                                            error_status);
         }
     }
@@ -1162,19 +1162,19 @@ ACE_POSIX_AIOCB_Proactor::find_completed_aio (int &error_status,
   // parameter index defines initial slot to scan
   // parameter count tells us how many slots should we scan
 
-  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->mutex_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->mutex_, nullptr));
 
-  ACE_POSIX_Asynch_Result *asynch_result = 0;
+  ACE_POSIX_Asynch_Result *asynch_result = nullptr;
 
   if (num_started_aio_ == 0)  // save time
-    return 0;
+    return nullptr;
 
   for (; count > 0; index++ , count--)
     {
       if (index >= aiocb_list_max_size_) // like a wheel
         index = 0;
 
-      if (aiocb_list_[index] == 0) // Dont process null blocks.
+      if (aiocb_list_[index] == nullptr) // Dont process null blocks.
         continue;
 
       if (0 != this->get_result_status (result_list_[index],
@@ -1184,11 +1184,11 @@ ACE_POSIX_AIOCB_Proactor::find_completed_aio (int &error_status,
     } // end for
 
   if (count == 0) // all processed , nothing found
-    return 0;
+    return nullptr;
   asynch_result = result_list_[index];
 
-  aiocb_list_[index] = 0;
-  result_list_[index] = 0;
+  aiocb_list_[index] = nullptr;
+  result_list_[index] = nullptr;
   aiocb_list_cur_size_--;
 
   num_started_aio_--;  // decrement count active aios
@@ -1213,7 +1213,7 @@ ACE_POSIX_AIOCB_Proactor::start_aio (ACE_POSIX_Asynch_Result *result,
 
   int ret_val = (aiocb_list_cur_size_ >= aiocb_list_max_size_) ? -1 : 0;
 
-  if (result == 0) // Just check the status of the list
+  if (result == nullptr) // Just check the status of the list
     return ret_val;
 
   // Save operation code in the aiocb
@@ -1268,7 +1268,7 @@ ACE_POSIX_AIOCB_Proactor::start_aio (ACE_POSIX_Asynch_Result *result,
       break;    // to start it later
     }
 
-  result_list_[index] = 0;
+  result_list_[index] = nullptr;
   aiocb_list_cur_size_--;
   return -1;
 }
@@ -1283,7 +1283,7 @@ ACE_POSIX_AIOCB_Proactor::allocate_aio_slot (ACE_POSIX_Asynch_Result *result)
 
   if (notify_pipe_read_handle_ == result->aio_fildes) // Notify_Pipe ?
     {                                       // should be free,
-      if (result_list_[i] != 0)           // only 1 request
+      if (result_list_[i] != nullptr)           // only 1 request
         {                                   // is allowed
           errno   = EAGAIN;
           ACELIB_ERROR_RETURN ((LM_ERROR,
@@ -1296,7 +1296,7 @@ ACE_POSIX_AIOCB_Proactor::allocate_aio_slot (ACE_POSIX_Asynch_Result *result)
   else  //try to find free slot as usual, but starting from 1
     {
       for (i= 1; i < this->aiocb_list_max_size_; i++)
-        if (result_list_[i] == 0)
+        if (result_list_[i] == nullptr)
           break;
     }
 
@@ -1324,7 +1324,7 @@ ACE_POSIX_AIOCB_Proactor::start_aio_i (ACE_POSIX_Asynch_Result *result)
   ACE_TRACE ("ACE_POSIX_AIOCB_Proactor::start_aio_i");
 
   int ret_val;
-  const ACE_TCHAR *ptype = 0;
+  const ACE_TCHAR *ptype = nullptr;
 
   // Start IO
   // The following aio_ptr anathema is required to work around a bug in
@@ -1384,8 +1384,8 @@ ACE_POSIX_AIOCB_Proactor::start_deferred_aio ()
   size_t i = 0;
 
   for (i= 0; i < this->aiocb_list_max_size_; i++)
-    if (result_list_[i] !=0       // check for
-       && aiocb_list_[i]  ==0)     // deferred AIO
+    if (result_list_[i] !=nullptr       // check for
+       && aiocb_list_[i]  ==nullptr)     // deferred AIO
       break;
 
   if (i >= this->aiocb_list_max_size_)
@@ -1415,7 +1415,7 @@ ACE_POSIX_AIOCB_Proactor::start_deferred_aio ()
 
   //AL notify  user
 
-  result_list_[i] = 0;
+  result_list_[i] = nullptr;
   --aiocb_list_cur_size_;
 
   --num_deferred_aiocb_;
@@ -1455,7 +1455,7 @@ ACE_POSIX_AIOCB_Proactor::cancel_aio (ACE_HANDLE handle)
 
     for (ai = 0; ai < this->aiocb_list_max_size_; ai++)
       {
-        if (this->result_list_[ai] == 0)    // Skip empty slot
+        if (this->result_list_[ai] == nullptr)    // Skip empty slot
           continue;
 
         if (this->result_list_[ai]->aio_fildes != handle)  // Not ours
@@ -1465,13 +1465,13 @@ ACE_POSIX_AIOCB_Proactor::cancel_aio (ACE_HANDLE handle)
 
         ACE_POSIX_Asynch_Result *asynch_result = this->result_list_[ai];
 
-        if (this->aiocb_list_[ai] == 0)  // Canceling a deferred operation
+        if (this->aiocb_list_[ai] == nullptr)  // Canceling a deferred operation
           {
             num_cancelled++;
             this->num_deferred_aiocb_--;
 
-            this->aiocb_list_[ai] = 0;
-            this->result_list_[ai] = 0;
+            this->aiocb_list_[ai] = nullptr;
+            this->result_list_[ai] = nullptr;
             this->aiocb_list_cur_size_--;
 
             asynch_result->set_error (ECANCELED);
@@ -1618,7 +1618,7 @@ ACE_POSIX_SIG_Proactor::handle_events (ACE_Time_Value &wait_time)
 int
 ACE_POSIX_SIG_Proactor::handle_events ()
 {
-  return this->handle_events_i (0);
+  return this->handle_events_i (nullptr);
 }
 
 int
@@ -1700,7 +1700,7 @@ ACE_POSIX_SIG_Proactor::create_asynch_timer
                                           event,
                                           priority,
                                           signal_number),
-                  0);
+                  nullptr);
   return implementation;
 }
 
@@ -1751,7 +1751,7 @@ ACE_POSIX_SIG_Proactor::setup_signal_handler (int signal_number) const
 int
 ACE_POSIX_SIG_Proactor::block_signals () const
 {
-  return ACE_OS::pthread_sigmask (SIG_BLOCK, &this->RT_completion_signals_, 0);
+  return ACE_OS::pthread_sigmask (SIG_BLOCK, &this->RT_completion_signals_, nullptr);
 }
 
 ssize_t
@@ -1761,7 +1761,7 @@ ACE_POSIX_SIG_Proactor::allocate_aio_slot (ACE_POSIX_Asynch_Result *result)
 
   //try to find free slot as usual, starting from 0
   for (i = 0; i < this->aiocb_list_max_size_; i++)
-    if (result_list_[i] == 0)
+    if (result_list_[i] == nullptr)
       break;
 
   if (i >= this->aiocb_list_max_size_)
@@ -1793,7 +1793,7 @@ ACE_POSIX_SIG_Proactor::handle_events_i (const ACE_Time_Value *timeout)
   do
     {
       // Wait for the signals.
-      if (timeout == 0)
+      if (timeout == nullptr)
         {
           result_sigwait = ACE_OS::sigwaitinfo (&this->RT_completion_signals_,
                                                 &sig_info);
@@ -1860,13 +1860,13 @@ ACE_POSIX_SIG_Proactor::handle_events_i (const ACE_Time_Value *timeout)
                               index,
                               count);
 
-        if (asynch_result == 0)
+        if (asynch_result == nullptr)
           break;
 
         // Call the application code.
         this->application_specific_code (asynch_result,
                                          transfer_count,
-                                         0,             // No completion key.
+                                         nullptr,             // No completion key.
                                          error_status); // Error
       }
 
@@ -1908,7 +1908,7 @@ ACE_POSIX_Asynch_Timer::complete (size_t       /* bytes_transferred */,
                                   u_long       /* error */)
 {
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_time_out (this->time_, this->act ());
 }
 
@@ -1943,7 +1943,7 @@ ACE_POSIX_Wakeup_Completion::complete (size_t       /* bytes_transferred */,
                                        u_long       /*  error */)
 {
   ACE_Handler *handler = this->handler_proxy_.get ()->handler ();
-  if (handler != 0)
+  if (handler != nullptr)
     handler->handle_wakeup ();
 }
 

--- a/ACE/ace/Parse_Node.cpp
+++ b/ACE/ace/Parse_Node.cpp
@@ -35,7 +35,7 @@ ACE_Stream_Node::apply (ACE_Service_Gestalt *config, int &yyerrno)
   ACE_TRACE ("ACE_Stream_Node::apply");
 
   const ACE_Service_Type *sst = this->node_->record (config);
-  if (sst == 0)
+  if (sst == nullptr)
     const_cast<ACE_Static_Node *> (this->node_)->apply (config, yyerrno);
 
   if (yyerrno != 0) return;
@@ -57,7 +57,7 @@ ACE_Stream_Node::apply (ACE_Service_Gestalt *config, int &yyerrno)
   list_t mod_list;
   const ACE_Static_Node *module;
   for (module = dynamic_cast<const ACE_Static_Node*> (this->mods_);
-       module != 0;
+       module != nullptr;
        module = dynamic_cast<ACE_Static_Node*> (module->link()))
     mod_list.push_front (module);
 
@@ -68,7 +68,7 @@ ACE_Stream_Node::apply (ACE_Service_Gestalt *config, int &yyerrno)
       ACE_ARGV args (module->parameters ());
 
       const ACE_Service_Type *mst = module->record (config);
-      if (mst == 0)
+      if (mst == nullptr)
         const_cast<ACE_Static_Node *> (module)->apply (config, yyerrno);
 
       if (yyerrno != 0)
@@ -141,7 +141,7 @@ ACE_Parse_Node::link (ACE_Parse_Node *n)
 
   // Find the last list entry (if any) ...
   ACE_Parse_Node *t = this;
-  while (t->next_ != 0)
+  while (t->next_ != nullptr)
       t = t->next_;
 
   // ... and insert n there.
@@ -150,7 +150,7 @@ ACE_Parse_Node::link (ACE_Parse_Node *n)
 
 ACE_Stream_Node::ACE_Stream_Node (const ACE_Static_Node *str_ops,
                                   const ACE_Parse_Node *str_mods)
-    : ACE_Parse_Node ((str_ops == 0 ? ACE_TEXT ("<unknown>") : str_ops->name ())),
+    : ACE_Parse_Node ((str_ops == nullptr ? ACE_TEXT ("<unknown>") : str_ops->name ())),
       node_ (str_ops),
       mods_ (str_mods)
 {
@@ -168,8 +168,8 @@ ACE_Stream_Node::~ACE_Stream_Node ()
 }
 
 ACE_Parse_Node::ACE_Parse_Node ()
-  : name_ (0),
-    next_ (0)
+  : name_ (nullptr),
+    next_ (nullptr)
 {
   ACE_TRACE ("ACE_Parse_Node::ACE_Parse_Node");
 }
@@ -177,7 +177,7 @@ ACE_Parse_Node::ACE_Parse_Node ()
 
 ACE_Parse_Node::ACE_Parse_Node (const ACE_TCHAR *nm)
   : name_ (ACE::strnew (nm)),
-    next_ (0)
+    next_ (nullptr)
 {
   ACE_TRACE ("ACE_Parse_Node::ACE_Parse_Node");
 }
@@ -384,10 +384,10 @@ const ACE_Service_Type *
 ACE_Static_Node::record (const ACE_Service_Gestalt *config) const
 {
   ACE_TRACE ("ACE_Static_Node::record");
-  ACE_Service_Type *sr = 0;
+  ACE_Service_Type *sr = nullptr;
 
   if (config->find (this->name (), (const ACE_Service_Type **) &sr) == -1)
-    return 0;
+    return nullptr;
 
   return sr;
 }
@@ -439,10 +439,10 @@ ACE_Location_Node::dump () const
 }
 
 ACE_Location_Node::ACE_Location_Node ()
-  : pathname_ (0),
+  : pathname_ (nullptr),
     must_delete_ (0),
     dll_ (),
-    symbol_ (0)
+    symbol_ (nullptr)
 {
   ACE_TRACE ("ACE_Location_Node::ACE_Location_Node");
 }
@@ -549,7 +549,7 @@ ACE_Object_Node::symbol (ACE_Service_Gestalt *,
       ACE_TCHAR *object_name = const_cast<ACE_TCHAR *> (this->object_name_);
 
       this->symbol_ = this->dll_.symbol (object_name);
-      if (this->symbol_ == 0)
+      if (this->symbol_ == nullptr)
         {
           ++yyerrno;
 
@@ -565,13 +565,13 @@ ACE_Object_Node::symbol (ACE_Service_Gestalt *,
             }
 #endif /* ACE_NLOGGING */
 
-          return 0;
+          return nullptr;
         }
 
       return this->symbol_;
     }
 
-  return 0;
+  return nullptr;
 }
 
 ACE_Object_Node::~ACE_Object_Node ()
@@ -673,7 +673,7 @@ ACE_Function_Node::symbol (ACE_Service_Gestalt *,
   ACE_TRACE ("ACE_Function_Node::symbol");
   if (this->open_dll (yyerrno) == 0)
     {
-      this->symbol_ = 0;
+      this->symbol_ = nullptr;
 
       // Locate the factory function <function_name> in the shared
       // object.
@@ -681,7 +681,7 @@ ACE_Function_Node::symbol (ACE_Service_Gestalt *,
         const_cast<ACE_TCHAR *> (this->function_name_);
 
       void * const func_p = this->dll_.symbol (function_name);
-      if (func_p == 0)
+      if (func_p == nullptr)
         {
           ++yyerrno;
 
@@ -697,7 +697,7 @@ ACE_Function_Node::symbol (ACE_Service_Gestalt *,
             }
 #endif /* ACE_NLOGGING */
 
-          return 0;
+          return nullptr;
         }
 
       intptr_t const temp_p = reinterpret_cast<intptr_t> (func_p);
@@ -707,7 +707,7 @@ ACE_Function_Node::symbol (ACE_Service_Gestalt *,
       // Invoke the factory function and record it's return value.
       this->symbol_ = (*func) (gobbler);
 
-      if (this->symbol_ == 0)
+      if (this->symbol_ == nullptr)
         {
           ++yyerrno;
           if (ACE::debug ())
@@ -716,7 +716,7 @@ ACE_Function_Node::symbol (ACE_Service_Gestalt *,
                          ACE_TEXT ("%p\n"),
                          this->function_name_));
             }
-          return 0;
+          return nullptr;
         }
     }
   return this->symbol_;
@@ -802,12 +802,12 @@ ACE_Static_Function_Node::symbol (ACE_Service_Gestalt *config,
 {
   ACE_TRACE ("ACE_Static_Function_Node::symbol");
 
-  this->symbol_ = 0;
+  this->symbol_ = nullptr;
 
   // Locate the factory function <function_name> in the statically
   // linked svcs.
 
-  ACE_Static_Svc_Descriptor *ssd = 0;
+  ACE_Static_Svc_Descriptor *ssd = nullptr;
   if (config->find_static_svc_descriptor (this->function_name_, &ssd) == -1)
     {
       ++yyerrno;
@@ -818,14 +818,14 @@ ACE_Static_Function_Node::symbol (ACE_Service_Gestalt *config,
                      ACE_TEXT ("registered for function %s\n"),
                      this->function_name_));
         }
-      return 0;
+      return nullptr;
     }
 
-  if (ssd->alloc_ == 0)
+  if (ssd->alloc_ == nullptr)
     {
       ++yyerrno;
 
-      if (this->symbol_ == 0)
+      if (this->symbol_ == nullptr)
         {
           ++yyerrno;
 
@@ -836,14 +836,14 @@ ACE_Static_Function_Node::symbol (ACE_Service_Gestalt *config,
                           ACE_TEXT ("function registered for function %s\n"),
                           this->function_name_));
             }
-          return 0;
+          return nullptr;
         }
     }
 
   // Invoke the factory function and record it's return value.
   this->symbol_ = (*ssd->alloc_) (gobbler);
 
-  if (this->symbol_ == 0)
+  if (this->symbol_ == nullptr)
     {
       ++yyerrno;
       if (ACE::debug ())
@@ -852,7 +852,7 @@ ACE_Static_Function_Node::symbol (ACE_Service_Gestalt *config,
                       ACE_TEXT ("%p\n"),
                       this->function_name_));
         }
-      return 0;
+      return nullptr;
     }
 
   return this->symbol_;
@@ -896,11 +896,11 @@ ACE_Service_Type_Factory::make_service_type (ACE_Service_Gestalt *cfg) const
     | (this->location_->dispose () == 0 ? 0 : ACE_Service_Type::DELETE_OBJ);
 
   int yyerrno = 0;
-  ACE_Service_Object_Exterminator gobbler = 0;
+  ACE_Service_Object_Exterminator gobbler = nullptr;
 
   void *sym = this->location_->symbol (cfg, yyerrno, &gobbler);
 
-  if (sym != 0)
+  if (sym != nullptr)
     {
       ACE_Service_Type_Impl *stp =
         ACE_Service_Config::create_service_type_impl (this->name (),
@@ -908,16 +908,16 @@ ACE_Service_Type_Factory::make_service_type (ACE_Service_Gestalt *cfg) const
                                                       sym,
                                                       flags,
                                                       gobbler);
-      if (stp == 0)
+      if (stp == nullptr)
         ++yyerrno;
 
-      ACE_Service_Type *tmp = 0;
+      ACE_Service_Type *tmp = nullptr;
       ACE_NEW_RETURN (tmp,
                       ACE_Service_Type (this->name (),
                                         stp,
                                         this->location_->dll (),
                                         this->is_active_),
-                      0);
+                      nullptr);
       return tmp;
     }
 
@@ -931,7 +931,7 @@ ACE_Service_Type_Factory::make_service_type (ACE_Service_Gestalt *cfg) const
     }
 #endif
   ++yyerrno;
-  return 0;
+  return nullptr;
 }
 
 ACE_TCHAR const*

--- a/ACE/ace/Ping_Socket.cpp
+++ b/ACE/ace/Ping_Socket.cpp
@@ -292,7 +292,7 @@ ACE_Ping_Socket::send_echo_check (ACE_INET_Addr &remote_addr,
       return -1;
     }
 
-  sockaddr_in *addr_connect = 0;
+  sockaddr_in *addr_connect = nullptr;
   addr_connect = (sockaddr_in *) remote_addr.get_addr ();
 
   /*
@@ -318,7 +318,7 @@ ACE_Ping_Socket::send_echo_check (ACE_INET_Addr &remote_addr,
 
   ACE_OS::memset (this->icmp_send_buff_, 0, sizeof this->icmp_send_buff_);
   int datalen = ICMP_DATA_LENGTH;
-  struct icmp *_icmp = 0;
+  struct icmp *_icmp = nullptr;
 
   _icmp = (struct icmp *) this->icmp_send_buff_;
   _icmp->icmp_type = ICMP_ECHO;
@@ -329,7 +329,7 @@ ACE_Ping_Socket::send_echo_check (ACE_INET_Addr &remote_addr,
 #if defined (ACE_WIN32)
   _icmp->icmp_data = GetTickCount ();
 #else  /* #if defined (ACE_WIN32) */
-  gettimeofday ((struct timeval *) &_icmp->icmp_data, 0);
+  gettimeofday ((struct timeval *) &_icmp->icmp_data, nullptr);
 #endif  /* #if defined (ACE_WIN32) */
 
   int length_icmp = ICMP_MIN + datalen; // checksum ICMP header and data.

--- a/ACE/ace/Priority_Reactor.cpp
+++ b/ACE/ace/Priority_Reactor.cpp
@@ -45,8 +45,8 @@ ACE_Priority_Reactor::init_bucket ()
 ACE_Priority_Reactor::ACE_Priority_Reactor (ACE_Sig_Handler *sh,
                                             ACE_Timer_Queue *tq)
   : ACE_Select_Reactor(sh, tq),
-    bucket_ (0),
-    tuple_allocator_ (0)
+    bucket_ (nullptr),
+    tuple_allocator_ (nullptr)
 {
   ACE_TRACE ("ACE_Priority_Reactor::ACE_Priority_Reactor");
   this->init_bucket ();
@@ -57,8 +57,8 @@ ACE_Priority_Reactor::ACE_Priority_Reactor (size_t size,
                                             ACE_Sig_Handler *sh,
                                             ACE_Timer_Queue *tq)
   : ACE_Select_Reactor (size, restart, sh, tq),
-    bucket_ (0),
-    tuple_allocator_ (0)
+    bucket_ (nullptr),
+    tuple_allocator_ (nullptr)
 {
   ACE_TRACE ("ACE_Priority_Reactor::ACE_Priority_Reactor");
   this->init_bucket ();
@@ -92,7 +92,7 @@ ACE_Priority_Reactor::build_bucket (ACE_Handle_Set &dispatch_mask,
     {
       ACE_Event_Handler *event_handler =
         this->handler_rep_.find (handle);
-      if (event_handler == 0)
+      if (event_handler == nullptr)
         return -1;
 
       ACE_Event_Tuple et (event_handler,

--- a/ACE/ace/Proactor.cpp
+++ b/ACE/ace/Proactor.cpp
@@ -32,7 +32,7 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /// Process-wide ACE_Proactor.
-ACE_Proactor *ACE_Proactor::proactor_ = 0;
+ACE_Proactor *ACE_Proactor::proactor_ = nullptr;
 
 /// Controls whether the Proactor is deleted when we shut down (we can
 /// only delete it safely if we created it!)
@@ -176,7 +176,7 @@ ACE_Proactor_Timer_Handler::svc ()
 // *********************************************************************
 
 ACE_Proactor_Handle_Timeout_Upcall::ACE_Proactor_Handle_Timeout_Upcall ()
-  : proactor_ (0)
+  : proactor_ (nullptr)
 {
 }
 
@@ -218,7 +218,7 @@ ACE_Proactor_Handle_Timeout_Upcall::timeout (ACE_Proactor_Timer_Queue &,
                                              int,
                                              const ACE_Time_Value &time)
 {
-  if (this->proactor_ == 0)
+  if (this->proactor_ == nullptr)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("(%t) No Proactor set in ACE_Proactor_Handle_Timeout_Upcall,")
                        ACE_TEXT (" no completion port to post timeout to?!@\n")),
@@ -233,7 +233,7 @@ ACE_Proactor_Handle_Timeout_Upcall::timeout (ACE_Proactor_Timer_Queue &,
                                           0,
                                           -1);
 
-  if (asynch_timer == 0)
+  if (asynch_timer == nullptr)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("%N:%l:(%P | %t):%p\n"),
                        ACE_TEXT ("ACE_Proactor_Handle_Timeout_Upcall::timeout:")
@@ -289,7 +289,7 @@ ACE_Proactor_Handle_Timeout_Upcall::deletion (ACE_Proactor_Timer_Queue &,
 int
 ACE_Proactor_Handle_Timeout_Upcall::proactor (ACE_Proactor &proactor)
 {
-  if (this->proactor_ == 0)
+  if (this->proactor_ == nullptr)
     {
       this->proactor_ = &proactor;
       return 0;
@@ -306,17 +306,17 @@ ACE_Proactor_Handle_Timeout_Upcall::proactor (ACE_Proactor &proactor)
 ACE_Proactor::ACE_Proactor (ACE_Proactor_Impl *implementation,
                             bool delete_implementation,
                             ACE_Proactor_Timer_Queue *tq)
-  : implementation_ (0),
+  : implementation_ (nullptr),
     delete_implementation_ (delete_implementation),
-    timer_handler_ (0),
-    timer_queue_ (0),
+    timer_handler_ (nullptr),
+    timer_queue_ (nullptr),
     delete_timer_queue_ (0),
     end_event_loop_ (0),
     event_loop_thread_count_ (0)
 {
   this->implementation (implementation);
 
-  if (this->implementation () == 0)
+  if (this->implementation () == nullptr)
     {
 #if defined (ACE_HAS_AIO_CALLS)
       // POSIX Proactor.
@@ -368,18 +368,18 @@ ACE_Proactor::instance (size_t /* threads */)
 {
   ACE_TRACE ("ACE_Proactor::instance");
 
-  if (ACE_Proactor::proactor_ == 0)
+  if (ACE_Proactor::proactor_ == nullptr)
     {
       // Perform Double-Checked Locking Optimization.
       ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
                                 *ACE_Static_Object_Lock::instance (),
-                                0));
+                                nullptr));
 
-      if (ACE_Proactor::proactor_ == 0)
+      if (ACE_Proactor::proactor_ == nullptr)
         {
           ACE_NEW_RETURN (ACE_Proactor::proactor_,
                           ACE_Proactor,
-                          0);
+                          nullptr);
 
           ACE_Proactor::delete_proactor_ = true;
           ACE_REGISTER_FRAMEWORK_COMPONENT(ACE_Proactor, ACE_Proactor::proactor_);
@@ -394,7 +394,7 @@ ACE_Proactor::instance (ACE_Proactor * r, bool delete_proactor)
   ACE_TRACE ("ACE_Proactor::instance");
 
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Static_Object_Lock::instance (), 0));
+                            *ACE_Static_Object_Lock::instance (), nullptr));
 
   ACE_Proactor *t = ACE_Proactor::proactor_;
 
@@ -416,7 +416,7 @@ ACE_Proactor::close_singleton ()
   if (ACE_Proactor::delete_proactor_)
     {
       delete ACE_Proactor::proactor_;
-      ACE_Proactor::proactor_ = 0;
+      ACE_Proactor::proactor_ = nullptr;
       ACE_Proactor::delete_proactor_ = false;
     }
 }
@@ -475,7 +475,7 @@ ACE_Proactor::proactor_run_event_loop (PROACTOR_EVENT_HOOK eh)
       // <end_event_loop> is not set. Ready to do <handle_events>.
       result = this->handle_events ();
 
-      if (eh != 0 && (*eh) (this))
+      if (eh != nullptr && (*eh) (this))
         continue;
 
       if (result == -1)
@@ -532,7 +532,7 @@ ACE_Proactor::proactor_run_event_loop (ACE_Time_Value &tv,
       // <end_event_loop> is not set. Ready to do <handle_events>.
       result = this->handle_events (tv);
 
-      if (eh != 0 && (*eh) (this))
+      if (eh != nullptr && (*eh) (this))
         continue;
 
       if (result == -1 || result == 0)
@@ -616,27 +616,27 @@ ACE_Proactor::close ()
   if (this->delete_implementation_)
     {
       delete this->implementation ();
-      this->implementation_ = 0;
+      this->implementation_ = nullptr;
     }
 
   // Delete the timer handler.
   if (this->timer_handler_)
     {
       delete this->timer_handler_;
-      this->timer_handler_ = 0;
+      this->timer_handler_ = nullptr;
     }
 
   // Delete the timer queue.
   if (this->delete_timer_queue_)
     {
       delete this->timer_queue_;
-      this->timer_queue_ = 0;
+      this->timer_queue_ = nullptr;
       this->delete_timer_queue_ = 0;
     }
   else if (this->timer_queue_)
     {
       this->timer_queue_->close ();
-      this->timer_queue_ = 0;
+      this->timer_queue_ = nullptr;
     }
 
   return 0;
@@ -774,7 +774,7 @@ ACE_Proactor::timer_queue (ACE_Proactor_Timer_Queue *tq)
     }
 
   // New timer queue.
-  if (tq == 0)
+  if (tq == nullptr)
     {
       ACE_NEW (this->timer_queue_,
                TIMER_HEAP);
@@ -791,7 +791,7 @@ ACE_Proactor::timer_queue (ACE_Proactor_Timer_Queue *tq)
 
   TQ_Base * tqb = dynamic_cast<TQ_Base*> (this->timer_queue_);
 
-  if (tqb != 0)
+  if (tqb != nullptr)
     {
       tqb->upcall_functor ().proactor (*this);
     }

--- a/ACE/ace/Process.cpp
+++ b/ACE/ace/Process.cpp
@@ -81,7 +81,7 @@ ACE_Process::spawn (ACE_Process_Options &options)
   // Stash the passed/duped handle sets away in this object for later
   // closing if needed or requested. At the same time, figure out which
   // ones to include in command line options if that's needed below.
-  ACE_Handle_Set *set_p = 0;
+  ACE_Handle_Set *set_p = nullptr;
   if (options.dup_handles (this->dup_handles_))
     set_p = &this->dup_handles_;
   else if (options.passed_handles (this->handles_passed_))
@@ -403,7 +403,7 @@ ACE_Process::spawn (ACE_Process_Options &options)
 
         // If we must, set the working directory for the child
         // process.
-        if (options.working_directory () != 0)
+        if (options.working_directory () != nullptr)
           ACE_OS::chdir (options.working_directory ());
         // Should check for error here!
 
@@ -444,7 +444,7 @@ ACE_Process::spawn (ACE_Process_Options &options)
           {
             // Add the new environment variables to the environment
             // context of the context before doing an <execvp>.
-            for (size_t i = 0; procenv[i] != 0; i++)
+            for (size_t i = 0; procenv[i] != nullptr; i++)
               if (ACE_OS::putenv (procenv[i]) != 0)
                 return ACE_INVALID_PID;
 
@@ -593,7 +593,7 @@ ACE_Process::wait (const ACE_Time_Value &tv,
         ACE_OS::waitpid (this->child_id_,
                          &this->exit_code_,
                          WNOHANG);
-      if (status != 0)
+      if (status != nullptr)
         *status = this->exit_code_;
 
       return retv;
@@ -620,7 +620,7 @@ ACE_Process::wait (const ACE_Time_Value &tv,
       pid = ACE_OS::waitpid (this->getpid (),
                              &this->exit_code_,
                              WNOHANG);
-      if (status != 0)
+      if (status != nullptr)
         *status = this->exit_code_;
 
       if (pid > 0 || pid == ACE_INVALID_PID)
@@ -754,16 +754,16 @@ ACE_Process_Options::ACE_Process_Options (bool inherit_environment,
     set_handles_called_ (0),
     environment_buf_index_ (0),
     environment_argv_index_ (0),
-    environment_buf_ (0),
+    environment_buf_ (nullptr),
     environment_buf_len_ (env_buf_len),
     max_environment_args_ (max_env_args),
     max_environ_argv_index_ (max_env_args - 1),
     command_line_argv_calculated_ (false),
-    command_line_buf_ (0),
-    command_line_copy_ (0),
+    command_line_buf_ (nullptr),
+    command_line_copy_ (nullptr),
     command_line_buf_len_ (command_line_buf_len),
     max_command_line_args_ (max_cmdline_args),
-    command_line_argv_ (0),
+    command_line_argv_ (nullptr),
     process_group_ (ACE_INVALID_PID),
     use_unicode_environment_ (false)
 {
@@ -793,7 +793,7 @@ ACE_Process_Options::ACE_Process_Options (bool inherit_environment,
            ACE_TCHAR *[max_env_args]);
 #endif /* ACE_HAS_ALLOC_HOOKS */
   environment_buf_[0] = '\0';
-  environment_argv_[0] = 0;
+  environment_argv_[0] = nullptr;
 #if defined (ACE_WIN32)
   ACE_OS::memset ((void *) &this->startup_info_,
                   0,
@@ -934,7 +934,7 @@ ACE_Process_Options::setenv (const ACE_TCHAR *variable_name,
   // To address the potential buffer overflow,
   // we now allocate the buffer on heap with a variable size.
   size_t const buflen = ACE_OS::strlen (variable_name) + ACE_OS::strlen (format) + 2;
-  ACE_TCHAR *newformat = 0;
+  ACE_TCHAR *newformat = nullptr;
   ACE_NEW_RETURN (newformat, ACE_TCHAR[buflen], -1);
   std::unique_ptr<ACE_TCHAR[]> safe_newformat (newformat);
 
@@ -951,7 +951,7 @@ ACE_Process_Options::setenv (const ACE_TCHAR *variable_name,
     }
   int retval = 0;
 
-  ACE_TCHAR *stack_buf = 0;
+  ACE_TCHAR *stack_buf = nullptr;
   ACE_NEW_RETURN (stack_buf, ACE_TCHAR[tmp_buflen], -1);
   std::unique_ptr<ACE_TCHAR[]> safe_stack_buf (stack_buf);
 
@@ -1034,7 +1034,7 @@ ACE_Process_Options::setenv_i (ACE_TCHAR *assignment,
 
   // Update the argv array.
   environment_argv_[environment_argv_index_++] = environment_buf_ + environment_buf_index_;
-  environment_argv_[environment_argv_index_] = 0;
+  environment_argv_[environment_argv_index_] = nullptr;
 
   // Update our index.
   environment_buf_index_ += len;
@@ -1234,7 +1234,7 @@ ACE_Process_Options::command_line (const ACE_TCHAR *format, ...)
 int
 ACE_Process_Options::command_line (const ACE_ANTI_TCHAR *format, ...)
 {
-  ACE_ANTI_TCHAR *anti_clb = 0;
+  ACE_ANTI_TCHAR *anti_clb = nullptr;
   ACE_NEW_RETURN (anti_clb,
                   ACE_ANTI_TCHAR[this->command_line_buf_len_],
                   -1);
@@ -1264,7 +1264,7 @@ ACE_TCHAR *
 ACE_Process_Options::env_buf ()
 {
   if (environment_buf_[0] == '\0')
-    return 0;
+    return nullptr;
   else
     return environment_buf_;
 }
@@ -1292,11 +1292,11 @@ ACE_Process_Options::command_line_argv ()
       unsigned int x = 0;
       do
         command_line_argv_[x] = parser.next ();
-      while (command_line_argv_[x] != 0
+      while (command_line_argv_[x] != nullptr
              // subtract one for the ending zero.
              && ++x < max_command_line_args_ - 1);
 
-      command_line_argv_[x] = 0;
+      command_line_argv_[x] = nullptr;
     }
 
   return command_line_argv_;

--- a/ACE/ace/Process_Manager.cpp
+++ b/ACE/ace/Process_Manager.cpp
@@ -54,7 +54,7 @@ sigchld_nop (int, siginfo_t *, ucontext_t *)
 ACE_ALLOC_HOOK_DEFINE(ACE_Process_Manager)
 
 // Singleton instance.
-ACE_Process_Manager *ACE_Process_Manager::instance_ = 0;
+ACE_Process_Manager *ACE_Process_Manager::instance_ = nullptr;
 
 // Controls whether the Process_Manager is deleted when we shut down
 // (we can only delete it safely if we created it!)
@@ -100,8 +100,8 @@ ACE_Process_Manager::dump () const
 }
 
 ACE_Process_Manager::Process_Descriptor::Process_Descriptor ()
-  : process_ (0),
-    exit_notify_ (0)
+  : process_ (nullptr),
+    exit_notify_ (nullptr)
 {
   ACE_TRACE ("ACE_Process_Manager::Process_Descriptor::Process_Descriptor");
 }
@@ -111,17 +111,17 @@ ACE_Process_Manager::instance ()
 {
   ACE_TRACE ("ACE_Process_Manager::instance");
 
-  if (ACE_Process_Manager::instance_ == 0)
+  if (ACE_Process_Manager::instance_ == nullptr)
     {
       // Perform Double-Checked Locking Optimization.
       ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                                *ACE_Static_Object_Lock::instance (), 0));
+                                *ACE_Static_Object_Lock::instance (), nullptr));
 
-      if (ACE_Process_Manager::instance_ == 0)
+      if (ACE_Process_Manager::instance_ == nullptr)
         {
           ACE_NEW_RETURN (ACE_Process_Manager::instance_,
                           ACE_Process_Manager,
-                          0);
+                          nullptr);
           ACE_Process_Manager::delete_instance_ = true;
 
           // Register with the Object_Manager so that the wrapper to
@@ -129,7 +129,7 @@ ACE_Process_Manager::instance ()
           // being terminated.
           ACE_Object_Manager::at_exit (ACE_Process_Manager::instance_,
                                        ACE_PROCESS_MANAGER_CLEANUP_FUNCTION,
-                                       0,
+                                       nullptr,
                                        typeid (ACE_Process_Manager).name ());
         }
     }
@@ -142,7 +142,7 @@ ACE_Process_Manager::instance (ACE_Process_Manager *tm)
 {
   ACE_TRACE ("ACE_Process_Manager::instance");
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Static_Object_Lock::instance (), 0));
+                            *ACE_Static_Object_Lock::instance (), nullptr));
 
   ACE_Process_Manager *t = ACE_Process_Manager::instance_;
   // We can't safely delete it since we don't know who created it!
@@ -153,7 +153,7 @@ ACE_Process_Manager::instance (ACE_Process_Manager *tm)
   // being terminated.
   ACE_Object_Manager::at_exit (ACE_Process_Manager::instance_,
                                ACE_PROCESS_MANAGER_CLEANUP_FUNCTION,
-                               0,
+                               nullptr,
                                typeid (*t).name ());
 
   ACE_Process_Manager::instance_ = tm;
@@ -171,7 +171,7 @@ ACE_Process_Manager::close_singleton( )
   if (ACE_Process_Manager::delete_instance_)
     {
       delete ACE_Process_Manager::instance_;
-      ACE_Process_Manager::instance_ = 0;
+      ACE_Process_Manager::instance_ = nullptr;
       ACE_Process_Manager::delete_instance_ = false;
     }
 }
@@ -184,7 +184,7 @@ ACE_Process_Manager::resize (size_t size)
   if (size <= this->max_process_table_size_)
     return 0;
 
-  Process_Descriptor *temp = 0;
+  Process_Descriptor *temp = nullptr;
 
   ACE_NEW_RETURN (temp,
                   Process_Descriptor[size],
@@ -231,10 +231,10 @@ ACE_Process_Manager::open (size_t size, ACE_Reactor *r)
 ACE_Process_Manager::ACE_Process_Manager (size_t size,
                                           ACE_Reactor *r)
   : ACE_Event_Handler (),
-    process_table_ (0),
+    process_table_ (nullptr),
     max_process_table_size_ (0),
     current_count_ (0),
-    default_exit_handler_ (0)
+    default_exit_handler_ (nullptr)
 #if defined (ACE_HAS_THREADS)
   , lock_ ()
 #endif /* ACE_HAS_THREADS */
@@ -255,30 +255,30 @@ ACE_Process_Manager::close ()
 {
   ACE_TRACE ("ACE_Process_Manager::close");
 
-  if (this->reactor () != 0)
+  if (this->reactor () != nullptr)
     {
 #if !defined (ACE_WIN32) && !defined (ACE_LACKS_UNIX_SIGNALS)
-      this->reactor ()->remove_handler (SIGCHLD, (ACE_Sig_Action *) 0);
+      this->reactor ()->remove_handler (SIGCHLD, (ACE_Sig_Action *) nullptr);
 #endif /*  !ACE_WIN32  */
-      this->reactor (0);
+      this->reactor (nullptr);
     }
 
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon, this->lock_, -1));
 
-  if (this->process_table_ != 0)
+  if (this->process_table_ != nullptr)
     {
       while (this->current_count_ > 0)
         this->remove_proc (0);
 
       delete [] this->process_table_;
-      this->process_table_ = 0;
+      this->process_table_ = nullptr;
       this->max_process_table_size_ = 0;
       this->current_count_ = 0;
     }
 
-  if (this->default_exit_handler_ != 0)
+  if (this->default_exit_handler_ != nullptr)
       this->default_exit_handler_->handle_close (ACE_INVALID_HANDLE,0);
-  this->default_exit_handler_ = 0;
+  this->default_exit_handler_ = nullptr;
 
   return 0;
 }
@@ -318,7 +318,7 @@ ACE_Process_Manager::handle_close (ACE_HANDLE /* handle */,
   if (close_mask == ACE_Event_Handler::SIGNAL_MASK)
     {
       // Reactor is telling us we're gone; don't unregister again later.
-      this->reactor (0);
+      this->reactor (nullptr);
     }
   return 0;
 }
@@ -386,7 +386,7 @@ ACE_Process_Manager::register_handler (ACE_Event_Handler *eh,
 
   if (pid == ACE_INVALID_PID)
     {
-      if (this->default_exit_handler_ != 0)
+      if (this->default_exit_handler_ != nullptr)
         this->default_exit_handler_->handle_close (ACE_INVALID_HANDLE, 0);
       this->default_exit_handler_ = eh;
       return 0;
@@ -402,7 +402,7 @@ ACE_Process_Manager::register_handler (ACE_Event_Handler *eh,
 
   Process_Descriptor &proc_desc = this->process_table_[i];
 
-  if (proc_desc.exit_notify_ != 0)
+  if (proc_desc.exit_notify_ != nullptr)
     proc_desc.exit_notify_->handle_close (ACE_INVALID_HANDLE, 0);
   proc_desc.exit_notify_ = eh;
   return 0;
@@ -413,7 +413,7 @@ pid_t
 ACE_Process_Manager::spawn (ACE_Process_Options &options,
                             ACE_Event_Handler *event_handler)
 {
-  ACE_Process *process = 0;
+  ACE_Process *process = nullptr;
   ACE_NEW_RETURN (process,
                   ACE_Managed_Process,
                   ACE_INVALID_PID);
@@ -458,7 +458,7 @@ ACE_Process_Manager::spawn_n (size_t n,
 {
   ACE_TRACE ("ACE_Process_Manager::spawn_n");
 
-  if (child_pids != 0)
+  if (child_pids != nullptr)
     for (size_t i = 0;
          i < n;
          ++i)
@@ -472,7 +472,7 @@ ACE_Process_Manager::spawn_n (size_t n,
       if (pid == ACE_INVALID_PID || pid == 0)
         // We're in the child or something's gone wrong.
         return pid;
-      else if (child_pids != 0)
+      else if (child_pids != nullptr)
         child_pids[i] = pid;
     }
 
@@ -559,12 +559,12 @@ ACE_Process_Manager::remove_proc (size_t i)
   // If there's an exit_notify_ <Event_Handler> for this pid, call its
   // <handle_close> method.
 
-  if (this->process_table_[i].exit_notify_ != 0)
+  if (this->process_table_[i].exit_notify_ != nullptr)
     {
       this->process_table_[i].exit_notify_->handle_close
         (this->process_table_[i].process_->gethandle(),
          0);
-      this->process_table_[i].exit_notify_ = 0;
+      this->process_table_[i].exit_notify_ = nullptr;
     }
 
 #if defined (ACE_WIN32)
@@ -576,7 +576,7 @@ ACE_Process_Manager::remove_proc (size_t i)
 
   this->process_table_[i].process_->unmanage ();
 
-  this->process_table_[i].process_ = 0;
+  this->process_table_[i].process_ = nullptr;
 
   this->current_count_--;
 
@@ -762,13 +762,13 @@ ACE_Process_Manager::wait (pid_t pid,
   ACE_TRACE ("ACE_Process_Manager::wait");
 
   ACE_exitcode local_stat = 0;
-  if (status == 0)
+  if (status == nullptr)
     status = &local_stat;
 
   *status = 0;
 
   ssize_t idx = -1;
-  ACE_Process *proc = 0;
+  ACE_Process *proc = nullptr;
 
   {
     // fake context after which the lock is released
@@ -784,7 +784,7 @@ ACE_Process_Manager::wait (pid_t pid,
       }
     // release the lock.
   }
-  if (proc != 0)
+  if (proc != nullptr)
     pid = proc->wait (timeout, status);
   else
     {
@@ -884,7 +884,7 @@ ACE_Process_Manager::wait (pid_t pid,
           // open(), and there's already a SIGCHLD action set, so no
           // action is needed here.
           ACE_Sig_Action old_action;
-          if (this->reactor () == 0)
+          if (this->reactor () == nullptr)
             {
               ACE_Sig_Handler_Ex sigchld_nop_ptr = sigchld_nop;
               ACE_Sig_Action do_sigchld (reinterpret_cast<ACE_SignalHandler> (reinterpret_cast<void*> (sigchld_nop_ptr)));
@@ -915,7 +915,7 @@ ACE_Process_Manager::wait (pid_t pid,
             }
 
           // Restore the previous SIGCHLD action if it was changed.
-          if (this->reactor () == 0)
+          if (this->reactor () == nullptr)
             old_action.register_action (SIGCHLD);
 # endif /* !ACE_LACKS_UNIX_SIGNALS */
         }
@@ -937,7 +937,7 @@ ACE_Process_Manager::wait (pid_t pid,
         }
       else
         proc = process_table_[idx].process_;
-      if (proc != 0)
+      if (proc != nullptr)
         ACE_ASSERT (pid == proc->getpid ());
 
       this->notify_proc_handler (idx,
@@ -962,13 +962,13 @@ ACE_Process_Manager::notify_proc_handler (size_t i,
 
       proc_desc.process_->exit_code (exit_code);
 
-      if (proc_desc.exit_notify_ != 0)
+      if (proc_desc.exit_notify_ != nullptr)
         proc_desc.exit_notify_->handle_exit (proc_desc.process_);
-      else if (this->default_exit_handler_ != 0
+      else if (this->default_exit_handler_ != nullptr
                && this->default_exit_handler_->handle_exit (proc_desc.process_) < 0)
         {
           this->default_exit_handler_->handle_close (ACE_INVALID_HANDLE, 0);
-          this->default_exit_handler_ = 0;
+          this->default_exit_handler_ = nullptr;
         }
       return 1;
     }

--- a/ACE/ace/Process_Semaphore.cpp
+++ b/ACE/ace/Process_Semaphore.cpp
@@ -99,13 +99,13 @@ ACE_Process_Semaphore::release ()
 ACE_Process_Semaphore *
 ACE_Malloc_Lock_Adapter_T<ACE_Process_Semaphore>::operator () (const ACE_TCHAR *name)
 {
-  ACE_Process_Semaphore *p = 0;
-  if (name == 0)
-    ACE_NEW_RETURN (p, ACE_Process_Semaphore (1, name), 0);
+  ACE_Process_Semaphore *p = nullptr;
+  if (name == nullptr)
+    ACE_NEW_RETURN (p, ACE_Process_Semaphore (1, name), nullptr);
   else
     ACE_NEW_RETURN (p, ACE_Process_Semaphore (1, ACE::basename (name,
                                                                 ACE_DIRECTORY_SEPARATOR_CHAR)),
-                    0);
+                    nullptr);
   return p;
 }
 

--- a/ACE/ace/Reactor.cpp
+++ b/ACE/ace/Reactor.cpp
@@ -42,12 +42,12 @@ ACE_ALLOC_HOOK_DEFINE(ACE_Reactor)
 
 ACE_Reactor::ACE_Reactor (ACE_Reactor_Impl *impl,
                           bool delete_implementation)
-  : implementation_ (0),
+  : implementation_ (nullptr),
     delete_implementation_ (delete_implementation)
 {
   this->implementation (impl);
 
-  if (this->implementation () == 0)
+  if (this->implementation () == nullptr)
     {
 #if !defined (ACE_WIN32) \
       || !defined (ACE_HAS_WINSOCK2) || (ACE_HAS_WINSOCK2 == 0) \
@@ -88,7 +88,7 @@ ACE_Reactor::~ACE_Reactor ()
 }
 
 // Process-wide ACE_Reactor.
-ACE_Reactor *ACE_Reactor::reactor_ = 0;
+ACE_Reactor *ACE_Reactor::reactor_ = nullptr;
 
 // Controls whether the Reactor is deleted when we shut down (we can
 // only delete it safely if we created it!)
@@ -99,17 +99,17 @@ ACE_Reactor::instance ()
 {
   ACE_TRACE ("ACE_Reactor::instance");
 
-  if (ACE_Reactor::reactor_ == 0)
+  if (ACE_Reactor::reactor_ == nullptr)
     {
       // Perform Double-Checked Locking Optimization.
       ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                                *ACE_Static_Object_Lock::instance (), 0));
+                                *ACE_Static_Object_Lock::instance (), nullptr));
 
-      if (ACE_Reactor::reactor_ == 0)
+      if (ACE_Reactor::reactor_ == nullptr)
         {
           ACE_NEW_RETURN (ACE_Reactor::reactor_,
                           ACE_Reactor,
-                          0);
+                          nullptr);
           ACE_Reactor::delete_reactor_ = true;
           ACE_REGISTER_FRAMEWORK_COMPONENT(ACE_Reactor, ACE_Reactor::reactor_)
         }
@@ -123,7 +123,7 @@ ACE_Reactor::instance (ACE_Reactor *r, bool delete_reactor)
   ACE_TRACE ("ACE_Reactor::instance");
 
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Static_Object_Lock::instance (), 0));
+                            *ACE_Static_Object_Lock::instance (), nullptr));
   ACE_Reactor *t = ACE_Reactor::reactor_;
   ACE_Reactor::delete_reactor_ = delete_reactor;
 
@@ -132,7 +132,7 @@ ACE_Reactor::instance (ACE_Reactor *r, bool delete_reactor)
   // We can't register the Reactor singleton as a framework component twice.
   // Therefore we test to see if we had an existing reactor instance, which
   // if so means it must have already been registered.
-  if (t == 0)
+  if (t == nullptr)
     ACE_REGISTER_FRAMEWORK_COMPONENT(ACE_Reactor, ACE_Reactor::reactor_);
 
   return t;
@@ -149,7 +149,7 @@ ACE_Reactor::close_singleton ()
   if (ACE_Reactor::delete_reactor_)
     {
       delete ACE_Reactor::reactor_;
-      ACE_Reactor::reactor_ = 0;
+      ACE_Reactor::reactor_ = nullptr;
       ACE_Reactor::delete_reactor_ = false;
     }
 }
@@ -191,7 +191,7 @@ ACE_Reactor::run_reactor_event_loop (REACTOR_EVENT_HOOK eh)
     {
       int const result = this->implementation_->handle_events ();
 
-      if (eh != 0 && (*eh)(this))
+      if (eh != nullptr && (*eh)(this))
         continue;
       else if (result == -1 && this->implementation_->deactivated ())
         return 0;
@@ -214,7 +214,7 @@ ACE_Reactor::run_alertable_reactor_event_loop (REACTOR_EVENT_HOOK eh)
     {
       int const result = this->implementation_->alertable_handle_events ();
 
-      if (eh != 0 && (*eh)(this))
+      if (eh != nullptr && (*eh)(this))
         continue;
       else if (result == -1 && this->implementation_->deactivated ())
         return 0;
@@ -238,7 +238,7 @@ ACE_Reactor::run_reactor_event_loop (ACE_Time_Value &tv,
     {
       int result = this->implementation_->handle_events (tv);
 
-      if (eh != 0 && (*eh) (this))
+      if (eh != nullptr && (*eh) (this))
         continue;
       else if (result == -1)
         {
@@ -280,7 +280,7 @@ ACE_Reactor::run_alertable_reactor_event_loop (ACE_Time_Value &tv,
     {
       int result = this->implementation_->alertable_handle_events (tv);
 
-      if (eh != 0 && (*eh)(this))
+      if (eh != nullptr && (*eh)(this))
         continue;
       else if (result == -1 && this->implementation_->deactivated ())
         return 0;
@@ -444,7 +444,7 @@ ACE_Reactor::notify (ACE_Event_Handler *event_handler,
 {
   // First, try to remember this reactor in the event handler, in case
   // the event handler goes away before the notification is delivered.
-  if (event_handler != 0 && event_handler->reactor () == 0)
+  if (event_handler != nullptr && event_handler->reactor () == nullptr)
     {
       event_handler->reactor (this);
     }

--- a/ACE/ace/Reactor_Token_T.cpp
+++ b/ACE/ace/Reactor_Token_T.cpp
@@ -30,7 +30,7 @@ ACE_Reactor_Token_T<ACE_TOKEN_TYPE>::ACE_Reactor_Token_T
 
 template <class ACE_TOKEN_TYPE>
 ACE_Reactor_Token_T<ACE_TOKEN_TYPE>::ACE_Reactor_Token_T (int s_queue)
-  : reactor_ (0)
+  : reactor_ (nullptr)
 {
   ACE_TRACE ("ACE_Reactor_Token_T::ACE_Reactor_Token");
 

--- a/ACE/ace/Read_Buffer.cpp
+++ b/ACE/ace/Read_Buffer.cpp
@@ -37,7 +37,7 @@ ACE_Read_Buffer::ACE_Read_Buffer (FILE *fp,
     allocator_ (alloc)
 {
   ACE_TRACE ("ACE_Read_Buffer::ACE_Read_Buffer");
-  if (this->allocator_ == 0)
+  if (this->allocator_ == nullptr)
     this->allocator_ = ACE_Allocator::instance ();
 }
 
@@ -52,7 +52,7 @@ ACE_Read_Buffer::ACE_Read_Buffer (ACE_HANDLE handle,
 {
   ACE_TRACE ("ACE_Read_Buffer::ACE_Read_Buffer");
 
-  if (this->allocator_ == 0)
+  if (this->allocator_ == nullptr)
     this->allocator_ = ACE_Allocator::instance ();
 }
 
@@ -136,9 +136,9 @@ ACE_Read_Buffer::rec_read (int term, int search, int replace)
 
   // Don't bother going any farther if the total size is 0.
   if (this->size_ == 0)
-    return 0;
+    return nullptr;
 
-  char *result = 0;
+  char *result = nullptr;
 
   // Recurse, when the recursion bottoms out, allocate the result
   // buffer.
@@ -148,18 +148,18 @@ ACE_Read_Buffer::rec_read (int term, int search, int replace)
       // space for the null terminator.
       result = (char *) this->allocator_->malloc (this->size_ + 1);
 
-      if (result == 0)
+      if (result == nullptr)
         {
           errno = ENOMEM;
-          return 0;
+          return nullptr;
         }
       result += this->size_;
 
       // Null terminate the buffer.
       *result = '\0';
     }
-  else if ((result = this->rec_read (term, search, replace)) == 0)
-    return 0;
+  else if ((result = this->rec_read (term, search, replace)) == nullptr)
+    return nullptr;
 
   // Copy buf into the appropriate location starting from end of
   // buffer.  Peter says this is confusing and that we should use

--- a/ACE/ace/Remote_Name_Space.cpp
+++ b/ACE/ace/Remote_Name_Space.cpp
@@ -89,7 +89,7 @@ ACE_Remote_Name_Space::resolve (const ACE_NS_WString &name,
   ACE_Name_Request request (ACE_Name_Request::RESOLVE,
                             name_urep.get (),
                             name_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
 
   if (this->ns_proxy_.send_request (request) == -1)
     return -1;
@@ -123,7 +123,7 @@ ACE_Remote_Name_Space::unbind (const ACE_NS_WString &name)
   ACE_Name_Request request (ACE_Name_Request::UNBIND,
                             name_urep.get (),
                             name_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
   return this->ns_proxy_.request_reply (request);
 }
 
@@ -137,11 +137,11 @@ ACE_Remote_Name_Space::list_names (ACE_WSTRING_SET &set,
   ACE_Name_Request request (ACE_Name_Request::LIST_NAMES,
                             pattern_urep.get (),
                             pattern_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
   if (this->ns_proxy_.send_request (request) == -1)
     return -1;
 
-  ACE_Name_Request reply (0, 0, 0, 0, 0, 0, 0, 0);
+  ACE_Name_Request reply (0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr);
 
   while (reply.msg_type () != ACE_Name_Request::MAX_ENUM)
     {
@@ -170,11 +170,11 @@ ACE_Remote_Name_Space::list_values (ACE_WSTRING_SET &set,
   ACE_Name_Request request (ACE_Name_Request::LIST_VALUES,
                             pattern_urep.get (),
                             pattern_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
   if (this->ns_proxy_.send_request (request) == -1)
     return -1;
 
-  ACE_Name_Request reply (0, 0, 0, 0, 0, 0, 0, 0);
+  ACE_Name_Request reply (0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr);
 
   while (reply.msg_type () != ACE_Name_Request::MAX_ENUM)
     {
@@ -204,12 +204,12 @@ ACE_Remote_Name_Space::list_types (ACE_WSTRING_SET &set,
   ACE_Name_Request request (ACE_Name_Request::LIST_TYPES,
                             pattern_urep.get (),
                             pattern_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
 
   if (this->ns_proxy_.send_request (request) == -1)
     return -1;
 
-  ACE_Name_Request reply (0, 0, 0, 0, 0, 0, 0, 0);
+  ACE_Name_Request reply (0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr);
 
   while (reply.msg_type () != ACE_Name_Request::MAX_ENUM)
     {
@@ -238,12 +238,12 @@ ACE_Remote_Name_Space::list_name_entries (ACE_BINDING_SET &set,
   ACE_Name_Request request (ACE_Name_Request::LIST_NAME_ENTRIES,
                             pattern_urep.get (),
                             pattern_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
 
   if (this->ns_proxy_.send_request (request) == -1)
     return -1;
 
-  ACE_Name_Request reply (0, 0, 0, 0, 0, 0, 0, 0);
+  ACE_Name_Request reply (0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr);
 
   while (reply.msg_type () != ACE_Name_Request::MAX_ENUM)
     {
@@ -278,12 +278,12 @@ ACE_Remote_Name_Space::list_value_entries (ACE_BINDING_SET &set,
   ACE_Name_Request request (ACE_Name_Request::LIST_VALUE_ENTRIES,
                             pattern_urep.get (),
                             pattern_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
 
   if (this->ns_proxy_.send_request (request) == -1)
     return -1;
 
-  ACE_Name_Request reply (0, 0, 0, 0, 0, 0, 0, 0);
+  ACE_Name_Request reply (0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr);
 
   while (reply.msg_type () != ACE_Name_Request::MAX_ENUM)
     {
@@ -318,12 +318,12 @@ ACE_Remote_Name_Space::list_type_entries (ACE_BINDING_SET &set,
   ACE_Name_Request request (ACE_Name_Request::LIST_TYPE_ENTRIES,
                             pattern_urep.get (),
                             pattern_len,
-                            0, 0, 0, 0);
+                            nullptr, 0, nullptr, 0);
 
   if (this->ns_proxy_.send_request (request) == -1)
     return -1;
 
-  ACE_Name_Request reply (0, 0, 0, 0, 0, 0, 0, 0);
+  ACE_Name_Request reply (0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr);
 
   while (reply.msg_type () != ACE_Name_Request::MAX_ENUM)
     {

--- a/ACE/ace/SOCK_Acceptor.cpp
+++ b/ACE/ace/SOCK_Acceptor.cpp
@@ -38,7 +38,7 @@ ACE_SOCK_Acceptor::shared_accept_start (ACE_Time_Value *timeout,
   ACE_HANDLE handle = this->get_handle ();
 
   // Handle the case where we're doing a timed <accept>.
-  if (timeout != 0)
+  if (timeout != nullptr)
     {
       if (ACE::handle_timed_accept (handle,
                                     timeout,
@@ -116,11 +116,11 @@ ACE_SOCK_Acceptor::accept (ACE_SOCK_Stream &new_stream,
     {
       // On Win32 the third parameter to <accept> must be a NULL
       // pointer if we want to ignore the client's address.
-      int *len_ptr = 0;
-      sockaddr *addr = 0;
+      int *len_ptr = nullptr;
+      sockaddr *addr = nullptr;
       int len = 0;
 
-      if (remote_addr != 0)
+      if (remote_addr != nullptr)
         {
           len = remote_addr->get_size ();
           len_ptr = &len;
@@ -134,12 +134,12 @@ ACE_SOCK_Acceptor::accept (ACE_SOCK_Stream &new_stream,
       while (new_stream.get_handle () == ACE_INVALID_HANDLE
              && restart
              && errno == EINTR
-             && timeout == 0);
+             && timeout == nullptr);
 
       // Reset the size of the addr, so the proper UNIX/IPv4/IPv6 family
       // is known.
       if (new_stream.get_handle () != ACE_INVALID_HANDLE
-          && remote_addr != 0)
+          && remote_addr != nullptr)
         {
           remote_addr->set_size (len);
           if (addr)
@@ -171,11 +171,11 @@ ACE_SOCK_Acceptor::accept (ACE_SOCK_Stream &new_stream,
     {
       // On Win32 the third parameter to <accept> must be a NULL
       // pointer if we want to ignore the client's address.
-      int *len_ptr = 0;
+      int *len_ptr = nullptr;
       int len = 0;
-      sockaddr *addr = 0;
+      sockaddr *addr = nullptr;
 
-      if (remote_addr != 0)
+      if (remote_addr != nullptr)
         {
           len = remote_addr->get_size ();
           len_ptr = &len;
@@ -190,12 +190,12 @@ ACE_SOCK_Acceptor::accept (ACE_SOCK_Stream &new_stream,
       while (new_stream.get_handle () == ACE_INVALID_HANDLE
              && restart
              && errno == EINTR
-             && timeout == 0);
+             && timeout == nullptr);
 
       // Reset the size of the addr, which is only necessary for UNIX
       // domain sockets.
       if (new_stream.get_handle () != ACE_INVALID_HANDLE
-          && remote_addr != 0)
+          && remote_addr != nullptr)
         remote_addr->set_size (len);
     }
 

--- a/ACE/ace/SOCK_Connector.cpp
+++ b/ACE/ace/SOCK_Connector.cpp
@@ -92,7 +92,7 @@ ACE_SOCK_Connector::shared_connect_start (ACE_SOCK_Stream &new_stream,
     }
 
   // Enable non-blocking, if required.
-  if (timeout != 0 && new_stream.enable (ACE_NONBLOCK) == -1)
+  if (timeout != nullptr && new_stream.enable (ACE_NONBLOCK) == -1)
     return -1;
   else
     return 0;
@@ -107,7 +107,7 @@ ACE_SOCK_Connector::shared_connect_finish (ACE_SOCK_Stream &new_stream,
   // Save/restore errno.
   ACE_Errno_Guard error (errno);
 
-  if (result == -1 && timeout != 0)
+  if (result == -1 && timeout != nullptr)
     {
       // Check whether the connection is in progress.
       if (error == EINPROGRESS || error == EWOULDBLOCK)
@@ -145,7 +145,7 @@ ACE_SOCK_Connector::shared_connect_finish (ACE_SOCK_Stream &new_stream,
 #endif /* ACE_WIN32 */
             }
           // Wait synchronously using timeout.
-          else if (this->complete (new_stream, 0, timeout) == -1)
+          else if (this->complete (new_stream, nullptr, timeout) == -1)
             error = errno;
           else
             return 0;
@@ -293,7 +293,7 @@ ACE_SOCK_Connector::complete (ACE_SOCK_Stream &new_stream,
 #endif /* ACE_NON_BLOCKING_BUG_DELAY */
     }
 
-  if (remote_sap != 0)
+  if (remote_sap != nullptr)
     {
       int len = remote_sap->get_size ();
       sockaddr *addr = reinterpret_cast<sockaddr *> (remote_sap->get_addr ());
@@ -332,7 +332,7 @@ ACE_SOCK_Connector::ACE_SOCK_Connector (ACE_SOCK_Stream &new_stream,
                      flags,
                      perms,
                      protocol) == -1
-      && timeout != 0
+      && timeout != nullptr
       && !(errno == EWOULDBLOCK || errno == ETIME || errno == ETIMEDOUT))
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("%p\n"),
@@ -362,7 +362,7 @@ ACE_SOCK_Connector::ACE_SOCK_Connector (ACE_SOCK_Stream &new_stream,
                      flags,
                      reuse_addr,
                      perms) == -1
-      && timeout != 0
+      && timeout != nullptr
       && !(errno == EWOULDBLOCK || errno == ETIME || errno == ETIMEDOUT))
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("%p\n"),

--- a/ACE/ace/SOCK_Dgram.cpp
+++ b/ACE/ace/SOCK_Dgram.cpp
@@ -88,7 +88,7 @@ ACE_SOCK_Dgram::recv (iovec *io_vec,
 #else
           delete [] (char *)io_vec->iov_base;
 #endif /* ACE_HAS_ALLOC_HOOKS */
-          io_vec->iov_base = 0;
+          io_vec->iov_base = nullptr;
         }
       else
         {
@@ -275,7 +275,7 @@ ACE_SOCK_Dgram::send (const iovec iov[],
   send_msg.msg_namelen = addr.get_size ();
 
 #if defined (ACE_HAS_4_4BSD_SENDMSG_RECVMSG)
-  send_msg.msg_control = 0;
+  send_msg.msg_control = nullptr;
   send_msg.msg_controllen = 0;
   send_msg.msg_flags = 0;
 #elif !defined ACE_LACKS_SENDMSG
@@ -643,7 +643,7 @@ ACE_SOCK_Dgram::make_multicast_ifaddr (ip_mreq *ret_mreq,
 {
   ACE_TRACE ("ACE_SOCK_Dgram::make_multicast_ifaddr");
   ip_mreq  lmreq;       // Scratch copy.
-  if (net_if != 0)
+  if (net_if != nullptr)
     {
 #if defined (ACE_WIN32)
       // This port number is not necessary, just convenient

--- a/ACE/ace/SOCK_Dgram_Bcast.cpp
+++ b/ACE/ace/SOCK_Dgram_Bcast.cpp
@@ -44,11 +44,11 @@ ACE_SOCK_Dgram_Bcast::close ()
   ACE_TRACE ("ACE_SOCK_Dgram_Bcast::close");
 
   ACE_Bcast_Node *temp = this->if_list_;
-  this->if_list_ = 0;
+  this->if_list_ = nullptr;
 
   // Release the dynamically allocated memory.
 
-  while (temp != 0)
+  while (temp != nullptr)
     {
       ACE_Bcast_Node *hold = temp->next_;
       delete temp;
@@ -62,7 +62,7 @@ ACE_SOCK_Dgram_Bcast::close ()
 // Here's the simple-minded constructor.
 
 ACE_SOCK_Dgram_Bcast::ACE_SOCK_Dgram_Bcast ()
-  : if_list_ (0)
+  : if_list_ (nullptr)
 {
   ACE_TRACE ("ACE_SOCK_Dgram_Bcast::ACE_SOCK_Dgram_Bcast");
 }
@@ -76,7 +76,7 @@ ACE_SOCK_Dgram_Bcast::ACE_SOCK_Dgram_Bcast (const ACE_Addr &local,
                                             int reuse_addr,
                                             const ACE_TCHAR *host_name)
   : ACE_SOCK_Dgram (local, protocol_family, protocol, reuse_addr),
-    if_list_ (0)
+    if_list_ (nullptr)
 {
   ACE_TRACE ("ACE_SOCK_Dgram_Bcast::ACE_SOCK_Dgram_Bcast");
 
@@ -149,7 +149,7 @@ ACE_SOCK_Dgram_Bcast::mk_broadcast (const ACE_TCHAR *host_name)
     {
       hostent *hp = ACE_OS::gethostbyname (ACE_TEXT_ALWAYS_CHAR (host_name));
 
-      if (hp == 0)
+      if (hp == nullptr)
         return -1;
       else
         ACE_OS::memcpy ((char *) &host_addr.sin_addr.s_addr,
@@ -263,7 +263,7 @@ ACE_SOCK_Dgram_Bcast::mk_broadcast (const ACE_TCHAR *host_name)
         }
       else
         {
-          if (host_name != 0)
+          if (host_name != nullptr)
             ACELIB_ERROR ((LM_ERROR, ACE_TEXT("%p [%C]\n"),
                         ACE_TEXT("ACE_SOCK_Dgram_Bcast::mk_broadcast: Broadcast is not enabled for this interface."),
                         flags.ifr_name));
@@ -279,7 +279,7 @@ ACE_SOCK_Dgram_Bcast::mk_broadcast (const ACE_TCHAR *host_name)
                                   this->if_list_),
                   -1);
 #endif /* !ACE_WIN32 */
-  if (this->if_list_ == 0)
+  if (this->if_list_ == nullptr)
     {
       errno = ENXIO;
       return -1;
@@ -301,11 +301,11 @@ ACE_SOCK_Dgram_Bcast::send (const void *buf,
   ssize_t iterations = 0;
   ssize_t total_bytes = 0;
 
-  if (this->if_list_ == 0)
+  if (this->if_list_ == nullptr)
     return -1;
 
   for (ACE_Bcast_Node *temp = this->if_list_;
-       temp != 0;
+       temp != nullptr;
        temp = temp->next_)
     {
       temp->bcast_addr_.set_port_number (port_number);
@@ -337,13 +337,13 @@ ACE_SOCK_Dgram_Bcast::send (const iovec iov[],
 {
   ACE_TRACE ("ACE_SOCK_Dgram_Bcast::send");
 
-  if (this->if_list_ == 0)
+  if (this->if_list_ == nullptr)
     return -1;
 
   // Send the message to every interface.
 
   for (ACE_Bcast_Node *temp = this->if_list_;
-       temp != 0;
+       temp != nullptr;
        temp = temp->next_)
     {
       temp->bcast_addr_.set_port_number (port_number);

--- a/ACE/ace/SOCK_Dgram_Mcast.cpp
+++ b/ACE/ace/SOCK_Dgram_Mcast.cpp
@@ -267,7 +267,7 @@ ACE_SOCK_Dgram_Mcast::subscribe_ifs (const ACE_INET_Addr &mcast_addr,
   ACE_TRACE ("ACE_SOCK_Dgram_Mcast::subscribe_ifs");
 
   if (ACE_BIT_ENABLED (this->opts_, OPT_NULLIFACE_ALL)
-      && net_if == 0)
+      && net_if == nullptr)
     {
       int family = mcast_addr.get_type ();
       size_t nr_subscribed = 0;
@@ -276,21 +276,21 @@ ACE_SOCK_Dgram_Mcast::subscribe_ifs (const ACE_INET_Addr &mcast_addr,
 
       // Take advantage of the BSD getifaddrs function that simplifies
       // access to connected interfaces.
-      struct ifaddrs *ifap = 0;
-      struct ifaddrs *p_if = 0;
+      struct ifaddrs *ifap = nullptr;
+      struct ifaddrs *p_if = nullptr;
 
       if (::getifaddrs (&ifap) != 0)
         return -1;
 
       // Not every interface is for IP, and not all are up and multicast.
       for (p_if = ifap;
-           p_if != 0;
+           p_if != nullptr;
            p_if = p_if->ifa_next)
         {
           // Some OSes can return interfaces with no ifa_addr if the
           // interface has no assigned address.
           // If there is an address but it's not the family we want, ignore it.
-          if (p_if->ifa_addr == 0 || p_if->ifa_addr->sa_family != family)
+          if (p_if->ifa_addr == nullptr || p_if->ifa_addr->sa_family != family)
             continue;
 
           // Check to see if it's up and supports multicast.
@@ -459,7 +459,7 @@ ACE_SOCK_Dgram_Mcast::subscribe_ifs (const ACE_INET_Addr &mcast_addr,
 #endif /* ACE_HAS_IPV6 - Fall into IPv4-only case */
     {
       // Validate passed multicast addr and iface specifications.
-      if (this->make_multicast_ifaddr (0,
+      if (this->make_multicast_ifaddr (nullptr,
                                        mcast_addr,
                                        net_if) == -1)
         return -1;
@@ -568,7 +568,7 @@ ACE_SOCK_Dgram_Mcast::subscribe_i (const ACE_INET_Addr &mcast_addr,
     return -1;
 
   // Only do this if net_if == 0, i.e., INADDR_ANY
-  if (net_if == 0)
+  if (net_if == nullptr)
     {
       int const result = this->subscribe_ifs (mcast_addr, net_if, reuse_addr);
       // Check for error or "short-circuit" return.
@@ -614,7 +614,7 @@ ACE_SOCK_Dgram_Mcast::unsubscribe_ifs (const ACE_INET_Addr &mcast_addr,
 
 
   if (ACE_BIT_ENABLED (this->opts_, OPT_NULLIFACE_ALL)
-      && net_if == 0)
+      && net_if == nullptr)
     {
 #if defined (ACE_HAS_IPV6)
       if (mcast_addr.get_type () == AF_INET6)
@@ -741,7 +741,7 @@ ACE_SOCK_Dgram_Mcast::unsubscribe_ifs (const ACE_INET_Addr &mcast_addr,
       // Unsubscribe on all local multicast-capable network interfaces, by
       // doing recursive calls with specific interfaces.
 
-      ACE_INET_Addr *if_addrs = 0;
+      ACE_INET_Addr *if_addrs = nullptr;
       size_t if_cnt;
 
       // NOTE - <get_ip_interfaces> doesn't always get all of the

--- a/ACE/ace/SOCK_IO.cpp
+++ b/ACE/ace/SOCK_IO.cpp
@@ -35,7 +35,7 @@ ACE_SOCK_IO::recvv (iovec *io_vec,
 {
   ACE_TRACE ("ACE_SOCK_IO::recvv");
 #if defined (FIONREAD)
-  io_vec->iov_base = 0;
+  io_vec->iov_base = nullptr;
   if( ACE::handle_read_ready (this->get_handle (), timeout) != 1 )
     {
       return -1;
@@ -90,7 +90,7 @@ ACE_SOCK_IO::send (size_t n, ...) const
 
   va_list argp;
   int const total_tuples = ACE_Utils::truncate_cast<int> (n / 2);
-  iovec *iovp = 0;
+  iovec *iovp = nullptr;
 #if defined (ACE_HAS_ALLOCA)
   iovp = (iovec *) alloca (total_tuples * sizeof (iovec));
 #else

--- a/ACE/ace/SOCK_Netlink.cpp
+++ b/ACE/ace/SOCK_Netlink.cpp
@@ -70,7 +70,7 @@ ACE_SOCK_Netlink::send (const iovec iov[],
   send_msg.msg_iovlen = n;
   send_msg.msg_name = (char *) addr.get_addr ();
   send_msg.msg_namelen = addr.get_size ();
-  send_msg.msg_control = 0;
+  send_msg.msg_control = nullptr;
   send_msg.msg_controllen = 0;
   send_msg.msg_flags = 0;
 
@@ -92,7 +92,7 @@ ACE_SOCK_Netlink::recv (iovec iov[],
   recv_msg.msg_iovlen = n;
   recv_msg.msg_name = (char *) addr.get_addr ();
   recv_msg.msg_namelen = addr.get_size ();
-  recv_msg.msg_control = 0;
+  recv_msg.msg_control = nullptr;
   recv_msg.msg_controllen = 0;
   recv_msg.msg_flags = 0;
 

--- a/ACE/ace/SOCK_SEQPACK_Acceptor.cpp
+++ b/ACE/ace/SOCK_SEQPACK_Acceptor.cpp
@@ -31,7 +31,7 @@ ACE_SOCK_SEQPACK_Acceptor::shared_accept_start (ACE_Time_Value *timeout,
   ACE_HANDLE handle = this->get_handle ();
 
   // Handle the case where we're doing a timed <accept>.
-  if (timeout != 0)
+  if (timeout != nullptr)
     {
       if (ACE::handle_timed_accept (handle,
                                     timeout,
@@ -108,11 +108,11 @@ ACE_SOCK_SEQPACK_Acceptor::accept (ACE_SOCK_SEQPACK_Association &new_association
     {
       // On Win32 the third parameter to <accept> must be a NULL
       // pointer if we want to ignore the client's address.
-      int *len_ptr = 0;
-      sockaddr *addr = 0;
+      int *len_ptr = nullptr;
+      sockaddr *addr = nullptr;
       int len = 0;
 
-      if (remote_addr != 0)
+      if (remote_addr != nullptr)
         {
           len = remote_addr->get_size ();
           len_ptr = &len;
@@ -126,12 +126,12 @@ ACE_SOCK_SEQPACK_Acceptor::accept (ACE_SOCK_SEQPACK_Association &new_association
       while (new_association.get_handle () == ACE_INVALID_HANDLE
              && restart != 0
              && errno == EINTR
-             && timeout == 0);
+             && timeout == nullptr);
 
       // Reset the size of the addr, so the proper UNIX/IPv4/IPv6 family
       // is known.
       if (new_association.get_handle () != ACE_INVALID_HANDLE
-          && remote_addr != 0)
+          && remote_addr != nullptr)
         {
           remote_addr->set_size (len);
           remote_addr->set_type (addr->sa_family);
@@ -328,7 +328,7 @@ ACE_SOCK_SEQPACK_Acceptor::shared_open (const ACE_Multihomed_INET_Addr &local_sa
           // Create an array of sockaddr_in to hold the underlying
           // representations of the primary and secondary
           // addresses.
-          sockaddr_in*  local_inet_addrs = 0;
+          sockaddr_in*  local_inet_addrs = nullptr;
 #if defined(ACE_HAS_ALLOC_HOOKS)
           ACE_ALLOCATOR_NORETURN (local_inet_addrs,
                                   static_cast<sockaddr_in*>(ACE_Allocator::instance()->malloc(sizeof(sockaddr_in) * num_addresses)));

--- a/ACE/ace/SOCK_SEQPACK_Association.cpp
+++ b/ACE/ace/SOCK_SEQPACK_Association.cpp
@@ -153,7 +153,7 @@ ACE_SOCK_SEQPACK_Association::get_local_addrs (ACE_INET_Addr *addrs, size_t &siz
   // bare sockaddr_in* --- because ACE_NEW_RETURN cannot act directory on
   // an ACE_Auto_Array_Ptr.)
   {
-    sockaddr_in *addr_structs_bootstrap = 0;
+    sockaddr_in *addr_structs_bootstrap = nullptr;
 #if defined(ACE_HAS_ALLOC_HOOKS)
     ACE_ALLOCATOR_RETURN (addr_structs_bootstrap, static_cast<sockaddr_in*>(ACE_Allocator::instance()->malloc(sizeof(sockaddr_in) * size)), -1);
 #else
@@ -296,7 +296,7 @@ ACE_SOCK_SEQPACK_Association::get_remote_addrs (ACE_INET_Addr *addrs, size_t &si
   // bare sockaddr_in* --- because ACE_NEW_RETURN cannot act directory on
   // an ACE_Auto_Array_Ptr.)
   {
-    sockaddr_in *addr_structs_bootstrap = 0;
+    sockaddr_in *addr_structs_bootstrap = nullptr;
 #if defined (ACE_HAS_ALLOC_HOOKS)
     ACE_ALLOCATOR_RETURN (addr_structs_bootstrap, static_cast<sockaddr_in*>(ACE_Allocator::instance()->malloc(sizeof(sockaddr_in) * (size))), -1);
 #else

--- a/ACE/ace/SOCK_SEQPACK_Connector.cpp
+++ b/ACE/ace/SOCK_SEQPACK_Connector.cpp
@@ -105,7 +105,7 @@ ACE_SOCK_SEQPACK_Connector::shared_connect_start (ACE_SOCK_SEQPACK_Association &
     }
 
   // Enable non-blocking, if required.
-  if (timeout != 0
+  if (timeout != nullptr
       && new_association.enable (ACE_NONBLOCK) == -1)
     return -1;
   else
@@ -129,7 +129,7 @@ ACE_SOCK_SEQPACK_Connector::shared_connect_start (ACE_SOCK_SEQPACK_Association &
       // Create an array of sockaddr_in to hold the underlying
       // representations of the primary and secondary
       // addresses.
-      sockaddr_in*  local_inet_addrs = 0;
+      sockaddr_in*  local_inet_addrs = nullptr;
 #if defined(ACE_HAS_ALLOC_HOOKS)
       ACE_ALLOCATOR_NORETURN (local_inet_addrs, static_cast<sockaddr_in*>(ACE_Allocator::instance()->malloc(sizeof(sockaddr_in) * (num_addresses))));
 #else
@@ -224,7 +224,7 @@ ACE_SOCK_SEQPACK_Connector::shared_connect_start (ACE_SOCK_SEQPACK_Association &
     }
 
   // Enable non-blocking, if required.
-  if (timeout != 0
+  if (timeout != nullptr
       && new_association.enable (ACE_NONBLOCK) == -1)
     return -1;
   else
@@ -240,7 +240,7 @@ ACE_SOCK_SEQPACK_Connector::shared_connect_finish (ACE_SOCK_SEQPACK_Association 
   // Save/restore errno.
   ACE_Errno_Guard error (errno);
 
-  if (result == -1 && timeout != 0)
+  if (result == -1 && timeout != nullptr)
     {
       // Check whether the connection is in progress.
       if (error == EINPROGRESS || error == EWOULDBLOCK)
@@ -250,7 +250,7 @@ ACE_SOCK_SEQPACK_Connector::shared_connect_finish (ACE_SOCK_SEQPACK_Association 
             error = EWOULDBLOCK;
           // Wait synchronously using timeout.
           else if (this->complete (new_association,
-                                   0,
+                                   nullptr,
                                    timeout) == -1)
             error = errno;
           else
@@ -369,7 +369,7 @@ ACE_SOCK_SEQPACK_Connector::complete (ACE_SOCK_SEQPACK_Association &new_associat
 #endif /* ACE_WIN32 */
     }
 
-  if (remote_sap != 0)
+  if (remote_sap != nullptr)
     {
       int len = remote_sap->get_size ();
       sockaddr *addr = reinterpret_cast<sockaddr *> (remote_sap->get_addr ());
@@ -408,7 +408,7 @@ ACE_SOCK_SEQPACK_Connector::ACE_SOCK_SEQPACK_Connector (ACE_SOCK_SEQPACK_Associa
                      flags,
                      perms,
                      protocol) == -1
-      && timeout != 0
+      && timeout != nullptr
       && !(errno == EWOULDBLOCK || errno == ETIME || errno == ETIMEDOUT))
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("%p\n"),
@@ -435,7 +435,7 @@ ACE_SOCK_SEQPACK_Connector::ACE_SOCK_SEQPACK_Connector (ACE_SOCK_SEQPACK_Associa
                      flags,
                      perms,
                      protocol) == -1
-      && timeout != 0
+      && timeout != nullptr
       && !(errno == EWOULDBLOCK || errno == ETIME || errno == ETIMEDOUT))
     ACELIB_ERROR ((LM_ERROR,
                 ACE_TEXT ("%p\n"),

--- a/ACE/ace/SPIPE_Connector.cpp
+++ b/ACE/ace/SPIPE_Connector.cpp
@@ -31,7 +31,7 @@ ACE_SPIPE_Connector::ACE_SPIPE_Connector (ACE_SPIPE_Stream &new_io,
   ACE_TRACE ("ACE_SPIPE_Connector::ACE_SPIPE_Connector");
   if (this->connect (new_io, remote_sap, timeout, local_sap,
                      reuse_addr, flags, perms, sa, pipe_mode) == -1
-      && timeout != 0 && !(errno == EWOULDBLOCK || errno == ETIME))
+      && timeout != nullptr && !(errno == EWOULDBLOCK || errno == ETIME))
     ACELIB_ERROR ((LM_ERROR, ACE_TEXT ("address %s, %p\n"),
                remote_sap.get_path_name (), ACE_TEXT ("ACE_SPIPE_Connector")));
 }

--- a/ACE/ace/SString.cpp
+++ b/ACE/ace/SString.cpp
@@ -275,7 +275,7 @@ ACE_SString::ACE_SString (const char *s,
   if (this->allocator_ == nullptr)
     this->allocator_ = ACE_Allocator::instance ();
 
-  if (s == 0)
+  if (s == nullptr)
     {
       this->len_ = 0;
       this->rep_ = (char *) this->allocator_->malloc (this->len_ + 1);

--- a/ACE/ace/SV_Semaphore_Complex.cpp
+++ b/ACE/ace/SV_Semaphore_Complex.cpp
@@ -247,7 +247,7 @@ ACE_SV_Semaphore_Complex::ACE_SV_Semaphore_Complex (const char *name,
   key_t key = ACE_DEFAULT_SEM_KEY;
 
 #ifdef ACE_HAS_SYSV_IPC
-  if (name != 0)
+  if (name != nullptr)
     key = this->name_2_key (name);
 #else
   ACE_UNUSED_ARG (name);

--- a/ACE/ace/SV_Semaphore_Simple.cpp
+++ b/ACE/ace/SV_Semaphore_Simple.cpp
@@ -132,7 +132,7 @@ ACE_SV_Semaphore_Simple::name_2_key (const char *name)
 {
   ACE_TRACE ("ACE_SV_Semaphore_Simple::name_2_key");
 
-  if (name == 0)
+  if (name == nullptr)
     {
       errno = EINVAL;
 #ifdef ACE_HAS_SYSV_IPC
@@ -179,7 +179,7 @@ ACE_SV_Semaphore_Simple::open (const char *name,
   key_t key = ACE_DEFAULT_SEM_KEY;
 
 #ifdef ACE_HAS_SYSV_IPC
-  if (name != 0)
+  if (name != nullptr)
     key = this->name_2_key (name);
 #else
   ACE_UNUSED_ARG (name);

--- a/ACE/ace/SV_Shared_Memory.cpp
+++ b/ACE/ace/SV_Shared_Memory.cpp
@@ -61,7 +61,7 @@ ACE_SV_Shared_Memory::ACE_SV_Shared_Memory (key_t external_id,
 ACE_SV_Shared_Memory::ACE_SV_Shared_Memory ()
   : internal_id_ (0),
     size_ (0),
-    segment_ptr_ (0)
+    segment_ptr_ (nullptr)
 {
   ACE_TRACE ("ACE_SV_Shared_Memory::ACE_SV_Shared_Memory");
 }
@@ -79,7 +79,7 @@ ACE_SV_Shared_Memory::ACE_SV_Shared_Memory (ACE_HANDLE int_id,
     size_ (0)
 {
   ACE_TRACE ("ACE_SV_Shared_Memory::ACE_SV_Shared_Memory");
-  if (this->attach (0, flags) == -1)
+  if (this->attach (nullptr, flags) == -1)
     ACELIB_ERROR ((LM_ERROR, ACE_TEXT ("%p\n"),
                 ACE_TEXT ("ACE_SV_Shared_Memory::ACE_SV_Shared_Memory")));
 }

--- a/ACE/ace/Sbrk_Memory_Pool.cpp
+++ b/ACE/ace/Sbrk_Memory_Pool.cpp
@@ -105,7 +105,7 @@ ACE_Sbrk_Memory_Pool::~ACE_Sbrk_Memory_Pool ()
 void *
 ACE_Sbrk_Memory_Pool::base_addr () const
 {
-  return 0;
+  return nullptr;
 }
 
 // Round up the request to a multiple of the page size.

--- a/ACE/ace/Select_Reactor_Base.cpp
+++ b/ACE/ace/Select_Reactor_Base.cpp
@@ -94,7 +94,7 @@ ACE_Select_Reactor_Handler_Repository::open (size_type size)
   // Initialize the ACE_Event_Handler pointers to 0.
   std::fill (this->event_handlers_.begin (),
              this->event_handlers_.end (),
-             static_cast<ACE_Event_Handler *> (0));
+             static_cast<ACE_Event_Handler *> (nullptr));
 
   this->max_handlep1_ = 0;
 #endif /* ACE_SELECT_REACTOR_BASE_USES_HASH_MAP */
@@ -177,7 +177,7 @@ ACE_Select_Reactor_Handler_Repository::find_eh (ACE_HANDLE handle)
 #else
   map_type::iterator const tmp = &this->event_handlers_[handle];
 
-  if (*tmp != 0)
+  if (*tmp != nullptr)
     pos = tmp;
 #endif /* ACE_SELECT_REACTOR_BASE_USES_HASH_MAP */
 
@@ -192,7 +192,7 @@ ACE_Select_Reactor_Handler_Repository::bind (ACE_HANDLE handle,
 {
   ACE_TRACE ("ACE_Select_Reactor_Handler_Repository::bind");
 
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     return -1;
 
   if (handle == ACE_INVALID_HANDLE)
@@ -296,7 +296,7 @@ ACE_Select_Reactor_Handler_Repository::unbind (
   // is unbound.
   ACE_Event_Handler * const event_handler =
     (pos == this->event_handlers_.end ()
-     ? 0
+     ? nullptr
      : ACE_SELECT_REACTOR_EVENT_HANDLER (pos));
 
   // Clear out the <mask> bits in the Select_Reactor's wait_set.
@@ -380,7 +380,7 @@ ACE_Select_Reactor_Handler_Repository::unbind (
       complete_removal = true;
     }
 
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     return -1;
 
   bool const requires_reference_counting =
@@ -416,7 +416,7 @@ ACE_Select_Reactor_Handler_Repository_Iterator::ACE_Select_Reactor_Handler_Repos
   // Advance to the next element containing a non-zero event handler.
   // There's no need to do this for the Windows case since the hash
   // map will only contain non-zero event handlers.
-  while (this->current_ != end && (*(this->current_) == 0))
+  while (this->current_ != end && (*(this->current_) == nullptr))
     ++this->current_;
 #endif
 }
@@ -461,7 +461,7 @@ ACE_Select_Reactor_Handler_Repository_Iterator::advance ()
   // Advance to the next element containing a non-zero event handler.
   // There's no need to do this for the Windows case since the hash
   // map will only contain non-zero event handlers.
-  while (this->current_ != end && (*(this->current_) == 0))
+  while (this->current_ != end && (*(this->current_) == nullptr))
     ++this->current_;
 #endif  /* !ACE_SELECT_REACTOR_BASE_USES_HASH_MAP */
 
@@ -529,7 +529,7 @@ ACE_Select_Reactor_Handler_Repository::dump () const
 }
 
 ACE_Select_Reactor_Notify::ACE_Select_Reactor_Notify ()
-  : select_reactor_ (0)
+  : select_reactor_ (nullptr)
   , max_notify_iterations_ (-1)
 {
 }
@@ -601,7 +601,7 @@ ACE_Select_Reactor_Notify::open (ACE_Reactor_Impl *r,
     {
       this->select_reactor_ = dynamic_cast<ACE_Select_Reactor_Impl *> (r);
 
-      if (select_reactor_ == 0)
+      if (select_reactor_ == nullptr)
         {
           errno = EINVAL;
           return -1;
@@ -648,7 +648,7 @@ ACE_Select_Reactor_Notify::open (ACE_Reactor_Impl *r,
     }
   else
     {
-      this->select_reactor_ = 0;
+      this->select_reactor_ = nullptr;
       return 0;
     }
 }
@@ -693,7 +693,7 @@ ACE_Select_Reactor_Notify::notify (ACE_Event_Handler *event_handler,
 
   // Just consider this method a "no-op" if there's no
   // <ACE_Select_Reactor> configured.
-  if (this->select_reactor_ == 0)
+  if (this->select_reactor_ == nullptr)
     return 0;
 
   ACE_Event_Handler_var safe_handler (event_handler);
@@ -829,7 +829,7 @@ ACE_Select_Reactor_Notify::dispatch_notify (ACE_Notification_Buffer &buffer)
   // internal structures.  Otherwise, we need to dispatch the
   // appropriate handle_* method on the <ACE_Event_Handler> pointer
   // we've been passed.
-  if (buffer.eh_ != 0)
+  if (buffer.eh_ != nullptr)
     {
       ACE_Event_Handler *event_handler = buffer.eh_;
 
@@ -977,7 +977,7 @@ int
 ACE_Select_Reactor_Impl::purge_pending_notifications (ACE_Event_Handler *eh,
                                                       ACE_Reactor_Mask mask)
 {
-  if (this->notify_handler_ == 0)
+  if (this->notify_handler_ == nullptr)
     return 0;
   else
     return this->notify_handler_->purge_pending_notifications (eh, mask);
@@ -1005,7 +1005,7 @@ ACE_Select_Reactor_Impl::bit_ops (ACE_HANDLE handle,
     return -1;
 
 #if !defined (ACE_WIN32)
-  ACE_Sig_Guard sb (0,
+  ACE_Sig_Guard sb (nullptr,
                     this->mask_signals_); // Block out all signals until method returns.
 #endif /* ACE_WIN32 */
 

--- a/ACE/ace/Select_Reactor_T.cpp
+++ b/ACE/ace/Select_Reactor_T.cpp
@@ -82,9 +82,9 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::handler_i (int signum,
   ACE_TRACE ("ACE_Select_Reactor_T::handler_i");
   ACE_Event_Handler *handler = this->signal_handler_->handler (signum);
 
-  if (handler == 0)
+  if (handler == nullptr)
     return -1;
-  else if (eh != 0)
+  else if (eh != nullptr)
     *eh = handler;
   return 0;
 }
@@ -230,7 +230,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::suspend_handlers ()
   ACE_TRACE ("ACE_Select_Reactor_T::suspend_handlers");
   ACE_MT (ACE_GUARD_RETURN (ACE_SELECT_REACTOR_TOKEN, ace_mon, this->token_, -1));
 
-  ACE_Event_Handler *eh = 0;
+  ACE_Event_Handler *eh = nullptr;
 
   for (ACE_Select_Reactor_Handler_Repository_Iterator iter (&this->handler_rep_);
        iter.next (eh) != 0;
@@ -248,7 +248,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::resume_handlers ()
   ACE_TRACE ("ACE_Select_Reactor_T::resume_handlers");
   ACE_MT (ACE_GUARD_RETURN (ACE_SELECT_REACTOR_TOKEN, ace_mon, this->token_, -1));
 
-  ACE_Event_Handler *eh = 0;
+  ACE_Event_Handler *eh = nullptr;
 
   for (ACE_Select_Reactor_Handler_Repository_Iterator iter (&this->handler_rep_);
        iter.next (eh) != 0;
@@ -297,7 +297,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::find_handler
   (ACE_HANDLE handle)
 {
   ACE_TRACE ("ACE_Select_Reactor_T::find_handler");
-  ACE_MT (ACE_GUARD_RETURN (ACE_SELECT_REACTOR_TOKEN, ace_mon, this->token_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_SELECT_REACTOR_TOKEN, ace_mon, this->token_, nullptr));
   return this->find_handler_i (handle);
 }
 
@@ -697,7 +697,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::cancel_timer (ACE_Event_Handler 
   ACE_TRACE ("ACE_Select_Reactor_T::cancel_timer");
   ACE_MT (ACE_GUARD_RETURN (ACE_SELECT_REACTOR_TOKEN, ace_mon, this->token_, -1));
 
-  if ((this->timer_queue_ != 0) && (handler != 0))
+  if ((this->timer_queue_ != 0) && (handler != nullptr))
     return this->timer_queue_->cancel (handler, dont_call_handle_close);
   else
     return 0;
@@ -806,7 +806,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::notify_handle
 {
   ACE_TRACE ("ACE_Select_Reactor_T::notify_handle");
   // Check for removed handlers.
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     return;
 
   bool const reference_counting_required =
@@ -888,7 +888,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::handler_i
   ACE_TRACE ("ACE_Select_Reactor_T::handler_i");
   ACE_Event_Handler *event_handler = this->handler_rep_.find (handle);
 
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     return -1;
   else
     {
@@ -904,7 +904,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::handler_i
         return -1;
     }
 
-  if (eh != 0)
+  if (eh != nullptr)
     {
       *eh = event_handler;
       event_handler->add_reference ();
@@ -1038,7 +1038,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::work_pending
 
   // Check if we have timers to fire.
   bool const timers_pending =
-    (this_timeout != 0 && *this_timeout != mwt ? true : false);
+    (this_timeout != nullptr && *this_timeout != mwt ? true : false);
 
 #ifdef ACE_WIN32
   // This arg is ignored on Windows and causes pointer truncation
@@ -1073,7 +1073,7 @@ ACE_Select_Reactor_T<ACE_SELECT_REACTOR_TOKEN>::wait_for_multiple_events
 {
   ACE_TRACE ("ACE_Select_Reactor_T::wait_for_multiple_events");
   ACE_Time_Value timer_buf (0);
-  ACE_Time_Value *this_timeout = 0;
+  ACE_Time_Value *this_timeout = nullptr;
 
   int number_of_active_handles = this->any_ready (dispatch_set);
 

--- a/ACE/ace/Select_Reactor_T.h
+++ b/ACE/ace/Select_Reactor_T.h
@@ -54,10 +54,10 @@ public:
   /// signal events, whereas if @a mask_signals is false the reactor will
   /// be more efficient, but not signal-safe (which may be perfectly
   /// fine if your application doesn't use the reactor to handle signals).
-  ACE_Select_Reactor_T (ACE_Sig_Handler * = 0,
-                        ACE_Timer_Queue * = 0,
+  ACE_Select_Reactor_T (ACE_Sig_Handler * = nullptr,
+                        ACE_Timer_Queue * = nullptr,
                         int disable_notify_pipe = ACE_DISABLE_NOTIFY_PIPE_DEFAULT,
-                        ACE_Reactor_Notify *notify = 0,
+                        ACE_Reactor_Notify *notify = nullptr,
                         bool mask_signals = true,
                         int s_queue = ACE_SELECT_TOKEN::FIFO);
 
@@ -79,10 +79,10 @@ public:
    */
   ACE_Select_Reactor_T (size_t size,
                         bool restart = false,
-                        ACE_Sig_Handler * = 0,
-                        ACE_Timer_Queue * = 0,
+                        ACE_Sig_Handler * = nullptr,
+                        ACE_Timer_Queue * = nullptr,
                         int disable_notify_pipe = ACE_DISABLE_NOTIFY_PIPE_DEFAULT,
-                        ACE_Reactor_Notify *notify = 0,
+                        ACE_Reactor_Notify *notify = nullptr,
                         bool mask_signals = true,
                         int s_queue = ACE_SELECT_TOKEN::FIFO);
 
@@ -105,10 +105,10 @@ public:
    */
   virtual int open (size_t max_number_of_handles = DEFAULT_SIZE,
                     bool restart = false,
-                    ACE_Sig_Handler * = 0,
-                    ACE_Timer_Queue * = 0,
+                    ACE_Sig_Handler * = nullptr,
+                    ACE_Timer_Queue * = nullptr,
                     int disable_notify_pipe = ACE_DISABLE_NOTIFY_PIPE_DEFAULT,
-                    ACE_Reactor_Notify * = 0);
+                    ACE_Reactor_Notify * = nullptr);
 
   /// Returns -1 (not used in this implementation);
   virtual int current_info (ACE_HANDLE, size_t &size);
@@ -158,8 +158,8 @@ public:
    * Current alertable_handle_events() is identical to
    * handle_events().
    */
-  virtual int handle_events (ACE_Time_Value *max_wait_time = 0);
-  virtual int alertable_handle_events (ACE_Time_Value *max_wait_time = 0);
+  virtual int handle_events (ACE_Time_Value *max_wait_time = nullptr);
+  virtual int alertable_handle_events (ACE_Time_Value *max_wait_time = nullptr);
   //@}
 
   //@{
@@ -241,15 +241,15 @@ public:
    */
   virtual int register_handler (int signum,
                                 ACE_Event_Handler *new_sh,
-                                ACE_Sig_Action *new_disp = 0,
-                                ACE_Event_Handler **old_sh = 0,
-                                ACE_Sig_Action *old_disp = 0);
+                                ACE_Sig_Action *new_disp = nullptr,
+                                ACE_Event_Handler **old_sh = nullptr,
+                                ACE_Sig_Action *old_disp = nullptr);
 
   /// Registers @a new_sh to handle a set of signals @a sigset using the
   /// @a new_disp.
   virtual int register_handler (const ACE_Sig_Set &sigset,
                                 ACE_Event_Handler *new_sh,
-                                ACE_Sig_Action *new_disp = 0);
+                                ACE_Sig_Action *new_disp = nullptr);
 
   /**
    * Removes the @a mask binding of @a eh from the Select_Reactor.  If
@@ -286,7 +286,7 @@ public:
    */
   virtual int remove_handler (int signum,
                               ACE_Sig_Action *new_disp,
-                              ACE_Sig_Action *old_disp = 0,
+                              ACE_Sig_Action *old_disp = nullptr,
                               int sigkey = -1);
 
   /// Calls <remove_handler> for every signal in @a sigset.
@@ -382,7 +382,7 @@ public:
    * succeeded and 0 if the @a timer_id wasn't found.
    */
   virtual int cancel_timer (long timer_id,
-                            const void **arg = 0,
+                            const void **arg = nullptr,
                             int dont_call_handle_close = 1);
 
   // = High-level Event_Handler scheduling operations
@@ -415,9 +415,9 @@ public:
    * action is possible, else will wait until the relative time
    * specified in *@a timeout elapses).
    */
-  virtual int notify (ACE_Event_Handler * = 0,
+  virtual int notify (ACE_Event_Handler * = nullptr,
                       ACE_Reactor_Mask = ACE_Event_Handler::EXCEPT_MASK,
-                      ACE_Time_Value * = 0);
+                      ACE_Time_Value * = nullptr);
 
   /**
    * Set the maximum number of times that the
@@ -483,7 +483,7 @@ public:
   // = Only the owner thread can perform a <handle_events>.
 
   /// Set the new owner of the thread and return the old owner.
-  virtual int owner (ACE_thread_t n_id, ACE_thread_t *o_id = 0);
+  virtual int owner (ACE_thread_t n_id, ACE_thread_t *o_id = nullptr);
 
   /// Return the current owner of the thread.
   virtual int owner (ACE_thread_t *);
@@ -503,7 +503,7 @@ public:
    */
   virtual int handler (ACE_HANDLE handle,
                        ACE_Reactor_Mask mask,
-                       ACE_Event_Handler **eh = 0);
+                       ACE_Event_Handler **eh = nullptr);
 
   /**
    * Check to see if @a signum is associated with a valid Event_Handler
@@ -511,7 +511,7 @@ public:
    * handler if @a eh != 0.
    */
   virtual int handler (int signum,
-                       ACE_Event_Handler ** = 0);
+                       ACE_Event_Handler ** = nullptr);
 
   /// Returns true if we've been successfully initialized, else false.
   virtual bool initialized ();
@@ -577,10 +577,10 @@ protected:
   /// Implement the public handler method.
   virtual int handler_i (ACE_HANDLE handle,
                          ACE_Reactor_Mask,
-                         ACE_Event_Handler ** = 0);
+                         ACE_Event_Handler ** = nullptr);
 
   /// Implement the public handler method.
-  virtual int handler_i (int signum, ACE_Event_Handler ** = 0);
+  virtual int handler_i (int signum, ACE_Event_Handler ** = nullptr);
 
   /**
    * Check if there are any HANDLEs enabled in the <ready_set_>, and
@@ -679,7 +679,7 @@ protected:
   int release_token ();
 
   /// Stops the VC++ compiler from bitching about exceptions and destructors
-  int handle_events_i (ACE_Time_Value *max_wait_time = 0);
+  int handle_events_i (ACE_Time_Value *max_wait_time = nullptr);
 
   /// This flag is used to keep track of whether we are actively handling
   /// events or not.

--- a/ACE/ace/Service_Config.cpp
+++ b/ACE/ace/Service_Config.cpp
@@ -41,7 +41,7 @@ ACE_Threading_Helper<ACE_Thread_Mutex>::ACE_Threading_Helper ()
   ACE_Object_Manager::init_tss ();
 # endif
 
-  if (ACE_Thread::keycreate (&key_, 0) == -1)
+  if (ACE_Thread::keycreate (&key_, nullptr) == -1)
     {
       ACELIB_ERROR ((LM_ERROR,
                   ACE_TEXT ("(%P|%t) Failed to create thread key: %p\n"),
@@ -61,7 +61,7 @@ ACE_Threading_Helper<ACE_Thread_Mutex>::set (void* p)
 void*
 ACE_Threading_Helper<ACE_Thread_Mutex>::get ()
 {
-  void* temp = 0;
+  void* temp = nullptr;
   if (ACE_Thread::getspecific (key_, &temp) == -1)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("(%P|%t) Service Config failed to get thread key value: %p\n"),
@@ -121,7 +121,7 @@ ACE_Service_Config_Guard::ACE_Service_Config_Guard (ACE_Service_Gestalt * psg)
 ACE_Service_Config_Guard::~ACE_Service_Config_Guard ()
 {
   ACE_Service_Gestalt* s = this->saved_.get ();
-  ACE_ASSERT (s != 0);
+  ACE_ASSERT (s != nullptr);
 
   ACE_Service_Config::current (s);
 
@@ -137,7 +137,7 @@ ACE_Service_Config_Guard::~ACE_Service_Config_Guard ()
 ACE_ALLOC_HOOK_DEFINE (ACE_Service_Config)
 
 // Set the signal handler to point to the handle_signal() function.
-ACE_Sig_Adapter *ACE_Service_Config::signal_handler_ = 0;
+ACE_Sig_Adapter *ACE_Service_Config::signal_handler_ = nullptr;
 
 // Trigger a reconfiguration.
 sig_atomic_t ACE_Service_Config::reconfig_occurred_ = 0;
@@ -145,7 +145,7 @@ sig_atomic_t ACE_Service_Config::reconfig_occurred_ = 0;
 // = Set by command-line options.
 
 /// Pathname of file to write process id.
-ACE_TCHAR *ACE_Service_Config::pid_file_name_ = 0;
+ACE_TCHAR *ACE_Service_Config::pid_file_name_ = nullptr;
 
 /// Shall we become a daemon process?
 bool ACE_Service_Config::be_a_daemon_ = false;
@@ -252,12 +252,12 @@ ACE_Service_Config::open_i (const ACE_TCHAR program_name[],
     }
 
   // Write process id to file.
-  if (this->pid_file_name_ != 0)
+  if (this->pid_file_name_ != nullptr)
     {
       FILE* pidf = ACE_OS::fopen (this->pid_file_name_,
                                   ACE_TEXT("w"));
 
-      if (pidf != 0)
+      if (pidf != nullptr)
         {
           ACE_OS::fprintf (pidf,
                            "%ld\n",
@@ -274,7 +274,7 @@ ACE_Service_Config::open_i (const ACE_TCHAR program_name[],
 
   const ACE_TCHAR *key = logger_key;
 
-  if (key == 0 || ACE_OS::strcmp (key, ACE_DEFAULT_LOGGER_KEY) == 0)
+  if (key == nullptr || ACE_OS::strcmp (key, ACE_DEFAULT_LOGGER_KEY) == 0)
     {
       // Only use the static <logger_key_> if the caller doesn't
       // override it in the parameter list or if the key supplied is
@@ -312,7 +312,7 @@ ACE_Service_Config::open_i (const ACE_TCHAR program_name[],
     {
       ACE_Sig_Set ss;
       ss.sig_add (ACE_Service_Config::signum_);
-      if ((ACE_Reactor::instance () != 0) &&
+      if ((ACE_Reactor::instance () != nullptr) &&
           (ACE_Reactor::instance ()->register_handler
            (ss, ACE_Service_Config::signal_handler_) == -1))
         ACELIB_ERROR ((LM_ERROR,
@@ -380,7 +380,7 @@ ACE_Service_Config::ACE_Service_Config (bool ignore_static_svcs,
   // TODO: Need to find a more customizable way of instantiating the
   // gestalt but perhaps we should leave this out untill such
   // customizations are identified.
-  ACE_Service_Gestalt* tmp = 0;
+  ACE_Service_Gestalt* tmp = nullptr;
   ACE_NEW_NORETURN (tmp,
                     ACE_Service_Gestalt (size, false, ignore_static_svcs));
 
@@ -399,7 +399,7 @@ ACE_Service_Config::ACE_Service_Config (const ACE_TCHAR program_name[],
   // TODO: Need to find a more customizable way of instantiating the
   // gestalt but perhaps we should leave this out untill such
   // customizations are identified.
-  ACE_Service_Gestalt* tmp = 0;
+  ACE_Service_Gestalt* tmp = nullptr;
   ACE_NEW_NORETURN (tmp,
                     ACE_Service_Gestalt (ACE_Service_Repository::DEFAULT_SIZE, false));
 
@@ -427,7 +427,7 @@ ACE_Service_Gestalt*
 ACE_Service_Config::current ()
 {
   void* temp = ACE_Service_Config::singleton()->threadkey_.get ();
-  if (temp == 0) {
+  if (temp == nullptr) {
     // The most likely reason is that the current thread was spawned
     // by some native primitive, like pthreads or Windows API - not
     // from ACE. This is perfectly legal for callers who are not, or
@@ -474,7 +474,7 @@ ACE_Service_Config::create_service_type_impl (const ACE_TCHAR *name,
                                               u_int flags,
                                               ACE_Service_Object_Exterminator gobbler)
 {
-  ACE_Service_Type_Impl *stp = 0;
+  ACE_Service_Type_Impl *stp = nullptr;
 
   // Note, the only place we need to put a case statement.  This is
   // also the place where we'd put the RTTI tests, if the compiler
@@ -487,17 +487,17 @@ ACE_Service_Config::create_service_type_impl (const ACE_TCHAR *name,
                       ACE_Service_Object_Type ((ACE_Service_Object *) symbol,
                                                name, flags,
                                                gobbler),
-                      0);
+                      nullptr);
       break;
     case ACE_Service_Type::MODULE:
       ACE_NEW_RETURN (stp,
                       ACE_Module_Type (symbol, name, flags),
-                      0);
+                      nullptr);
       break;
     case ACE_Service_Type::STREAM:
       ACE_NEW_RETURN (stp,
                       ACE_Stream_Type (symbol, name, flags),
-                      0);
+                      nullptr);
       break;
     default:
       ACELIB_ERROR ((LM_ERROR,
@@ -532,7 +532,7 @@ ACE_Service_Config::reconfigure ()
   if (ACE::debug ())
     {
 #if !defined (ACE_NLOGGING)
-      time_t t = ACE_OS::time (0);
+      time_t t = ACE_OS::time (nullptr);
 
       if (ACE::debug ())
         ACELIB_DEBUG ((LM_DEBUG,
@@ -573,7 +573,7 @@ ACE_Service_Config::fini_svcs ()
     ACE_Log_Msg::disable_debug_messages ();
 
   int result = 0;
-  if (ACE_Service_Repository::instance () != 0)
+  if (ACE_Service_Repository::instance () != nullptr)
     result = ACE_Service_Repository::instance ()->fini ();
 
   if (ACE::debug ())

--- a/ACE/ace/Service_Gestalt.cpp
+++ b/ACE/ace/Service_Gestalt.cpp
@@ -61,14 +61,14 @@ ACE_Service_Type_Dynamic_Guard::ACE_Service_Type_Dynamic_Guard
                     this->name_,
                     this->repo_begin_));
 
-  ACE_ASSERT (this->name_ != 0); // No name?
+  ACE_ASSERT (this->name_ != nullptr); // No name?
 }
 
 
 /// Destructor
 ACE_Service_Type_Dynamic_Guard::~ACE_Service_Type_Dynamic_Guard ()
 {
-  const ACE_Service_Type *tmp = 0;
+  const ACE_Service_Type *tmp = nullptr;
 
   // Lookup without ignoring suspended services. Making sure
   // not to ignore any inactive services, since those may be forward
@@ -77,7 +77,7 @@ ACE_Service_Type_Dynamic_Guard::~ACE_Service_Type_Dynamic_Guard ()
   int const ret = this->repo_.find_i (this->name_, slot, &tmp, false);
 
   // We inserted it (as inactive), so we expect to find it, right?
-  if ((ret < 0 && ret != -2) || tmp == 0)
+  if ((ret < 0 && ret != -2) || tmp == nullptr)
     {
       if (ACE::debug ())
         ACELIB_ERROR ((LM_WARNING,
@@ -86,7 +86,7 @@ ACE_Service_Type_Dynamic_Guard::~ACE_Service_Type_Dynamic_Guard ()
       return;
     }
 
-  if (tmp->type () != 0)
+  if (tmp->type () != nullptr)
     {
       // Something has registered a proper (non-forward-decl) service with
       // the same name as our dummy.
@@ -126,7 +126,7 @@ ACE_Service_Type_Dynamic_Guard::~ACE_Service_Type_Dynamic_Guard ()
 
 ACE_Service_Gestalt::Processed_Static_Svc::
 Processed_Static_Svc (const ACE_Static_Svc_Descriptor *assd)
-  :name_(0),
+  :name_(nullptr),
    assd_(assd)
 {
 #if defined (ACE_HAS_ALLOC_HOOKS)
@@ -151,7 +151,7 @@ ACE_ALLOC_HOOK_DEFINE(ACE_Service_Gestalt::Processed_Static_Svc)
 void
 ACE_Service_Gestalt::intrusive_add_ref (ACE_Service_Gestalt* g)
 {
-  if (g != 0)
+  if (g != nullptr)
     {
       ++g->refcnt_;
       ACE_ASSERT (g->refcnt_ > 0);
@@ -161,7 +161,7 @@ ACE_Service_Gestalt::intrusive_add_ref (ACE_Service_Gestalt* g)
 void
 ACE_Service_Gestalt::intrusive_remove_ref (ACE_Service_Gestalt* g)
 {
-  if (g != 0)
+  if (g != nullptr)
     {
       long tmp = --g->refcnt_;
       if (tmp <= 0)  delete g;
@@ -175,10 +175,10 @@ ACE_Service_Gestalt::~ACE_Service_Gestalt ()
   if (this->svc_repo_is_owned_)
     delete this->repo_;
 
-  this->repo_ =0;
+  this->repo_ =nullptr;
 
   delete this->static_svcs_;
-  this->static_svcs_ = 0;
+  this->static_svcs_ = nullptr;
 
   // Delete the dynamically allocated static_svcs instance.
 #ifndef ACE_NLOGGING
@@ -191,7 +191,7 @@ ACE_Service_Gestalt::~ACE_Service_Gestalt ()
   if (this->processed_static_svcs_ &&
       !this->processed_static_svcs_->is_empty())
     {
-      Processed_Static_Svc **pss = 0;
+      Processed_Static_Svc **pss = nullptr;
       for (ACE_PROCESSED_STATIC_SVCS_ITERATOR iter (*this->processed_static_svcs_);
            iter.next (pss) != 0;
            iter.advance ())
@@ -201,13 +201,13 @@ ACE_Service_Gestalt::~ACE_Service_Gestalt ()
     }
 
   delete this->processed_static_svcs_;
-  this->processed_static_svcs_ = 0;
+  this->processed_static_svcs_ = nullptr;
 
   delete this->svc_conf_file_queue_;
-  this->svc_conf_file_queue_ = 0;
+  this->svc_conf_file_queue_ = nullptr;
 
   delete this->svc_queue_;
-  this->svc_queue_ = 0;
+  this->svc_queue_ = nullptr;
 }
 
 ACE_Service_Gestalt::ACE_Service_Gestalt (size_t size,
@@ -218,11 +218,11 @@ ACE_Service_Gestalt::ACE_Service_Gestalt (size_t size,
   , is_opened_ (0)
   , logger_key_ (ACE_DEFAULT_LOGGER_KEY)
   , no_static_svcs_ (no_static_svcs)
-  , svc_queue_ (0)
-  , svc_conf_file_queue_ (0)
-  , repo_ (0)
-  , static_svcs_ (0)
-  , processed_static_svcs_ (0)
+  , svc_queue_ (nullptr)
+  , svc_conf_file_queue_ (nullptr)
+  , repo_ (nullptr)
+  , static_svcs_ (nullptr)
+  , processed_static_svcs_ (nullptr)
   , refcnt_ (0)
 {
   (void)this->init_i ();
@@ -244,7 +244,7 @@ ACE_Service_Gestalt::init_i ()
   // Only initialize the repo_ if (a) we are being constructed, or;
   // (b) we're being open()-ed, perhaps after previously having been
   // close()-ed. In both cases: repo_ == 0 and we need a repository.
-  if (this->repo_ == 0)
+  if (this->repo_ == nullptr)
     {
       if (this->svc_repo_is_owned_)
         {
@@ -273,10 +273,10 @@ ACE_Service_Gestalt::load_static_svcs ()
 {
   ACE_TRACE ("ACE_Service_Gestalt::load_static_svcs");
 
-  if (this->static_svcs_ == 0)
+  if (this->static_svcs_ == nullptr)
     return 0; // Nothing to do
 
-  ACE_Static_Svc_Descriptor **ssdp = 0;
+  ACE_Static_Svc_Descriptor **ssdp = nullptr;
   for (ACE_STATIC_SVCS_ITERATOR iter (*this->static_svcs_);
        iter.next (ssdp) != 0;
        iter.advance ())
@@ -297,17 +297,17 @@ ACE_Service_Gestalt::find_static_svc_descriptor (const ACE_TCHAR* name,
 {
   ACE_TRACE ("ACE_Service_Gestalt::find_static_svc_descriptor");
 
-  if (this->static_svcs_ == 0)
+  if (this->static_svcs_ == nullptr)
     return -1;
 
-  ACE_Static_Svc_Descriptor **ssdp = 0;
+  ACE_Static_Svc_Descriptor **ssdp = nullptr;
   for (ACE_STATIC_SVCS_ITERATOR iter ( *this->static_svcs_);
        iter.next (ssdp) != 0;
        iter.advance ())
     {
       if (ACE_OS::strcmp ((*ssdp)->name_, name) == 0)
         {
-          if (ssd != 0)
+          if (ssd != nullptr)
             *ssd = *ssdp;
 
           return 0;
@@ -321,10 +321,10 @@ ACE_Service_Gestalt::find_static_svc_descriptor (const ACE_TCHAR* name,
 const ACE_Static_Svc_Descriptor*
 ACE_Service_Gestalt::find_processed_static_svc (const ACE_TCHAR* name)
 {
-  if (this->processed_static_svcs_ == 0 || name == 0)
-    return 0;
+  if (this->processed_static_svcs_ == nullptr || name == nullptr)
+    return nullptr;
 
-  Processed_Static_Svc **pss = 0;
+  Processed_Static_Svc **pss = nullptr;
   for (ACE_PROCESSED_STATIC_SVCS_ITERATOR iter (*this->processed_static_svcs_);
        iter.next (pss) != 0;
        iter.advance ())
@@ -332,7 +332,7 @@ ACE_Service_Gestalt::find_processed_static_svc (const ACE_TCHAR* name)
       if (ACE_OS::strcmp ((*pss)->name_, name) == 0)
         return (*pss)->assd_;
     }
-  return 0;
+  return nullptr;
 }
 
 
@@ -361,11 +361,11 @@ ACE_Service_Gestalt::add_processed_static_svc
   /// information about the hosting repository and the gestalt must
   /// employ some lookup strategy to find it elsewhere.
 
-  if (this->processed_static_svcs_ == 0)
+  if (this->processed_static_svcs_ == nullptr)
     ACE_NEW (this->processed_static_svcs_,
              ACE_PROCESSED_STATIC_SVCS);
 
-  Processed_Static_Svc **pss = 0;
+  Processed_Static_Svc **pss = nullptr;
   for (ACE_PROCESSED_STATIC_SVCS_ITERATOR iter (*this->processed_static_svcs_);
        iter.next (pss) != 0;
        iter.advance ())
@@ -376,7 +376,7 @@ ACE_Service_Gestalt::add_processed_static_svc
           return;
         }
     }
-  Processed_Static_Svc *tmp = 0;
+  Processed_Static_Svc *tmp = nullptr;
   ACE_NEW (tmp,Processed_Static_Svc(assd));
   this->processed_static_svcs_->insert(tmp);
 
@@ -397,7 +397,7 @@ ACE_Service_Gestalt::add_processed_static_svc
 int
 ACE_Service_Gestalt::insert (ACE_Static_Svc_Descriptor *stsd)
 {
-  if (this->static_svcs_ == 0)
+  if (this->static_svcs_ == nullptr)
     ACE_NEW_RETURN (this->static_svcs_,
                     ACE_STATIC_SVCS,
                     -1);
@@ -436,13 +436,13 @@ ACE_Service_Gestalt::initialize (const ACE_TCHAR *svc_name,
     }
 #endif
 
-  const ACE_Service_Type *srp = 0;
+  const ACE_Service_Type *srp = nullptr;
   for (int i = 0; this->find (svc_name, &srp) == -1 && i < 2; i++)
     //  if (this->repo_->find (svc_name, &srp) == -1)
     {
       const ACE_Static_Svc_Descriptor *assd =
         ACE_Service_Config::global()->find_processed_static_svc(svc_name);
-      if (assd != 0)
+      if (assd != nullptr)
         {
           this->process_directive_i(*assd, 0);
         }
@@ -455,7 +455,7 @@ ACE_Service_Gestalt::initialize (const ACE_TCHAR *svc_name,
                             -1);
         }
     }
-  if (srp == 0)
+  if (srp == nullptr)
     ACELIB_ERROR_RETURN ((LM_ERROR,
                        ACE_TEXT ("ACE (%P|%t) ERROR: SG::initialize - service \'%s\'")
                        ACE_TEXT (" was not located.\n"),
@@ -497,7 +497,7 @@ ACE_Service_Gestalt::initialize (const ACE_Service_Type_Factory *stf,
                 stf->name ()));
 #endif
 
-  ACE_Service_Type *srp = 0;
+  ACE_Service_Type *srp = nullptr;
   int const retv = this->repo_->find (stf->name (),
                                       (const ACE_Service_Type **) &srp);
 
@@ -526,7 +526,7 @@ ACE_Service_Gestalt::initialize (const ACE_Service_Type_Factory *stf,
   // invocations. This use case must be handled here, because if the
   // DLL_Manager was re-entrant we would have entered an infinite
   // recursion here.
-  if (retv == -2 && srp->type () == 0)
+  if (retv == -2 && srp->type () == nullptr)
     ACELIB_ERROR_RETURN ((LM_WARNING,
                        ACE_TEXT ("ACE (%P|%t) SG::initialize - repo=%@,")
                        ACE_TEXT (" name=%s - forward-declared; ")
@@ -551,7 +551,7 @@ ACE_Service_Gestalt::initialize (const ACE_Service_Type_Factory *stf,
   // any static initializers
   std::unique_ptr<ACE_Service_Type> tmp (stf->make_service_type (this));
 
-  if (tmp.get () != 0 &&
+  if (tmp.get () != nullptr &&
       this->initialize_i (tmp.get (), parameters) == 0)
     {
       // All good. Tthe ACE_Service_Type instance is now owned by the
@@ -589,7 +589,7 @@ ACE_Service_Gestalt::initialize (const ACE_Service_Type *sr,
                 this->repo_,
                 sr->name ()));
 
-  ACE_Service_Type *srp = 0;
+  ACE_Service_Type *srp = nullptr;
   if (this->repo_->find (sr->name (),
                          (const ACE_Service_Type **) &srp) >= 0)
     {
@@ -618,7 +618,7 @@ ACE_Service_Gestalt::initialize_i (const ACE_Service_Type *sr,
                          args.argv ()) == -1)
     {
       // We just get ps to avoid having remove() delete it.
-      ACE_Service_Type *ps = 0;
+      ACE_Service_Type *ps = nullptr;
       this->repo_->remove (sr->name (), &ps);
 
 #ifndef ACE_NLOGGING
@@ -659,7 +659,7 @@ int
 ACE_Service_Gestalt::remove (const ACE_TCHAR svc_name[])
 {
   ACE_TRACE ("ACE_Service_Gestalt::remove");
-  if (this->repo_ == 0)
+  if (this->repo_ == nullptr)
     return -1;
 
   return this->repo_->remove (svc_name);
@@ -674,7 +674,7 @@ int
 ACE_Service_Gestalt::suspend (const ACE_TCHAR svc_name[])
 {
   ACE_TRACE ("ACE_Service_Gestalt::suspend");
-  if (this->repo_ == 0)
+  if (this->repo_ == nullptr)
     return -1;
 
   return this->repo_->suspend (svc_name);
@@ -687,7 +687,7 @@ int
 ACE_Service_Gestalt::resume (const ACE_TCHAR svc_name[])
 {
   ACE_TRACE ("ACE_Service_Gestalt::resume");
-  if (this->repo_ == 0)
+  if (this->repo_ == nullptr)
     return -1;
 
   return this->repo_->resume (svc_name);
@@ -710,12 +710,12 @@ int
 ACE_Service_Gestalt::process_directive_i (const ACE_Static_Svc_Descriptor &ssd,
                                           bool force_replace)
 {
-  if (this->repo_ == 0)
+  if (this->repo_ == nullptr)
     return -1;
 
   if (!force_replace)
     {
-      if (this->repo_->find (ssd.name_, 0, 0) >= 0)
+      if (this->repo_->find (ssd.name_, nullptr, 0) >= 0)
         {
           // The service is already there, just return
           return 0;
@@ -732,10 +732,10 @@ ACE_Service_Gestalt::process_directive_i (const ACE_Static_Svc_Descriptor &ssd,
                                                   sym,
                                                   ssd.flags_,
                                                   gobbler);
-  if (stp == 0)
+  if (stp == nullptr)
     return 0;
 
-  ACE_Service_Type *service_type = 0;
+  ACE_Service_Type *service_type = nullptr;
 
   // This is just a temporary to force the compiler to use the right
   // constructor in ACE_Service_Type. Note that, in cases where we are
@@ -757,7 +757,7 @@ ACE_Service_Gestalt::process_directive_i (const ACE_Static_Svc_Descriptor &ssd,
                 ACE_TEXT ("repo=%@ - %s, dll=%s, force=%d\n"),
                 this->repo_,
                 ssd.name_,
-                (tmp_dll.dll_name_ == 0) ? ACE_TEXT ("<null>") : tmp_dll.dll_name_,
+                (tmp_dll.dll_name_ == nullptr) ? ACE_TEXT ("<null>") : tmp_dll.dll_name_,
                 force_replace));
 #endif
 
@@ -843,7 +843,7 @@ ACE_Service_Gestalt::process_file (const ACE_TCHAR file[])
   // being processed. Anytime we have to open a new file, we then can check
   // to see if it is not already being processed by searching for a dummy
   // service with a matching name.
-  if (this->repo_->find (file, 0, 0) >=0)
+  if (this->repo_->find (file, nullptr, 0) >=0)
     {
       ACELIB_DEBUG ((LM_WARNING,
                   ACE_TEXT ("ACE (%P|%t) Configuration file %s is currently")
@@ -866,7 +866,7 @@ ACE_Service_Gestalt::process_file (const ACE_TCHAR file[])
   FILE *fp = ACE_OS::fopen (file,
                             ACE_TEXT ("r"));
 
-  if (fp == 0)
+  if (fp == nullptr)
     {
       // Invalid svc.conf file.  We'll report it here and break out of
       // the method.
@@ -952,9 +952,9 @@ ACE_Service_Gestalt::process_directive (const ACE_TCHAR directive[])
 int
 ACE_Service_Gestalt::init_svc_conf_file_queue ()
 {
-  if (this->svc_conf_file_queue_ == 0)
+  if (this->svc_conf_file_queue_ == nullptr)
     {
-      ACE_SVC_QUEUE *tmp = 0;
+      ACE_SVC_QUEUE *tmp = nullptr;
       ACE_NEW_RETURN (tmp,
           ACE_SVC_QUEUE,
           -1);
@@ -1018,7 +1018,7 @@ ACE_Service_Gestalt::open_i (const ACE_TCHAR program_name[],
 
   const ACE_TCHAR *key = logger_key;
 
-  if (key == 0 || ACE_OS::strcmp (key, ACE_DEFAULT_LOGGER_KEY) == 0)
+  if (key == nullptr || ACE_OS::strcmp (key, ACE_DEFAULT_LOGGER_KEY) == 0)
     {
       // Only use the static <logger_key_> if the caller doesn't
       // override it in the parameter list or if the key supplied is
@@ -1055,7 +1055,7 @@ ACE_Service_Gestalt::open_i (const ACE_TCHAR program_name[],
       if (has_files || has_cmdline)
         {
           // check if default file is already listed
-          ACE_TString *sptr = 0;
+          ACE_TString *sptr = nullptr;
           ACE_TString default_svc_conf (ACE_DEFAULT_SVC_CONF);
 
           for (ACE_SVC_QUEUE_ITERATOR iter (*this->svc_conf_file_queue_);
@@ -1068,7 +1068,7 @@ ACE_Service_Gestalt::open_i (const ACE_TCHAR program_name[],
           if (add_default)
             {
               FILE *fp = ACE_OS::fopen (ACE_DEFAULT_SVC_CONF, ACE_TEXT ("r"));
-              if (fp != 0)
+              if (fp != nullptr)
                 ACE_OS::fclose(fp);
               else
                 add_default = false;
@@ -1133,9 +1133,9 @@ int
 ACE_Service_Gestalt::process_commandline_directives ()
 {
   int result = 0;
-  if (this->svc_queue_ != 0)
+  if (this->svc_queue_ != nullptr)
     {
-      ACE_TString *sptr = 0;
+      ACE_TString *sptr = nullptr;
       for (ACE_SVC_QUEUE_ITERATOR iter (*this->svc_queue_);
            iter.next (sptr) != 0;
            iter.advance ())
@@ -1151,7 +1151,7 @@ ACE_Service_Gestalt::process_commandline_directives ()
         }
 
       delete this->svc_queue_;
-      this->svc_queue_ = 0;
+      this->svc_queue_ = nullptr;
     }
 
   return result;
@@ -1208,7 +1208,7 @@ ACE_Service_Gestalt::parse_args_i (int argc,
         this->no_static_svcs_ = 0;
         break;
       case 'S':
-        if (this->svc_queue_ == 0)
+        if (this->svc_queue_ == nullptr)
           {
             ACE_NEW_RETURN (this->svc_queue_,
                             ACE_SVC_QUEUE,
@@ -1238,13 +1238,13 @@ int
 ACE_Service_Gestalt::process_directives (bool )
 {
   ACE_TRACE ("ACE_Service_Gestalt::process_directives");
-  if (this->svc_conf_file_queue_ == 0
+  if (this->svc_conf_file_queue_ == nullptr
        || this->svc_conf_file_queue_->is_empty ())
     {
       return 0;
     }
 
-  ACE_TString *sptr = 0;
+  ACE_TString *sptr = nullptr;
   int failed = 0;
 
   // Iterate through all the svc.conf files.
@@ -1272,12 +1272,12 @@ ACE_Service_Gestalt::close ()
 
   // Delete the list fo svc.conf files
   delete this->svc_conf_file_queue_;
-  this->svc_conf_file_queue_ = 0;
+  this->svc_conf_file_queue_ = nullptr;
 
   if (this->processed_static_svcs_ &&
       !this->processed_static_svcs_->is_empty())
     {
-      Processed_Static_Svc **pss = 0;
+      Processed_Static_Svc **pss = nullptr;
       for (ACE_PROCESSED_STATIC_SVCS_ITERATOR iter (*this->processed_static_svcs_);
            iter.next (pss) != 0;
            iter.advance ())
@@ -1286,7 +1286,7 @@ ACE_Service_Gestalt::close ()
         }
     }
   delete this->processed_static_svcs_;
-  this->processed_static_svcs_ = 0;
+  this->processed_static_svcs_ = nullptr;
 
 #ifndef ACE_NLOGGING
   if (ACE::debug ())
@@ -1298,7 +1298,7 @@ ACE_Service_Gestalt::close ()
   if (this->svc_repo_is_owned_)
     delete this->repo_;
 
-  this->repo_ = 0;
+  this->repo_ = nullptr;
 
   return 0;
 } /* close () */

--- a/ACE/ace/Service_Manager.cpp
+++ b/ACE/ace/Service_Manager.cpp
@@ -84,7 +84,7 @@ ACE_Service_Manager::info (ACE_TCHAR **strp, size_t length) const
                     ACE_TEXT ("tcp"),
                     ACE_TEXT ("# lists all services in the daemon\n"));
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (buf)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (buf)) == nullptr)
     {
       return -1;
     }
@@ -313,8 +313,8 @@ ACE_Service_Manager::handle_input (ACE_HANDLE)
     ACE_Reactor::instance ()->uses_event_associations ();
 
   if (this->acceptor_.accept (this->client_stream_, // stream
-                              0, // remote address
-                              0, // timeout
+                              nullptr, // remote address
+                              nullptr, // timeout
                               1, // restart
                               reset_new_handle  // reset new handler
                               ) == -1)
@@ -379,8 +379,8 @@ ACE_Service_Manager::handle_input (ACE_HANDLE)
           offset += result;
           *offset = 0;
 
-          if (ACE_OS::strchr (request, '\r') != 0
-              || ACE_OS::strchr (request, '\n') != 0)
+          if (ACE_OS::strchr (request, '\r') != nullptr
+              || ACE_OS::strchr (request, '\n') != nullptr)
             {
               remaining = 0;
             }
@@ -404,10 +404,10 @@ ACE_Service_Manager::handle_input (ACE_HANDLE)
       /* NOTREACHED */
     default:
       {
-        ACE_Event_Handler *old_signal_handler = 0;
+        ACE_Event_Handler *old_signal_handler = nullptr;
         ACE_Reactor::instance ()->register_handler (SIGPIPE,
                                                     this,
-                                                    0,
+                                                    nullptr,
                                                     &old_signal_handler);
 
         this->process_request (request);

--- a/ACE/ace/Service_Object.cpp
+++ b/ACE/ace/Service_Object.cpp
@@ -37,7 +37,7 @@ ACE_Service_Type::dump () const
                   static_cast<void const *> (this),
                   ACE_TEXT_ALWAYS_CHAR (this->name_),
                   static_cast<void const *> (this->type_),
-                  (this->type_ != 0) ? this->type_->object () : 0,
+                  (this->type_ != nullptr) ? this->type_->object () : nullptr,
                   this->active_);
 #endif
 }
@@ -46,7 +46,7 @@ ACE_Service_Type::ACE_Service_Type (const ACE_TCHAR *n,
                                     ACE_Service_Type_Impl *t,
                                     const ACE_DLL &dll,
                                     bool active)
-  : name_ (0),
+  : name_ (nullptr),
     type_ (t),
     dll_ (dll),
     active_ (active),
@@ -60,7 +60,7 @@ ACE_Service_Type::ACE_Service_Type (const ACE_TCHAR *n,
                                     ACE_Service_Type_Impl *t,
                                     ACE_SHLIB_HANDLE handle,
                                     bool active)
-  : name_ (0),
+  : name_ (nullptr),
     type_ (t),
     active_ (active),
     fini_already_called_ (false)
@@ -96,7 +96,7 @@ ACE_Service_Type::fini ()
 
   this->fini_already_called_ = true;
 
-  if (this->type_ == 0)
+  if (this->type_ == nullptr)
     {
       // Returning 1 currently only makes sense for dummy instances, used
       // to "reserve" a spot (kind of like forward-declarations) for a
@@ -110,7 +110,7 @@ ACE_Service_Type::fini ()
   int const ret = this->type_->fini ();
 
   // Ensure type is 0 to prevent invalid access after call to fini.
-  this->type_ = 0;
+  this->type_ = nullptr;
 
   // Ensure that closing the DLL is done after type_->fini() as it may
   // require access to the code for the service object destructor,

--- a/ACE/ace/Service_Repository.cpp
+++ b/ACE/ace/Service_Repository.cpp
@@ -17,7 +17,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 ACE_ALLOC_HOOK_DEFINE(ACE_Service_Repository)
 
 /// Process-wide Service Repository.
-ACE_Service_Repository *ACE_Service_Repository::svc_rep_ = 0;
+ACE_Service_Repository *ACE_Service_Repository::svc_rep_ = nullptr;
 
 /// Controls whether the Service_Repository is deleted when we shut
 /// down (we can only delete it safely if we created it)!
@@ -61,7 +61,7 @@ ACE_Service_Repository::instance (ACE_Service_Repository *s)
 {
   ACE_TRACE ("ACE_Service_Repository::instance");
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Static_Object_Lock::instance (), 0));
+                            *ACE_Static_Object_Lock::instance (), nullptr));
 
   ACE_Service_Repository *t = ACE_Service_Repository::svc_rep_;
   // We can't safely delete it since we don't know who created it!
@@ -82,7 +82,7 @@ ACE_Service_Repository::close_singleton ()
   if (ACE_Service_Repository::delete_svc_rep_)
     {
       delete ACE_Service_Repository::svc_rep_;
-      ACE_Service_Repository::svc_rep_ = 0;
+      ACE_Service_Repository::svc_rep_ = nullptr;
       ACE_Service_Repository::delete_svc_rep_ = false;
     }
 }
@@ -128,7 +128,7 @@ ACE_Service_Repository::fini ()
     {
       ACE_Service_Type *s =
         const_cast<ACE_Service_Type *> (this->service_array_[i]);
-      if (s == 0)
+      if (s == nullptr)
         ACELIB_DEBUG ((LM_DEBUG,
                     ACE_TEXT ("ACE (%P|%t) SR::fini, repo=%@ [%d] -> 0\n"),
                     this,
@@ -145,8 +145,8 @@ ACE_Service_Repository::fini ()
     ACE_Service_Type *s =
       const_cast<ACE_Service_Type *> (this->service_array_[i]);
 
-    if (s != 0 &&
-        s->type () != 0 &&
+    if (s != nullptr &&
+        s->type () != nullptr &&
         (s->type ()->service_type () != ACE_Service_Type::MODULE))
     {
 #ifndef ACE_NLOGGING
@@ -159,7 +159,7 @@ ACE_Service_Repository::fini ()
                     i,
                     s->name (),
                     s->type (),
-                    (s->type () != 0) ? s->type ()->object () : 0,
+                    (s->type () != nullptr) ? s->type ()->object () : nullptr,
                     s->active ()));
       }
 #endif
@@ -177,8 +177,8 @@ ACE_Service_Repository::fini ()
     ACE_Service_Type *s =
       const_cast<ACE_Service_Type *> (this->service_array_[i]);
 
-    if (s != 0 &&
-        s->type () != 0 &&
+    if (s != nullptr &&
+        s->type () != nullptr &&
         (s->type ()->service_type () == ACE_Service_Type::MODULE))
     {
 #ifndef ACE_NLOGGING
@@ -191,7 +191,7 @@ ACE_Service_Repository::fini ()
                     i,
                     s->name (),
                     s->type (),
-                    (s->type () != 0) ? s->type ()->object () : 0,
+                    (s->type () != nullptr) ? s->type ()->object () : nullptr,
                     s->active ()));
       }
 #endif
@@ -229,7 +229,7 @@ ACE_Service_Repository::close ()
 #ifndef ACE_NLOGGING
       if(ACE::debug ())
         {
-          if (s == 0)
+          if (s == nullptr)
             ACELIB_DEBUG ((LM_DEBUG,
                         ACE_TEXT ("ACE (%P|%t) SR::close - repo=%@ [%d] -> 0\n"),
                         this,
@@ -290,12 +290,12 @@ ACE_Service_Repository::find_i (const ACE_TCHAR name[],
       slot = (*iter).first;
       if ((*iter).second->fini_called ())
         {
-          if (srp != 0)
-            *srp = 0;
+          if (srp != nullptr)
+            *srp = nullptr;
           return -1;
         }
 
-      if (srp != 0)
+      if (srp != nullptr)
         *srp = (*iter).second;
 
       if (ignore_suspended
@@ -327,13 +327,13 @@ ACE_Service_Repository::relocate_i (size_t begin,
       ACE_Service_Type *type =
         const_cast<ACE_Service_Type *> (this->service_array_[i]);
 
-      ACE_SHLIB_HANDLE old_handle = (type == 0) ? ACE_SHLIB_INVALID_HANDLE
+      ACE_SHLIB_HANDLE old_handle = (type == nullptr) ? ACE_SHLIB_INVALID_HANDLE
                                                 : type->dll ().get_handle (0);
 
 #ifndef ACE_NLOGGING
       if (ACE::debug ())
         {
-          if (type == 0)
+          if (type == nullptr)
             ACELIB_DEBUG ((LM_DEBUG,
                         ACE_TEXT ("ACE (%P|%t) SR::relocate_i - repo=%@ [%d]")
                         ACE_TEXT (": skipping empty slot\n"),
@@ -351,7 +351,7 @@ ACE_Service_Repository::relocate_i (size_t begin,
         }
 #endif
 
-      if (type != 0  // skip any gaps
+      if (type != nullptr  // skip any gaps
           && old_handle == ACE_SHLIB_INVALID_HANDLE
           && new_handle != old_handle)
         {
@@ -395,7 +395,7 @@ ACE_Service_Repository::insert (const ACE_Service_Type *sr)
 
   size_t i = 0;
   int return_value = -1;
-  ACE_Service_Type const *s = 0;
+  ACE_Service_Type const *s = nullptr;
 
   // Establish scope for locking while manipulating the service
   // storage
@@ -407,7 +407,7 @@ ACE_Service_Repository::insert (const ACE_Service_Type *sr)
     return_value = find_i (sr->name (), i, &s, false);
 
     // Adding an entry.
-    if (s != 0)
+    if (s != nullptr)
       {
         this->service_array_[i] = sr;
       }
@@ -434,9 +434,9 @@ ACE_Service_Repository::insert (const ACE_Service_Type *sr)
                 this,
                 i,
                 sr->name(),
-                (return_value == 0 ? ((s==0) ? "new" : "replacing") : "failed"),
+                (return_value == 0 ? ((s==nullptr) ? "new" : "replacing") : "failed"),
                 sr->type (),
-                (sr->type () != 0) ? sr->type ()->object () : 0,
+                (sr->type () != nullptr) ? sr->type ()->object () : nullptr,
                 sr->active ()));
 #endif
 
@@ -488,7 +488,7 @@ int
 ACE_Service_Repository::remove (const ACE_TCHAR name[], ACE_Service_Type **ps)
 {
   ACE_TRACE ("ACE_Service_Repository::remove");
-  ACE_Service_Type *s = 0;
+  ACE_Service_Type *s = nullptr;
   {
     ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, ace_mon, this->lock_, -1);
 
@@ -497,7 +497,7 @@ ACE_Service_Repository::remove (const ACE_TCHAR name[], ACE_Service_Type **ps)
       return -1;
   }
 
-  if (ps != 0)
+  if (ps != nullptr)
     *ps = s;
   else
     delete s;
@@ -528,7 +528,7 @@ int
 ACE_Service_Repository::remove_i (const ACE_TCHAR name[], ACE_Service_Type **ps)
 {
   size_t i = 0;
-  if (-1 == this->find_i (name, i, 0, false))
+  if (-1 == this->find_i (name, i, nullptr, false))
     return -1;    // Not found
 
   // We may need the old ptr - to be delete outside the lock!
@@ -546,7 +546,7 @@ ACE_Service_Repository::remove_i (const ACE_TCHAR name[], ACE_Service_Type **ps)
                 (*ps)->active ()));
 #endif
 
-  this->service_array_[i] = 0; // simply leave a gap
+  this->service_array_[i] = nullptr; // simply leave a gap
   return 0;
 }
 
@@ -608,9 +608,9 @@ ACE_Service_Repository_Iterator::valid () const
 {
   ACE_TRACE ("ACE_Service_Repository_Iterator::valid");
   if (!this->ignore_suspended_)
-    return (this->svc_rep_.service_array_[this->next_] != 0); // skip over gaps
+    return (this->svc_rep_.service_array_[this->next_] != nullptr); // skip over gaps
 
-  return (this->svc_rep_.service_array_[this->next_] != 0
+  return (this->svc_rep_.service_array_[this->next_] != nullptr
           && this->svc_rep_.service_array_[this->next_]->active ());
 }
 

--- a/ACE/ace/Service_Types.cpp
+++ b/ACE/ace/Service_Types.cpp
@@ -30,7 +30,7 @@ ACE_Service_Type_Impl::ACE_Service_Type_Impl (void *so,
                                               u_int f,
                                               ACE_Service_Object_Exterminator gobbler,
                                               int stype)
-  : name_ (0),
+  : name_ (nullptr),
     obj_ (so),
     gobbler_ (gobbler),
     flags_ (f),
@@ -63,12 +63,12 @@ ACE_Service_Type_Impl::fini () const
 #else
   delete [] const_cast <ACE_TCHAR *> (this->name_);
 #endif /* ACE_HAS_ALLOC_HOOKS */
-  (const_cast <ACE_Service_Type_Impl *> (this))->name_ = 0;
+  (const_cast <ACE_Service_Type_Impl *> (this))->name_ = nullptr;
 
   if (ACE_BIT_ENABLED (this->flags_,
                        ACE_Service_Type::DELETE_OBJ))
     {
-      if (gobbler_ != 0)
+      if (gobbler_ != nullptr)
         gobbler_ (this->object ());
       else
         // Cast to remove const-ness.
@@ -103,7 +103,7 @@ ACE_Service_Object_Type::init (int argc, ACE_TCHAR *argv[]) const
   ACE_Service_Object * const so =
     static_cast<ACE_Service_Object *> (obj);
 
-  if (so == 0)
+  if (so == nullptr)
     return -1;
 
   this->initialized_ = so->init (argc, argv);
@@ -124,7 +124,7 @@ ACE_Service_Object_Type::fini () const
   // Call fini() if an only if, the object was successfully
   // initialized, i.e. init() returned 0. This is necessary to
   // maintain the ctor/dtor-like semantics for init/fini.
-  if (so != 0 && this->initialized_ == 0)
+  if (so != nullptr && this->initialized_ == 0)
       so->fini ();
 
   return ACE_Service_Type_Impl::fini ();
@@ -170,8 +170,8 @@ ACE_Module_Type::ACE_Module_Type (void *m,
                                   const ACE_TCHAR *m_name,
                                   u_int f,
                                   int stype)
-  : ACE_Service_Type_Impl (m, m_name, f, 0, stype)
-  , link_ (0)
+  : ACE_Service_Type_Impl (m, m_name, f, nullptr, stype)
+  , link_ (nullptr)
 {
   ACE_TRACE ("ACE_Module_Type::ACE_Module_Type");
 }
@@ -250,10 +250,10 @@ ACE_Module_Type::fini () const
   MT_Task *reader = mod->reader ();
   MT_Task *writer = mod->writer ();
 
-  if (reader != 0)
+  if (reader != nullptr)
     reader->fini ();
 
-  if (writer != 0)
+  if (writer != nullptr)
     writer->fini ();
 
   // Close the module and delete the memory.
@@ -272,7 +272,7 @@ ACE_Module_Type::info (ACE_TCHAR **str, size_t len) const
                     this->name (),
                     ACE_TEXT ("# ACE_Module\n"));
 
-  if (*str == 0 && (*str = ACE_OS::strdup (buf)) == 0)
+  if (*str == nullptr && (*str = ACE_OS::strdup (buf)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*str, buf, len);
@@ -316,7 +316,7 @@ ACE_Stream_Type::suspend () const
   ACE_TRACE ("ACE_Stream_Type::suspend");
 
   for (ACE_Module_Type *m = this->head_;
-       m != 0;
+       m != nullptr;
        m = m->link ())
     m->suspend ();
 
@@ -329,7 +329,7 @@ ACE_Stream_Type::resume () const
   ACE_TRACE ("ACE_Stream_Type::resume");
 
   for (ACE_Module_Type *m = this->head_;
-       m != 0;
+       m != nullptr;
        m = m->link ())
     m->resume ();
 
@@ -340,8 +340,8 @@ ACE_Stream_Type::ACE_Stream_Type (void *s,
                                   const ACE_TCHAR *s_name,
                                   u_int f,
                                   int stype)
-  : ACE_Service_Type_Impl (s, s_name, f, 0, stype),
-    head_ (0)
+  : ACE_Service_Type_Impl (s, s_name, f, nullptr, stype),
+    head_ (nullptr)
 {
   ACE_TRACE ("ACE_Stream_Type::ACE_Stream_Type");
 }
@@ -362,7 +362,7 @@ ACE_Stream_Type::info (ACE_TCHAR **str, size_t len) const
                     this->name (),
                     ACE_TEXT ("# STREAM\n"));
 
-  if (*str == 0 && (*str = ACE_OS::strdup (buf)) == 0)
+  if (*str == nullptr && (*str = ACE_OS::strdup (buf)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*str, buf, len);
@@ -376,7 +376,7 @@ ACE_Stream_Type::fini () const
   void *obj = this->object ();
   MT_Stream *str = (MT_Stream *) obj;
 
-  for (ACE_Module_Type *m = this->head_; m != 0;)
+  for (ACE_Module_Type *m = this->head_; m != nullptr;)
   {
     ACE_Module_Type *t = m->link ();
 
@@ -397,19 +397,19 @@ ACE_Stream_Type::remove (ACE_Module_Type *mod)
 {
   ACE_TRACE ("ACE_Stream_Type::remove");
 
-  ACE_Module_Type *prev = 0;
+  ACE_Module_Type *prev = nullptr;
   void *obj = this->object ();
   MT_Stream *str = (MT_Stream *) obj;
   int result = 0;
 
-  for (ACE_Module_Type *m = this->head_; m != 0; )
+  for (ACE_Module_Type *m = this->head_; m != nullptr; )
     {
       // We need to do this first so we don't bomb out if we delete m!
       ACE_Module_Type *link = m->link ();
 
       if (m == mod)
         {
-          if (prev == 0)
+          if (prev == nullptr)
             this->head_ = link;
           else
             prev->link (link);
@@ -450,12 +450,12 @@ ACE_Stream_Type::find (const ACE_TCHAR *module_name) const
   ACE_TRACE ("ACE_Stream_Type::find");
 
   for (ACE_Module_Type *m = this->head_;
-       m != 0;
+       m != nullptr;
        m = m->link ())
     if (ACE_OS::strcmp (m->name (), module_name) == 0)
       return m;
 
-  return 0;
+  return nullptr;
 }
 
 // @@@ Eliminated ommented out explicit template instantiation code

--- a/ACE/ace/Shared_Memory_MM.cpp
+++ b/ACE/ace/Shared_Memory_MM.cpp
@@ -80,9 +80,9 @@ void *
 ACE_Shared_Memory_MM::malloc (size_t)
 {
   ACE_TRACE ("ACE_Shared_Memory_MM::malloc");
-  void *addr = 0;
+  void *addr = nullptr;
 
-  return this->shared_memory_ (addr) == -1 ? 0 : addr;
+  return this->shared_memory_ (addr) == -1 ? nullptr : addr;
 }
 
 ACE_HANDLE
@@ -96,7 +96,7 @@ int
 ACE_Shared_Memory_MM::free (void *p)
 {
   ACE_TRACE ("ACE_Shared_Memory_MM::free");
-  return p != 0;
+  return p != nullptr;
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Shared_Memory_Pool.cpp
+++ b/ACE/ace/Shared_Memory_Pool.cpp
@@ -165,7 +165,7 @@ ACE_Shared_Memory_Pool::handle_signal (int, siginfo_t *siginfo, ucontext_t *)
   // it does not define SEGV_MAPERR.
 #if defined (ACE_HAS_SIGINFO_T) && !defined (ACE_LACKS_SI_ADDR) && \
         (defined (SEGV_MAPERR) || defined (SEGV_MEMERR))
-  if (siginfo == 0)
+  if (siginfo == nullptr)
     return -1;
 
   // Make sure that the pointer causing the problem is within the
@@ -428,7 +428,7 @@ ACE_Shared_Memory_Pool::release (int destroy)
           // OS to release it
           if (destroy == 1 && used == 1)
             {
-              if (ACE_OS::shmctl (shmid, IPC_RMID, 0) == -1)
+              if (ACE_OS::shmctl (shmid, IPC_RMID, nullptr) == -1)
                 {
                   result = -1;
                 }

--- a/ACE/ace/Shared_Memory_SV.cpp
+++ b/ACE/ace/Shared_Memory_SV.cpp
@@ -75,7 +75,7 @@ int
 ACE_Shared_Memory_SV::free (void *p)
 {
   ACE_TRACE ("ACE_Shared_Memory_SV::free");
-  return p != 0;
+  return p != nullptr;
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Sig_Handler.cpp
+++ b/ACE/ace/Sig_Handler.cpp
@@ -91,12 +91,12 @@ ACE_Sig_Handler::handler (int signum)
   ACE_MT (ACE_Recursive_Thread_Mutex *lock =
     ACE_Managed_Object<ACE_Recursive_Thread_Mutex>::get_preallocated_object
       (ACE_Object_Manager::ACE_SIG_HANDLER_LOCK);
-    ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, m, *lock, 0));
+    ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, m, *lock, nullptr));
 
   if (ACE_Sig_Handler::in_range (signum))
     return ACE_Sig_Handler::signal_handlers_[signum];
   else
-    return 0;
+    return nullptr;
 }
 
 ACE_Event_Handler *
@@ -113,7 +113,7 @@ ACE_Sig_Handler::handler_i (int signum,
       return sh;
     }
   else
-    return 0;
+    return nullptr;
 }
 
 ACE_Event_Handler *
@@ -124,7 +124,7 @@ ACE_Sig_Handler::handler (int signum,
   ACE_MT (ACE_Recursive_Thread_Mutex *lock =
     ACE_Managed_Object<ACE_Recursive_Thread_Mutex>::get_preallocated_object
       (ACE_Object_Manager::ACE_SIG_HANDLER_LOCK);
-    ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, m, *lock, 0));
+    ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, m, *lock, nullptr));
 
   return ACE_Sig_Handler::handler_i (signum, new_sh);
 }
@@ -148,12 +148,12 @@ ACE_Sig_Handler::register_handler_i (int signum,
 
       // Return a pointer to the old ACE_Event_Handler if the user
       // asks for this.
-      if (old_sh != 0)
+      if (old_sh != nullptr)
         *old_sh = sh;
 
       // Make sure that @a new_disp points to a valid location if the
       // user doesn't care...
-      if (new_disp == 0)
+      if (new_disp == nullptr)
         new_disp = &sa;
 
       new_disp->handler (ace_signal_handler_dispatcher);
@@ -195,13 +195,13 @@ ACE_Sig_Handler::remove_handler_i (int signum,
 {
   ACE_TRACE ("ACE_Sig_Handler::remove_handler_i");
 
-  ACE_Sig_Action sa (SIG_DFL, (sigset_t *) 0); // Reset to default disposition.
+  ACE_Sig_Action sa (SIG_DFL, (sigset_t *) nullptr); // Reset to default disposition.
 
-  if (new_disp == 0)
+  if (new_disp == nullptr)
     new_disp = &sa;
 
   ACE_Event_Handler *eh = ACE_Sig_Handler::signal_handlers_[signum];
-  ACE_Sig_Handler::signal_handlers_[signum] = 0;
+  ACE_Sig_Handler::signal_handlers_[signum] = nullptr;
 
   // Allow the event handler to close down if necessary.
   if (eh)
@@ -252,7 +252,7 @@ ACE_Sig_Handler::dispatch (int signum, siginfo_t *siginfo, ucontext_t *ucontext)
 
   ACE_Event_Handler *eh = ACE_Sig_Handler::signal_handlers_[signum];
 
-  if (eh != 0)
+  if (eh != nullptr)
     {
       if (eh->handle_signal (signum, siginfo, ucontext) == -1)
         ACE_Sig_Handler::remove_handler_i (signum);
@@ -306,10 +306,10 @@ ACE_Sig_Handlers_Set::instance (int signum)
 {
   if (signum <= 0 || signum >= ACE_NSIG)
     return nullptr; // This will cause problems...
-  else if (ACE_Sig_Handlers_Set::sig_handlers_[signum] == 0)
+  else if (ACE_Sig_Handlers_Set::sig_handlers_[signum] == nullptr)
     ACE_NEW_RETURN (ACE_Sig_Handlers_Set::sig_handlers_[signum],
                     ACE_SIG_HANDLERS_SET,
-                    0);
+                    nullptr);
   return ACE_Sig_Handlers_Set::sig_handlers_[signum];
 }
 
@@ -417,7 +417,7 @@ ACE_Sig_Handlers::register_handler (int signum,
         {
           // Make sure that new_disp points to a valid location if the
           // user doesn't care...
-          if (new_disp == 0)
+          if (new_disp == nullptr)
             new_disp = &sa;
 
           new_disp->handler (ace_signal_handlers_dispatcher);
@@ -496,9 +496,9 @@ ACE_Sig_Handlers::remove_handler (int signum,
           // If there are no more handlers left for a signal then
           // register the new disposition or restore the default
           // disposition.
-          ACE_Sig_Action sa (SIG_DFL, (sigset_t *) 0);
+          ACE_Sig_Action sa (SIG_DFL, (sigset_t *) nullptr);
 
-          if (new_disp == 0)
+          if (new_disp == nullptr)
             new_disp = &sa;
 
           return new_disp->register_action (signum, old_disp);
@@ -537,7 +537,7 @@ ACE_Sig_Handlers::dispatch (int signum, siginfo_t *siginfo, ucontext_t *ucontext
 
   ACE_SIG_HANDLERS_ITERATOR handler_iterator (*handler_set);
 
-  for (ACE_Event_Handler **eh = 0;
+  for (ACE_Event_Handler **eh = nullptr;
        handler_iterator.next (eh) != 0;
        )
     if ((*eh)->handle_signal (signum, siginfo, ucontext) == -1)
@@ -557,7 +557,7 @@ ACE_Sig_Handlers::handler (int signum)
   ACE_SIG_HANDLERS_SET *handler_set =
     ACE_Sig_Handlers_Set::instance (signum);
   ACE_SIG_HANDLERS_ITERATOR handler_iterator (*handler_set);
-  ACE_Event_Handler **eh = 0;
+  ACE_Event_Handler **eh = nullptr;
   handler_iterator.next (eh);
   return *eh;
 }

--- a/ACE/ace/Sig_Handler.cpp
+++ b/ACE/ace/Sig_Handler.cpp
@@ -305,7 +305,7 @@ ACE_SIG_HANDLERS_SET *
 ACE_Sig_Handlers_Set::instance (int signum)
 {
   if (signum <= 0 || signum >= ACE_NSIG)
-    return 0; // This will cause problems...
+    return nullptr; // This will cause problems...
   else if (ACE_Sig_Handlers_Set::sig_handlers_[signum] == 0)
     ACE_NEW_RETURN (ACE_Sig_Handlers_Set::sig_handlers_[signum],
                     ACE_SIG_HANDLERS_SET,

--- a/ACE/ace/Signal.cpp
+++ b/ACE/ace/Signal.cpp
@@ -48,7 +48,7 @@ ACE_Sig_Guard::~ACE_Sig_Guard ()
 #else
   ACE_OS::thr_sigsetmask (SIG_SETMASK,
                           (sigset_t *) this->omask_,
-                          0);
+                          nullptr);
 #endif /* ACE_LACKS_PTHREAD_THR_SIGSETMASK */
 #endif /* !ACE_LACKS_UNIX_SIGNALS */
 }
@@ -82,7 +82,7 @@ ACE_Sig_Action::ACE_Sig_Action ()
 #if !defined (ACE_WIN32)
   ACE_OS::sigemptyset (&this->sa_.sa_mask);
 #endif /* ACE_WIN32 */
-  this->sa_.sa_handler = 0;
+  this->sa_.sa_handler = nullptr;
 }
 
 ACE_Sig_Action::ACE_Sig_Action (ACE_SignalHandler sig_handler,
@@ -126,7 +126,7 @@ ACE_Sig_Action::ACE_Sig_Action (ACE_SignalHandler sig_handler,
     this->sa_.sa_mask = *sig_mask; // Structure assignment...
 
   this->sa_.sa_handler = ACE_SignalHandlerV (sig_handler);
-  ACE_OS::sigaction (signum, &this->sa_, 0);
+  ACE_OS::sigaction (signum, &this->sa_, nullptr);
 }
 
 ACE_Sig_Action::ACE_Sig_Action (ACE_SignalHandler sig_handler,
@@ -140,7 +140,7 @@ ACE_Sig_Action::ACE_Sig_Action (ACE_SignalHandler sig_handler,
   // Structure assignment...
   this->sa_.sa_mask = sig_mask.sigset ();
   this->sa_.sa_handler = ACE_SignalHandlerV (sig_handler);
-  ACE_OS::sigaction (signum, &this->sa_, 0);
+  ACE_OS::sigaction (signum, &this->sa_, nullptr);
 }
 
 ACE_Sig_Action::ACE_Sig_Action (const ACE_Sig_Set &signals,
@@ -158,7 +158,7 @@ ACE_Sig_Action::ACE_Sig_Action (const ACE_Sig_Set &signals,
 #if (ACE_NSIG > 0)
   for (int s = 1; s < ACE_NSIG; s++)
     if ((signals.is_member (s)) == 1)
-      ACE_OS::sigaction (s, &this->sa_, 0);
+      ACE_OS::sigaction (s, &this->sa_, nullptr);
 #else  /* ACE_NSIG <= 0  */
   ACE_UNUSED_ARG (signals);
 #endif /* ACE_NSIG <= 0  */
@@ -172,7 +172,7 @@ ACE_Sig_Action::ACE_Sig_Action (const ACE_Sig_Set &signals,
   // ACE_TRACE ("ACE_Sig_Action::ACE_Sig_Action");
   this->sa_.sa_flags = sig_flags;
 
-  if (sig_mask == 0)
+  if (sig_mask == nullptr)
     ACE_OS::sigemptyset (&this->sa_.sa_mask);
   else
     this->sa_.sa_mask = *sig_mask; // Structure assignment...
@@ -182,7 +182,7 @@ ACE_Sig_Action::ACE_Sig_Action (const ACE_Sig_Set &signals,
 #if (ACE_NSIG > 0)
   for (int s = 1; s < ACE_NSIG; s++)
     if ((signals.is_member (s)) == 1)
-      ACE_OS::sigaction (s, &this->sa_, 0);
+      ACE_OS::sigaction (s, &this->sa_, nullptr);
 #else  /* ACE_NSIG <= 0  */
   ACE_UNUSED_ARG (signals);
 #endif /* ACE_NSIG <= 0  */

--- a/ACE/ace/Sock_Connect.cpp
+++ b/ACE/ace/Sock_Connect.cpp
@@ -177,7 +177,7 @@ ACE::get_bcast_addr (ACE_UINT32 &bcast_addr,
     {
       hostent *hp = ACE_OS::gethostbyname (ACE_TEXT_ALWAYS_CHAR (host_name));
 
-      if (hp == 0)
+      if (hp == nullptr)
         return -1;
       else
         ACE_OS::memcpy ((char *) &ip_addr.sin_addr.s_addr,
@@ -319,7 +319,7 @@ ACE::get_fqdn (ACE_INET_Addr const & addr,
   if (ACE_OS::getnameinfo ((const sockaddr *) addr.get_addr (),
                            addr_size, hostname,
                            static_cast<ACE_SOCKET_LEN> (len),
-                           0, 0, NI_NAMEREQD) != 0)
+                           nullptr, 0, NI_NAMEREQD) != 0)
     return -1;
 
   if (ACE::debug ())
@@ -562,15 +562,15 @@ get_ip_interfaces_getifaddrs (size_t &count,
 {
   // Take advantage of the BSD getifaddrs function that simplifies
   // access to connected interfaces.
-  struct ifaddrs *ifap = 0;
-  struct ifaddrs *p_if = 0;
+  struct ifaddrs *ifap = nullptr;
+  struct ifaddrs *p_if = nullptr;
 
   if (::getifaddrs (&ifap) != 0)
     return -1;
 
   // Count number of interfaces.
   size_t num_ifs = 0;
-  for (p_if = ifap; p_if != 0; p_if = p_if->ifa_next)
+  for (p_if = ifap; p_if != nullptr; p_if = p_if->ifa_next)
     ++num_ifs;
 
   // Now create and initialize output array.
@@ -585,10 +585,10 @@ get_ip_interfaces_getifaddrs (size_t &count,
   count = 0;
 
   for (p_if = ifap;
-       p_if != 0;
+       p_if != nullptr;
        p_if = p_if->ifa_next)
     {
-      if (p_if->ifa_addr == 0)
+      if (p_if->ifa_addr == nullptr)
         continue;
 
       // Check to see if it's up.
@@ -644,7 +644,7 @@ ACE::get_ip_interfaces (size_t &count, ACE_INET_Addr *&addrs)
   ACE_TRACE ("ACE::get_ip_interfaces");
 
   count = 0;
-  addrs = 0;
+  addrs = nullptr;
 
 #if defined (ACE_WIN32)
   return get_ip_interfaces_win32 (count, addrs);

--- a/ACE/ace/Strategies_T.cpp
+++ b/ACE/ace/Strategies_T.cpp
@@ -129,13 +129,13 @@ ACE_DLL_Strategy<SVC_HANDLER>::make_svc_handler (SVC_HANDLER *&sh)
       // Create an ACE_Service_Type containing the SVC_Handler and
       // insert into this->svc_rep_;
 
-      ACE_Service_Type_Impl *stp = 0;
+      ACE_Service_Type_Impl *stp = nullptr;
       ACE_NEW_RETURN (stp,
                       ACE_Service_Object_Type (svc_handler,
                                                this->svc_name_),
                       -1);
 
-      ACE_Service_Type *srp = 0;
+      ACE_Service_Type *srp = nullptr;
 
       ACE_NEW_RETURN (srp,
                       ACE_Service_Type (this->svc_name_,
@@ -143,7 +143,7 @@ ACE_DLL_Strategy<SVC_HANDLER>::make_svc_handler (SVC_HANDLER *&sh)
                                         handle,
                                         1),
                       -1);
-      if (srp == 0)
+      if (srp == nullptr)
         {
           delete stp;
           errno = ENOMEM;
@@ -1146,7 +1146,7 @@ ACE_Cached_Connect_Strategy<SVC_HANDLER, ACE_PEER_CONNECTOR_2, MUTEX>::cleanup_h
   // Reset the <*act_holder> in the confines and protection of the
   // lock.
   if (act_holder)
-    *act_holder = 0;
+    *act_holder = nullptr;
 
   // The wonders and perils of ACT
   CONNECTION_MAP_ENTRY *entry = (CONNECTION_MAP_ENTRY *) recycling_act;

--- a/ACE/ace/Strategies_T.h
+++ b/ACE/ace/Strategies_T.h
@@ -87,12 +87,12 @@ public:
   typedef typename SVC_HANDLER::stream_type  stream_type;
 
   /// Default constructor.
-  ACE_Creation_Strategy (ACE_Thread_Manager * = 0,
+  ACE_Creation_Strategy (ACE_Thread_Manager * = nullptr,
                          ACE_Reactor * = ACE_Reactor::instance ());
 
   /// An ACE_Thread_Manager is useful when creating active objects and
   /// the ACE_Reactor is used to initialize the service handler's reactor.
-  int open (ACE_Thread_Manager * = 0,
+  int open (ACE_Thread_Manager * = nullptr,
             ACE_Reactor * = ACE_Reactor::instance ());
 
   virtual ~ACE_Creation_Strategy ();
@@ -139,9 +139,9 @@ public:
   typedef ACE_Creation_Strategy<SVC_HANDLER> base_type;
 
   ACE_Singleton_Strategy (SVC_HANDLER * = 0,
-                          ACE_Thread_Manager * = 0);
+                          ACE_Thread_Manager * = nullptr);
   int open (SVC_HANDLER *,
-            ACE_Thread_Manager * = 0);
+            ACE_Thread_Manager * = nullptr);
   virtual ~ACE_Singleton_Strategy ();
 
   // = Factory method.
@@ -187,7 +187,7 @@ public:
                     const ACE_TCHAR factory_function[],
                     const ACE_TCHAR svc_name[],
                     ACE_Service_Repository *,
-                    ACE_Thread_Manager * = 0);
+                    ACE_Thread_Manager * = nullptr);
 
   /// Initialize the DLL strategy based upon the service's DLL
   /// information contained in the <svc_dll_info> string.
@@ -195,7 +195,7 @@ public:
             const ACE_TCHAR factory_function[],
             const ACE_TCHAR svc_name[],
             ACE_Service_Repository *,
-            ACE_Thread_Manager * = 0);
+            ACE_Thread_Manager * = nullptr);
 
   // = Factory method.
   /// Create a SVC_HANDLER by dynamically linking it from a DLL.
@@ -258,7 +258,7 @@ public:
    * SVC_HANDLER to define its own concurrency strategy).
    */
   virtual int activate_svc_handler (SVC_HANDLER *svc_handler,
-                                    void *arg = 0);
+                                    void *arg = nullptr);
 
   virtual ~ACE_Concurrency_Strategy ();
 
@@ -312,7 +312,7 @@ public:
   /// Activate the @a svc_handler by registering it with the <Reactor>
   /// and then calling it's <open> hook.
   virtual int activate_svc_handler (SVC_HANDLER *svc_handler,
-                                    void *arg = 0);
+                                    void *arg = nullptr);
 
   /// Dump the state of an object.
   void dump () const;
@@ -376,7 +376,7 @@ public:
    * it into an active object.
    */
   virtual int activate_svc_handler (SVC_HANDLER *svc_handler,
-                                    void *arg = 0);
+                                    void *arg = nullptr);
 
   /// Dump the state of an object.
   void dump () const;
@@ -421,15 +421,15 @@ public:
   /// Initialize the strategy.  If @a avoid_zombies is non-0 then set a
   /// flag to ACE::fork() to avoid zombies.
   ACE_Process_Strategy (size_t n_processes = 1,
-                        ACE_Event_Handler *acceptor = 0,
-                        ACE_Reactor * = 0,
+                        ACE_Event_Handler *acceptor = nullptr,
+                        ACE_Reactor * = nullptr,
                         int avoid_zombies = 0);
 
   /// Initialize the strategy.  If @a avoid_zombies is non-0 then set a
   /// flag to ACE::fork() to avoid zombies.
   virtual int open (size_t n_processes = 1,
-                    ACE_Event_Handler *acceptor = 0,
-                    ACE_Reactor * = 0,
+                    ACE_Event_Handler *acceptor = nullptr,
+                    ACE_Reactor * = nullptr,
                     int avoid_zombies = 0);
 
   virtual ~ACE_Process_Strategy ();
@@ -442,7 +442,7 @@ public:
    * child.
    */
   virtual int activate_svc_handler (SVC_HANDLER *svc_handler,
-                                    void *arg = 0);
+                                    void *arg = nullptr);
 
   /// Dump the state of an object.
   void dump () const;
@@ -752,7 +752,7 @@ public:
   // = Factory method.
   /// This is a no-op.
   virtual int activate_svc_handler (SVC_HANDLER *svc_handler,
-                                    void *arg = 0);
+                                    void *arg = nullptr);
 };
 
 template <class T>
@@ -910,7 +910,7 @@ public:
 
   /// Cleanup hint and reset <*act_holder> to zero if <act_holder != 0>.
   virtual int cleanup_hint (const void *recycling_act,
-                            void **act_holder = 0);
+                            void **act_holder = nullptr);
 
   // = Traits for managing the map
   typedef ACE_Refcounted_Hash_Recyclable<ACE_PEER_CONNECTOR_ADDR>

--- a/ACE/ace/Stream.cpp
+++ b/ACE/ace/Stream.cpp
@@ -443,19 +443,19 @@ ACE_Stream<ACE_SYNCH_USE, TIME_POLICY>::control (ACE_IO_Cntl_Msg::ACE_IO_Cntl_Cm
   ACE_TRACE ("ACE_Stream<ACE_SYNCH_USE, TIME_POLICY>::control");
   ACE_IO_Cntl_Msg ioc (cmd);
 
-  ACE_Message_Block *db = 0;
+  ACE_Message_Block *db = nullptr;
 
   // Try to create a data block that contains the user-supplied data.
   ACE_NEW_RETURN (db,
                   ACE_Message_Block (sizeof (int),
                                      ACE_Message_Block::MB_IOCTL,
-                                     0,
+                                     nullptr,
                                      (char *) a),
                   -1);
   // Try to create a control block <cb> that contains the control
   // field and a pointer to the data block <db> in <cb>'s continuation
   // field.
-  ACE_Message_Block *cb = 0;
+  ACE_Message_Block *cb = nullptr;
 
   ACE_NEW_NORETURN (cb,
                     ACE_Message_Block (sizeof ioc,
@@ -468,7 +468,7 @@ ACE_Stream<ACE_SYNCH_USE, TIME_POLICY>::control (ACE_IO_Cntl_Msg::ACE_IO_Cntl_Cm
 
   // If we can't allocate <cb> then we need to delete db and return
   // -1.
-  if (cb == 0)
+  if (cb == nullptr)
     {
       db->release ();
       errno = ENOMEM;

--- a/ACE/ace/Stream.h
+++ b/ACE/ace/Stream.h
@@ -66,9 +66,9 @@ public:
    * ACE_Stream_Head and ACE_Stream_Tail are used, respectively.
    * @a arg is the value past in to the <open> methods of the tasks.
    */
-  ACE_Stream (void *arg = 0,
-              ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *head = 0,
-              ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *tail = 0);
+  ACE_Stream (void *arg = nullptr,
+              ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *head = nullptr,
+              ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *tail = nullptr);
 
   /**
    * Create a Stream consisting of @a head and @a tail as the Stream
@@ -77,8 +77,8 @@ public:
    * @a arg is the value past in to the @c open() methods of the tasks.
    */
   virtual int open (void *arg,
-                    ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *head = 0,
-                    ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *tail = 0);
+                    ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *head = nullptr,
+                    ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *tail = nullptr);
 
   /// Close down the stream and release all the resources.
   virtual int close (int flags = M_DELETE);
@@ -139,7 +139,7 @@ public:
    * @a timeout == 0).
    */
   virtual int put (ACE_Message_Block *mb,
-                   ACE_Time_Value *timeout = 0);
+                   ACE_Time_Value *timeout = nullptr);
 
   /**
    * Read the message @a mb that is stored in the stream head.
@@ -147,7 +147,7 @@ public:
    * to complete (or block forever if @a timeout == 0).
    */
   virtual int get (ACE_Message_Block *&mb,
-                   ACE_Time_Value *timeout = 0);
+                   ACE_Time_Value *timeout = nullptr);
 
   /// Send control message down the stream.
   virtual int control (ACE_IO_Cntl_Msg::ACE_IO_Cntl_Cmds cmd,
@@ -198,8 +198,8 @@ private:
 
   /// Must a new module onto the Stream.
   int push_module (ACE_Module<ACE_SYNCH_USE, TIME_POLICY> *,
-                   ACE_Module<ACE_SYNCH_USE, TIME_POLICY> * = 0,
-                   ACE_Module<ACE_SYNCH_USE, TIME_POLICY> * = 0);
+                   ACE_Module<ACE_SYNCH_USE, TIME_POLICY> * = nullptr,
+                   ACE_Module<ACE_SYNCH_USE, TIME_POLICY> * = nullptr);
 };
 
 /**

--- a/ACE/ace/Stream_Modules.cpp
+++ b/ACE/ace/Stream_Modules.cpp
@@ -137,7 +137,7 @@ ACE_Stream_Head<ACE_SYNCH_USE, TIME_POLICY>::info (ACE_TCHAR **strp, size_t leng
   ACE_TRACE ("ACE_Stream_Head<ACE_SYNCH_USE, TIME_POLICY>::info");
   const ACE_TCHAR *name = this->name ();
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (name)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (name)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, name, length);
@@ -281,7 +281,7 @@ ACE_Stream_Tail<ACE_SYNCH_USE, TIME_POLICY>::info (ACE_TCHAR **strp, size_t leng
   ACE_TRACE ("ACE_Stream_Tail<ACE_SYNCH_USE, TIME_POLICY>::info");
   const ACE_TCHAR *name = this->name ();
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (name)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (name)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, name, length);
@@ -360,7 +360,7 @@ ACE_Thru_Task<ACE_SYNCH_USE, TIME_POLICY>::info (ACE_TCHAR **strp,
   ACE_TRACE ("ACE_Thru_Task<ACE_SYNCH_USE, TIME_POLICY>::info");
   const ACE_TCHAR *name = this->name ();
 
-  if (*strp == 0 && (*strp = ACE_OS::strdup (name)) == 0)
+  if (*strp == nullptr && (*strp = ACE_OS::strdup (name)) == nullptr)
     return -1;
   else
     ACE_OS::strsncpy (*strp, name, length);

--- a/ACE/ace/Stream_Modules.h
+++ b/ACE/ace/Stream_Modules.h
@@ -94,9 +94,9 @@ public:
   virtual ~ACE_Stream_Tail ();
 
   // = ACE_Task hooks
-  virtual int open (void *a = 0);
+  virtual int open (void *a = nullptr);
   virtual int close (u_long flags = 0);
-  virtual int put (ACE_Message_Block *msg, ACE_Time_Value * = 0);
+  virtual int put (ACE_Message_Block *msg, ACE_Time_Value * = nullptr);
   virtual int svc ();
 
   // = Dynamic linking hooks
@@ -133,9 +133,9 @@ public:
   virtual ~ACE_Thru_Task ();
 
   // = ACE_Task hooks
-  virtual int open (void *a = 0);
+  virtual int open (void *a = nullptr);
   virtual int close (u_long flags = 0);
-  virtual int put (ACE_Message_Block *msg, ACE_Time_Value * = 0);
+  virtual int put (ACE_Message_Block *msg, ACE_Time_Value * = nullptr);
   virtual int svc ();
 
   // = Dynamic linking hooks

--- a/ACE/ace/String_Base.h
+++ b/ACE/ace/String_Base.h
@@ -84,7 +84,7 @@ public:
     *  @param the_allocator ACE_Allocator associated with string
     *  @return Default ACE_String_Base string.
     */
-  ACE_String_Base (ACE_Allocator *the_allocator = 0);
+  ACE_String_Base (ACE_Allocator *the_allocator = nullptr);
 
   /**
    * Constructor that copies @a s into dynamically allocated memory.
@@ -142,7 +142,7 @@ public:
    *  @param the_allocator ACE_Allocator associated with string
    *  @return ACE_String_Base containing ACE_CHAR_T 'c'
    */
-  ACE_String_Base (ACE_CHAR_T c, ACE_Allocator *the_allocator = 0);
+  ACE_String_Base (ACE_CHAR_T c, ACE_Allocator *the_allocator = nullptr);
 
   /**
    *  Constructor that allocates a len long string.

--- a/ACE/ace/Svc_Conf_Lexer.cpp
+++ b/ACE/ace/Svc_Conf_Lexer.cpp
@@ -135,7 +135,7 @@ ACE_Svc_Conf_Lexer::yylex (ACE_YYSTYPE* ace_yylval,
   ACE_Encoding_Converter_Factory::Encoding_Hint hint =
                 ACE_Encoding_Converter_Factory::ACE_NONE;
 #endif /* ACE_USES_WCHAR */
-  if (param->buffer == 0)
+  if (param->buffer == nullptr)
     {
 #if defined (ACE_USES_WCHAR)
       look_for_bom = true;
@@ -371,7 +371,7 @@ ACE_Svc_Conf_Lexer::scan (ACE_YYSTYPE* ace_yylval,
               {
                 buffer->state_ = ACE_COMMENT;
               }
-            else if (ACE_OS::strchr (separators, c) != 0)
+            else if (ACE_OS::strchr (separators, c) != nullptr)
               {
                 if (c == '\n')
                   {
@@ -518,7 +518,7 @@ ACE_Svc_Conf_Lexer::scan (ACE_YYSTYPE* ace_yylval,
                                                 ACE_TEXT ("/\\:%.~-");
                         for (const ACE_TCHAR* p = path_parts; *p != '\0'; p++)
                           {
-                            if (ACE_OS::strchr (ace_yylval->ident_, *p) != 0)
+                            if (ACE_OS::strchr (ace_yylval->ident_, *p) != nullptr)
                               {
                                 token = ACE_PATHNAME;
                                 break;

--- a/ACE/ace/Svc_Conf_Param.h
+++ b/ACE/ace/Svc_Conf_Param.h
@@ -66,7 +66,7 @@ public:
     : type (SVC_CONF_FILE),
       yyerrno (0),
       yylineno (1),
-      buffer (0),
+      buffer (nullptr),
       obstack (),
       config (gestalt)
   {
@@ -78,7 +78,7 @@ public:
     : type (SVC_CONF_DIRECTIVE),
       yyerrno (0),
       yylineno (1),
-      buffer (0),
+      buffer (nullptr),
       obstack (),
       config (gestalt)
   {

--- a/ACE/ace/Svc_Conf_y.cpp
+++ b/ACE/ace/Svc_Conf_y.cpp
@@ -1201,7 +1201,7 @@ ace_yyreduce:
     {
   case 2: /* svc_config_entries: svc_config_entries svc_config_entry  */
     {
-      if ((ace_yyvsp[0].parse_node_) != 0)
+      if ((ace_yyvsp[0].parse_node_) != nullptr)
       {
         (ace_yyvsp[0].parse_node_)->apply (ACE_SVC_CONF_PARAM->config, ACE_SVC_CONF_PARAM->yyerrno);
         delete (ace_yyvsp[0].parse_node_);
@@ -1218,10 +1218,10 @@ ace_yyreduce:
 
   case 11: /* dynamic: ACE_DYNAMIC svc_location parameters_opt  */
     {
-      if ((ace_yyvsp[-1].svc_record_) != 0)
+      if ((ace_yyvsp[-1].svc_record_) != nullptr)
         (ace_yyval.parse_node_) = new ACE_Dynamic_Node ((ace_yyvsp[-1].svc_record_), (ace_yyvsp[0].ident_));
       else
-        (ace_yyval.parse_node_) = 0;
+        (ace_yyval.parse_node_) = nullptr;
     }
     break;
 
@@ -1289,12 +1289,12 @@ ace_yyreduce:
     break;
 
   case 23: /* stream_modules: %empty  */
-                { (ace_yyval.parse_node_) = 0; }
+                { (ace_yyval.parse_node_) = nullptr; }
     break;
 
   case 24: /* module_list: module_list module  */
     {
-      if ((ace_yyvsp[0].parse_node_) != 0)
+      if ((ace_yyvsp[0].parse_node_) != nullptr)
         {
           (ace_yyvsp[0].parse_node_)->link ((ace_yyvsp[-1].parse_node_));
           (ace_yyval.parse_node_) = (ace_yyvsp[0].parse_node_);
@@ -1303,7 +1303,7 @@ ace_yyreduce:
     break;
 
   case 25: /* module_list: %empty  */
-                { (ace_yyval.parse_node_) = 0; }
+                { (ace_yyval.parse_node_) = nullptr; }
     break;
 
   case 26: /* module: dynamic  */
@@ -1332,7 +1332,7 @@ ace_yyreduce:
       ACE_Module_Type *mt = ace_get_module (sn->record (ACE_SVC_CONF_PARAM->config),
                                             sn->name (),
                                             ACE_SVC_CONF_PARAM->yyerrno);
-      if (mt != 0)
+      if (mt != nullptr)
         mt->suspend ();
     }
     break;
@@ -1343,7 +1343,7 @@ ace_yyreduce:
       ACE_Module_Type *mt = ace_get_module (sn->record (ACE_SVC_CONF_PARAM->config),
                                             (ace_yyvsp[0].static_node_)->name (),
                                             ACE_SVC_CONF_PARAM->yyerrno);
-      if (mt != 0)
+      if (mt != nullptr)
         mt->resume ();
     }
     break;
@@ -1358,7 +1358,7 @@ ace_yyreduce:
 
       ACE_Stream_Type *st =
         dynamic_cast<ACE_Stream_Type *> (const_cast<ACE_Service_Type_Impl *> (stream->record (ACE_SVC_CONF_PARAM->config)->type ()));
-      if (!st || (mt != 0 && st->remove (mt) == -1))
+      if (!st || (mt != nullptr && st->remove (mt) == -1))
         {
           ACELIB_ERROR ((LM_ERROR,
                          ACE_TEXT ("cannot remove Module_Type %s from STREAM_Type %s\n"),
@@ -1430,7 +1430,7 @@ ace_yyreduce:
     break;
 
   case 42: /* parameters_opt: %empty  */
-                { (ace_yyval.ident_) = 0; }
+                { (ace_yyval.ident_) = nullptr; }
     break;
 
 
@@ -1664,12 +1664,12 @@ ace_get_module (ACE_Service_Type const * sr,
                 int & ace_yyerrno)
 {
   ACE_Stream_Type const * const st =
-    (sr == 0
-     ? 0
+    (sr == nullptr
+     ? nullptr
      : dynamic_cast<ACE_Stream_Type const *> (sr->type ()));
-  ACE_Module_Type const * const mt = (st == 0 ? 0 : st->find (svc_name));
+  ACE_Module_Type const * const mt = (st == nullptr ? nullptr : st->find (svc_name));
 
-  if (sr == 0 || st == 0 || mt == 0)
+  if (sr == nullptr || st == nullptr || mt == nullptr)
     {
       ACELIB_ERROR ((LM_ERROR,
                      ACE_TEXT ("cannot locate Module_Type %s ")

--- a/ACE/ace/Svc_Handler.cpp
+++ b/ACE/ace/Svc_Handler.cpp
@@ -40,7 +40,7 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t n)
       // If this ACE_ASSERT fails, it may be due to running of out TSS
       // keys.  Try using ACE_HAS_TSS_EMULATION, or increasing
       // ACE_DEFAULT_THREAD_KEYS if already using TSS emulation.
-      ACE_ASSERT (dynamic_instance != 0);
+      ACE_ASSERT (dynamic_instance != nullptr);
 
       throw std::bad_alloc ();
     }
@@ -62,14 +62,14 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::operator new (size_t n,
 
   ACE_Dynamic *const dynamic_instance = ACE_Dynamic::instance ();
 
-  if (dynamic_instance == 0)
+  if (dynamic_instance == nullptr)
     {
       // If this ACE_ASSERT fails, it may be due to running of out TSS
       // keys.  Try using ACE_HAS_TSS_EMULATION, or increasing
       // ACE_DEFAULT_THREAD_KEYS if already using TSS emulation.
-      ACE_ASSERT (dynamic_instance != 0);
+      ACE_ASSERT (dynamic_instance != nullptr);
 
-      return 0;
+      return nullptr;
     }
   else
     {
@@ -122,8 +122,8 @@ ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::ACE_Svc_Handler (ACE_Thread_Manager 
                                                           ACE_Reactor *reactor)
   : ACE_Task<SYNCH_TRAITS> (tm, mq),
     closing_ (false),
-    recycler_ (0),
-    recycling_act_ (0)
+    recycler_ (nullptr),
+    recycling_act_ (nullptr)
 {
   ACE_TRACE ("ACE_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::ACE_Svc_Handler");
 
@@ -458,7 +458,7 @@ template <typename PEER_STREAM, typename SYNCH_TRAITS> int
 ACE_Buffered_Svc_Handler<PEER_STREAM, SYNCH_TRAITS>::flush_i ()
 {
   ACE_Message_Queue_Iterator<SYNCH_TRAITS> iterator (*this->msg_queue ());
-  ACE_Message_Block *mblk = 0;
+  ACE_Message_Block *mblk = nullptr;
   ssize_t result = 0;
 
   // Get the first <ACE_Message_Block> so that we can write everything

--- a/ACE/ace/Svc_Handler.h
+++ b/ACE/ace/Svc_Handler.h
@@ -78,8 +78,8 @@ public:
    * down to the ACE_Task base class.  The @a reactor is passed to
    * the ACE_Event_Handler.
    */
-  ACE_Svc_Handler (ACE_Thread_Manager *thr_mgr = 0,
-                   ACE_Message_Queue<SYNCH_TRAITS> *mq = 0,
+  ACE_Svc_Handler (ACE_Thread_Manager *thr_mgr = nullptr,
+                   ACE_Message_Queue<SYNCH_TRAITS> *mq = nullptr,
                    ACE_Reactor *reactor = ACE_Reactor::instance ());
 
   /// Destructor.
@@ -89,7 +89,7 @@ public:
   /// ACE_Acceptor or ACE_Connector, which passes "this" in as the
   /// parameter to open.  If this method returns -1 the Svc_Handler's
   /// close() method is automatically called.
-  virtual int open (void *acceptor_or_connector = 0);
+  virtual int open (void *acceptor_or_connector = nullptr);
 
   /**
    * Object termination hook -- application-specific cleanup code goes
@@ -123,7 +123,7 @@ public:
    * this method. In addition, reset @c *act_holder to zero if
    * @a act_holder != 0.
    */
-  virtual void cleanup_hint (void **act_holder = 0);
+  virtual void cleanup_hint (void **act_holder = nullptr);
 
   // = Dynamic linking hooks.
   /// Default version does no work and returns -1.  Must be overloaded
@@ -236,7 +236,7 @@ public:
    * recycling.  Return 0 if the object is ready for recycling, -1 on
    * failures.
    */
-  virtual int recycle (void * = 0);
+  virtual int recycle (void * = nullptr);
 
 protected:
   /// Maintain connection with client.
@@ -281,11 +281,11 @@ public:
    * @a relative_timeout value is interpreted to be in a unit that's
    * relative to the current time returned by <ACE_OS::gettimeofday>.
    */
-  ACE_Buffered_Svc_Handler (ACE_Thread_Manager *thr_mgr = 0,
-                            ACE_Message_Queue<SYNCH_TRAITS> *mq = 0,
+  ACE_Buffered_Svc_Handler (ACE_Thread_Manager *thr_mgr = nullptr,
+                            ACE_Message_Queue<SYNCH_TRAITS> *mq = nullptr,
                             ACE_Reactor *reactor = ACE_Reactor::instance (),
                             size_t max_buffer_size = 0,
-                            ACE_Time_Value *relative_timeout = 0);
+                            ACE_Time_Value *relative_timeout = nullptr);
 
   /// Destructor, which calls <flush>.
   virtual ~ACE_Buffered_Svc_Handler ();
@@ -298,7 +298,7 @@ public:
    * has elapsed.
    */
   virtual int put (ACE_Message_Block *message_block,
-                   ACE_Time_Value *timeout = 0);
+                   ACE_Time_Value *timeout = nullptr);
 
   /// Flush the ACE_Message_Queue, which writes all the queued
   /// ACE_Message_Blocks to the <PEER_STREAM>.

--- a/ACE/ace/Synch_Options.cpp
+++ b/ACE/ace/Synch_Options.cpp
@@ -91,7 +91,7 @@ const ACE_Time_Value *
 ACE_Synch_Options::time_value () const
 {
   ACE_TRACE ("ACE_Synch_Options::time_value");
-  return (*this)[USE_TIMEOUT] ? &this->timeout_ : 0;
+  return (*this)[USE_TIMEOUT] ? &this->timeout_ : nullptr;
 }
 
 const void *

--- a/ACE/ace/System_Time.cpp
+++ b/ACE/ace/System_Time.cpp
@@ -12,14 +12,14 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_System_Time::ACE_System_Time (const ACE_TCHAR *poolname)
-  : shmem_ (0)
-  , delta_time_ (0)
+  : shmem_ (nullptr)
+  , delta_time_ (nullptr)
 {
   ACE_TRACE ("ACE_System_Time::ACE_System_Time");
 
   // Only create a new unique filename for the memory pool file
   // if the user didn't supply one...
-  if (poolname == 0)
+  if (poolname == nullptr)
     {
 #if defined (ACE_DEFAULT_BACKING_STORE)
       // Create a temporary file.
@@ -62,7 +62,7 @@ int
 ACE_System_Time::get_local_system_time (time_t & time_out)
 {
   ACE_TRACE ("ACE_System_Time::get_local_system_time");
-  time_out = ACE_OS::time (0);
+  time_out = ACE_OS::time (nullptr);
   return 0;
 }
 
@@ -70,7 +70,7 @@ int
 ACE_System_Time::get_local_system_time (ACE_Time_Value &time_out)
 {
   ACE_TRACE ("ACE_System_Time::get_local_system_time");
-  time_out.set (ACE_OS::time (0), 0);
+  time_out.set (ACE_OS::time (nullptr), 0);
   return 0;
 }
 
@@ -81,10 +81,10 @@ ACE_System_Time::get_master_system_time (time_t &time_out)
 {
   ACE_TRACE ("ACE_System_Time::get_master_system_time");
 
-  if (this->delta_time_ == 0)
+  if (this->delta_time_ == nullptr)
     {
       // Try to find it
-      void * temp = 0;
+      void * temp = nullptr;
       if (this->shmem_->find (ACE_DEFAULT_TIME_SERVER_STR, temp) == -1)
         {
           // No time entry in shared memory (meaning no Clerk exists)

--- a/ACE/ace/TP_Reactor.cpp
+++ b/ACE/ace/TP_Reactor.cpp
@@ -31,7 +31,7 @@ ACE_TP_Token_Guard::acquire_read_token (ACE_Time_Value *max_wait_time)
       tv += *max_wait_time;
 
       ACE_MT (result = this->token_.acquire_read (&ACE_TP_Reactor::no_op_sleep_hook,
-                                                  0,
+                                                  nullptr,
                                                   &tv));
     }
   else
@@ -68,8 +68,8 @@ ACE_TP_Token_Guard::acquire_token (ACE_Time_Value *max_wait_time)
       ACE_Time_Value tv = ACE_OS::gettimeofday ();
       tv += *max_wait_time;
 
-      ACE_MT (result = this->token_.acquire (0,
-                                             0,
+      ACE_MT (result = this->token_.acquire (nullptr,
+                                             nullptr,
                                              &tv));
     }
   else
@@ -97,7 +97,7 @@ ACE_TP_Reactor::ACE_TP_Reactor (ACE_Sig_Handler *sh,
                                 ACE_Timer_Queue *tq,
                                 bool mask_signals,
                                 int s_queue)
-  : ACE_Select_Reactor (sh, tq, ACE_DISABLE_NOTIFY_PIPE_DEFAULT, 0, mask_signals, s_queue)
+  : ACE_Select_Reactor (sh, tq, ACE_DISABLE_NOTIFY_PIPE_DEFAULT, nullptr, mask_signals, s_queue)
 {
   ACE_TRACE ("ACE_TP_Reactor::ACE_TP_Reactor");
   this->supress_notify_renew (true);
@@ -109,7 +109,7 @@ ACE_TP_Reactor::ACE_TP_Reactor (size_t max_number_of_handles,
                                 ACE_Timer_Queue *tq,
                                 bool mask_signals,
                                 int s_queue)
-  : ACE_Select_Reactor (max_number_of_handles, restart, sh, tq, ACE_DISABLE_NOTIFY_PIPE_DEFAULT, 0, mask_signals, s_queue)
+  : ACE_Select_Reactor (max_number_of_handles, restart, sh, tq, ACE_DISABLE_NOTIFY_PIPE_DEFAULT, nullptr, mask_signals, s_queue)
 {
   ACE_TRACE ("ACE_TP_Reactor::ACE_TP_Reactor");
   this->supress_notify_renew (true);
@@ -376,7 +376,7 @@ ACE_TP_Reactor::handle_socket_events (int &event_count,
   if (!dispatch_info.dispatch ())
     {
       // Check for removed handlers.
-      if (dispatch_info.event_handler_ == 0)
+      if (dispatch_info.event_handler_ == nullptr)
         {
           this->handler_rep_.unbind(dispatch_info.handle_,
                                     dispatch_info.mask_);
@@ -529,7 +529,7 @@ ACE_TP_Reactor::dispatch_socket_event (ACE_EH_Dispatch_Info &dispatch_info)
   ACE_EH_PTMF const callback = dispatch_info.callback_;
 
   // Check for removed handlers.
-  if (event_handler == 0)
+  if (event_handler == nullptr)
     return -1;
 
   // Upcall. If the handler returns positive value (requesting a
@@ -626,7 +626,7 @@ ACE_TP_Reactor::notify_handle (ACE_HANDLE,
               ACE_TEXT ("ACE_TP_Reactor::notify_handle: ")
               ACE_TEXT ("Wrong version of notify_handle() got called\n")));
 
-  ACE_ASSERT (eh == 0);
+  ACE_ASSERT (eh == nullptr);
   ACE_UNUSED_ARG (eh);
 }
 

--- a/ACE/ace/TP_Reactor.h
+++ b/ACE/ace/TP_Reactor.h
@@ -103,7 +103,7 @@ public:
 
   /// A helper method that grabs the token for us, after which the
   /// thread that owns that can do some actual work.
-  int acquire_read_token (ACE_Time_Value *max_wait_time = 0);
+  int acquire_read_token (ACE_Time_Value *max_wait_time = nullptr);
 
   /**
    * A helper method that grabs the token for us, after which the
@@ -111,7 +111,7 @@ public:
    * acquire_read_token() as it uses acquire () to get the token instead of
    * acquire_read ()
    */
-  int acquire_token (ACE_Time_Value *max_wait_time = 0);
+  int acquire_token (ACE_Time_Value *max_wait_time = nullptr);
 
 private:
   ACE_TP_Token_Guard () = delete;

--- a/ACE/ace/TSS_Adapter.cpp
+++ b/ACE/ace/TSS_Adapter.cpp
@@ -31,7 +31,7 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 extern "C" ACE_Export void
 ACE_TSS_C_cleanup (void *object)
 {
-  if (object != 0)
+  if (object != nullptr)
     {
       ACE_TSS_Adapter * const tss_adapter = (ACE_TSS_Adapter *) object;
       // Perform cleanup on the real TS object.

--- a/ACE/ace/Task.cpp
+++ b/ACE/ace/Task.cpp
@@ -75,7 +75,7 @@ ACE_Task_Base::wait ()
 
   // If we don't have a thread manager, we probably were never
   // activated.
-  if (this->thr_mgr () != 0)
+  if (this->thr_mgr () != nullptr)
     return this->thr_mgr ()->wait_task (this);
   else
     return 0;
@@ -124,7 +124,7 @@ ACE_Task_Base::activate (long flags,
   ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, -1);
 
   // If the task passed in is zero, we will use <this>
-  if (task == 0)
+  if (task == nullptr)
     task = this;
 
   if (this->thr_count_ > 0 && force_active == 0)
@@ -145,7 +145,7 @@ ACE_Task_Base::activate (long flags,
   // Use the ACE_Thread_Manager singleton if we're running as an
   // active object and the caller didn't supply us with a
   // Thread_Manager.
-  if (this->thr_mgr_ == 0)
+  if (this->thr_mgr_ == nullptr)
 # if defined (ACE_THREAD_MANAGER_LACKS_STATICS)
     this->thr_mgr_ = ACE_THREAD_MANAGER_SINGLETON::instance ();
 # else /* ! ACE_THREAD_MANAGER_LACKS_STATICS */
@@ -153,7 +153,7 @@ ACE_Task_Base::activate (long flags,
 # endif /* ACE_THREAD_MANAGER_LACKS_STATICS */
 
   int grp_spawned = -1;
-  if (thread_ids == 0)
+  if (thread_ids == nullptr)
     // Thread Ids were not specified
     grp_spawned =
       this->thr_mgr_->spawn_n (n_threads,
@@ -261,7 +261,7 @@ ACE_Task_Base::svc_run (void *args)
 #if defined ACE_HAS_SIG_C_FUNC
   t->thr_mgr ()->at_exit (t, ACE_Task_Base_cleanup, 0);
 #else
-  t->thr_mgr ()->at_exit (t, ACE_Task_Base::cleanup, 0);
+  t->thr_mgr ()->at_exit (t, ACE_Task_Base::cleanup, nullptr);
 #endif /* ACE_HAS_SIG_C_FUNC */
 
   ACE_THR_FUNC_RETURN status;
@@ -281,11 +281,11 @@ ACE_Task_Base::svc_run (void *args)
   ACE_Thread_Manager *thr_mgr_ptr = t->thr_mgr ();
 
   // This calls the Task->close () hook.
-  t->cleanup (t, 0);
+  t->cleanup (t, nullptr);
 
   // This prevents a second invocation of the cleanup code
   // (called later by <ACE_Thread_Manager::exit>.
-  thr_mgr_ptr->at_exit (t, 0, 0);
+  thr_mgr_ptr->at_exit (t, nullptr, nullptr);
 #endif
   return status;
 }

--- a/ACE/ace/Task_Ex_T.cpp
+++ b/ACE/ace/Task_Ex_T.cpp
@@ -100,7 +100,7 @@ ACE_Task_Ex<ACE_SYNCH_USE, ACE_MESSAGE_TYPE, TIME_POLICY>::name () const
 {
   ACE_TRACE ("ACE_Task_Ex<ACE_SYNCH_USE, ACE_MESSAGE_TYPE, TIME_POLICY>::name");
   if (this->mod_ == 0)
-    return 0;
+    return nullptr;
   else
     return this->mod_->name ();
 }

--- a/ACE/ace/Task_Ex_T.h
+++ b/ACE/ace/Task_Ex_T.h
@@ -100,32 +100,32 @@ public: // Should be protected:
 
   /// Insert message into the message queue.  Note that @a timeout uses
   /// <{absolute}> time rather than <{relative}> time.
-  int putq (ACE_MESSAGE_TYPE *, ACE_Time_Value *timeout = 0);
+  int putq (ACE_MESSAGE_TYPE *, ACE_Time_Value *timeout = nullptr);
 
   /**
    * Extract the first message from the queue (blocking).  Note that
    * @a timeout uses <{absolute}> time rather than <{relative}> time.
    * Returns number of items in queue if the call succeeds or -1 otherwise.
    */
-  int getq (ACE_MESSAGE_TYPE *&mb, ACE_Time_Value *timeout = 0);
+  int getq (ACE_MESSAGE_TYPE *&mb, ACE_Time_Value *timeout = nullptr);
 
   /// Return a message to the queue.  Note that @a timeout uses
   /// <{absolute}> time rather than <{relative}> time.
-  int ungetq (ACE_MESSAGE_TYPE *, ACE_Time_Value *timeout = 0);
+  int ungetq (ACE_MESSAGE_TYPE *, ACE_Time_Value *timeout = nullptr);
 
   /**
    * Turn the message around and send it back down the Stream.  Note
    * that @a timeout uses <{absolute}> time rather than <{relative}>
    * time.
    */
-  int reply (ACE_MESSAGE_TYPE *, ACE_Time_Value *timeout = 0);
+  int reply (ACE_MESSAGE_TYPE *, ACE_Time_Value *timeout = nullptr);
 
   /**
    * Transfer message to the adjacent ACE_Task_Ex in a ACE_Stream.  Note
    * that @a timeout uses <{absolute}> time rather than <{relative}>
    * time.
    */
-  int put_next (ACE_MESSAGE_TYPE *msg, ACE_Time_Value *timeout = 0);
+  int put_next (ACE_MESSAGE_TYPE *msg, ACE_Time_Value *timeout = nullptr);
 
   // = ACE_Task utility routines to identify names et al.
   /// Return the name of the enclosing Module if there's one associated

--- a/ACE/ace/Task_T.cpp
+++ b/ACE/ace/Task_T.cpp
@@ -92,7 +92,7 @@ ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::name () const
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::name");
   if (this->mod_ == 0)
-    return 0;
+    return nullptr;
   else
     return this->mod_->name ();
 }

--- a/ACE/ace/Task_T.h
+++ b/ACE/ace/Task_T.h
@@ -50,8 +50,8 @@ public:
    * then we'll allocate one dynamically.  Otherwise, we'll use the
    * one passed as a parameter.
    */
-  ACE_Task (ACE_Thread_Manager *thr_mgr = 0,
-            ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> *mq = 0);
+  ACE_Task (ACE_Thread_Manager *thr_mgr = nullptr,
+            ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> *mq = nullptr);
 
   /// Destructor.
   virtual ~ACE_Task ();
@@ -84,18 +84,18 @@ public: // Should be protected:
 
   /// Insert message into the message queue.  Note that @a timeout uses
   /// <{absolute}> time rather than <{relative}> time.
-  int putq (ACE_Message_Block *, ACE_Time_Value *timeout = 0);
+  int putq (ACE_Message_Block *, ACE_Time_Value *timeout = nullptr);
 
   /**
    * Extract the first message from the queue (blocking).  Note that
    * @a timeout uses <{absolute}> time rather than <{relative}> time.
    * Returns number of items in queue if the call succeeds or -1 otherwise.
    */
-  int getq (ACE_Message_Block *&mb, ACE_Time_Value *timeout = 0);
+  int getq (ACE_Message_Block *&mb, ACE_Time_Value *timeout = nullptr);
 
   /// Return a message to the queue.  Note that @a timeout uses
   /// <{absolute}> time rather than <{relative}> time.
-  int ungetq (ACE_Message_Block *, ACE_Time_Value *timeout = 0);
+  int ungetq (ACE_Message_Block *, ACE_Time_Value *timeout = nullptr);
 
   /**
    * Turn the message around, sending it in the opposite direction in
@@ -108,14 +108,14 @@ public: // Should be protected:
    *           will time out. If 0, this call blocks until it can be
    *           completed.
    */
-  int reply (ACE_Message_Block *mb, ACE_Time_Value *tv = 0);
+  int reply (ACE_Message_Block *mb, ACE_Time_Value *tv = nullptr);
 
   /**
    * Transfer message to the adjacent ACE_Task in a ACE_Stream.  Note
    * that @a timeout uses <{absolute}> time rather than <{relative}>
    * time.
    */
-  int put_next (ACE_Message_Block *msg, ACE_Time_Value *timeout = 0);
+  int put_next (ACE_Message_Block *msg, ACE_Time_Value *timeout = nullptr);
 
   // = ACE_Task utility routines to identify names et al.
   /// Return the name of the enclosing Module if there's one associated

--- a/ACE/ace/Thread.cpp
+++ b/ACE/ace/Thread.cpp
@@ -30,12 +30,12 @@ ACE_Thread::spawn_n (size_t n,
                               arg,
                               flags,
                               &t_id,
-                              0,
+                              nullptr,
                               priority,
-                              stack == 0 ? 0 : stack[i],
-                              stack_size == 0 ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
+                              stack == nullptr ? nullptr : stack[i],
+                              stack_size == nullptr ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
                               thread_adapter,
-                              thr_name == 0 ? 0 : &thr_name[i]) != 0)
+                              thr_name == nullptr ? nullptr : &thr_name[i]) != 0)
         break;
    }
 
@@ -70,16 +70,16 @@ ACE_Thread::spawn_n (ACE_thread_t thread_ids[],
                             &t_id,
                             &t_handle,
                             priority,
-                            stack == 0 ? 0 : stack[i],
-                            stack_size == 0 ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
+                            stack == nullptr ? nullptr : stack[i],
+                            stack_size == nullptr ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
                             thread_adapter,
-                            thr_name == 0 ? 0 : &thr_name[i]);
+                            thr_name == nullptr ? nullptr : &thr_name[i]);
 
       if (result == 0)
         {
-          if (thread_ids != 0)
+          if (thread_ids != nullptr)
             thread_ids[i] = t_id;
-          if (thread_handles != 0)
+          if (thread_handles != nullptr)
             thread_handles[i] = t_handle;
         }
       else

--- a/ACE/ace/Thread_Adapter.cpp
+++ b/ACE/ace/Thread_Adapter.cpp
@@ -124,7 +124,7 @@ ACE_Thread_Adapter::invoke_i ()
         ACE_OS::thr_setcanceltype (val, &old);
     }
 
-  ACE_THR_FUNC_RETURN status = nullptr;
+  ACE_THR_FUNC_RETURN status = 0;
 
   ACE_SEH_TRY
     {

--- a/ACE/ace/Thread_Adapter.cpp
+++ b/ACE/ace/Thread_Adapter.cpp
@@ -66,13 +66,13 @@ ACE_Thread_Adapter::invoke ()
   // -jxh
 
   ACE_Thread_Exit *exit_hook_instance = ACE_Thread_Exit::instance ();
-  ACE_Thread_Exit_Maybe exit_hook_maybe (exit_hook_instance == 0);
+  ACE_Thread_Exit_Maybe exit_hook_maybe (exit_hook_instance == nullptr);
   ACE_Thread_Exit *exit_hook_ptr = exit_hook_instance
                                    ? exit_hook_instance
                                    : exit_hook_maybe.instance ();
   ACE_Thread_Exit &exit_hook = *exit_hook_ptr;
 
-  if (this->thr_mgr () != 0)
+  if (this->thr_mgr () != nullptr)
     {
       // Keep track of the <Thread_Manager> that's associated with this
       // <exit_hook>.
@@ -124,7 +124,7 @@ ACE_Thread_Adapter::invoke_i ()
         ACE_OS::thr_setcanceltype (val, &old);
     }
 
-  ACE_THR_FUNC_RETURN status = 0;
+  ACE_THR_FUNC_RETURN status = nullptr;
 
   ACE_SEH_TRY
     {

--- a/ACE/ace/Thread_Control.cpp
+++ b/ACE/ace/Thread_Control.cpp
@@ -34,11 +34,11 @@ ACE_Thread_Control::insert (ACE_Thread_Manager *tm, bool insert)
 ACE_Thread_Control::ACE_Thread_Control (ACE_Thread_Manager *t,
                                         int insert)
   : tm_ (t),
-    status_ (0)
+    status_ (nullptr)
 {
   ACE_OS_TRACE ("ACE_Thread_Control::ACE_Thread_Control");
 
-  if (this->tm_ != 0 && insert)
+  if (this->tm_ != nullptr && insert)
     {
       ACE_hthread_t t_id;
       ACE_OS::thr_self (t_id);
@@ -64,7 +64,7 @@ ACE_Thread_Control::exit (ACE_THR_FUNC_RETURN exit_status, int do_thr_exit)
 {
   ACE_OS_TRACE ("ACE_Thread_Control::exit");
 
-  if (this->tm_ != 0)
+  if (this->tm_ != nullptr)
     return this->tm_->exit (exit_status, do_thr_exit);
   else
     {
@@ -73,7 +73,7 @@ ACE_Thread_Control::exit (ACE_THR_FUNC_RETURN exit_status, int do_thr_exit)
       // exit the thread after cleaning up TSS.
       ACE_OS::thr_exit (exit_status);
 #endif /* ! ACE_HAS_TSS_EMULATION */
-      return 0;
+      return nullptr;
     }
 }
 

--- a/ACE/ace/Thread_Control.cpp
+++ b/ACE/ace/Thread_Control.cpp
@@ -34,7 +34,7 @@ ACE_Thread_Control::insert (ACE_Thread_Manager *tm, bool insert)
 ACE_Thread_Control::ACE_Thread_Control (ACE_Thread_Manager *t,
                                         int insert)
   : tm_ (t),
-    status_ (nullptr)
+    status_ (0)
 {
   ACE_OS_TRACE ("ACE_Thread_Control::ACE_Thread_Control");
 
@@ -73,7 +73,7 @@ ACE_Thread_Control::exit (ACE_THR_FUNC_RETURN exit_status, int do_thr_exit)
       // exit the thread after cleaning up TSS.
       ACE_OS::thr_exit (exit_status);
 #endif /* ! ACE_HAS_TSS_EMULATION */
-      return nullptr;
+      return 0;
     }
 }
 

--- a/ACE/ace/Thread_Exit.cpp
+++ b/ACE/ace/Thread_Exit.cpp
@@ -16,7 +16,7 @@ ACE_Thread_Exit::cleanup (void *instance)
 
   // Set the thr_exit_ static to null to keep things from crashing if
   // ACE::fini() is enabled here.
-  ACE_Thread_Manager::thr_exit_ = 0;
+  ACE_Thread_Manager::thr_exit_ = nullptr;
 
   ACE_Thread_Exit::is_constructed_ = false;
   // All TSS objects have been destroyed.  Reset this flag so
@@ -43,13 +43,13 @@ ACE_Thread_Exit::instance ()
       ACE_MT (ACE_Thread_Mutex *lock =
               ACE_Managed_Object<ACE_Thread_Mutex>::get_preallocated_object
                 (ACE_Object_Manager::ACE_THREAD_EXIT_LOCK);
-              ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, *lock, 0));
+              ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, *lock, nullptr));
 
       if (!ACE_Thread_Exit::is_constructed_)
         {
           ACE_NEW_RETURN (instance_,
                           ACE_TSS_TYPE (ACE_Thread_Exit),
-                          0);
+                          nullptr);
 
           ACE_Thread_Exit::is_constructed_ = true;
 
@@ -78,7 +78,7 @@ ACE_Thread_Exit::thr_mgr (ACE_Thread_Manager *tm)
 {
   ACE_OS_TRACE ("ACE_Thread_Exit::thr_mgr");
 
-  if (tm != 0)
+  if (tm != nullptr)
     this->thread_control_.insert (tm, 0);
 }
 
@@ -93,7 +93,7 @@ ACE_Thread_Exit::~ACE_Thread_Exit ()
 ACE_ALLOC_HOOK_DEFINE(ACE_Thread_Exit)
 
 ACE_Thread_Exit_Maybe::ACE_Thread_Exit_Maybe (int flag)
-  : instance_ (0)
+  : instance_ (nullptr)
 {
   if (flag)
     {

--- a/ACE/ace/Thread_Manager.cpp
+++ b/ACE/ace/Thread_Manager.cpp
@@ -1675,7 +1675,7 @@ ACE_Thread_Manager::exit (ACE_THR_FUNC_RETURN status, bool do_thread_exit)
 
   // Just hold onto the guard while finding this thread's id and
   {
-    ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
+    ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
 
     // Find the thread id, but don't use the cache.  It might have been
     // deleted already.
@@ -1701,7 +1701,7 @@ ACE_Thread_Manager::exit (ACE_THR_FUNC_RETURN status, bool do_thread_exit)
       // storage this call can return (don't ask...).
     }
 
-  return nullptr;
+  return 0;
 }
 
 // Wait for all the threads to exit.

--- a/ACE/ace/Thread_Manager.cpp
+++ b/ACE/ace/Thread_Manager.cpp
@@ -38,19 +38,19 @@ ACE_ALLOC_HOOK_DEFINE(ACE_Thread_Manager)
 
 #if ! defined (ACE_THREAD_MANAGER_LACKS_STATICS)
 // Process-wide Thread Manager.
-ACE_Thread_Manager *ACE_Thread_Manager::thr_mgr_ = 0;
+ACE_Thread_Manager *ACE_Thread_Manager::thr_mgr_ = nullptr;
 
 // Controls whether the Thread_Manager is deleted when we shut down
 // (we can only delete it safely if we created it!)
 bool ACE_Thread_Manager::delete_thr_mgr_ = false;
 #endif /* ! defined (ACE_THREAD_MANAGER_LACKS_STATICS) */
 
-ACE_TSS_TYPE (ACE_Thread_Exit) *ACE_Thread_Manager::thr_exit_ = 0;
+ACE_TSS_TYPE (ACE_Thread_Exit) *ACE_Thread_Manager::thr_exit_ = nullptr;
 
 int
 ACE_Thread_Manager::set_thr_exit (ACE_TSS_TYPE (ACE_Thread_Exit) *ptr)
 {
-  if (ACE_Thread_Manager::thr_exit_ == 0)
+  if (ACE_Thread_Manager::thr_exit_ == nullptr)
     ACE_Thread_Manager::thr_exit_ = ptr;
   else
     return -1;
@@ -131,7 +131,7 @@ int
 ACE_Thread_Descriptor::at_exit (ACE_At_Thread_Exit* cleanup)
 {
   ACE_TRACE ("ACE_Thread_Descriptor::at_exit");
-  if (cleanup==0)
+  if (cleanup==nullptr)
    return -1;
   else
    {
@@ -144,7 +144,7 @@ void
 ACE_Thread_Descriptor::do_at_exit ()
 {
   ACE_TRACE ("ACE_Thread_Descriptor::do_at_exit");
-  while (at_exit_list_!=0)
+  while (at_exit_list_!=nullptr)
     this->at_pop ();
 }
 
@@ -160,7 +160,7 @@ ACE_Thread_Descriptor::terminate ()
      // Run at_exit hooks
      this->do_at_exit ();
      // We must remove Thread_Descriptor from Thread_Manager list
-     if (this->tm_ != 0)
+     if (this->tm_ != nullptr)
       {
          int close_handle = 0;
 
@@ -190,23 +190,23 @@ ACE_Thread_Descriptor::terminate ()
 
          // Remove thread descriptor from the table. 'this' is invalid
          // upon return.
-         if (this->tm_ != 0)
+         if (this->tm_ != nullptr)
            {
              // remove_thr makes use of 'this' invalid on return.
              // Code below will free log_msg, so clear our pointer
              // now - it's already been saved in log_msg.
-             this->log_msg_ = 0;
+             this->log_msg_ = nullptr;
              tm_->remove_thr (this, close_handle);
            }
       }
 
      // Check if we need delete ACE_Log_Msg instance
      // If ACE_TSS_cleanup was not executed first log_msg == 0
-     if (log_msg == 0)
+     if (log_msg == nullptr)
       {
         // Only inform to ACE_TSS_cleanup that it must delete the log instance
         // setting ACE_LOG_MSG thr_desc to 0.
-        ACE_LOG_MSG->thr_desc (0);
+        ACE_LOG_MSG->thr_desc (nullptr);
       }
      else
       {
@@ -223,14 +223,14 @@ ACE_Thread_Descriptor::at_exit (void *object,
   ACE_TRACE ("ACE_Thread_Descriptor::at_exit");
   // To keep compatibility, when cleanup_hook is null really is a at_pop
   // without apply.
-  if (cleanup_hook == 0)
+  if (cleanup_hook == nullptr)
    {
-     if (this->at_exit_list_!= 0)
+     if (this->at_exit_list_!= nullptr)
       this->at_pop(0);
    }
   else
    {
-     ACE_At_Thread_Exit* cleanup = 0;
+     ACE_At_Thread_Exit* cleanup = nullptr;
      ACE_NEW_RETURN (cleanup,
                      ACE_At_Thread_Exit_Func (object,
                                               cleanup_hook,
@@ -259,9 +259,9 @@ ACE_Thread_Descriptor::dump () const
 }
 
 ACE_Thread_Descriptor::ACE_Thread_Descriptor ()
-  : log_msg_ (0),
-    at_exit_list_ (0),
-    tm_ (0),
+  : log_msg_ (nullptr),
+    at_exit_list_ (nullptr),
+    tm_ (nullptr),
     terminated_ (false)
 {
   ACE_TRACE ("ACE_Thread_Descriptor::ACE_Thread_Descriptor");
@@ -323,7 +323,7 @@ ACE_Thread_Descriptor *
 ACE_Thread_Manager::thread_descriptor (ACE_thread_t thr_id)
 {
   ACE_TRACE ("ACE_Thread_Manager::thread_descriptor");
-  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
 
   ACE_FIND (this->find_thread (thr_id), ptr);
   return ptr;
@@ -333,7 +333,7 @@ ACE_Thread_Descriptor *
 ACE_Thread_Manager::hthread_descriptor (ACE_hthread_t thr_handle)
 {
   ACE_TRACE ("ACE_Thread_Manager::hthread_descriptor");
-  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
+  ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
 
   ACE_FIND (this->find_hthread (thr_handle), ptr);
   return ptr;
@@ -349,7 +349,7 @@ ACE_Thread_Manager::thr_self (ACE_hthread_t &self)
   ACE_Thread_Descriptor *desc =
     this->thread_desc_self ();
 
-  if (desc == 0)
+  if (desc == nullptr)
     return -1;
   else
     desc->self (self);
@@ -405,17 +405,17 @@ ACE_Thread_Manager::instance ()
 {
   ACE_TRACE ("ACE_Thread_Manager::instance");
 
-  if (ACE_Thread_Manager::thr_mgr_ == 0)
+  if (ACE_Thread_Manager::thr_mgr_ == nullptr)
     {
       // Perform Double-Checked Locking Optimization.
       ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                                *ACE_Static_Object_Lock::instance (), 0));
+                                *ACE_Static_Object_Lock::instance (), nullptr));
 
-      if (ACE_Thread_Manager::thr_mgr_ == 0)
+      if (ACE_Thread_Manager::thr_mgr_ == nullptr)
         {
           ACE_NEW_RETURN (ACE_Thread_Manager::thr_mgr_,
                           ACE_Thread_Manager,
-                          0);
+                          nullptr);
           ACE_Thread_Manager::delete_thr_mgr_ = true;
         }
     }
@@ -428,7 +428,7 @@ ACE_Thread_Manager::instance (ACE_Thread_Manager *tm)
 {
   ACE_TRACE ("ACE_Thread_Manager::instance");
   ACE_MT (ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex, ace_mon,
-                            *ACE_Static_Object_Lock::instance (), 0));
+                            *ACE_Static_Object_Lock::instance (), nullptr));
 
   ACE_Thread_Manager *t = ACE_Thread_Manager::thr_mgr_;
   // We can't safely delete it since we don't know who created it!
@@ -451,7 +451,7 @@ ACE_Thread_Manager::close_singleton ()
       // First, we clean up the thread descriptor list.
       ACE_Thread_Manager::thr_mgr_->close ();
       delete ACE_Thread_Manager::thr_mgr_;
-      ACE_Thread_Manager::thr_mgr_ = 0;
+      ACE_Thread_Manager::thr_mgr_ = nullptr;
       ACE_Thread_Manager::delete_thr_mgr_ = false;
     }
 
@@ -468,7 +468,7 @@ ACE_Thread_Manager::close ()
 
   // Clean up the thread descriptor list.
   if (this->automatic_wait_)
-    this->wait (0, 1);
+    this->wait (nullptr, 1);
   else
     {
       ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, -1));
@@ -593,7 +593,7 @@ ACE_Thread_Manager::spawn_i (ACE_THR_FUNC func,
   // Reset thread descriptor status
   new_thr_desc->reset (this);
 
-  ACE_Thread_Adapter *thread_args = 0;
+  ACE_Thread_Adapter *thread_args = nullptr;
 # if defined (ACE_HAS_WIN32_STRUCTURED_EXCEPTIONS)
   ACE_NEW_RETURN (thread_args,
                   ACE_Thread_Adapter (func,
@@ -621,7 +621,7 @@ ACE_Thread_Manager::spawn_i (ACE_THR_FUNC func,
   ACE_hthread_t thr_handle;
 
   ACE_thread_t thr_id;
-  if (t_id == 0)
+  if (t_id == nullptr)
     t_id = &thr_id;
 
   // Acquire the <sync_> lock to block the spawned thread from
@@ -666,7 +666,7 @@ ACE_Thread_Manager::spawn_i (ACE_THR_FUNC func,
                             DUPLICATE_SAME_ACCESS);
 # endif /* ! ACE_LACKS_DUP */
 #else  /* ! ACE_HAS_WTHREADS */
-  if (t_handle != 0)
+  if (t_handle != nullptr)
     *t_handle = thr_handle;
 #endif /* ! ACE_HAS_WTHREADS */
 
@@ -713,7 +713,7 @@ ACE_Thread_Manager::spawn (ACE_THR_FUNC func,
                      grp_id,
                      stack,
                      stack_size,
-                     0,
+                     nullptr,
                      thr_name) == -1)
     return -1;
 
@@ -748,14 +748,14 @@ ACE_Thread_Manager::spawn_n (size_t n,
       if (this->spawn_i (func,
                          args,
                          flags,
-                         0,
-                         thread_handles == 0 ? 0 : &thread_handles[i],
+                         nullptr,
+                         thread_handles == nullptr ? nullptr : &thread_handles[i],
                          priority,
                          grp_id,
-                         stack == 0 ? 0 : stack[i],
-                         stack_size == 0 ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
+                         stack == nullptr ? nullptr : stack[i],
+                         stack_size == nullptr ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
                          task,
-                         thr_name == 0 ? 0 : &thr_name [i]) == -1)
+                         thr_name == nullptr ? nullptr : &thr_name [i]) == -1)
         return -1;
     }
 
@@ -791,14 +791,14 @@ ACE_Thread_Manager::spawn_n (ACE_thread_t thread_ids[],
       if (this->spawn_i (func,
                          args,
                          flags,
-                         thread_ids == 0 ? 0 : &thread_ids[i],
-                         thread_handles == 0 ? 0 : &thread_handles[i],
+                         thread_ids == nullptr ? nullptr : &thread_ids[i],
+                         thread_handles == nullptr ? nullptr : &thread_handles[i],
                          priority,
                          grp_id,
-                         stack == 0 ? 0 : stack[i],
-                         stack_size == 0 ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
+                         stack == nullptr ? nullptr : stack[i],
+                         stack_size == nullptr ? ACE_DEFAULT_THREAD_STACKSIZE : stack_size[i],
                          task,
-                         thr_name == 0 ? 0 : &thr_name [i]) == -1)
+                         thr_name == nullptr ? nullptr : &thr_name [i]) == -1)
         return -1;
     }
 
@@ -818,9 +818,9 @@ ACE_Thread_Manager::append_thr (ACE_thread_t t_id,
                                 ACE_Thread_Descriptor *td)
 {
   ACE_TRACE ("ACE_Thread_Manager::append_thr");
-  ACE_Thread_Descriptor *thr_desc = 0;
+  ACE_Thread_Descriptor *thr_desc = nullptr;
 
-  if (td == 0)
+  if (td == nullptr)
     {
       ACE_NEW_RETURN (thr_desc,
                       ACE_Thread_Descriptor,
@@ -859,7 +859,7 @@ ACE_Thread_Manager::find_hthread (ACE_hthread_t h_id)
         }
     }
 
-  return 0;
+  return nullptr;
 }
 
 // Locate the index in the table associated with <t_id>.  Must be
@@ -879,7 +879,7 @@ ACE_Thread_Manager::find_thread (ACE_thread_t t_id)
           return iter.next ();
         }
     }
-  return 0;
+  return nullptr;
 }
 
 // Insert a thread into the pool (checks for duplicates and doesn't
@@ -895,7 +895,7 @@ ACE_Thread_Manager::insert_thr (ACE_thread_t t_id,
   ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, -1));
 
   // Check for duplicates and bail out if we're already registered...
-  if (this->find_thread (t_id) != 0 )
+  if (this->find_thread (t_id) != nullptr )
     return -1;
 
   if (grp_id == -1)
@@ -905,7 +905,7 @@ ACE_Thread_Manager::insert_thr (ACE_thread_t t_id,
                         t_handle,
                         ACE_THR_SPAWNED,
                         grp_id,
-                        0,
+                        nullptr,
                         flags) == -1)
     return -1;
 
@@ -949,7 +949,7 @@ ACE_Thread_Manager::remove_thr (ACE_Thread_Descriptor *td,
 {
   ACE_TRACE ("ACE_Thread_Manager::remove_thr");
 
-  td->tm_ = 0;
+  td->tm_ = nullptr;
   this->thr_list_.remove (td);
 
 #if defined (ACE_WIN32)
@@ -973,9 +973,9 @@ ACE_Thread_Manager::remove_thr (ACE_Thread_Descriptor *td,
 void
 ACE_Thread_Manager::remove_thr_all ()
 {
-  ACE_Thread_Descriptor *td = 0;
+  ACE_Thread_Descriptor *td = nullptr;
 
-  while ((td = this->thr_list_.delete_head ()) != 0)
+  while ((td = this->thr_list_.delete_head ()) != nullptr)
     {
       this->remove_thr (td, 1);
     }
@@ -1192,7 +1192,7 @@ ACE_Thread_Manager::check_state (ACE_UINT32 state,
   if (self_check)
     {
       ACE_Thread_Descriptor *desc = ACE_LOG_MSG->thr_desc ();
-      if (desc == 0)
+      if (desc == nullptr)
         return 0;               // Always return false.
       thr_state = desc->thr_state_;
     }
@@ -1200,7 +1200,7 @@ ACE_Thread_Manager::check_state (ACE_UINT32 state,
     {
       // Not calling from self, have to look it up from the list.
       ACE_FIND (this->find_thread (id), ptr);
-      if (ptr == 0)
+      if (ptr == nullptr)
         return 0;
       thr_state = ptr->thr_state_;
     }
@@ -1557,7 +1557,7 @@ ACE_Thread_Manager::wait_grp (int grp_id)
   ACE_TRACE ("ACE_Thread_Manager::wait_grp");
 
   int copy_count = 0;
-  ACE_Thread_Descriptor_Base *copy_table = 0;
+  ACE_Thread_Descriptor_Base *copy_table = nullptr;
 
   // We have to make sure that while we wait for these threads to
   // exit, we do not have the lock.  Therefore we make a copy of all
@@ -1675,13 +1675,13 @@ ACE_Thread_Manager::exit (ACE_THR_FUNC_RETURN status, bool do_thread_exit)
 
   // Just hold onto the guard while finding this thread's id and
   {
-    ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, 0));
+    ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, this->lock_, nullptr));
 
     // Find the thread id, but don't use the cache.  It might have been
     // deleted already.
     ACE_thread_t const id = ACE_OS::thr_self ();
     ACE_Thread_Descriptor* td = this->find_thread (id);
-    if (td != 0)
+    if (td != nullptr)
      {
        // @@ We call Thread_Descriptor terminate this realize the cleanup
        // process itself.
@@ -1701,7 +1701,7 @@ ACE_Thread_Manager::exit (ACE_THR_FUNC_RETURN status, bool do_thread_exit)
       // storage this call can return (don't ask...).
     }
 
-  return 0;
+  return nullptr;
 }
 
 // Wait for all the threads to exit.
@@ -1714,7 +1714,7 @@ ACE_Thread_Manager::wait (const ACE_Time_Value *timeout,
 
   std::unique_ptr<ACE_Time_Value> local_timeout;
   // Check to see if we're using absolute time or not.
-  if (!use_absolute_time && timeout != 0)
+  if (!use_absolute_time && timeout != nullptr)
     {
       // create time value duplicate (preserves time policy)
       local_timeout.reset (timeout->duplicate ());
@@ -1771,8 +1771,8 @@ ACE_Thread_Manager::wait (const ACE_Time_Value *timeout,
         this->remove_thr_all ();
 
 #if !defined (ACE_HAS_VXTHREADS)
-  ACE_Thread_Descriptor_Base* item = 0;
-  while ((item = this->terminated_thr_list_.delete_head ()) != 0)
+  ACE_Thread_Descriptor_Base* item = nullptr;
+  while ((item = this->terminated_thr_list_.delete_head ()) != nullptr)
     {
       term_thr_list_copy.insert_tail (item);
     }
@@ -1785,7 +1785,7 @@ ACE_Thread_Manager::wait (const ACE_Time_Value *timeout,
     // on our implementation.
     ACE_Thread_Descriptor_Base *item {};
 
-    while ((item = term_thr_list_copy.delete_head ()) != 0)
+    while ((item = term_thr_list_copy.delete_head ()) != nullptr)
       {
 #ifndef ACE_LACKS_PTHREAD_JOIN
         if (ACE_BIT_DISABLED (item->flags_, THR_DETACHED | THR_DAEMON)
@@ -1831,7 +1831,7 @@ ACE_Thread_Manager::apply_task (ACE_Task_Base *task,
       // Save/restore errno.
       ACE_Errno_Guard error (errno);
 
-      for (ACE_Thread_Descriptor *td = 0;
+      for (ACE_Thread_Descriptor *td = nullptr;
            this->thr_to_be_removed_.dequeue_head (td) != -1;
            )
         this->remove_thr (td, 1);
@@ -1846,7 +1846,7 @@ int
 ACE_Thread_Manager::wait_task (ACE_Task_Base *task)
 {
   int copy_count = 0;
-  ACE_Thread_Descriptor_Base *copy_table = 0;
+  ACE_Thread_Descriptor_Base *copy_table = nullptr;
 
   // We have to make sure that while we wait for these threads to
   // exit, we do not have the lock.  Therefore we make a copy of all
@@ -2010,7 +2010,7 @@ ACE_Thread_Manager::find_task (ACE_Task_Base *task, size_t slot)
       ++i;
     }
 
-  return 0;
+  return nullptr;
 }
 
 // Returns the number of ACE_Task in a group.
@@ -2029,8 +2029,8 @@ ACE_Thread_Manager::num_tasks_in_group (int grp_id)
        iter.advance ())
     {
       if (iter.next ()->grp_id_ == grp_id
-          && this->find_task (iter.next ()->task_, i) == 0
-          && iter.next ()->task_ != 0)
+          && this->find_task (iter.next ()->task_, i) == nullptr
+          && iter.next ()->task_ != nullptr)
         {
           ++tasks_count;
         }
@@ -2085,7 +2085,7 @@ ACE_Thread_Manager::task_all_list (ACE_Task_Base *task_list[],
 
       ACE_Task_Base *task_p = iter.next ()->task_;
 
-      if (0 != task_p)
+      if (nullptr != task_p)
         {
           // This thread has a task pointer; see if it's already in the
           // list. Don't add duplicates.
@@ -2152,7 +2152,7 @@ ACE_Thread_Manager::thr_state (ACE_thread_t id,
     {
       ACE_Thread_Descriptor *desc = ACE_LOG_MSG->thr_desc ();
 
-      if (desc == 0)
+      if (desc == nullptr)
         {
           return 0;               // Always return false.
         }
@@ -2164,7 +2164,7 @@ ACE_Thread_Manager::thr_state (ACE_thread_t id,
       // Not calling from self, have to look it up from the list.
       ACE_FIND (this->find_thread (id), ptr);
 
-      if (ptr == 0)
+      if (ptr == nullptr)
         {
           return 0;
         }
@@ -2199,7 +2199,7 @@ ACE_Thread_Manager::task_list (int grp_id,
         }
 
       if (iter.next ()->grp_id_ == grp_id
-          && this->find_task (iter.next ()->task_, i) == 0)
+          && this->find_task (iter.next ()->task_, i) == nullptr)
         {
           task_list_iterator[task_list_count] = iter.next ()->task_;
           ++task_list_count;

--- a/ACE/ace/Thread_Semaphore.cpp
+++ b/ACE/ace/Thread_Semaphore.cpp
@@ -46,13 +46,13 @@ ACE_Thread_Semaphore::ACE_Thread_Semaphore (unsigned int count,
 ACE_Thread_Semaphore *
 ACE_Malloc_Lock_Adapter_T<ACE_Thread_Semaphore>::operator () (const ACE_TCHAR *name)
 {
-  ACE_Thread_Semaphore *p = 0;
-  if (name == 0)
-    ACE_NEW_RETURN (p, ACE_Thread_Semaphore (1, name), 0);
+  ACE_Thread_Semaphore *p = nullptr;
+  if (name == nullptr)
+    ACE_NEW_RETURN (p, ACE_Thread_Semaphore (1, name), nullptr);
   else
     ACE_NEW_RETURN (p, ACE_Thread_Semaphore (1, ACE::basename (name,
                                                                ACE_DIRECTORY_SEPARATOR_CHAR)),
-                    0);
+                    nullptr);
   return p;
 }
 

--- a/ACE/ace/Time_Policy.cpp
+++ b/ACE/ace/Time_Policy.cpp
@@ -25,7 +25,7 @@ ACE_Time_Value_T<ACE_Delegating_Time_Policy> NULL_Time_Policy::gettimeofday () c
 static NULL_Time_Policy null_policy_;
 
 ACE_Delegating_Time_Policy::ACE_Delegating_Time_Policy (ACE_Dynamic_Time_Policy_Base const * delegate)
-  : delegate_ (delegate != 0 ? delegate : &null_policy_)
+  : delegate_ (delegate != nullptr ? delegate : &null_policy_)
 {
 }
 

--- a/ACE/ace/Time_Value.cpp
+++ b/ACE/ace/Time_Value.cpp
@@ -152,8 +152,8 @@ ACE_Time_Value::to_absolute_time () const
 ACE_Time_Value *
 ACE_Time_Value::duplicate () const
 {
-  ACE_Time_Value * tmp = 0;
-  ACE_NEW_RETURN (tmp, ACE_Time_Value (*this), 0);
+  ACE_Time_Value * tmp = nullptr;
+  ACE_NEW_RETURN (tmp, ACE_Time_Value (*this), nullptr);
   return tmp;
 }
 

--- a/ACE/ace/Time_Value_T.cpp
+++ b/ACE/ace/Time_Value_T.cpp
@@ -41,7 +41,7 @@ ACE_Time_Value *
 ACE_Time_Value_T<TIME_POLICY>::duplicate () const
 {
   ACE_Time_Value_T<TIME_POLICY> * tmp = 0;
-  ACE_NEW_RETURN (tmp, ACE_Time_Value_T<TIME_POLICY> (*this), 0);
+  ACE_NEW_RETURN (tmp, ACE_Time_Value_T<TIME_POLICY> (*this), nullptr);
   return tmp;
 }
 

--- a/ACE/ace/Timer_Hash_T.cpp
+++ b/ACE/ace/Timer_Hash_T.cpp
@@ -19,7 +19,7 @@ class Hash_Token
 public:
   // This constructor is required by ACE_Locked_Free_List::alloc.
   Hash_Token () :
-    act_ (0),
+    act_ (nullptr),
     pos_ (0),
     orig_id_ (0),
     next_ (0)
@@ -610,7 +610,7 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (long tim
       if (h->pos_ == this->earliest_position_)
         this->find_new_earliest ();
 
-      if (act != 0)
+      if (act != nullptr)
         *act = h->act_;
 
       // We could destruct Hash_Token explicitly but we better
@@ -841,7 +841,7 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::expire (const AC
 
           info.act_ = h->act_;
 
-          const void *upcall_act = 0;
+          const void *upcall_act = nullptr;
 
           this->preinvoke (info, cur_time, upcall_act);
 

--- a/ACE/ace/Timer_Hash_T.h
+++ b/ACE/ace/Timer_Hash_T.h
@@ -185,7 +185,7 @@ public:
    */
   ACE_Timer_Hash_T (size_t table_size,
                     FUNCTOR *upcall_functor = 0,
-                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = 0,
+                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = nullptr,
                     TIME_POLICY const & time_policy = TIME_POLICY());
 
   /**
@@ -196,7 +196,7 @@ public:
    * size will be ACE_DEFAULT_TIMERS and there will be no preallocation.
    */
   ACE_Timer_Hash_T (FUNCTOR *upcall_functor = 0,
-                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = 0,
+                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = nullptr,
                     TIME_POLICY const & time_policy = TIME_POLICY());
 
   /// Destructor
@@ -241,7 +241,7 @@ public:
    * this instance of ACE_Timer_Hash_T then user will get a memory leak.
    */
   virtual int cancel (long timer_id,
-                      const void **act = 0,
+                      const void **act = nullptr,
                       int dont_call_handle_close = 1);
 
   /**

--- a/ACE/ace/Timer_Heap_T.cpp
+++ b/ACE/ace/Timer_Heap_T.cpp
@@ -583,7 +583,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::grow_heap ()
 
   // Grow the array of timer ids.
 
-  ssize_t *new_timer_ids = 0;
+  ssize_t *new_timer_ids = nullptr;
 
 #if defined (ACE_HAS_ALLOC_HOOKS)
   new_timer_ids = reinterpret_cast<ssize_t *>
@@ -806,7 +806,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
                                             dont_call,
                                             cookie);
 
-      if (act != 0)
+      if (act != nullptr)
         *act = temp->get_act ();
 
       this->free_node (temp);

--- a/ACE/ace/Timer_Heap_T.h
+++ b/ACE/ace/Timer_Heap_T.h
@@ -110,7 +110,7 @@ public:
   ACE_Timer_Heap_T (size_t size,
                     bool preallocated = false,
                     FUNCTOR *upcall_functor = 0,
-                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = 0,
+                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = nullptr,
                     TIME_POLICY const & time_policy = TIME_POLICY());
 
   /**
@@ -121,7 +121,7 @@ public:
    * size will be ACE_DEFAULT_TIMERS and there will be no preallocation.
    */
   ACE_Timer_Heap_T (FUNCTOR *upcall_functor = 0,
-                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = 0,
+                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = nullptr,
                     TIME_POLICY const & time_policy = TIME_POLICY());
 
   /// Destructor.
@@ -162,7 +162,7 @@ public:
    * succeeded and 0 if the @a timer_id wasn't found.
    */
   virtual int cancel (long timer_id,
-                      const void **act = 0,
+                      const void **act = nullptr,
                       int dont_call_handle_close = 1);
 
   /**

--- a/ACE/ace/Timer_List_T.cpp
+++ b/ACE/ace/Timer_List_T.cpp
@@ -295,7 +295,7 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
   ACE_Timer_Node_T<TYPE>* n = this->find_node(timer_id);
   if (n != 0)
     {
-      if (act != 0)
+      if (act != nullptr)
         *act = n->get_act ();
 
       // Call the close hooks.

--- a/ACE/ace/Timer_List_T.h
+++ b/ACE/ace/Timer_List_T.h
@@ -100,7 +100,7 @@ public:
    * default FUNCTOR will be created.  @a freelist is the freelist of
    * timer nodes.  If 0, then a default freelist will be created.
    */
-  ACE_Timer_List_T (FUNCTOR* upcall_functor = 0, FreeList* freelist = 0,
+  ACE_Timer_List_T (FUNCTOR* upcall_functor = 0, FreeList* freelist = nullptr,
                     TIME_POLICY const & time_policy = TIME_POLICY());
 
   /// Destructor
@@ -141,7 +141,7 @@ public:
    * succeeded and 0 if the @a timer_id wasn't found.
    */
   virtual int cancel (long timer_id,
-                      const void** act = 0,
+                      const void** act = nullptr,
                       int dont_call_handle_close = 1);
 
   /**

--- a/ACE/ace/Timer_Queue_Adapters.cpp
+++ b/ACE/ace/Timer_Queue_Adapters.cpp
@@ -105,7 +105,7 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::ACE_Async_Timer_Queue_Adapter (ACE_Sig_
   // signals when SIGALRM is running.  Also, we always restart system
   // calls that are interrupted by the signals.
 
-  ACE_Sig_Action sa ((ACE_SignalHandler) 0,
+  ACE_Sig_Action sa ((ACE_SignalHandler) nullptr,
                      this->mask_,
                      SA_RESTART);
 

--- a/ACE/ace/Timer_Queue_Adapters.h
+++ b/ACE/ace/Timer_Queue_Adapters.h
@@ -59,7 +59,7 @@ public:
    * signals when @c SIGALRM is run.  Otherwise, just block the signals
    * indicated in @a mask.
    */
-  ACE_Async_Timer_Queue_Adapter (ACE_Sig_Set *mask = 0);
+  ACE_Async_Timer_Queue_Adapter (ACE_Sig_Set *mask = nullptr);
 
   /// Schedule the timer according to the semantics of the
   /// ACE_Timer_List.
@@ -75,7 +75,7 @@ public:
 
   /// Cancel the @a timer_id and pass back the @a act if an address is
   /// passed in.
-  int cancel (long timer_id, const void **act = 0);
+  int cancel (long timer_id, const void **act = nullptr);
 
   /// Dispatch all timers with expiry time at or before the current time.
   /// Returns the number of timers expired.
@@ -149,7 +149,7 @@ public:
 
   /// Cancel the @a timer_id and return the @a act parameter if an
   /// address is passed in. Also wakes up the dispatching thread.
-  int cancel (long timer_id, const void **act = 0);
+  int cancel (long timer_id, const void **act = nullptr);
 
   /// Runs the dispatching thread.
   virtual int svc ();
@@ -179,12 +179,12 @@ public:
                         int force_active = 0,
                         long priority = ACE_DEFAULT_THREAD_PRIORITY,
                         int grp_id = -1,
-                        ACE_Task_Base *task = 0,
-                        ACE_hthread_t thread_handles[] = 0,
-                        void *stack[] = 0,
-                        size_t stack_size[] = 0,
-                        ACE_thread_t thread_ids[] = 0,
-                        const char* thr_name[] = 0);
+                        ACE_Task_Base *task = nullptr,
+                        ACE_hthread_t thread_handles[] = nullptr,
+                        void *stack[] = nullptr,
+                        size_t stack_size[] = nullptr,
+                        ACE_thread_t thread_ids[] = nullptr,
+                        const char* thr_name[] = nullptr);
 
 # if defined (ACE_HAS_DEFERRED_TIMER_COMMANDS)
 

--- a/ACE/ace/Timer_Queue_T.cpp
+++ b/ACE/ace/Timer_Queue_T.cpp
@@ -87,7 +87,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (ACE_
           // time on the Timer_Queue.
 
           this->timeout_ = this->earliest_time () - cur_time;
-          if (max_wait_time == 0 || *max_wait_time > timeout_)
+          if (max_wait_time == nullptr || *max_wait_time > timeout_)
             return &this->timeout_;
           else
             return max_wait_time;
@@ -109,8 +109,8 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (ACE_
 {
   ACE_TRACE ("ACE_Timer_Queue_T::calculate_timeout");
 
-  if (the_timeout == 0)
-    return 0;
+  if (the_timeout == nullptr)
+    return nullptr;
 
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, max_wait_time));
 
@@ -120,7 +120,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (ACE_
       if (max_wait_time)
         *the_timeout = *max_wait_time;
       else
-        return 0;
+        return nullptr;
     }
   else
     {
@@ -134,7 +134,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (ACE_
           // time on the Timer_Queue.
 
           *the_timeout = this->earliest_time () - cur_time;
-          if (!(max_wait_time == 0 || *max_wait_time > *the_timeout))
+          if (!(max_wait_time == nullptr || *max_wait_time > *the_timeout))
             *the_timeout = *max_wait_time;
         }
       else
@@ -276,7 +276,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::expire (const ACE_Time_
       ACE_MT (ACE_Reverse_Lock<ACE_LOCK> rev_lk(this->mutex_));
       ACE_MT (ACE_GUARD_RETURN (ACE_Reverse_Lock<ACE_LOCK>, rmon, rev_lk, -1));
 
-      const void *upcall_act = 0;
+      const void *upcall_act = nullptr;
 
       this->preinvoke (info, cur_time, upcall_act);
 
@@ -377,7 +377,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::expire_single (
   }
   // We do not need the lock anymore, all these operations take place
   // with local variables.
-  const void *upcall_act = 0;
+  const void *upcall_act = nullptr;
 
   // Preinvoke (handles refcount if needed, etc.)
   this->preinvoke (info, cur_time, upcall_act);

--- a/ACE/ace/Timer_Queue_T.h
+++ b/ACE/ace/Timer_Queue_T.h
@@ -86,7 +86,7 @@ public:
    * timer nodes.  If 0, then a default freelist will be created.
    */
   ACE_Timer_Queue_T (FUNCTOR *upcall_functor = 0,
-                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = 0,
+                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = nullptr,
                     TIME_POLICY const & time_policy = TIME_POLICY());
 
   /// Destructor - make virtual for proper destruction of inherited

--- a/ACE/ace/Timer_Wheel_T.cpp
+++ b/ACE/ace/Timer_Wheel_T.cpp
@@ -600,7 +600,7 @@ ACE_Timer_Wheel_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
                                             n->get_type (),
                                             skip_close,
                                             cookie);
-      if (act != 0)
+      if (act != nullptr)
         *act = n->get_act ();
 
       this->cancel_i (n);
@@ -822,7 +822,7 @@ ACE_Timer_Wheel_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::expire (const ACE_Time_
           this->free_node (n);
         }
 
-      const void *upcall_act = 0;
+      const void *upcall_act = nullptr;
 
       this->preinvoke (info, cur_time, upcall_act);
 

--- a/ACE/ace/Timer_Wheel_T.h
+++ b/ACE/ace/Timer_Wheel_T.h
@@ -101,7 +101,7 @@ public:
   typedef ACE_Free_List<Node> FreeList;
 
   /// Default constructor
-  ACE_Timer_Wheel_T (FUNCTOR* upcall_functor = 0, FreeList* freelist = 0,
+  ACE_Timer_Wheel_T (FUNCTOR* upcall_functor = 0, FreeList* freelist = nullptr,
                      TIME_POLICY const & time_policy = TIME_POLICY());
 
   /// Constructor with opportunities to set the wheelsize and resolution
@@ -109,7 +109,7 @@ public:
                      u_int resolution,
                      size_t prealloc = 0,
                      FUNCTOR* upcall_functor = 0,
-                     FreeList* freelist = 0,
+                     FreeList* freelist = nullptr,
                      TIME_POLICY const & time_policy = TIME_POLICY());
 
   /// Destructor
@@ -137,7 +137,7 @@ public:
   // Calls the functor if dont_call_handle_close is 0 and returns 1
   // on success
   virtual int cancel (long timer_id,
-                      const void** act = 0,
+                      const void** act = nullptr,
                       int dont_call_handle_close = 1);
 
   /**

--- a/ACE/ace/Token.cpp
+++ b/ACE/ace/Token.cpp
@@ -39,7 +39,7 @@ ACE_Token::dump () const
 
 ACE_Token::ACE_Token_Queue_Entry::ACE_Token_Queue_Entry (ACE_Thread_Mutex &m,
                                                          ACE_thread_t t_id)
-  : next_ (0),
+  : next_ (nullptr),
     thread_id_ (t_id),
 #if defined (ACE_TOKEN_USES_SEMAPHORE)
     cv_ (0),
@@ -58,7 +58,7 @@ ACE_Token::ACE_Token_Queue_Entry::ACE_Token_Queue_Entry (ACE_Thread_Mutex &m,
 ACE_Token::ACE_Token_Queue_Entry::ACE_Token_Queue_Entry (ACE_Thread_Mutex &m,
                                                          ACE_thread_t t_id,
                                                          ACE_Condition_Attributes &attributes)
-  : next_ (0),
+  : next_ (nullptr),
     thread_id_ (t_id),
 #if defined (ACE_TOKEN_USES_SEMAPHORE)
     cv_ (0),
@@ -76,8 +76,8 @@ ACE_Token::ACE_Token_Queue_Entry::ACE_Token_Queue_Entry (ACE_Thread_Mutex &m,
 }
 
 ACE_Token::ACE_Token_Queue::ACE_Token_Queue ()
-  : head_ (0),
-    tail_ (0)
+  : head_ (nullptr),
+    tail_ (nullptr)
 {
   ACE_TRACE ("ACE_Token::ACE_Token_Queue::ACE_Token_Queue");
 }
@@ -89,21 +89,21 @@ void
 ACE_Token::ACE_Token_Queue::remove_entry (ACE_Token::ACE_Token_Queue_Entry *entry)
 {
   ACE_TRACE ("ACE_Token::ACE_Token_Queue::remove_entry");
-  ACE_Token_Queue_Entry *curr = 0;
-  ACE_Token_Queue_Entry *prev = 0;
+  ACE_Token_Queue_Entry *curr = nullptr;
+  ACE_Token_Queue_Entry *prev = nullptr;
 
-  if (this->head_ == 0)
+  if (this->head_ == nullptr)
     return;
 
   for (curr = this->head_;
-       curr != 0 && curr != entry;
+       curr != nullptr && curr != entry;
        curr = curr->next_)
     prev = curr;
 
-  if (curr == 0)
+  if (curr == nullptr)
     // Didn't find the entry...
     return;
-  else if (prev == 0)
+  else if (prev == nullptr)
     // Delete at the head.
     this->head_ = this->head_->next_;
   else
@@ -112,7 +112,7 @@ ACE_Token::ACE_Token_Queue::remove_entry (ACE_Token::ACE_Token_Queue_Entry *entr
 
   // We need to update the tail of the list if we've deleted the last
   // entry.
-  if (curr->next_ == 0)
+  if (curr->next_ == nullptr)
     this->tail_ = prev;
 }
 
@@ -123,7 +123,7 @@ void
 ACE_Token::ACE_Token_Queue::insert_entry (ACE_Token::ACE_Token_Queue_Entry &entry,
                                           int requeue_position)
 {
-  if (this->head_ == 0)
+  if (this->head_ == nullptr)
     {
       // No other threads - just add me
       this->head_ = &entry;
@@ -147,12 +147,12 @@ ACE_Token::ACE_Token_Queue::insert_entry (ACE_Token::ACE_Token_Queue_Entry &entr
       // Determine where our thread should go in the queue of waiters.
 
       ACE_Token::ACE_Token_Queue_Entry *insert_after = this->head_;
-      while (requeue_position-- && insert_after->next_ != 0)
+      while (requeue_position-- && insert_after->next_ != nullptr)
         insert_after = insert_after->next_;
 
       entry.next_ = insert_after->next_;
 
-      if (entry.next_ == 0)
+      if (entry.next_ == nullptr)
         this->tail_ = &entry;
 
       insert_after->next_ = &entry;
@@ -210,7 +210,7 @@ ACE_Token::shared_acquire (void (*sleep_hook_func)(void *),
     }
 
   // Do a quick check for "polling" behavior.
-  if (timeout != 0 && *timeout == ACE_Time_Value::zero)
+  if (timeout != nullptr && *timeout == ACE_Time_Value::zero)
     {
       errno = ETIME;
       return -1;
@@ -330,7 +330,7 @@ int
 ACE_Token::acquire (ACE_Time_Value *timeout)
 {
   ACE_TRACE ("ACE_Token::acquire");
-  return this->shared_acquire (0, 0, timeout, ACE_Token::WRITE_TOKEN);
+  return this->shared_acquire (nullptr, nullptr, timeout, ACE_Token::WRITE_TOKEN);
 }
 
 // Acquire the token, sleeping until it is obtained or until <timeout>
@@ -363,9 +363,9 @@ ACE_Token::renew (int requeue_position,
   // for.
 
   // If no writers and either we are a writer or there are no readers.
-  if (this->writers_.head_ == 0 &&
+  if (this->writers_.head_ == nullptr &&
       (this->in_use_ == ACE_Token::WRITE_TOKEN ||
-       this->readers_.head_ == 0))
+       this->readers_.head_ == nullptr))
     // Immediate return.
     return 0;
 
@@ -505,18 +505,18 @@ ACE_Token::wakeup_next_waiter ()
   this->in_use_ = 0;
 
   // Any waiters...
-  if (this->writers_.head_ == 0 &&
-      this->readers_.head_ == 0)
+  if (this->writers_.head_ == nullptr &&
+      this->readers_.head_ == nullptr)
     {
       // No more waiters...
       return;
     }
 
   // Wakeup next waiter.
-  ACE_Token_Queue *queue = 0;
+  ACE_Token_Queue *queue = nullptr;
 
   // Writer threads get priority to run first.
-  if (this->writers_.head_ != 0)
+  if (this->writers_.head_ != nullptr)
     {
       this->in_use_ = ACE_Token::WRITE_TOKEN;
       queue = &this->writers_;

--- a/ACE/ace/UPIPE_Acceptor.cpp
+++ b/ACE/ace/UPIPE_Acceptor.cpp
@@ -79,7 +79,7 @@ ACE_UPIPE_Acceptor::accept (ACE_UPIPE_Stream &new_stream,
     return -1;
   else
     {
-      ACE_UPIPE_Stream *remote_stream = 0;
+      ACE_UPIPE_Stream *remote_stream = nullptr;
 
       ACE_MT (ACE_GUARD_RETURN (ACE_Thread_Mutex, ace_mon, new_stream.lock_, -1));
 
@@ -105,7 +105,7 @@ ACE_UPIPE_Acceptor::accept (ACE_UPIPE_Stream &new_stream,
                     ACE_TEXT ("ACE_UPIPE_Acceptor: %p\n"),
                     ACE_TEXT ("link streams failed")));
       // Send a message over the new streampipe to confirm acceptance.
-      else if (new_stream.send (&mb_, 0) == -1)
+      else if (new_stream.send (&mb_, nullptr) == -1)
         ACELIB_ERROR ((LM_ERROR,
                     ACE_TEXT ("ACE_UPIPE_Acceptor: %p\n"),
                     ACE_TEXT ("linked stream.put failed")));

--- a/ACE/ace/UPIPE_Connector.cpp
+++ b/ACE/ace/UPIPE_Connector.cpp
@@ -71,10 +71,10 @@ ACE_UPIPE_Connector::connect (ACE_UPIPE_Stream &new_stream,
                     ACE_TEXT ("write to pipe failed")));
 
       // Wait for confirmation of stream linking.
-      ACE_Message_Block *mb_p = 0;
+      ACE_Message_Block *mb_p = nullptr;
 
       // Our part is done, wait for server to confirm connection.
-      result = new_stream.recv (mb_p, 0);
+      result = new_stream.recv (mb_p, nullptr);
 
       // Do *not* coalesce the following two checks for result == -1.
       // They perform different checks and cannot be merged.

--- a/ACE/ace/UPIPE_Stream.cpp
+++ b/ACE/ace/UPIPE_Stream.cpp
@@ -13,7 +13,7 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 ACE_ALLOC_HOOK_DEFINE(ACE_UPIPE_Stream)
 
 ACE_UPIPE_Stream::ACE_UPIPE_Stream ()
-  : mb_last_ (0),
+  : mb_last_ (nullptr),
     reference_count_ (0)
 {
   ACE_TRACE ("ACE_UPIPE_Stream::ACE_UPIPE_STREAM");
@@ -21,10 +21,10 @@ ACE_UPIPE_Stream::ACE_UPIPE_Stream ()
 
 ACE_UPIPE_Stream::~ACE_UPIPE_Stream ()
 {
-  if (this->mb_last_ != 0)
+  if (this->mb_last_ != nullptr)
     {
       this->mb_last_->release ();
-      this->mb_last_ = 0;
+      this->mb_last_ = nullptr;
     }
 }
 
@@ -122,7 +122,7 @@ ACE_UPIPE_Stream::recv (char *buffer,
   size_t bytes_read = 0;
 
   while (bytes_read < n)
-    if (this->mb_last_ != 0)
+    if (this->mb_last_ != nullptr)
       {
         // We have remaining data in our last read Message_Buffer.
         size_t this_len = this->mb_last_->length ();

--- a/ACE/ace/UUID.cpp
+++ b/ACE/ace/UUID.cpp
@@ -38,9 +38,9 @@ namespace ACE_Utils
       {
         // Reset the string version of the UUID a string version
         // exist, and the UUID is not equal to the old UUID.
-        if (0 != this->as_string_.get ())
+        if (nullptr != this->as_string_.get ())
           {
-            if (0 == rhs.as_string_.get () || *this != rhs)
+            if (nullptr == rhs.as_string_.get () || *this != rhs)
               this->as_string_.reset ();
           }
 
@@ -59,14 +59,14 @@ namespace ACE_Utils
   const ACE_CString * UUID::to_string () const
   {
     // Compute the string representation only once.
-    if (0 != this->as_string_.get ())
+    if (nullptr != this->as_string_.get ())
       return this->as_string_.get ();
 
     // Get a buffer exactly the correct size. Use the nil UUID as a
     // gauge.  Don't forget the trailing nul.
     std::unique_ptr <char[]> auto_clean;
     size_t UUID_STRING_LENGTH = 36 + thr_id_.length () + pid_.length ();
-    char *buf = 0;
+    char *buf = nullptr;
 
     if (36 == UUID_STRING_LENGTH)
       {
@@ -77,7 +77,7 @@ namespace ACE_Utils
 #else
         ACE_NEW_RETURN (buf,
                         char[UUID_STRING_LENGTH + 1],
-                        0);
+                        nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
         // Let the auto array pointer manage the buffer.
@@ -108,7 +108,7 @@ namespace ACE_Utils
 #else
         ACE_NEW_RETURN (buf,
                         char[UUID_STRING_LENGTH + 1],
-                        0);
+                        nullptr);
 #endif /* ACE_HAS_ALLOC_HOOKS */
 
         // Let the auto array pointer manage the buffer.
@@ -132,11 +132,11 @@ namespace ACE_Utils
       }
 
     // Save the string.
-    ACE_CString * as_string = 0;
+    ACE_CString * as_string = nullptr;
 
     ACE_NEW_RETURN (as_string,
                     ACE_CString (buf, UUID_STRING_LENGTH),
-                    0);
+                    nullptr);
 
     this->as_string_.reset (as_string);
     return this->as_string_.get ();
@@ -419,10 +419,10 @@ namespace ACE_Utils
   UUID*
   UUID_Generator::generate_UUID (ACE_UINT16 version, u_char variant)
   {
-    UUID* uuid = 0;
+    UUID* uuid = nullptr;
     ACE_NEW_RETURN (uuid,
                     UUID,
-                    0);
+                    nullptr);
 
     this->generate_UUID (*uuid, version, variant);
     return uuid;

--- a/ACE/ace/Vector_T.h
+++ b/ACE/ace/Vector_T.h
@@ -83,7 +83,7 @@ public:
    *              default ACE allocator is used
    */
   ACE_Vector (const size_t init_size = DEFAULT_SIZE,
-              ACE_Allocator* alloc = 0);
+              ACE_Allocator* alloc = nullptr);
 
   /**
    * Destructor.

--- a/TAO/tao/Acceptor_Impl.cpp
+++ b/TAO/tao/Acceptor_Impl.cpp
@@ -118,7 +118,7 @@ TAO_Concurrency_Strategy<SVC_HANDLER>::activate_svc_handler (SVC_HANDLER *sh,
   if (f->activate_server_connections ())
     {
       // Thread-per-connection concurrency model
-      TAO_Thread_Per_Connection_Handler *tpch = 0;
+      TAO_Thread_Per_Connection_Handler *tpch = nullptr;
 
       ACE_NEW_RETURN (tpch,
                       TAO_Thread_Per_Connection_Handler (sh,
@@ -167,7 +167,7 @@ TAO_Concurrency_Strategy<SVC_HANDLER>::activate_svc_handler (SVC_HANDLER *sh,
 
       if (TAO_debug_level > 0)
          {
-           const ACE_TCHAR *error_message = 0;
+           const ACE_TCHAR *error_message = nullptr;
            if (f->activate_server_connections ())
              error_message = ACE_TEXT("could not activate new connection");
            else

--- a/TAO/tao/Asynch_Reply_Dispatcher_Base.h
+++ b/TAO/tao/Asynch_Reply_Dispatcher_Base.h
@@ -46,7 +46,7 @@ class TAO_Export TAO_Asynch_Reply_Dispatcher_Base
 public:
   /// Default constructor.
   TAO_Asynch_Reply_Dispatcher_Base (TAO_ORB_Core *orb_core,
-                                    ACE_Allocator *allocator = 0);
+                                    ACE_Allocator *allocator = nullptr);
 
   /// Sets the transport for this invocation.
   void transport (TAO_Transport *t);

--- a/TAO/tao/CORBA_methods.h
+++ b/TAO/tao/CORBA_methods.h
@@ -35,7 +35,7 @@ namespace CORBA
    */
   extern TAO_Export ORB_ptr ORB_init (int & argc,
                                       char * argv[],
-                                      const char * orb_name = 0);
+                                      const char * orb_name = nullptr);
 #if defined (ACE_USES_WCHAR)
   extern TAO_Export ORB_ptr ORB_init (int & argc,
                                       wchar_t * argv[],

--- a/TAO/tao/Condition.h
+++ b/TAO/tao/Condition.h
@@ -75,7 +75,7 @@ public:
    * call times out before the condition is signaled <wait> returns -1
    * and sets errno to ETIME.
    */
-  int wait (MUTEX &mutex, const ACE_Time_Value *abstime = 0);
+  int wait (MUTEX &mutex, const ACE_Time_Value *abstime = nullptr);
 
   /// Signal one waiting thread.
   int signal ();

--- a/TAO/tao/Fixed_Array_Argument_T.cpp
+++ b/TAO/tao/Fixed_Array_Argument_T.cpp
@@ -53,7 +53,7 @@ TAO::In_Fixed_Array_Clonable_Argument_T<S_forany,Insert_Policy>::clone ()
   typename ARRAY_TRAITS::slice_type * tmp_ptr = 0;
   ACE_ALLOCATOR_RETURN (tmp_ptr,
                         ARRAY_TRAITS::alloc (),
-                        0);
+                        nullptr);
   ARRAY_TRAITS::copy (tmp_ptr, this->x_.in ());
 
   In_Fixed_Array_Clonable_Argument_T<S_forany,Insert_Policy>* clone_arg

--- a/TAO/tao/HTTP_Handler.h
+++ b/TAO/tao/HTTP_Handler.h
@@ -50,7 +50,7 @@ public:
   size_t byte_count () const;
 
   /// Activate this instance of the <HTTP_Handler>
-  virtual int open (void * = 0);
+  virtual int open (void * = nullptr);
 
   /// Close down the Blob
   virtual int close (u_long flags = 0);

--- a/TAO/tao/IIOP_Acceptor.h
+++ b/TAO/tao/IIOP_Acceptor.h
@@ -78,12 +78,12 @@ public:
                     int version_major,
                     int version_minor,
                     const char *address,
-                    const char *options = 0);
+                    const char *options = nullptr);
   virtual int open_default (TAO_ORB_Core *orb_core,
                             ACE_Reactor *reactor,
                             int version_major,
                             int version_minor,
-                            const char *options = 0);
+                            const char *options = nullptr);
   virtual int close ();
   virtual int create_profile (const TAO::ObjectKey &object_key,
                               TAO_MProfile &mprofile,
@@ -114,7 +114,7 @@ public:
   virtual int hostname (TAO_ORB_Core *orb_core,
                         const ACE_INET_Addr &addr,
                         char *&host,
-                        const char *specified_hostname = 0);
+                        const char *specified_hostname = nullptr);
 
 protected:
   /**
@@ -130,7 +130,7 @@ protected:
   parse_address (const char *address,
                  ACE_INET_Addr &addr,
                  ACE_CString &specified_hostname,
-                 int *def_type = 0);
+                 int *def_type = nullptr);
 
   /**
    * Set the host name for the given address using the dotted decimal

--- a/TAO/tao/IIOP_Connection_Handler.h
+++ b/TAO/tao/IIOP_Connection_Handler.h
@@ -62,7 +62,7 @@ public:
   Reference_Count remove_reference ();
 #endif
 
-  TAO_IIOP_Connection_Handler (ACE_Thread_Manager * = 0);
+  TAO_IIOP_Connection_Handler (ACE_Thread_Manager * = nullptr);
 
   /// Constructor.
   TAO_IIOP_Connection_Handler (TAO_ORB_Core *orb_core);
@@ -87,7 +87,7 @@ public:
   virtual int handle_output (ACE_HANDLE);
   virtual int handle_close (ACE_HANDLE, ACE_Reactor_Mask);
   virtual int handle_timeout (const ACE_Time_Value &current_time,
-                              const void *act = 0);
+                              const void *act = nullptr);
   //@}
 
   /// Add ourselves to Cache.

--- a/TAO/tao/IIOP_Connector.h
+++ b/TAO/tao/IIOP_Connector.h
@@ -95,12 +95,12 @@ protected:
   virtual TAO_Transport *make_connection (
       TAO::Profile_Transport_Resolver *r,
       TAO_Transport_Descriptor_Interface &desc,
-      ACE_Time_Value *timeout = 0);
+      ACE_Time_Value *timeout = nullptr);
 
   virtual TAO_Transport *make_parallel_connection (
       TAO::Profile_Transport_Resolver *r,
                                   TAO_Transport_Descriptor_Interface &desc,
-                                  ACE_Time_Value *timeout = 0);
+                                  ACE_Time_Value *timeout = nullptr);
 
   /// More TAO_Connector methods, please check the documentation on
   /// Transport_Connector.h
@@ -115,7 +115,7 @@ private:
   int begin_connection (TAO_IIOP_Connection_Handler *&svc_handler,
                         TAO::Profile_Transport_Resolver *r,
                         TAO_IIOP_Endpoint *endpoint,
-                        ACE_Time_Value *timeout = 0);
+                        ACE_Time_Value *timeout = nullptr);
 
   /// This is the second half of making a connection when several endpoints
   /// are involved. This works with modified wait strategies to wait for one
@@ -128,7 +128,7 @@ private:
                                       unsigned count,
                                       TAO::Profile_Transport_Resolver *r,
                                       TAO_LF_Multi_Event *mev,
-                                      ACE_Time_Value *timeout = 0);
+                                      ACE_Time_Value *timeout = nullptr);
 
 
   /// Return the remote endpoint, a helper function

--- a/TAO/tao/IIOP_Transport.h
+++ b/TAO/tao/IIOP_Transport.h
@@ -72,7 +72,7 @@ protected:
 
   virtual ssize_t send (iovec *iov, int iovcnt,
                         size_t &bytes_transferred,
-                        const ACE_Time_Value *timeout = 0);
+                        const ACE_Time_Value *timeout = nullptr);
 
 #if TAO_HAS_SENDFILE == 1
   virtual ssize_t sendfile (TAO_MMAP_Allocator * allocator,
@@ -82,7 +82,7 @@ protected:
                             TAO::Transport::Drain_Constraints const & dc);
 #endif  /* TAO_HAS_SENDFILE==1 */
 
-  virtual ssize_t recv (char *buf, size_t len, const ACE_Time_Value *s = 0);
+  virtual ssize_t recv (char *buf, size_t len, const ACE_Time_Value *s = nullptr);
 
 public:
   /// Bridge method to call a similar method on the connection handler
@@ -100,10 +100,10 @@ public:
                             ACE_Time_Value *max_wait_time);
 
   virtual int send_message (TAO_OutputCDR &stream,
-                            TAO_Stub *stub = 0,
-                            TAO_ServerRequest *request = 0,
+                            TAO_Stub *stub = nullptr,
+                            TAO_ServerRequest *request = nullptr,
                             TAO_Message_Semantics message_semantics = TAO_Message_Semantics (),
-                            ACE_Time_Value *max_time_wait = 0);
+                            ACE_Time_Value *max_time_wait = nullptr);
 
   virtual int tear_listen_point_list (TAO_InputCDR &cdr);
 

--- a/TAO/tao/Invocation_Adapter.h
+++ b/TAO/tao/Invocation_Adapter.h
@@ -178,7 +178,7 @@ namespace TAO
         TAO_Operation_Details &details,
         CORBA::Object_var &effective_target,
         ACE_Time_Value *&max_wait_time,
-        Invocation_Retry_State *retry_state = 0);
+        Invocation_Retry_State *retry_state = nullptr);
 
     /// Make a collocated call.
     /**
@@ -209,7 +209,7 @@ namespace TAO
         CORBA::Object_var &effective_target,
         Profile_Transport_Resolver &r,
         ACE_Time_Value *&max_wait_time,
-        Invocation_Retry_State *retry_state = 0);
+        Invocation_Retry_State *retry_state = nullptr);
 
     /// Helper method to make a one way invocation.
     /**

--- a/TAO/tao/Leader_Follower.h
+++ b/TAO/tao/Leader_Follower.h
@@ -50,7 +50,7 @@ class TAO_Export TAO_Leader_Follower
 public:
   /// Constructor
   TAO_Leader_Follower (TAO_ORB_Core *orb_core,
-                       TAO_New_Leader_Generator *new_leader_generator = 0);
+                       TAO_New_Leader_Generator *new_leader_generator = nullptr);
 
   /// Destructor
   ~TAO_Leader_Follower ();

--- a/TAO/tao/Load_Protocol_Factory_T.h
+++ b/TAO/tao/Load_Protocol_Factory_T.h
@@ -32,10 +32,10 @@ namespace TAO
     load_protocol_factory (TAO_ProtocolFactorySet &protocol_set,
                            const char *name)
     {
-      TAO_Protocol_Factory *protocol_factory = 0;
+      TAO_Protocol_Factory *protocol_factory = nullptr;
       std::unique_ptr<TAO_Protocol_Factory> safe_protocol_factory;
 
-      TAO_Protocol_Item *item = 0;
+      TAO_Protocol_Item *item = nullptr;
 
       // If a protocol factory is obtained from the Service
       // Configurator then do not transfer ownership to the
@@ -46,7 +46,7 @@ namespace TAO
         ACE_Dynamic_Service<TAO_Protocol_Factory>::instance (
           ACE_TEXT_CHAR_TO_TCHAR (name));
 
-      if (protocol_factory == 0)
+      if (protocol_factory == nullptr)
         {
           if (TAO_debug_level > 0)
             TAOLIB_ERROR ((LM_WARNING,

--- a/TAO/tao/ORB.h
+++ b/TAO/tao/ORB.h
@@ -476,7 +476,7 @@ namespace CORBA
      */
     CORBA::Object_ptr resolve_initial_references (
       const char *name,
-      ACE_Time_Value *timeout = 0);
+      ACE_Time_Value *timeout = nullptr);
 
 #if !defined(CORBA_E_MICRO)
     /// Register an object reference with the ORB.

--- a/TAO/tao/ORB_Core.cpp
+++ b/TAO/tao/ORB_Core.cpp
@@ -878,7 +878,7 @@ TAO_ORB_Core::init (int &argc, char *argv[] )
 
           (ACE_LOG_MSG->*flagop)(value);
         }
-      else if (0 != (current_arg = arg_shifter.get_the_parameter
+      else if (nullptr != (current_arg = arg_shifter.get_the_parameter
                 (ACE_TEXT("-ORBHandleLoggingStrategyEvents"))))
         {
           ACE_Logging_Strategy *logging_strategy =

--- a/TAO/tao/Object.h
+++ b/TAO/tao/Object.h
@@ -267,8 +267,8 @@ namespace CORBA
     /// Constructor
     Object (TAO_Stub *p,
             CORBA::Boolean collocated = false,
-            TAO_Abstract_ServantBase *servant = 0,
-            TAO_ORB_Core *orb_core = 0);
+            TAO_Abstract_ServantBase *servant = nullptr,
+            TAO_ORB_Core *orb_core = nullptr);
 
     Object (IOP::IOR *ior, TAO_ORB_Core *orb_core);
 

--- a/TAO/tao/Object_T.cpp
+++ b/TAO/tao/Object_T.cpp
@@ -51,7 +51,7 @@ namespace TAO
           {
             TAO_Stub* stub = obj->_stubobj ();
 
-            if (stub != 0)
+            if (stub != nullptr)
               {
                 stub->_incr_refcnt ();
 

--- a/TAO/tao/Queued_Data.h
+++ b/TAO/tao/Queued_Data.h
@@ -46,19 +46,19 @@ class TAO_Export TAO_Queued_Data
 {
 public:
   /// Default Constructor
-  TAO_Queued_Data (ACE_Allocator *alloc = 0);
+  TAO_Queued_Data (ACE_Allocator *alloc = nullptr);
 
   /// Constructor.
-  TAO_Queued_Data (ACE_Message_Block *mb, ACE_Allocator *alloc = 0);
+  TAO_Queued_Data (ACE_Message_Block *mb, ACE_Allocator *alloc = nullptr);
 
   /// Copy constructor.
   TAO_Queued_Data (const TAO_Queued_Data &qd);
 
   /// Creation of a node in the queue.
   static TAO_Queued_Data* make_queued_data (
-                                    ACE_Allocator *message_buffer_alloc = 0,
-                                    ACE_Allocator *input_cdr_alloc = 0,
-                                    ACE_Data_Block *db = 0);
+                                    ACE_Allocator *message_buffer_alloc = nullptr,
+                                    ACE_Allocator *input_cdr_alloc = nullptr,
+                                    ACE_Data_Block *db = nullptr);
 
   /// Deletion of a node from the queue.
   static void release (TAO_Queued_Data *qd);

--- a/TAO/tao/Queued_Message.h
+++ b/TAO/tao/Queued_Message.h
@@ -74,7 +74,7 @@ class TAO_Export TAO_Queued_Message : public TAO_LF_Invocation_Event
 public:
   /// Constructor
   TAO_Queued_Message (TAO_ORB_Core *oc,
-                      ACE_Allocator *alloc = 0,
+                      ACE_Allocator *alloc = nullptr,
                       bool is_heap_allocated = false);
 
   /// Destructor

--- a/TAO/tao/Reply_Dispatcher.h
+++ b/TAO/tao/Reply_Dispatcher.h
@@ -56,7 +56,7 @@ class TAO_Export TAO_Reply_Dispatcher
 {
 public:
   /// Constructor.
-  TAO_Reply_Dispatcher (ACE_Allocator *allocator = 0);
+  TAO_Reply_Dispatcher (ACE_Allocator *allocator = nullptr);
 
   /// Destructor.
   virtual ~TAO_Reply_Dispatcher ();

--- a/TAO/tao/Resume_Handle.h
+++ b/TAO/tao/Resume_Handle.h
@@ -46,7 +46,7 @@ class TAO_Export TAO_Resume_Handle
 {
 public:
   /// Constructor.
-  TAO_Resume_Handle (TAO_ORB_Core *orb_core = 0,
+  TAO_Resume_Handle (TAO_ORB_Core *orb_core = nullptr,
                      ACE_HANDLE h = ACE_INVALID_HANDLE);
   /// Destructor
   ~TAO_Resume_Handle ();

--- a/TAO/tao/Synch_Queued_Message.h
+++ b/TAO/tao/Synch_Queued_Message.h
@@ -53,7 +53,7 @@ public:
    */
   TAO_Synch_Queued_Message (const ACE_Message_Block *contents,
                             TAO_ORB_Core *oc,
-                            ACE_Allocator *alloc = 0,
+                            ACE_Allocator *alloc = nullptr,
                             bool is_heap_allocated = false);
 
   /// Destructor

--- a/TAO/tao/Thread_Lane_Resources.h
+++ b/TAO/tao/Thread_Lane_Resources.h
@@ -52,7 +52,7 @@ public:
   /// Constructor.
   TAO_Thread_Lane_Resources (
       TAO_ORB_Core &orb_core,
-      TAO_New_Leader_Generator *new_leader_generator = 0);
+      TAO_New_Leader_Generator *new_leader_generator = nullptr);
 
   /// Destructor.
   ~TAO_Thread_Lane_Resources ();

--- a/TAO/tao/Thread_Per_Connection_Handler.cpp
+++ b/TAO/tao/Thread_Per_Connection_Handler.cpp
@@ -55,11 +55,11 @@ TAO_Thread_Per_Connection_Handler::activate_ch (long flags,
                          0,
                          ACE_DEFAULT_THREAD_PRIORITY,
                          -1,
-                         0,
-                         0,
-                         0,
-                         0,
-                         0,
+                         nullptr,
+                         nullptr,
+                         nullptr,
+                         nullptr,
+                         nullptr,
                          &thread_names[0]);
 }
 

--- a/TAO/tao/Transport.h
+++ b/TAO/tao/Transport.h
@@ -102,7 +102,7 @@ namespace TAO
   public:
     /// Default constructor
     Drain_Constraints()
-      : timeout_(0)
+      : timeout_(nullptr)
       , block_on_io_(false)
     {
     }
@@ -538,7 +538,7 @@ public:
    */
   virtual ssize_t recv (char *buffer,
                         size_t len,
-                        const ACE_Time_Value *timeout = 0) = 0;
+                        const ACE_Time_Value *timeout = nullptr) = 0;
 
   /**
    * @name Control connection lifecycle
@@ -692,7 +692,7 @@ public:
    * those cases a maximum read time can be specified.
    */
   virtual int handle_input (TAO_Resume_Handle &rh,
-                            ACE_Time_Value *max_wait_time = 0);
+                            ACE_Time_Value *max_wait_time = nullptr);
 
   /// Prepare the waiting and demuxing strategy to receive a reply for
   /// a new request.
@@ -736,10 +736,10 @@ public:
    *
    */
   virtual int send_message (TAO_OutputCDR &stream,
-                            TAO_Stub *stub = 0,
-                            TAO_ServerRequest *request = 0,
+                            TAO_Stub *stub = nullptr,
+                            TAO_ServerRequest *request = nullptr,
                             TAO_Message_Semantics message_semantics = TAO_Message_Semantics (),
-                            ACE_Time_Value *max_time_wait = 0) = 0;
+                            ACE_Time_Value *max_time_wait = nullptr) = 0;
 
   /// Sent the contents of @a message_block
   /**
@@ -815,7 +815,7 @@ public:
    */
   int send_message_block_chain (const ACE_Message_Block *message_block,
                                 size_t &bytes_transferred,
-                                ACE_Time_Value *max_wait_time = 0);
+                                ACE_Time_Value *max_wait_time = nullptr);
 
   /// Send a message block chain, assuming the lock is held
   int send_message_block_chain_i (const ACE_Message_Block *message_block,

--- a/TAO/tao/Transport_Acceptor.h
+++ b/TAO/tao/Transport_Acceptor.h
@@ -91,7 +91,7 @@ public:
                     int version_major,
                     int version_minor,
                     const char *address,
-                    const char *options = 0) = 0;
+                    const char *options = nullptr) = 0;
 
   /**
    * Open an acceptor with the given protocol version on a default
@@ -101,7 +101,7 @@ public:
                             ACE_Reactor *reactor,
                             int version_major,
                             int version_minor,
-                            const char *options = 0) = 0;
+                            const char *options = nullptr) = 0;
 
   /// Closes the acceptor
   virtual int close () = 0;

--- a/TAO/tao/Transport_Cache_Manager_T.cpp
+++ b/TAO/tao/Transport_Cache_Manager_T.cpp
@@ -32,7 +32,7 @@ namespace TAO
     : percent_ (percent)
     , purging_strategy_ (purging)
     , cache_map_ (cache_maximum)
-    , cache_lock_ (0)
+    , cache_lock_ (nullptr)
     , cache_maximum_ (cache_maximum)
 #if defined (TAO_HAS_MONITOR_POINTS) && (TAO_HAS_MONITOR_POINTS == 1)
     , purge_monitor_ (0)

--- a/TAO/tao/Var_Array_Argument_T.cpp
+++ b/TAO/tao/Var_Array_Argument_T.cpp
@@ -55,7 +55,7 @@ TAO::In_Var_Array_Clonable_Argument_T<S_forany,Insert_Policy>::clone ()
   typename ARRAY_TRAITS::slice_type * tmp_ptr = 0;
   ACE_ALLOCATOR_RETURN (tmp_ptr,
                         ARRAY_TRAITS::alloc (),
-                        0);
+                        nullptr);
   ARRAY_TRAITS::copy(tmp_ptr, this->x_.in ());
 
   In_Var_Array_Clonable_Argument_T<S_forany,Insert_Policy>* clone_arg

--- a/TAO/tao/operation_details.h
+++ b/TAO/tao/operation_details.h
@@ -71,10 +71,10 @@ public:
   /// Constructor
   TAO_Operation_Details (const char *name,
                          const CORBA::ULong len,
-                         TAO::Argument **args = 0,
+                         TAO::Argument **args = nullptr,
                          const CORBA::ULong num_args = 0,
                          const CORBA::Boolean has_in_args = true,
-                         const TAO::Exception_Data *ex_data = 0,
+                         const TAO::Exception_Data *ex_data = nullptr,
                          const CORBA::ULong ex_count = 0);
 
   /// Operation name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modernized pointer null-handling semantics across the library by updating default parameter values to use C++11 null pointer literals instead of integer zero. Changes span constructors, methods, and API defaults throughout the framework. This improves code type safety and consistency while preserving full backward compatibility with existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->