### PR TITLE
Updated all download links to just github, can't access download.dre …

### DIFF
--- a/ACE/Kokyu/docs/Kokyu.html
+++ b/ACE/Kokyu/docs/Kokyu.html
@@ -357,7 +357,7 @@ interface is in <tt>Kokyu::DSRT_Dispatcher (Kokyu_dsrt.h)</tt>
 <h3>
 <a NAME="Status"></a>Current status</h3>
 Kokyu dispatching framework is available as a separate module under <tt><font size=+1>ACE_wrappers/Kokyu</font></tt>
-as part of the <a href="https://download.dre.vanderbilt.edu">ACE/TAO
+as part of the <a href="https://github.com/DOCGroup/ACE_TAO">ACE/TAO
 distribution</a>. Note that this module is not dependent on TAO, though
 it is built on top of ACE. The TAO Event Channel uses the Strategy and
 Service Configurator patterns to use configurable dispatching modules.

--- a/ACE/README
+++ b/ACE/README
@@ -2,8 +2,7 @@ This document is also available at the following URL:
 
 https://www.dre.vanderbilt.edu/~schmidt/ACE.html
 
-All software and documentation is available via both anonymous ftp and
-http.
+All software and documentation is available via http.
 
 THE ADAPTIVE COMMUNICATION ENVIRONMENT (ACE)
 

--- a/ACE/README
+++ b/ACE/README
@@ -147,7 +147,7 @@ applications provided with the ACE release include:
 OBTAINING ACE
 
 ACE may be obtained electronically from
-https://download.dre.vanderbilt.edu.  This release contains the source
+https://github.com/DOCGroup/ACE_TAO.  This release contains the source
 code, test drivers, and example applications (including JAWS) for C++
 wrapper libraries and the higher-level ACE network programming
 framework developed as part of the ADAPTIVE project at the University

--- a/ACE/docs/Download.html
+++ b/ACE/docs/Download.html
@@ -96,75 +96,45 @@ Windows line feeds. For all other platforms download a .gz/.bz2 package.
   <TR><TH>Filename</TH><TH>Description</TH><TH>Full</TH><TH>Sources only</TH></TR>
   <TR><TD>ACE+TAO.tar.gz</TD>
       <TD>ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.6.tar.gz">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.6.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE+TAO.tar.bz2</TD>
       <TD>ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.6.tar.bz2">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.6.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE+TAO.zip</TD>
       <TD>ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-8.0.6.zip">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-8.0.6.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.zip">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html.tar.gz</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.6.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html.tar.bz2</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.6.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html.zip</TD>
       <TD>Doxygen documentation for ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-8.0.6.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.zip">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE.tar.gz</TD>
       <TD>ACE only (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.6.tar.gz">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.6.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE.tar.bz2</TD>
       <TD>ACE only (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.6.tar.bz2">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.6.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE.zip</TD>
       <TD>ACE only (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-8.0.6.zip">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-8.0.6.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.zip">HTTP</A>]</TD>
   </TR>
 </TABLE>
 
@@ -175,75 +145,45 @@ Windows line feeds. For all other platforms download a .gz/.bz2 package.
   <TR><TH>Filename</TH><TH>Description</TH><TH>Full</TH><TH>Sources only</TH></TR>
   <TR><TD>ACE+TAO-7.1.0.tar.gz</TD>
       <TD>ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-7.1.0.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.1.0.tar.gz">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-src-7.1.0.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.1.0.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-7.1.0.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-src-7.1.0.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE+TAO-7.1.0.tar.bz2</TD>
       <TD>ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-7.1.0.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.1.0.tar.bz2">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-src-7.1.0.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.1.0.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-7.1.0.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-src-7.1.0.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE+TAO-7.1.0.zip</TD>
       <TD>ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-7.1.0.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-7.1.0.zip">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-src-7.1.0.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE+TAO-src-7.1.0.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-7.1.0.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE+TAO-src-7.1.0.zip">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html-7.1.0.tar.gz</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-html-7.1.0.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.1.0.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-html-7.1.0.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html-7.1.0.tar.bz2</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-html-7.1.0.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.1.0.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-html-7.1.0.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html-7.1.0.zip</TD>
       <TD>Doxygen documentation for ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-html-7.1.0.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-html-7.1.0.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-html-7.1.0.zip">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-7.1.0.tar.gz</TD>
       <TD>ACE only (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-7.1.0.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.1.0.tar.gz">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-src-7.1.0.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.1.0.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-7.1.0.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-src-7.1.0.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-7.1.0.tar.bz2</TD>
       <TD>ACE only (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-7.1.0.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.1.0.tar.bz2">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-src-7.1.0.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.1.0.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-7.1.0.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-src-7.1.0.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-7.1.0.zip</TD>
       <TD>ACE only (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-7.1.0.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-7.1.0.zip">FTP</A>]
-      </TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-src-7.1.0.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/ACE-src-7.1.0.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-7.1.0.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_0/ACE-src-7.1.0.zip">HTTP</A>]</TD>
   </TR>
 </TABLE>
 
@@ -256,21 +196,15 @@ of the CIAO micro release is available for
   <TR><TH>Filename</TH><TH>Description</TH><TH>Sources only</TH></TR>
   <TR><TD>CIAO.tar.gz</TD>
       <TD>CIAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/CIAO/releases/download/CIAO-1_3_10/CIAO-1_3_10-src.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/CIAO-1_3_10-src.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/CIAO/releases/download/CIAO-1_3_10/CIAO-1_3_10-src.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>CIAO.tar.bz2</TD>
       <TD>CIAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/CIAO/releases/download/CIAO-1_3_10/CIAO-1_3_10-src.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/CIAO-1_3_10-src.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/CIAO/releases/download/CIAO-1_3_10/CIAO-1_3_10-src.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>CIAO.zip</TD>
       <TD>CIAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/CIAO/releases/download/CIAO-1_3_10/CIAO-1_3_10-src.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/CIAO-1_3_10-src.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/CIAO/releases/download/CIAO-1_3_10/CIAO-1_3_10-src.zip">HTTP</A>]</TD>
   </TR>
 </TABLE>
 
@@ -283,21 +217,15 @@ of the DAnCE micro release is available for
   <TR><TH>Filename</TH><TH>Description</TH><TH>Sources only</TH></TR>
   <TR><TD>DAnCE.tar.gz</TD>
       <TD>DAnCE (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/DAnCE/releases/download/DAnCE-1_3_10/DAnCE-1_3_10-src.tar.gz">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/DAnCE-1_3_10-src.tar.gz">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/DAnCE/releases/download/DAnCE-1_3_10/DAnCE-1_3_10-src.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>DAnCE.tar.bz2</TD>
       <TD>DAnCE (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/DAnCE/releases/download/DAnCE-1_3_10/DAnCE-1_3_10-src.tar.bz2">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/DAnCE-1_3_10-src.tar.bz2">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/DAnCE/releases/download/DAnCE-1_3_10/DAnCE-1_3_10-src.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>DAnCE.zip</TD>
       <TD>DAnCE (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/DAnCE/releases/download/DAnCE-1_3_10/DAnCE-1_3_10-src.zip">HTTP</A>]
-          [<A HREF="ftp://download.dre.vanderbilt.edu/previous_versions/DAnCE-1_3_10-src.zip">FTP</A>]
-      </TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/DAnCE/releases/download/DAnCE-1_3_10/DAnCE-1_3_10-src.zip">HTTP</A>]</TD>
   </TR>
 </TABLE>
 

--- a/TAO/TAO-INSTALL.html
+++ b/TAO/TAO-INSTALL.html
@@ -66,14 +66,10 @@ wrappers on the platforms shown above please open a github <A
 HREF="https://github.com/DOCGroup/ACE_TAO">issue or discussion</A> and we'll
 try to help you fix the problems.<P>
 
-TAO can be obtained <A
-HREF="https://download.dre.vanderbilt.edu">electronically</A>
-via the WWW and ftp.  <A
-HREF="https://www.cs.wm.edu/~dcschmidt/TAO.html">TAO</A> is bundled
-with the <A
-HREF="https://www.cs.wm.edu/~dcschmidt/ACE.html"> ACE </A> release.  You'll
+TAO can be obtained <A HREF="https://github.com/DOCGroup/ACE_TAO">electronically</A>.
+TAO is bundled with ACE. You'll
 always need the most recent version of ACE because TAO tracks and
-influences changes to ACE.  Always use the ACE+TAO release
+influences changes to ACE. Always use the ACE+TAO release
 bundle as a single piece instead of trying to mix and match things up.<P>
 
 <HR><P>

--- a/TAO/docs/Security/Download.html
+++ b/TAO/docs/Security/Download.html
@@ -73,7 +73,7 @@ function MM_nbGroup(event, grpName) { //v3.0
     by the BXA from this US site.</p>
   <h3>TAO CORBA Security Service Software</h3>
   <ul>
-    <li><a href="https://download.dre.vanderbilt.edu"> TAO: The ACE
+    <li><a href="https://github.com/DOCGroup/ACE_TAO"> TAO: The ACE
       ORB</a> (TAO's CORBA Security Service is now shipped with the main TAO distribution)</li>
   </ul>
   <h3>Cryptographic Software</h3>

--- a/TAO/docs/tutorials/Quoter/index.html
+++ b/TAO/docs/tutorials/Quoter/index.html
@@ -42,7 +42,7 @@
     files for which links are provided.  If you choose to build and
     run the example, however, use the files which are part of
     the TAO source you <A
-    HREF="https://download.dre.vanderbilt.edu">download</a>. You can
+    HREF="https://github.com/DOCGroup/ACE_TAO">download</a>. You can
     find those source files in <CODE>$TAO_ROOT/docs/tutorials/Quoter</CODE>,
     where there's also a Makefile to build them with. Downloading the files
     individually from these links may result in source that does not build


### PR DESCRIPTION
…anymore for new uploads

    * ACE/Kokyu/docs/Kokyu.html:
    * ACE/README:
    * ACE/docs/Download.html:
    * TAO/TAO-INSTALL.html:
    * TAO/docs/Security/Download.html:
    * TAO/docs/tutorials/Quoter/index.html:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ACE and TAO documentation download links to use the GitHub-hosted repository instead of the Vanderbilt URLs.
  * Refreshed ACE+TAO, CIAO, and DAnCE download tables to remove FTP references and show HTTP-only options for current releases.
  * Updated install and tutorial pages to direct readers to the latest ACE+TAO release guidance and GitHub-based download links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->