### PR TITLE
Updated to a working server

### DIFF
--- a/ACE/tests/NonBlocking_Conn_Test.cpp
+++ b/ACE/tests/NonBlocking_Conn_Test.cpp
@@ -89,7 +89,7 @@ Svc_Handler::handle_close (ACE_HANDLE handle, ACE_Reactor_Mask mask)
 using CONNECTOR = ACE_Connector<Svc_Handler, ACE_SOCK_Connector>;
 
 static const char* hosts[] = {
-  "www.russiantvguide.com:80",
+  "tweakers.net:80",
   "news.bbc.co.uk:80",
   "www.cnn.com:80",
   "www.waca.com.au:80",


### PR DESCRIPTION
    * ACE/tests/NonBlocking_Conn_Test.cpp:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the non-blocking connection test endpoint to use `tweakers.net` instead of the previous site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->