### PR TITLE
Compile fixes for SSL on Windows 64bit

### DIFF
--- a/ACE/ace/ACE.cpp
+++ b/ACE/ace/ACE.cpp
@@ -2206,7 +2206,7 @@ ACE::handle_ready (ACE_HANDLE handle,
   int select_width = 0;
 #if !defined (ACE_WIN32)
   select_width = int (handle) + 1;
-#  endif /* ACE_WIN32 */
+#endif /* ACE_WIN32 */
   int result = ACE_OS::select (select_width,
                                read_ready ? handle_set.fdset () : 0, // read_fds.
                                write_ready ? handle_set.fdset () : 0, // write_fds.

--- a/ACE/ace/ACE.cpp
+++ b/ACE/ace/ACE.cpp
@@ -2205,7 +2205,7 @@ ACE::handle_ready (ACE_HANDLE handle,
   // Wait for data or for the timeout to elapse.
   int select_width = 0;
 #if !defined (ACE_WIN32)
-  select_width = int (handle) + 1;
+  select_width = handle + 1;
 #endif /* ACE_WIN32 */
   int result = ACE_OS::select (select_width,
                                read_ready ? handle_set.fdset () : 0, // read_fds.

--- a/ACE/ace/SSL/SSL_Context.cpp
+++ b/ACE/ace/SSL/SSL_Context.cpp
@@ -784,7 +784,6 @@ ACE_SSL_Context::dh_params (const char *file_name,
 
   {
     // Swiped from Rescorla's examples and the OpenSSL s_server.c app
-    DH * ret = nullptr;
     BIO * bio = nullptr;
 
     if ((bio = ::BIO_new_file (this->dh_params_.file_name (), "r")) == nullptr)
@@ -793,7 +792,7 @@ ACE_SSL_Context::dh_params (const char *file_name,
         return -1;
       }
 
-    ret = PEM_read_bio_DHparams (bio, nullptr, nullptr, nullptr);
+    DH * ret = PEM_read_bio_DHparams (bio, nullptr, nullptr, nullptr);
     BIO_free (bio);
 
     if (ret == nullptr)

--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -130,7 +130,7 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
         {
           // Must have at least one handle to wait for at this point.
           ACE_ASSERT (rd_handle.num_set() == 1 || wr_handle.num_set () == 1);
-          status = ACE::select (int (handle) + 1,
+          status = ACE::select (static_cast<int>(handle) + 1,
                                 &rd_handle,
                                 &wr_handle,
                                 nullptr,

--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -130,7 +130,7 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
         {
           // Must have at least one handle to wait for at this point.
           ACE_ASSERT (rd_handle.num_set() == 1 || wr_handle.num_set () == 1);
-          status = ACE::select (static_cast<int>(handle) + 1,
+          status = ACE::select (reinterpret_cast<int>(handle) + 1,
                                 &rd_handle,
                                 &wr_handle,
                                 nullptr,

--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -133,7 +133,7 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
           int select_width = 0;
 #if !defined (ACE_WIN32)
           select_width = int (handle) + 1;
-#  endif /* ACE_WIN32 */
+#endif /* ACE_WIN32 */
           status = ACE::select (select_width,
                                 &rd_handle,
                                 &wr_handle,

--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -130,7 +130,11 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
         {
           // Must have at least one handle to wait for at this point.
           ACE_ASSERT (rd_handle.num_set() == 1 || wr_handle.num_set () == 1);
-          status = ACE::select (reinterpret_cast<int>(handle) + 1,
+          int select_width = 0;
+#if !defined (ACE_WIN32)
+          select_width = int (handle) + 1;
+#  endif /* ACE_WIN32 */
+          status = ACE::select (select_width,
                                 &rd_handle,
                                 &wr_handle,
                                 nullptr,

--- a/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Acceptor.cpp
@@ -132,7 +132,7 @@ ACE_SSL_SOCK_Acceptor::ssl_accept (ACE_SSL_SOCK_Stream &new_stream,
           ACE_ASSERT (rd_handle.num_set() == 1 || wr_handle.num_set () == 1);
           int select_width = 0;
 #if !defined (ACE_WIN32)
-          select_width = int (handle) + 1;
+          select_width = handle + 1;
 #endif /* ACE_WIN32 */
           status = ACE::select (select_width,
                                 &rd_handle,

--- a/ACE/ace/SSL/SSL_SOCK_Connector.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.cpp
@@ -155,7 +155,7 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
           int select_width = 0;
 #if !defined (ACE_WIN32)
           select_width = int (handle) + 1;
-#  endif /* ACE_WIN32 */
+#endif /* ACE_WIN32 */
           status = ACE::select (select_width,
                                 &rd_handle,
                                 &wr_handle,

--- a/ACE/ace/SSL/SSL_SOCK_Connector.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.cpp
@@ -152,7 +152,11 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
           ACE_ASSERT (rd_handle.num_set () == 1 || wr_handle.num_set () == 1);
 
           // Block indefinitely if timeout pointer is zero.
-          status = ACE::select (reinterpret_cast<int>(handle) + 1,
+          int select_width = 0;
+#if !defined (ACE_WIN32)
+          select_width = int (handle) + 1;
+#  endif /* ACE_WIN32 */
+          status = ACE::select (select_width,
                                 &rd_handle,
                                 &wr_handle,
                                 nullptr,

--- a/ACE/ace/SSL/SSL_SOCK_Connector.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.cpp
@@ -154,7 +154,7 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
           // Block indefinitely if timeout pointer is zero.
           int select_width = 0;
 #if !defined (ACE_WIN32)
-          select_width = int (handle) + 1;
+          select_width = handle + 1;
 #endif /* ACE_WIN32 */
           status = ACE::select (select_width,
                                 &rd_handle,

--- a/ACE/ace/SSL/SSL_SOCK_Connector.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.cpp
@@ -152,7 +152,7 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
           ACE_ASSERT (rd_handle.num_set () == 1 || wr_handle.num_set () == 1);
 
           // Block indefinitely if timeout pointer is zero.
-          status = ACE::select (int (handle) + 1,
+          status = ACE::select (static_cast<int>(handle) + 1,
                                 &rd_handle,
                                 &wr_handle,
                                 nullptr,

--- a/ACE/ace/SSL/SSL_SOCK_Connector.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Connector.cpp
@@ -152,7 +152,7 @@ ACE_SSL_SOCK_Connector::ssl_connect (ACE_SSL_SOCK_Stream &new_stream,
           ACE_ASSERT (rd_handle.num_set () == 1 || wr_handle.num_set () == 1);
 
           // Block indefinitely if timeout pointer is zero.
-          status = ACE::select (static_cast<int>(handle) + 1,
+          status = ACE::select (reinterpret_cast<int>(handle) + 1,
                                 &rd_handle,
                                 &wr_handle,
                                 nullptr,

--- a/ACE/ace/SSL/SSL_SOCK_Stream.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Stream.cpp
@@ -129,7 +129,7 @@ ACE_SSL_SOCK_Stream::recvv (iovec *io_vec,
 
   int select_width = 0;
 #if !defined (ACE_WIN32)
-  select_width = int (this->get_handle ()) + 1;
+  select_width = this->get_handle () + 1;
 #endif /* ACE_WIN32 */
 
   // Check the status of the current socket.

--- a/ACE/ace/SSL/SSL_SOCK_Stream.cpp
+++ b/ACE/ace/SSL/SSL_SOCK_Stream.cpp
@@ -127,9 +127,14 @@ ACE_SSL_SOCK_Stream::recvv (iovec *io_vec,
 
   io_vec->iov_base = nullptr;
 
+  int select_width = 0;
+#if !defined (ACE_WIN32)
+  select_width = int (this->get_handle ()) + 1;
+#endif /* ACE_WIN32 */
+
   // Check the status of the current socket.
   switch (
-    ACE_OS::select (int (this->get_handle ()) + 1,
+    ACE_OS::select (select_width,
                     handle_set,
                     nullptr,
                     nullptr,

--- a/ACE/ace/SSL/SSL_SOCK_Stream.inl
+++ b/ACE/ace/SSL/SSL_SOCK_Stream.inl
@@ -14,7 +14,7 @@ ACE_SSL_SOCK_Stream::set_handle (ACE_HANDLE fd)
     }
   else
     {
-      (void) ::SSL_set_fd (this->ssl_, (int) fd);
+      (void) ::SSL_set_fd (this->ssl_, static_cast<int>(fd));
       this->ACE_SSL_SOCK::set_handle (fd);
       this->stream_.set_handle (fd);
     }

--- a/ACE/ace/SSL/SSL_SOCK_Stream.inl
+++ b/ACE/ace/SSL/SSL_SOCK_Stream.inl
@@ -14,7 +14,7 @@ ACE_SSL_SOCK_Stream::set_handle (ACE_HANDLE fd)
     }
   else
     {
-      (void) ::SSL_set_fd (this->ssl_, static_cast<int>(fd));
+      (void) ::SSL_set_fd (this->ssl_, reinterpret_cast<int>(fd));
       this->ACE_SSL_SOCK::set_handle (fd);
       this->stream_.set_handle (fd);
     }

--- a/ACE/ace/SSL/SSL_SOCK_Stream.inl
+++ b/ACE/ace/SSL/SSL_SOCK_Stream.inl
@@ -14,7 +14,11 @@ ACE_SSL_SOCK_Stream::set_handle (ACE_HANDLE fd)
     }
   else
     {
-      (void) ::SSL_set_fd (this->ssl_, reinterpret_cast<int>(fd));
+#if defined (ACE_WIN32)
+      (void) ::SSL_set_fd (this->ssl_, static_cast<int>((intptr_t)fd));
+#else
+      (void) ::SSL_set_fd (this->ssl_, fd);
+#endif
       this->ACE_SSL_SOCK::set_handle (fd);
       this->stream_.set_handle (fd);
     }

--- a/ACE/examples/C++NPv2/AC_Client_Logging_Daemon.cpp
+++ b/ACE/examples/C++NPv2/AC_Client_Logging_Daemon.cpp
@@ -348,8 +348,7 @@ int AC_CLD_Connector::connect_svc_handler
 #if defined (ACE_WIN32)
   // ACE_WIN32 is the only platform where ACE_HANDLE is not an int.
   // See ace/config-lite.h for the typedefs.
-  SSL_set_fd (ssl_,
-              reinterpret_cast<int> (svc_handler->get_handle ()));
+  SSL_set_fd (ssl_, static_cast<int> ((intptr_t)svc_handler->get_handle ()));
 #else
   SSL_set_fd (ssl_, svc_handler->get_handle ());
 #endif /* ACE_WIN32 */

--- a/ACE/examples/C++NPv2/AIO_Client_Logging_Daemon.cpp
+++ b/ACE/examples/C++NPv2/AIO_Client_Logging_Daemon.cpp
@@ -259,7 +259,7 @@ int AIO_CLD_Connector::validate_connection
 #if defined (ACE_WIN32)
   // ACE_WIN32 is the only platform where ACE_HANDLE is not an int.
   // See ace/config-lite.h for the typedefs.
-  SSL_set_fd (ssl_, reinterpret_cast<int> (result.connect_handle ()));
+  SSL_set_fd (ssl_, static_cast<int> ((intptr_t)result.connect_handle ()));
 #else
   SSL_set_fd (ssl_, result.connect_handle ());
 #endif /* ACE_WIN32 */

--- a/ACE/examples/C++NPv2/TPC_Logging_Server.cpp
+++ b/ACE/examples/C++NPv2/TPC_Logging_Server.cpp
@@ -82,7 +82,7 @@ int TPC_Logging_Acceptor::accept_svc_handler
 #if defined (ACE_WIN32)
   // ACE_WIN32 is the only platform where ACE_HANDLE is not an int.
   // See ace/config-lite.h for the typedefs.
-  SSL_set_fd (ssl_, reinterpret_cast<int> (sh->get_handle ()));
+  SSL_set_fd (ssl_, static_cast<int> ((intptr_t)sh->get_handle ()));
 #else
   SSL_set_fd (ssl_, sh->get_handle ());
 #endif /* ACE_WIN32 */

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
@@ -552,8 +552,12 @@ Handler_Factory::handle_events ()
       ACE_Time_Value timeout (ACE_DEFAULT_TIMEOUT);
       fd_set temp = handles;
 
+      int select_width = 0;
+#if !defined (ACE_WIN32)
+      select_width = this->oneway_acceptor_.get_handle ()) + 1;
+#  endif /* ACE_WIN32 */
       int result =
-        ACE_OS::select (reinterpret_cast<int>(this->oneway_acceptor_.get_handle ()) + 1,
+        ACE_OS::select (select_width,
                         (fd_set *) &temp,
                         0,
                         0,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
@@ -555,7 +555,7 @@ Handler_Factory::handle_events ()
       int select_width = 0;
 #if !defined (ACE_WIN32)
       select_width = this->oneway_acceptor_.get_handle ()) + 1;
-#  endif /* ACE_WIN32 */
+#endif /* ACE_WIN32 */
       int result =
         ACE_OS::select (select_width,
                         (fd_set *) &temp,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
@@ -554,7 +554,7 @@ Handler_Factory::handle_events ()
 
       int select_width = 0;
 #if !defined (ACE_WIN32)
-      select_width = this->oneway_acceptor_.get_handle ()) + 1;
+      select_width = this->oneway_acceptor_.get_handle () + 1;
 #endif /* ACE_WIN32 */
       int result =
         ACE_OS::select (select_width,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
@@ -553,7 +553,7 @@ Handler_Factory::handle_events ()
       fd_set temp = handles;
 
       int result =
-        ACE_OS::select (int (this->oneway_acceptor_.get_handle ()) + 1,
+        ACE_OS::select (static_cast<int>(this->oneway_acceptor_.get_handle ()) + 1,
                         (fd_set *) &temp,
                         0,
                         0,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-fancy.cpp
@@ -553,7 +553,7 @@ Handler_Factory::handle_events ()
       fd_set temp = handles;
 
       int result =
-        ACE_OS::select (static_cast<int>(this->oneway_acceptor_.get_handle ()) + 1,
+        ACE_OS::select (reinterpret_cast<int>(this->oneway_acceptor_.get_handle ()) + 1,
                         (fd_set *) &temp,
                         0,
                         0,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
@@ -293,9 +293,9 @@ run_event_loop (u_short port)
       ACE_Time_Value timeout (ACE_DEFAULT_TIMEOUT);
       ACE_Handle_Set temp = handle_set;
 
-      int maxfd = static_cast<int>(oneway_acceptor.get_handle ());
-      if (maxfd < static_cast<int>(twoway_acceptor.get_handle ()))
-        maxfd = static_cast<int>(twoway_acceptor.get_handle ());
+      int maxfd = reinterpret_cast<int>(oneway_acceptor.get_handle ());
+      if (maxfd < reinterpret_cast<int>(twoway_acceptor.get_handle ()))
+        maxfd = reinterpret_cast<int>(twoway_acceptor.get_handle ());
       int result = ACE_OS::select (maxfd + 1,
                                    (fd_set *) temp,
                                    0,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
@@ -293,9 +293,9 @@ run_event_loop (u_short port)
       ACE_Time_Value timeout (ACE_DEFAULT_TIMEOUT);
       ACE_Handle_Set temp = handle_set;
 
-      int maxfd = int(oneway_acceptor.get_handle ());
-      if (maxfd < int(twoway_acceptor.get_handle ()))
-        maxfd = int(twoway_acceptor.get_handle ());
+      int maxfd = static_cast<int>(oneway_acceptor.get_handle ());
+      if (maxfd < static_cast<int>(twoway_acceptor.get_handle ()))
+        maxfd = static_cast<int>(twoway_acceptor.get_handle ());
       int result = ACE_OS::select (maxfd + 1,
                                    (fd_set *) temp,
                                    0,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
@@ -293,9 +293,14 @@ run_event_loop (u_short port)
       ACE_Time_Value timeout (ACE_DEFAULT_TIMEOUT);
       ACE_Handle_Set temp = handle_set;
 
-      int maxfd = reinterpret_cast<int>(oneway_acceptor.get_handle ());
-      if (maxfd < reinterpret_cast<int>(twoway_acceptor.get_handle ()))
-        maxfd = reinterpret_cast<int>(twoway_acceptor.get_handle ());
+      int maxfd = 0;
+#if !defined (ACE_WIN32)
+      maxfd = (int)oneway_acceptor.get_handle ();
+      if (maxfd < (int)twoway_acceptor.get_handle ())
+        {
+          maxfd = (int)twoway_acceptor.get_handle ();
+        }
+#  endif /* ACE_WIN32 */
       int result = ACE_OS::select (maxfd + 1,
                                    (fd_set *) temp,
                                    0,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server-simple.cpp
@@ -295,10 +295,10 @@ run_event_loop (u_short port)
 
       int maxfd = 0;
 #if !defined (ACE_WIN32)
-      maxfd = (int)oneway_acceptor.get_handle ();
-      if (maxfd < (int)twoway_acceptor.get_handle ())
+      maxfd = oneway_acceptor.get_handle ();
+      if (maxfd < twoway_acceptor.get_handle ())
         {
-          maxfd = (int)twoway_acceptor.get_handle ();
+          maxfd = twoway_acceptor.get_handle ();
         }
 #  endif /* ACE_WIN32 */
       int result = ACE_OS::select (maxfd + 1,

--- a/ACE/examples/IPC_SAP/SSL_SAP/SSL-server.cpp
+++ b/ACE/examples/IPC_SAP/SSL_SAP/SSL-server.cpp
@@ -328,11 +328,11 @@ run_event_loop (u_short port)
       ACE_Time_Value timeout (ACE_DEFAULT_TIMEOUT);
       ACE_Handle_Set temp = handle_set;
 
-      int result = ACE_OS::select (int (oneway_acceptor.get_handle ()) + 1,
-                                   (fd_set *) temp,
-                                   0,
-                                   0,
-                                   timeout);
+      int select_width = 0;
+#if !defined (ACE_WIN32)
+      select_width = oneway_acceptor.get_handle () + 1;
+#endif /* ACE_WIN32 */
+      int const result = ACE_OS::select (select_width, (fd_set *) temp, 0, 0, timeout);
       if (result == -1)
         ACE_ERROR ((LM_ERROR,
                     "(%P|%t) %p\n",

--- a/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
+++ b/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
@@ -148,7 +148,7 @@ namespace ACE
                 ACE_ASSERT (rd_handle.num_set () == 1 || wr_handle.num_set () == 1);
 
                 // Block indefinitely if timeout pointer is zero.
-                status = ACE::select (static_cast<int>(handle) + 1,
+                status = ACE::select (reinterpret_cast<int>(handle) + 1,
                                       &rd_handle,
                                       &wr_handle,
                                       0,

--- a/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
+++ b/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
@@ -150,7 +150,7 @@ namespace ACE
                 // Block indefinitely if timeout pointer is zero.
                 int select_width = 0;
 #if !defined (ACE_WIN32)
-                select_width = int (handle) + 1;
+                select_width = handle + 1;
 #endif /* ACE_WIN32 */
                 status = ACE::select (select_width,
                                       &rd_handle,

--- a/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
+++ b/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
@@ -148,7 +148,7 @@ namespace ACE
                 ACE_ASSERT (rd_handle.num_set () == 1 || wr_handle.num_set () == 1);
 
                 // Block indefinitely if timeout pointer is zero.
-                status = ACE::select (int (handle) + 1,
+                status = ACE::select (static_cast<int>(handle) + 1,
                                       &rd_handle,
                                       &wr_handle,
                                       0,

--- a/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
+++ b/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
@@ -151,7 +151,7 @@ namespace ACE
                 int select_width = 0;
 #if !defined (ACE_WIN32)
                 select_width = int (handle) + 1;
-#  endif /* ACE_WIN32 */
+#endif /* ACE_WIN32 */
                 status = ACE::select (select_width,
                                       &rd_handle,
                                       &wr_handle,

--- a/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
+++ b/ACE/protocols/ace/INet/SSL_Proxy_Connector.cpp
@@ -148,7 +148,11 @@ namespace ACE
                 ACE_ASSERT (rd_handle.num_set () == 1 || wr_handle.num_set () == 1);
 
                 // Block indefinitely if timeout pointer is zero.
-                status = ACE::select (reinterpret_cast<int>(handle) + 1,
+                int select_width = 0;
+#if !defined (ACE_WIN32)
+                select_width = int (handle) + 1;
+#  endif /* ACE_WIN32 */
+                status = ACE::select (select_width,
                                       &rd_handle,
                                       &wr_handle,
                                       0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clarified platform-aware `select()` width/range handling across SSL accept/connect, proxy connector, SSL stream, and related example event loops without changing behavior.
  * Updated Win32 OpenSSL file-descriptor assignment to use safer integer casting.
  * Streamlined a small SSL context variable initialization in DH parameter loading.
* **Style**
  * Minor cleanup to make readiness/event-loop `select()` calculations more explicit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->