### PR TITLE
Make ACE/TAO 8.0.7 and 4.0.7 public

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN ACE-8.0.7 and ACE-8.0.8
+====================================================
+
 USER VISIBLE CHANGES BETWEEN ACE-8.0.6 and ACE-8.0.7
 ====================================================
 

--- a/ACE/bin/copy-local-script.sh
+++ b/ACE/bin/copy-local-script.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 for i in *.gz *.bz2 *.zip *.md5; do
-  d=`echo $i | sed 's/\.[tz][ai][rp]/-8.0.7&/'`
+  d=`echo $i | sed 's/\.[tz][ai][rp]/-8.0.8&/'`
   echo "Copying $i to $d"
   cp -ip $i $d
 done

--- a/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
+++ b/ACE/bin/diff-builds-and-group-fixed-tests-only.sh
@@ -2,7 +2,7 @@
 
 if test -z $1; then newdate=`date -u +%Y_%m_%d`; else newdate=$1; fi
 if test -z $2; then prefix=`date -u +%Y%m%d%a`; else prefix=$2; fi
-if test -z $3; then olddate=2026_05_11; else olddate=$3; fi
+if test -z $3; then olddate=2026_08_14; else olddate=$3; fi
 if test -z $ACE_ROOT; then ACE_ROOT=..; fi
 if test -z $TAO_ROOT; then TAO_ROOT=${ACE_ROOT}/TAO; fi
 #

--- a/ACE/docs/Download.html
+++ b/ACE/docs/Download.html
@@ -90,51 +90,51 @@ Windows line feeds. For all other platforms download a .gz/.bz2 package.
 </P>
 
 <UL>
-<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 8.0.6 and TAO 4.0.6, please use the links below to download it.<P>
+<LI> <B>Latest ACE+TAO Micro Release.</B> The latest micro release is ACE 8.0.7 and TAO 4.0.7, please use the links below to download it.<P>
 
 <TABLE BORDER="4">
   <TR><TH>Filename</TH><TH>Description</TH><TH>Full</TH><TH>Sources only</TH></TR>
   <TR><TD>ACE+TAO.tar.gz</TD>
       <TD>ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.tar.gz">HTTP</A>]</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE+TAO-8.0.7.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE+TAO-src-8.0.7.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE+TAO.tar.bz2</TD>
       <TD>ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.tar.bz2">HTTP</A>]</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE+TAO-8.0.7.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE+TAO-src-8.0.7.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE+TAO.zip</TD>
       <TD>ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-8.0.6.zip">HTTP</A>]</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE+TAO-src-8.0.6.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE+TAO-8.0.7.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE+TAO-src-8.0.7.zip">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html.tar.gz</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-html-8.0.7.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html.tar.bz2</TD>
       <TD>Doxygen documentation for ACE+TAO (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-html-8.0.7.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE-html.zip</TD>
       <TD>Doxygen documentation for ACE+TAO (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-html-8.0.6.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-html-8.0.7.zip">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE.tar.gz</TD>
       <TD>ACE only (tar+gzip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.tar.gz">HTTP</A>]</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-8.0.7.tar.gz">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-src-8.0.7.tar.gz">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE.tar.bz2</TD>
       <TD>ACE only (tar+bzip2 format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.tar.bz2">HTTP</A>]</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-8.0.7.tar.bz2">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-src-8.0.7.tar.bz2">HTTP</A>]</TD>
   </TR>
   <TR><TD>ACE.zip</TD>
       <TD>ACE only (zip format)</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-8.0.6.zip">HTTP</A>]</TD>
-      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_6/ACE-src-8.0.6.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-8.0.7.zip">HTTP</A>]</TD>
+      <TD>[<A HREF="https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_7/ACE-src-8.0.7.zip">HTTP</A>]</TD>
   </TR>
 </TABLE>
 

--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,3 +1,6 @@
+USER VISIBLE CHANGES BETWEEN TAO-4.0.7 and TAO-4.0.8
+====================================================
+
 USER VISIBLE CHANGES BETWEEN TAO-4.0.6 and TAO-4.0.7
 ====================================================
 


### PR DESCRIPTION
    * ACE/NEWS:
    * ACE/bin/copy-local-script.sh:
    * ACE/bin/diff-builds-and-group-fixed-tests-only.sh:
    * ACE/docs/Download.html:
    * TAO/NEWS:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the download page to list the latest ACE 8.0.7 and TAO 4.0.7 micro-release packages, including full, source-only, and documentation downloads.
  * Added new ACE 8.0.8 and TAO 4.0.0.8 release-note sections for upcoming user-visible changes.

* **Chores**
  * Updated release packaging and build-comparison defaults for the latest release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->