### PR TITLE
Document changes

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,7 +1,7 @@
 USER VISIBLE CHANGES BETWEEN ACE-8.0.6 and ACE-8.0.7
 ====================================================
 
-. Fixed compile errors in ACE SSL with the Embarcader C++ Builder bcc64x compiler
+. Fixed compile errors in ACE SSL with the Embarcadero C++ Builder bcc64x compiler
 
 . Minor ACE SSL fixes
 

--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,6 +1,12 @@
 USER VISIBLE CHANGES BETWEEN ACE-8.0.6 and ACE-8.0.7
 ====================================================
 
+. Fixed compile errors in ACE SSL with the Embarcader C++ Builder bcc64x compiler
+
+. Minor ACE SSL fixes
+
+. Dropped support for OpenSSL 1.0.x
+
 USER VISIBLE CHANGES BETWEEN ACE-8.0.5 and ACE-8.0.6
 ====================================================
 

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,6 +1,11 @@
 USER VISIBLE CHANGES BETWEEN TAO-4.0.6 and TAO-4.0.7
 ====================================================
 
+. Fixed compile errors in SSLIOP with the Embarcader C++ Builder bcc64x compiler
+
+. Updated the certificates for the SSLIOP tests because OpenSSL 3.x rejected
+  our old ones
+
 USER VISIBLE CHANGES BETWEEN TAO-4.0.5 and TAO-4.0.6
 ====================================================
 

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,7 +1,7 @@
 USER VISIBLE CHANGES BETWEEN TAO-4.0.6 and TAO-4.0.7
 ====================================================
 
-. Fixed compile errors in SSLIOP with the Embarcader C++ Builder bcc64x compiler
+. Fixed compile errors in SSLIOP with the Embarcadero C++ Builder bcc64x compiler
 
 . Updated the certificates for the SSLIOP tests because OpenSSL 3.x rejected
   our old ones


### PR DESCRIPTION
    * ACE/NEWS:
    * TAO/NEWS:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSL compilation issues with the Embarcadero bcc64x compiler.
  * Resolved minor SSL-related issues in ACE.
  * Updated SSLIOP test certificates for OpenSSL 3.x compatibility.
* **Compatibility**
  * Removed support for OpenSSL 1.0.x.
* **Documentation**
  * Corrected the spelling of the Embarcadero compiler name in release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->