### PR TITLE
Support TransportIdleTimeout in a pure server role

### DIFF
--- a/TAO/docs/Options.html
+++ b/TAO/docs/Options.html
@@ -1393,9 +1393,11 @@ example</a> of how this is used in TAO.</p>
         <td>Number of seconds after which idle connections are closed and purged from
         the transport cache. By default idle connections are kept until they are
         explicitly closed or purged because the transport cache is almost full.
-        Synchronous incoming requests are not considered idle while they are being
-        processed. AMH and CSD deferred server request processing are not supported
-        when this option is enabled.</td>
+        Any successfully received data, including partial GIOP messages, cancels the
+        idle timer. The idle timer is started again when data is successfully sent
+        on the transport. AMH and CSD deferred server request processing are not
+        supported when this option is enabled and result in
+        <code>CORBA::NO_IMPLEMENT</code>.</td>
       </tr>
     </tbody>
   </table>

--- a/TAO/docs/Options.html
+++ b/TAO/docs/Options.html
@@ -1392,7 +1392,10 @@ example</a> of how this is used in TAO.</p>
         <td><code>-ORBTransportIdleTimeout</code> <em>number</em></td>
         <td>Number of seconds after which idle connections are closed and purged from
         the transport cache. By default idle connections are kept until they are
-        explicitly closed or purged because the transport cache is almost full.</td>
+        explicitly closed or purged because the transport cache is almost full.
+        Synchronous incoming requests are not considered idle while they are being
+        processed. AMH and CSD deferred server request processing are not supported
+        when this option is enabled.</td>
       </tr>
     </tbody>
   </table>

--- a/TAO/tao/CSD_ThreadPool/CSD_TP_Strategy.cpp
+++ b/TAO/tao/CSD_ThreadPool/CSD_TP_Strategy.cpp
@@ -7,6 +7,7 @@
 #include "tao/CSD_ThreadPool/CSD_TP_Collocated_Synch_With_Server_Request.h"
 #include "ace/Trace.h"
 #include "tao/ORB_Core.h"
+#include "tao/Resource_Factory.h"
 
 #if !defined (__ACE_INLINE__)
 # include "tao/CSD_ThreadPool/CSD_TP_Strategy.inl"
@@ -56,6 +57,14 @@ TAO::CSD::TP_Strategy::custom_asynch_request(TP_Custom_Request_Operation* op)
 bool
 TAO::CSD::TP_Strategy::poa_activated_event_i(TAO_ORB_Core& orb_core)
 {
+  if (orb_core.resource_factory ()->transport_idle_timeout () > 0)
+    {
+      TAOLIB_ERROR ((LM_ERROR,
+                    ACE_TEXT ("TAO (%P|%t) - CSD cannot be used when ")
+                    ACE_TEXT ("-ORBTransportIdleTimeout is enabled\n")));
+      throw CORBA::NO_IMPLEMENT ();
+    }
+
   this->task_.thr_mgr(orb_core.thr_mgr());
   // Activates the worker threads, and waits until all have been started.
   return (this->task_.open(&(this->num_threads_)) == 0);

--- a/TAO/tao/GIOP_Message_Base.h
+++ b/TAO/tao/GIOP_Message_Base.h
@@ -155,6 +155,13 @@ public:
   /// request/response?
   bool is_ready_for_bidirectional (TAO_OutputCDR &msg) const;
 
+  /// Whether incoming GIOP fragments are awaiting reassembly.
+  bool has_pending_fragments () const
+  {
+    TAO_Queued_Data *qd = nullptr;
+    return this->fragment_stack_.top (qd) == 0;
+  }
+
 private:
 #if defined (TAO_HAS_ZIOP) && TAO_HAS_ZIOP ==1
   /// Decompresses a ZIOP message and turns it into a GIOP message
@@ -243,13 +250,6 @@ private:
    *       thing marshaled into the output CDR stream @a msg.
    */
   void set_giop_flags (TAO_OutputCDR & msg) const;
-
-  /// Whether incoming GIOP fragments are awaiting reassembly.
-  bool has_pending_fragments () const
-  {
-    TAO_Queued_Data *qd = nullptr;
-    return this->fragment_stack_.top (qd) == 0;
-  }
 
 private:
   /// Cached ORB_Core pointer...

--- a/TAO/tao/GIOP_Message_Base.h
+++ b/TAO/tao/GIOP_Message_Base.h
@@ -244,6 +244,13 @@ private:
    */
   void set_giop_flags (TAO_OutputCDR & msg) const;
 
+  /// Whether incoming GIOP fragments are awaiting reassembly.
+  bool has_pending_fragments () const
+  {
+    TAO_Queued_Data *qd = nullptr;
+    return this->fragment_stack_.top (qd) == 0;
+  }
+
 private:
   /// Cached ORB_Core pointer...
   TAO_ORB_Core *orb_core_;

--- a/TAO/tao/Transport.cpp
+++ b/TAO/tao/Transport.cpp
@@ -566,7 +566,7 @@ TAO_Transport::make_idle ()
   int const result = this->transport_cache_manager ().make_idle (this->cache_map_entry_);
   if (result == 0)
     {
-      this->schedule_idle_timer ();
+      this->reschedule_idle_timer ();
     }
   return result;
 }
@@ -1007,7 +1007,7 @@ TAO_Transport::handle_idle_timeout (const ACE_Time_Value & /* current_time */, c
             ACE_TEXT ("idle_timeout, transport is not purgable, don't close it, reschedule it\n"),
             this->id ()));
 
-      this->schedule_idle_timer ();
+      this->reschedule_idle_timer ();
     }
   else
     {
@@ -1106,6 +1106,9 @@ TAO_Transport::drain_queue_helper (int &iovcnt, iovec iov[],
 
       return DR_ERROR;
     }
+
+  // Any successfully sent data means this transport is active.
+  this->reschedule_idle_timer ();
 
   // ... now we need to update the queue, removing elements
   // that have been sent, and updating the last element if it
@@ -1460,10 +1463,6 @@ TAO_Transport::send_message_shared_i (TAO_Stub *stub,
     this->stats_->messages_sent (message_length);
 #endif /* TAO_HAS_TRANSPORT_CURRENT == 1 */
 
-  // We have send a reply back on a call, the request has finished, so
-  // let us schedule our idle timer again
-  this->schedule_idle_timer ();
-
   return ret;
 }
 
@@ -1755,12 +1754,6 @@ TAO_Transport::handle_input (TAO_Resume_Handle &rh,
          this->id ()));
     }
 
-  if (this->idle_timer_id_ != -1)
-    {
-      // We have an idle running so cancel it, we received a call
-      this->cancel_idle_timer ();
-    }
-
   // First try to process messages of the head of the incoming queue.
   int const retval = this->process_queue_head (rh);
 
@@ -2015,6 +2008,10 @@ TAO_Transport::handle_input_missing_data (TAO_Resume_Handle &rh,
       return ACE_Utils::truncate_cast<int> (n);
     }
 
+  // Any successfully received data means the transport is active.
+  // Disable the idle timer until data is sent again.
+  this->cancel_idle_timer ();
+
   if (TAO_debug_level > 3)
     {
       TAOLIB_DEBUG ((LM_DEBUG,
@@ -2243,6 +2240,10 @@ TAO_Transport::handle_input_parse_data  (TAO_Resume_Handle &rh,
 
       return ACE_Utils::truncate_cast<int> (n);
     }
+
+  // Any successfully received data means the transport is active.
+  // Disable the idle timer until data is sent again.
+  this->cancel_idle_timer ();
 
   if (this->partial_message_ != nullptr && this->partial_message_->length () > 0)
     {
@@ -2887,7 +2888,7 @@ TAO_Transport::post_open (size_t id)
   this->transport_cache_manager ().set_entry_state (this->cache_map_entry_, TAO::ENTRY_IDLE_AND_PURGABLE);
 
   // this transport is just opened, so schedule it for the idle timer
-  this->schedule_idle_timer ();
+  this->reschedule_idle_timer ();
 
   return true;
 }
@@ -2952,7 +2953,7 @@ TAO_Transport::connection_closed_on_read () const
 }
 
 void
-TAO_Transport::schedule_idle_timer ()
+TAO_Transport::reschedule_idle_timer ()
 {
   int const timeout_sec = this->orb_core_->resource_factory ()->transport_idle_timeout ();
   if (timeout_sec > 0)
@@ -2972,9 +2973,9 @@ TAO_Transport::schedule_idle_timer ()
           if (TAO_debug_level > 6)
             {
               TAOLIB_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("TAO (%P|%t) - Transport[%d]::schedule_idle_timer, ")
+                      ACE_TEXT ("TAO (%P|%t) - Transport[%d]::reschedule_idle_timer, ")
                       ACE_TEXT ("schedule idle timer with id [%d] ")
-                      ACE_TEXT ("for %d seconds in the reactor.\n"),
+                      ACE_TEXT ("for [%d] seconds in the reactor.\n"),
                       this->id (), this->idle_timer_id_, timeout_sec));
             }
         }

--- a/TAO/tao/Transport.cpp
+++ b/TAO/tao/Transport.cpp
@@ -1460,6 +1460,10 @@ TAO_Transport::send_message_shared_i (TAO_Stub *stub,
     this->stats_->messages_sent (message_length);
 #endif /* TAO_HAS_TRANSPORT_CURRENT == 1 */
 
+  // We have send a reply back on a call, the request has finished, so
+  // let us schedule our idle timer again
+  this->schedule_idle_timer ();
+
   return ret;
 }
 
@@ -1749,6 +1753,12 @@ TAO_Transport::handle_input (TAO_Resume_Handle &rh,
       TAOLIB_DEBUG ((LM_DEBUG,
          ACE_TEXT ("TAO (%P|%t) - Transport[%d]::handle_input\n"),
          this->id ()));
+    }
+
+  if (this->idle_timer_id_ != -1)
+    {
+      // We have an idle running so cancel it, we received a call
+      this->cancel_idle_timer ();
     }
 
   // First try to process messages of the head of the incoming queue.

--- a/TAO/tao/Transport.cpp
+++ b/TAO/tao/Transport.cpp
@@ -992,12 +992,32 @@ TAO_Transport::handle_idle_timeout (const ACE_Time_Value & /* current_time */, c
     {
       TAOLIB_DEBUG ((LM_DEBUG,
          ACE_TEXT ("TAO (%P|%t) - Transport[%d]::handle_idle_timeout, ")
-         ACE_TEXT ("idle timer expired, closing transport\n"),
+         ACE_TEXT ("idle timer expired, checking transport\n"),
          this->id ()));
     }
 
   // Timer has expired, so setting the idle timer id back to -1
   this->idle_timer_id_ = -1;
+
+  // Pending data, including incomplete messages and GIOP fragments,
+  // prevents closure by the transport idle timer.
+  TAO_Queued_Data *qd = nullptr;
+  if (!this->queue_is_empty ()
+      || this->incoming_message_queue_.queue_length () != 0
+      || this->incoming_message_stack_.top (qd) == 0
+      || (this->partial_message_ != nullptr
+          && this->partial_message_->length () != 0)
+      || this->messaging_object ()->has_pending_fragments ())
+    {
+      if (TAO_debug_level > 6)
+        TAOLIB_DEBUG ((LM_DEBUG,
+            ACE_TEXT ("TAO (%P|%t) - Transport[%d]::handle_idle_timeout, ")
+            ACE_TEXT ("pending input or output, rescheduling idle timer\n"),
+            this->id ()));
+
+      this->reschedule_idle_timer ();
+      return 0;
+    }
 
   if (this->transport_cache_manager ().purge_entry_when_purgable (this->cache_map_entry_) == -1)
     {

--- a/TAO/tao/Transport.cpp
+++ b/TAO/tao/Transport.cpp
@@ -1107,9 +1107,6 @@ TAO_Transport::drain_queue_helper (int &iovcnt, iovec iov[],
       return DR_ERROR;
     }
 
-  // Any successfully sent data means this transport is active.
-  this->reschedule_idle_timer ();
-
   // ... now we need to update the queue, removing elements
   // that have been sent, and updating the last element if it
   // was only partially sent ...
@@ -2568,6 +2565,10 @@ TAO_Transport::process_parsed_messages (TAO_Queued_Data *qd,
           // closing connection and the necessary memory management.
           return -1;
         }
+
+      // Restart the idle timer after synchronous request processing,
+      // including oneway requests for which no reply is sent.
+      this->reschedule_idle_timer ();
       break;
     case GIOP::Reply:
     case GIOP::LocateReply:

--- a/TAO/tao/Transport.h
+++ b/TAO/tao/Transport.h
@@ -1061,8 +1061,10 @@ private:
    */
   bool using_blocking_io_for_asynch_messages() const;
 
-  /// Helper method to schedule a timer when the transport is made idle
-  void schedule_idle_timer ();
+  /// Helper method to (re)schedule a timer when the transport is made idle
+  /// or has been used for data, cancels an existing idle timer when one is
+  /// active
+  void reschedule_idle_timer ();
 
 protected:
   /// IOP protocol tag.

--- a/TAO/tao/Transport_Idle_Timer.h
+++ b/TAO/tao/Transport_Idle_Timer.h
@@ -30,7 +30,7 @@ namespace TAO
   *
   * @brief One-shot reactor timer that closes an idle transport.
   *
-  * Created by TAO_Transport::schedule_idle_timer() when a transport
+  * Created by TAO_Transport::reschedule_idle_timer() when a transport
   * enters the ENTRY_IDLE_AND_PURGABLE state.  Cancelled if the
   * transport is reacquired for a new request before the timer fires.
   */

--- a/TAO/tests/Transport_Idle_Timeout/client_multiple.cpp
+++ b/TAO/tests/Transport_Idle_Timeout/client_multiple.cpp
@@ -158,8 +158,8 @@ tc1_basic_idle_close (CORBA::ORB_ptr orb, Test::Echo_ptr echo, Test::Echo_ptr ec
   ACE_DEBUG ((LM_INFO, ACE_TEXT ("\n=== TC-1: Call again ping ===\n")));
 
   // Make another call, but let wait sleep_sec after the ping to the second server,
-  // which means the call takes longer as the idle time.
-  ok &= echo->ping (0, 1, echo2, sleep_sec, 0, 0);
+  // which means the call takes longer as the idle time, but it keeps it in the cache
+  ok &= echo->ping (0, 1, echo2, sleep_sec, 1, 1);
 
   ok &= check ("TC-1 after ping longer as timeout (expect 1)", cache_size(orb), 1);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transport idle-timeout tracking when data is sent or received.
  - Partial incoming messages now cancel the idle timer, while successful sends restart it.
  - Deferred server request processing with transport idle timeouts enabled now reports `CORBA::NO_IMPLEMENT`.
  - Improved handling of connections retained during calls that exceed the idle timeout.

- **Documentation**
  - Clarified idle-timeout behavior for sent and received data, including partial messages.
  - Documented the limitation on deferred server request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->