### PR TITLE
Remove openssl11 feature, openssl 1.0 itself was supported until 2015

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -125,7 +125,6 @@ jobs:
         echo "ipv6=1" | out-file -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "xerces3=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "ssl=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
-        echo "openssl11=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "versioned_namespace=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "zlib=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
       shell: pwsh

--- a/ACE/ACE-INSTALL.html
+++ b/ACE/ACE-INSTALL.html
@@ -1918,10 +1918,6 @@ below.</p>
   <li>Add <code>ssl=1</code> to your MPC
       <code>$ACE_ROOT/bin/MakeProjectCreator/config/default.features</code>
       or <code>$ACE_ROOT/local.features</code> file.
-  <li>At the moment you are using OpenSSL v1.1 or
-      newer also add <code>openssl11=1</code> to your MPC
-      <code>$ACE_ROOT/bin/MakeProjectCreator/config/default.features</code>
-      or <code>$ACE_ROOT/local.features</code> file.
   <li>Re-run MPC to add
       support for building the ACE_SSL library to your MSVC++
       workspaces and projects.

--- a/ACE/bin/MakeProjectCreator/config/global.features
+++ b/ACE/bin/MakeProjectCreator/config/global.features
@@ -26,7 +26,6 @@ ace_idl_dependencies = 1
 ace_for_tao   = 0
 cross_compile = 0
 ssl           = 0
-openssl11     = 0
 qos           = 0
 rapi          = 0
 repo          = 0


### PR DESCRIPTION
    * .github/workflows/windows.yml:
    * ACE/ACE-INSTALL.html:
    * ACE/bin/MakeProjectCreator/config/global.features:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated Windows build configuration to enable IPv6, Xerces3, and SSL support by default.
  * Removed the obsolete OpenSSL 1.1-specific configuration option.

* **Documentation**
  * Updated Microsoft Visual Studio installation instructions to reflect the streamlined SSL configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->