### PR TITLE
Test extensions

### DIFF
--- a/TAO/bin/tao_orb_tests.lst
+++ b/TAO/bin/tao_orb_tests.lst
@@ -432,6 +432,8 @@ TAO/tests/TransportCurrent/IIOP/run_test.pl -dynamic: !DISABLE_TRANSPORT_CURRENT
 TAO/tests/TransportCurrent/IIOP/run_test.pl -static: !DISABLE_TRANSPORT_CURRENT STATIC !CORBA_E_COMPACT !CORBA_E_MICRO !DISABLE_INTERCEPTORS !MINIMUM
 TAO/tests/Transport_Cache_Manager/run_test.pl
 TAO/tests/Transport_Idle_Timeout/run_test.pl
+TAO/tests/Transport_Idle_Timeout_Long_Request/run_test.pl
+TAO/tests/Transport_Idle_Timeout_server/run_test.pl
 TAO/tests/UNKNOWN_Exception/run_test.pl:
 TAO/tests/Native_Exceptions/run_test.pl:
 TAO/tests/Servant_To_Reference_Test/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !ST

--- a/TAO/tao/Transport.cpp
+++ b/TAO/tao/Transport.cpp
@@ -2964,8 +2964,8 @@ TAO_Transport::schedule_idle_timer ()
               TAOLIB_DEBUG ((LM_DEBUG,
                       ACE_TEXT ("TAO (%P|%t) - Transport[%d]::schedule_idle_timer, ")
                       ACE_TEXT ("schedule idle timer with id [%d] ")
-                      ACE_TEXT ("in the reactor.\n"),
-                      this->id (), this->idle_timer_id_));
+                      ACE_TEXT ("for %d seconds in the reactor.\n"),
+                      this->id (), this->idle_timer_id_, timeout_sec));
             }
         }
     }

--- a/TAO/tests/Transport_Idle_Timeout_Long_Request/README.md
+++ b/TAO/tests/Transport_Idle_Timeout_Long_Request/README.md
@@ -1,0 +1,18 @@
+# Long server request and transport idle timeout regression
+
+The server uses:
+
+    -ORBTransportIdleTimeout 1
+
+`long_request()` sleeps for two seconds before returning.
+
+The test succeeds only when the server can keep the transport alive while the
+request is actively being processed and send the reply afterwards.
+
+This exposes a weakness in a patch that merely calls `schedule_idle_timer()`
+when a request is received: that schedules a new one-second timer, but does
+not protect a request whose processing takes longer than one second.
+
+A robust implementation should cancel the server-side idle timer before
+processing a request and schedule a new timer after request processing has
+completed.

--- a/TAO/tests/Transport_Idle_Timeout_Long_Request/Transport_Idle_Timeout_Long_Request.idl
+++ b/TAO/tests/Transport_Idle_Timeout_Long_Request/Transport_Idle_Timeout_Long_Request.idl
@@ -1,0 +1,9 @@
+module Transport_Idle_Timeout_Long_Request_Test
+{
+  interface Test
+  {
+    void long_request ();
+    void ping ();
+    void shutdown ();
+  };
+};

--- a/TAO/tests/Transport_Idle_Timeout_Long_Request/Transport_Idle_Timeout_Long_Request.mpc
+++ b/TAO/tests/Transport_Idle_Timeout_Long_Request/Transport_Idle_Timeout_Long_Request.mpc
@@ -1,0 +1,28 @@
+project(*idl): taoidldefaults {
+  idlflags += -Sp
+  IDL_Files {
+    Transport_Idle_Timeout_Long_Request.idl
+  }
+  custom_only = 1
+}
+
+project(*Server): taoserver {
+  after += *idl
+  Source_Files {
+    server.cpp
+    Transport_Idle_Timeout_Long_RequestC.cpp
+    Transport_Idle_Timeout_Long_RequestS.cpp
+  }
+  IDL_Files {
+  }
+}
+
+project(*Client): taoclient {
+  after += *idl
+  Source_Files {
+    client.cpp
+    Transport_Idle_Timeout_Long_RequestC.cpp
+  }
+  IDL_Files {
+  }
+}

--- a/TAO/tests/Transport_Idle_Timeout_Long_Request/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Long_Request/client.cpp
@@ -1,0 +1,62 @@
+#include "Transport_Idle_Timeout_Long_RequestC.h"
+
+#include "ace/Get_Opt.h"
+
+const ACE_TCHAR *ior = ACE_TEXT ("file://server.ior");
+
+int
+parse_args (int argc, ACE_TCHAR *argv[])
+{
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("k:"));
+  int c;
+
+  while ((c = get_opts ()) != -1)
+    {
+      switch (c)
+        {
+        case 'k':
+          ior = get_opts.opt_arg ();
+          break;
+        default:
+          ACE_ERROR_RETURN ((LM_ERROR,
+                             "usage: %s -k <ior>\n", argv[0]), -1);
+        }
+    }
+  return 0;
+}
+
+int
+ACE_TMAIN (int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb = CORBA::ORB_init (argc, argv);
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      CORBA::Object_var object = orb->string_to_object (ior);
+      Transport_Idle_Timeout_Long_Request_Test::Test_var test =
+        Transport_Idle_Timeout_Long_Request_Test::Test::_narrow (object.in ());
+
+      if (CORBA::is_nil (test.in ()))
+        ACE_ERROR_RETURN ((LM_ERROR, "nil Test reference\n"), 1);
+
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) client: long_request\n"));
+      test->long_request ();
+
+      // long_request() only returns if the server could send its reply after
+      // two seconds, despite a one second transport idle timeout.
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) client: ping\n"));
+      test->ping ();
+
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) client: shutdown\n"));
+      test->shutdown ();
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception& ex)
+    {
+      ex._tao_print_exception ("Exception caught:");
+      return 1;
+    }
+  return 0;
+}

--- a/TAO/tests/Transport_Idle_Timeout_Long_Request/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_Long_Request/run_test.pl
@@ -1,0 +1,78 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+# -*- perl -*-
+
+use lib "$ENV{ACE_ROOT}/bin";
+use PerlACE::TestTarget;
+
+$status = 0;
+my $server = PerlACE::TestTarget::create_target (1)
+    || die "Create target 1 failed\n";
+my $client = PerlACE::TestTarget::create_target (2)
+    || die "Create target 2 failed\n";
+
+my $iorbase = "server.ior";
+my $server_iorfile = $server->LocalFile ($iorbase);
+my $client_iorfile = $client->LocalFile ($iorbase);
+$debug_level = '0';
+$cdebug_level = '0';
+foreach $i (@ARGV) {
+    if ($i eq '-debug') {
+        $debug_level = '10';
+    }
+    if ($i eq '-cdebug') {
+      $cdebug_level = '10';
+    }
+}
+
+$server->DeleteFile ($iorbase);
+$client->DeleteFile ($iorbase);
+
+my $SV = $server->CreateProcess (
+    "server",
+    "-ORBSvcConf svc.conf -o $server_iorfile -ORBdebuglevel $debug_level -ORBVerboseLogging 1");
+
+my $CL = $client->CreateProcess (
+    "client",
+    "-ORBSvcConf svc.conf -k file://$client_iorfile -ORBdebuglevel $cdebug_level -ORBVerboseLogging 1");
+
+if ($SV->Spawn () != 0) {
+    print STDERR "ERROR: server failed to start\n";
+    exit 1;
+}
+
+if ($server->WaitForFileTimed (
+        $iorbase, $server->ProcessStartWaitInterval ()) == -1) {
+    print STDERR "ERROR: cannot find <$server_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+if ($server->GetFile ($iorbase) == -1 ||
+    $client->PutFile ($iorbase) == -1) {
+    print STDERR "ERROR: cannot transfer IOR\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+my $client_status =
+    $CL->SpawnWaitKill ($client->ProcessStartWaitInterval () + 15);
+
+if ($client_status != 0) {
+    print STDERR "ERROR: client returned $client_status\n";
+    $status = 1;
+}
+
+my $server_status =
+    $SV->WaitKill ($server->ProcessStopWaitInterval ());
+
+if ($server_status != 0) {
+    print STDERR "ERROR: server returned $server_status\n";
+    $status = 1;
+}
+
+$server->DeleteFile ($iorbase);
+$client->DeleteFile ($iorbase);
+
+exit $status;

--- a/TAO/tests/Transport_Idle_Timeout_Long_Request/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Long_Request/server.cpp
@@ -1,0 +1,118 @@
+#include "Transport_Idle_Timeout_Long_RequestS.h"
+
+#include "ace/Get_Opt.h"
+#include "ace/OS_NS_stdio.h"
+#include "ace/OS_NS_unistd.h"
+#include "ace/OS_NS_sys_time.h"
+
+const ACE_TCHAR *ior_output_file = ACE_TEXT ("server.ior");
+
+void
+sleep_with_reactor (CORBA::ORB_ptr orb, int seconds)
+{
+  ACE_Time_Value const deadline = ACE_OS::gettimeofday () + ACE_Time_Value (seconds);
+
+  while (ACE_OS::gettimeofday () < deadline)
+    {
+      ACE_Time_Value tv (0, 50000); // 50 ms slices
+      orb->perform_work (tv);
+    }
+}
+
+class Test_i
+  : public virtual POA_Transport_Idle_Timeout_Long_Request_Test::Test
+{
+public:
+  explicit Test_i (CORBA::ORB_ptr orb)
+    : orb_ (CORBA::ORB::_duplicate (orb))
+  {
+  }
+
+  void long_request () override
+  {
+    ACE_DEBUG ((LM_DEBUG,
+                "(%P|%t) server: long_request, sleeping 2 seconds\n"));
+    sleep_with_reactor (orb_.in(), 2);
+    ACE_DEBUG ((LM_DEBUG,
+                "(%P|%t) server: long_request finished\n"));
+  }
+
+  void ping () override
+  {
+    ACE_DEBUG ((LM_DEBUG, "(%P|%t) server: ping received\n"));
+  }
+
+  void shutdown () override
+  {
+    ACE_DEBUG ((LM_DEBUG, "(%P|%t) server: shutdown received\n"));
+    this->orb_->shutdown (false);
+  }
+
+private:
+  CORBA::ORB_var orb_;
+};
+
+int
+parse_args (int argc, ACE_TCHAR *argv[])
+{
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("o:"));
+  int c;
+
+  while ((c = get_opts ()) != -1)
+    {
+      switch (c)
+        {
+        case 'o':
+          ior_output_file = get_opts.opt_arg ();
+          break;
+        default:
+          ACE_ERROR_RETURN ((LM_ERROR,
+                             "usage: %s [-o <iorfile>]\n", argv[0]), -1);
+        }
+    }
+  return 0;
+}
+
+int
+ACE_TMAIN (int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb = CORBA::ORB_init (argc, argv);
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      CORBA::Object_var poa_object =
+        orb->resolve_initial_references ("RootPOA");
+      PortableServer::POA_var root_poa =
+        PortableServer::POA::_narrow (poa_object.in ());
+      PortableServer::POAManager_var poa_manager =
+        root_poa->the_POAManager ();
+
+      Test_i *servant = 0;
+      ACE_NEW_RETURN (servant, Test_i (orb.in ()), 1);
+      PortableServer::ServantBase_var owner_transfer (servant);
+
+      PortableServer::ObjectId_var id = root_poa->activate_object (servant);
+      CORBA::Object_var object = root_poa->id_to_reference (id.in ());
+      CORBA::String_var ior = orb->object_to_string (object.in ());
+
+      FILE *output_file = ACE_OS::fopen (ior_output_file, "w");
+      if (output_file == 0)
+        ACE_ERROR_RETURN ((LM_ERROR, "Cannot open output file <%s>\n",
+                           ior_output_file), 1);
+      ACE_OS::fprintf (output_file, "%s", ior.in ());
+      ACE_OS::fclose (output_file);
+
+      poa_manager->activate ();
+      orb->run ();
+      root_poa->destroy (true, true);
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception& ex)
+    {
+      ex._tao_print_exception ("Exception caught:");
+      return 1;
+    }
+  return 0;
+}

--- a/TAO/tests/Transport_Idle_Timeout_Long_Request/svc.conf
+++ b/TAO/tests/Transport_Idle_Timeout_Long_Request/svc.conf
@@ -1,0 +1,1 @@
+static Resource_Factory "-ORBTransportIdleTimeout 1"

--- a/TAO/tests/Transport_Idle_Timeout_server/README.md
+++ b/TAO/tests/Transport_Idle_Timeout_server/README.md
@@ -21,16 +21,11 @@ opening, causing the second `ping()` to fail.
 The fix restarts the idle timer when parsed incoming traffic is received,
 so the second `ping()` succeeds.
 
-The client disables invocation retries for communication failures, closed
-replies, and transient exceptions so that a closed server transport cannot
-be transparently replaced by a new connection and make the test pass
-accidentally.
-
 ## Build
 
 Generate the projects with MPC in this directory, for example:
 
-    $ACE_ROOT/bin/mwc.pl -type <your-type> Transport_Idle_Timeout.mpc
+    $ACE_ROOT/bin/mwc.pl -type <your-type> Transport_Idle_Timeout_server.mpc
 
 Then build the generated workspace/project.
 

--- a/TAO/tests/Transport_Idle_Timeout_server/README.md
+++ b/TAO/tests/Transport_Idle_Timeout_server/README.md
@@ -1,0 +1,43 @@
+# Transport idle timeout regression test
+
+This test covers the server-side `-ORBTransportIdleTimeout` behavior.
+
+The client performs:
+
+1. `ping()` — opens the transport.
+2. Waits 1.5 seconds.
+3. `ping()` again.
+4. `shutdown()`.
+
+The server runs with:
+
+    -ORBTransportIdleTimeout 2
+
+Before the fix, the server-side idle timer starts when the transport is
+opened and is not restarted when the server receives the first `ping()`.
+Consequently the transport can be closed after roughly two seconds from
+opening, causing the second `ping()` to fail.
+
+The fix restarts the idle timer when parsed incoming traffic is received,
+so the second `ping()` succeeds.
+
+The client disables invocation retries for communication failures, closed
+replies, and transient exceptions so that a closed server transport cannot
+be transparently replaced by a new connection and make the test pass
+accidentally.
+
+## Build
+
+Generate the projects with MPC in this directory, for example:
+
+    $ACE_ROOT/bin/mwc.pl -type <your-type> Transport_Idle_Timeout.mpc
+
+Then build the generated workspace/project.
+
+## Run
+
+    perl run_test.pl
+
+For transport diagnostics:
+
+    perl run_test.pl -debug

--- a/TAO/tests/Transport_Idle_Timeout_server/Transport_Idle_Timeout.idl
+++ b/TAO/tests/Transport_Idle_Timeout_server/Transport_Idle_Timeout.idl
@@ -1,0 +1,8 @@
+module Transport_Idle_Timeout_Test
+{
+  interface Test
+  {
+    void ping ();
+    void shutdown ();
+  };
+};

--- a/TAO/tests/Transport_Idle_Timeout_server/Transport_Idle_Timeout_server.mpc
+++ b/TAO/tests/Transport_Idle_Timeout_server/Transport_Idle_Timeout_server.mpc
@@ -1,0 +1,33 @@
+// -*- MPC -*-
+project(*idl): taoidldefaults {
+  idlflags += -Sp
+  IDL_Files {
+    Transport_Idle_Timeout.idl
+  }
+  custom_only = 1
+}
+
+project(*Server): taoserver {
+  after += *idl
+  Source_Files {
+    server.cpp
+  }
+  Source_Files {
+    Transport_Idle_TimeoutC.cpp
+    Transport_Idle_TimeoutS.cpp
+  }
+  IDL_Files {
+  }
+}
+
+project(*Client): taoclient {
+  after += *idl
+  Source_Files {
+    client.cpp
+  }
+  Source_Files {
+    Transport_Idle_TimeoutC.cpp
+  }
+  IDL_Files {
+  }
+}

--- a/TAO/tests/Transport_Idle_Timeout_server/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_server/client.cpp
@@ -1,0 +1,81 @@
+#include "Transport_Idle_TimeoutC.h"
+
+#include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
+#include "ace/Time_Value.h"
+
+const ACE_TCHAR *ior = ACE_TEXT ("file://server.ior");
+
+int
+parse_args (int argc, ACE_TCHAR *argv[])
+{
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("k:"));
+  int c;
+
+  while ((c = get_opts ()) != -1)
+    {
+      switch (c)
+        {
+        case 'k':
+          ior = get_opts.opt_arg ();
+          break;
+        case '?':
+        default:
+          ACE_ERROR_RETURN ((LM_ERROR,
+                             "usage: %s -k <ior>\n",
+                             argv[0]),
+                            -1);
+        }
+    }
+
+  return 0;
+}
+
+int
+ACE_TMAIN (int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb = CORBA::ORB_init (argc, argv);
+
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      CORBA::Object_var object = orb->string_to_object (ior);
+
+      Transport_Idle_Timeout_Test::Test_var test =
+        Transport_Idle_Timeout_Test::Test::_narrow (object.in ());
+
+      if (CORBA::is_nil (test.in ()))
+        ACE_ERROR_RETURN ((LM_ERROR, "nil Test reference\n"), 1);
+
+      // The first request opens the transport. With a 2 second idle
+      // timeout, the server-side transport must remain usable because
+      // this request is followed by another request before 2 seconds
+      // have elapsed since the first request.
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) client: first ping\n"));
+      test->ping ();
+
+      ACE_OS::sleep (ACE_Time_Value (1, 500000));
+
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) client: second ping\n"));
+      test->ping ();
+
+      ACE_OS::sleep (ACE_Time_Value (1, 500000));
+
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) client: third ping\n"));
+      test->ping ();
+
+      ACE_DEBUG ((LM_DEBUG, "(%P|%t) client: shutdown\n"));
+      test->shutdown ();
+
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception& ex)
+    {
+      ex._tao_print_exception ("Exception caught:");
+      return 1;
+    }
+
+  return 0;
+}

--- a/TAO/tests/Transport_Idle_Timeout_server/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_server/run_test.pl
@@ -1,0 +1,93 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+# -*- perl -*-
+
+use lib "$ENV{ACE_ROOT}/bin";
+use PerlACE::TestTarget;
+
+$status = 0;
+$debug_level = '0';
+$cdebug_level = '0';
+foreach $i (@ARGV) {
+    if ($i eq '-debug') {
+        $debug_level = '10';
+    }
+    if ($i eq '-cdebug') {
+      $cdebug_level = '10';
+    }
+}
+
+my $server = PerlACE::TestTarget::create_target (1)
+    || die "Create target 1 failed\n";
+my $client = PerlACE::TestTarget::create_target (2)
+    || die "Create target 2 failed\n";
+
+my $iorbase = "server.ior";
+my $server_iorfile = $server->LocalFile ($iorbase);
+my $client_iorfile = $client->LocalFile ($iorbase);
+
+$server->DeleteFile ($iorbase);
+$client->DeleteFile ($iorbase);
+
+# The timeout is intentionally short. The first ping opens the transport
+# and is followed 1.5 seconds later by the second ping. Without the fix,
+# the server-side timer started when the transport was opened expires after
+# 2 seconds and the second request fails. With the fix, receiving the first
+# request restarts the server-side timer and the second request succeeds.
+my $server_args =
+    "-ORBSvcConf svc.conf -ORBdebuglevel $debug_level -ORBVerboseLogging 1 " .
+    "-o $server_iorfile";
+
+my $client_args =
+    "-ORBdebuglevel $cdebug_level -ORBVerboseLogging 1 " .
+    "-k file://$client_iorfile";
+
+$SV = $server->CreateProcess ("server", $server_args);
+$CL = $client->CreateProcess ("client", $client_args);
+
+$server_status = $SV->Spawn ();
+if ($server_status != 0) {
+    print STDERR "ERROR: server returned $server_status\n";
+    exit 1;
+}
+
+if ($server->WaitForFileTimed (
+        $iorbase, $server->ProcessStartWaitInterval ()) == -1) {
+    print STDERR "ERROR: cannot find file <$server_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+if ($server->GetFile ($iorbase) == -1) {
+    print STDERR "ERROR: cannot retrieve file <$server_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+if ($client->PutFile ($iorbase) == -1) {
+    print STDERR "ERROR: cannot set file <$client_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+$client_status = $CL->SpawnWaitKill (
+    $client->ProcessStartWaitInterval () + 10);
+
+if ($client_status != 0) {
+    print STDERR "ERROR: client returned $client_status\n";
+    $status = 1;
+}
+
+$server_status = $SV->WaitKill (
+    $server->ProcessStopWaitInterval ());
+
+if ($server_status != 0) {
+    print STDERR "ERROR: server returned $server_status\n";
+    $status = 1;
+}
+
+$server->DeleteFile ($iorbase);
+$client->DeleteFile ($iorbase);
+
+exit $status;

--- a/TAO/tests/Transport_Idle_Timeout_server/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_server/server.cpp
@@ -1,0 +1,116 @@
+#include "Transport_Idle_TimeoutS.h"
+
+#include "ace/Get_Opt.h"
+#include "ace/OS_NS_stdio.h"
+
+#include <cstdio>
+
+const ACE_TCHAR *ior_output_file = ACE_TEXT ("server.ior");
+
+class Test_i : public virtual POA_Transport_Idle_Timeout_Test::Test
+{
+public:
+  explicit Test_i (CORBA::ORB_ptr orb)
+    : orb_ (CORBA::ORB::_duplicate (orb))
+  {
+  }
+
+  void ping () override
+  {
+    ACE_DEBUG ((LM_DEBUG, "(%P|%t) server: ping received\n"));
+  }
+
+  void shutdown () override
+  {
+    ACE_DEBUG ((LM_DEBUG, "(%P|%t) server: shutdown received\n"));
+    this->orb_->shutdown (false);
+  }
+
+private:
+  CORBA::ORB_var orb_;
+};
+
+int
+parse_args (int argc, ACE_TCHAR *argv[])
+{
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("o:"));
+  int c;
+
+  while ((c = get_opts ()) != -1)
+    {
+      switch (c)
+        {
+        case 'o':
+          ior_output_file = get_opts.opt_arg ();
+          break;
+        case '?':
+        default:
+          ACE_ERROR_RETURN ((LM_ERROR,
+                             "usage: %s [-o <iorfile>]\n",
+                             argv[0]),
+                            -1);
+        }
+    }
+
+  return 0;
+}
+
+int
+ACE_TMAIN (int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb = CORBA::ORB_init (argc, argv);
+
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      CORBA::Object_var poa_object =
+        orb->resolve_initial_references ("RootPOA");
+
+      PortableServer::POA_var root_poa =
+        PortableServer::POA::_narrow (poa_object.in ());
+
+      if (CORBA::is_nil (root_poa.in ()))
+        ACE_ERROR_RETURN ((LM_ERROR, "nil RootPOA\n"), 1);
+
+      PortableServer::POAManager_var poa_manager =
+        root_poa->the_POAManager ();
+
+      Test_i *servant = 0;
+      ACE_NEW_RETURN (servant, Test_i (orb.in ()), 1);
+      PortableServer::ServantBase_var owner_transfer (servant);
+
+      PortableServer::ObjectId_var id =
+        root_poa->activate_object (servant);
+
+      CORBA::Object_var object =
+        root_poa->id_to_reference (id.in ());
+
+      CORBA::String_var ior =
+        orb->object_to_string (object.in ());
+
+      FILE *output_file = ACE_OS::fopen (ior_output_file, "w");
+      if (output_file == 0)
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           "Cannot open output file <%s>\n",
+                           ior_output_file),
+                          1);
+
+      ACE_OS::fprintf (output_file, "%s", ior.in ());
+      ACE_OS::fclose (output_file);
+
+      poa_manager->activate ();
+      orb->run ();
+
+      root_poa->destroy (true, true);
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception& ex)
+    {
+      ex._tao_print_exception ("Exception caught:");
+      return 1;
+    }
+
+  return 0;
+}

--- a/TAO/tests/Transport_Idle_Timeout_server/svc.conf
+++ b/TAO/tests/Transport_Idle_Timeout_server/svc.conf
@@ -1,0 +1,1 @@
+static Resource_Factory "-ORBTransportIdleTimeout 2"


### PR DESCRIPTION
    * TAO/tests/Transport_Idle_Timeout_Long_Request/README.md:
    * TAO/tests/Transport_Idle_Timeout_Long_Request/Transport_Idle_Timeout_Long_Request.idl:
    * TAO/tests/Transport_Idle_Timeout_Long_Request/Transport_Idle_Timeout_Long_Request.mpc:
    * TAO/tests/Transport_Idle_Timeout_Long_Request/client.cpp:
    * TAO/tests/Transport_Idle_Timeout_Long_Request/run_test.pl:
    * TAO/tests/Transport_Idle_Timeout_Long_Request/server.cpp:
    * TAO/tests/Transport_Idle_Timeout_Long_Request/svc.conf:
    * TAO/tests/Transport_Idle_Timeout_server/README.md:
    * TAO/tests/Transport_Idle_Timeout_server/Transport_Idle_Timeout.idl:
    * TAO/tests/Transport_Idle_Timeout_server/Transport_Idle_Timeout_server.mpc:
    * TAO/tests/Transport_Idle_Timeout_server/client.cpp:
    * TAO/tests/Transport_Idle_Timeout_server/run_test.pl:
    * TAO/tests/Transport_Idle_Timeout_server/server.cpp:
    * TAO/tests/Transport_Idle_Timeout_server/svc.conf: Added.

    * TAO/bin/tao_orb_tests.lst:
    * TAO/tao/Transport.cpp:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Diagnostics**
  - Transport idle-timeout messages now include the configured timeout duration.

- **Tests**
  - Added regression coverage confirming idle-timeout renewal during server traffic.
  - Added coverage ensuring active, long-running requests remain connected beyond the idle-timeout interval.
  - Added automated client/server scenarios and configurations for both behaviors.

- **Documentation**
  - Added test documentation describing idle-timeout behavior, setup, execution, and expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->