### PR TITLE
Remove obsolete old_stdstream feature

### DIFF
--- a/ACE/bin/MakeProjectCreator/config/global.features
+++ b/ACE/bin/MakeProjectCreator/config/global.features
@@ -64,7 +64,6 @@ mcpp          = 0
 wireshark_any = 0
 wireshark     = 0
 wireshark_cmake = 0
-old_stdstream = 0
 exclude_inet  = 0
 inet_ssl      = 0
 coredx        = 0

--- a/ACE/bin/MakeProjectCreator/config/inet.mpb
+++ b/ACE/bin/MakeProjectCreator/config/inet.mpb
@@ -1,6 +1,5 @@
 // -*- MPC -*-
 project : acelib {
-  avoids   += old_stdstream
   avoids   += exclude_inet
   avoids   += ace_for_tao
   avoids   += corba_e_compact

--- a/ACE/protocols/ace/INet/inet.mpc
+++ b/ACE/protocols/ace/INet/inet.mpc
@@ -3,7 +3,6 @@ project(INet) : acelib, ace_output, install {
   sharedname   = ACE_INet
   dynamicflags += ACE_INET_BUILD_DLL
   includes += $(ACE_ROOT)/protocols
-  avoids += old_stdstream
   avoids += exclude_inet
   avoids += ace_for_tao
   Source_Files {


### PR DESCRIPTION
    * ACE/bin/MakeProjectCreator/config/global.features:
    * ACE/bin/MakeProjectCreator/config/inet.mpb:
    * ACE/protocols/ace/INet/inet.mpc:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete build configuration flags to streamline the build system configuration and reduce maintenance overhead of legacy features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DOCGroup/ACE_TAO/pull/2543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->