### PR TITLE
Add new test for oneways combined with -ORBTransportIdleTimeout

### DIFF
--- a/TAO/bin/tao_orb_tests.lst
+++ b/TAO/bin/tao_orb_tests.lst
@@ -432,6 +432,7 @@ TAO/tests/TransportCurrent/IIOP/run_test.pl -dynamic: !DISABLE_TRANSPORT_CURRENT
 TAO/tests/TransportCurrent/IIOP/run_test.pl -static: !DISABLE_TRANSPORT_CURRENT STATIC !CORBA_E_COMPACT !CORBA_E_MICRO !DISABLE_INTERCEPTORS !MINIMUM
 TAO/tests/Transport_Cache_Manager/run_test.pl
 TAO/tests/Transport_Idle_Timeout/run_test.pl
+TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
 TAO/tests/Transport_Idle_Timeout_Long_Request/run_test.pl
 TAO/tests/Transport_Idle_Timeout_server/run_test.pl
 TAO/tests/UNKNOWN_Exception/run_test.pl:

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.cpp
@@ -1,31 +1,16 @@
 #include "OnewayIdle_i.h"
 #include "ace/Log_Msg.h"
-#include "ace/OS_NS_sys_time.h"
 #include "tao/ORB_Core.h"
 #include "tao/Thread_Lane_Resources.h"
 #include "tao/Transport_Cache_Manager_T.h"
 
 namespace
 {
-  void
-  wait_with_reactor (CORBA::ORB_ptr orb, int seconds)
-  {
-    ACE_Time_Value const deadline =
-      ACE_OS::gettimeofday () + ACE_Time_Value (seconds);
-
-    while (ACE_OS::gettimeofday () < deadline)
-      {
-        ACE_Time_Value tv (0, 50000);
-        orb->perform_work (tv);
-      }
-  }
-
-  CORBA::Long
+  size_t
   cache_size (CORBA::ORB_ptr orb)
   {
     TAO_ORB_Core *core = orb->orb_core ();
-    return static_cast<CORBA::Long> (
-      core->lane_resources ().transport_cache ().current_size ());
+    return core->lane_resources ().transport_cache ().current_size ();
   }
 }
 
@@ -35,29 +20,25 @@ OnewayIdle_i::OnewayIdle_i (CORBA::ORB_ptr orb)
 }
 
 void
-OnewayIdle_i::ping (CORBA::Long wait_seconds)
+OnewayIdle_i::ping ()
 {
-  ACE_DEBUG ((LM_INFO,
-              ACE_TEXT ("(%P|%t) oneway ping: waiting %d seconds\n"),
-              wait_seconds));
-
-  wait_with_reactor (this->orb_.in (), wait_seconds);
-
-  this->observed_cache_size_ = cache_size (this->orb_.in ());
+  size_t const size = cache_size (this->orb_.in ());
 
   ACE_DEBUG ((LM_INFO,
-              ACE_TEXT ("(%P|%t) oneway ping: cache size after wait = %d\n"),
-              this->observed_cache_size_));
+              ACE_TEXT ("(%P|%t) oneway ping: transport cache size = %B\n"),
+              size));
+
+  if (size != 1)
+    {
+      ACE_ERROR ((LM_ERROR,
+                  ACE_TEXT ("(%P|%t) ERROR: expected transport cache size 1, got %B\n"),
+                  size));
+      this->test_failed_ = true;
+    }
 }
 
-CORBA::Long
-OnewayIdle_i::observed_cache_size ()
+bool
+OnewayIdle_i::test_failed () const
 {
-  return this->observed_cache_size_;
-}
-
-void
-OnewayIdle_i::shutdown ()
-{
-  this->orb_->shutdown (false);
+  return this->test_failed_;
 }

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.cpp
@@ -1,0 +1,63 @@
+#include "OnewayIdle_i.h"
+#include "ace/Log_Msg.h"
+#include "ace/OS_NS_sys_time.h"
+#include "tao/ORB_Core.h"
+#include "tao/Thread_Lane_Resources.h"
+#include "tao/Transport_Cache_Manager_T.h"
+
+namespace
+{
+  void
+  wait_with_reactor (CORBA::ORB_ptr orb, int seconds)
+  {
+    ACE_Time_Value const deadline =
+      ACE_OS::gettimeofday () + ACE_Time_Value (seconds);
+
+    while (ACE_OS::gettimeofday () < deadline)
+      {
+        ACE_Time_Value tv (0, 50000);
+        orb->perform_work (tv);
+      }
+  }
+
+  CORBA::Long
+  cache_size (CORBA::ORB_ptr orb)
+  {
+    TAO_ORB_Core *core = orb->orb_core ();
+    return static_cast<CORBA::Long> (
+      core->lane_resources ().transport_cache ().current_size ());
+  }
+}
+
+OnewayIdle_i::OnewayIdle_i (CORBA::ORB_ptr orb)
+  : orb_ (CORBA::ORB::_duplicate (orb))
+{
+}
+
+void
+OnewayIdle_i::ping (CORBA::Long wait_seconds)
+{
+  ACE_DEBUG ((LM_INFO,
+              ACE_TEXT ("(%P|%t) oneway ping: waiting %d seconds\n"),
+              wait_seconds));
+
+  wait_with_reactor (this->orb_.in (), wait_seconds);
+
+  this->observed_cache_size_ = cache_size (this->orb_.in ());
+
+  ACE_DEBUG ((LM_INFO,
+              ACE_TEXT ("(%P|%t) oneway ping: cache size after wait = %d\n"),
+              this->observed_cache_size_));
+}
+
+CORBA::Long
+OnewayIdle_i::observed_cache_size ()
+{
+  return this->observed_cache_size_;
+}
+
+void
+OnewayIdle_i::shutdown ()
+{
+  this->orb_->shutdown (false);
+}

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.h
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.h
@@ -8,13 +8,13 @@ class OnewayIdle_i : public virtual POA_Test::OnewayIdle
 public:
   explicit OnewayIdle_i (CORBA::ORB_ptr orb);
 
-  void ping (CORBA::Long wait_seconds) override;
-  CORBA::Long observed_cache_size () override;
-  void shutdown () override;
+  void ping () override;
+
+  bool test_failed () const;
 
 private:
   CORBA::ORB_var orb_;
-  CORBA::Long observed_cache_size_ { -1 };
+  bool test_failed_ { false };
 };
 
 #endif /* TRANSPORT_IDLE_TIMEOUT_ONEWAY_I_H */

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.h
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/OnewayIdle_i.h
@@ -1,0 +1,20 @@
+#ifndef TRANSPORT_IDLE_TIMEOUT_ONEWAY_I_H
+#define TRANSPORT_IDLE_TIMEOUT_ONEWAY_I_H
+
+#include "testS.h"
+
+class OnewayIdle_i : public virtual POA_Test::OnewayIdle
+{
+public:
+  explicit OnewayIdle_i (CORBA::ORB_ptr orb);
+
+  void ping (CORBA::Long wait_seconds) override;
+  CORBA::Long observed_cache_size () override;
+  void shutdown () override;
+
+private:
+  CORBA::ORB_var orb_;
+  CORBA::Long observed_cache_size_ { -1 };
+};
+
+#endif /* TRANSPORT_IDLE_TIMEOUT_ONEWAY_I_H */

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/Oneway_Idle_Timeout.mpc
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/Oneway_Idle_Timeout.mpc
@@ -1,0 +1,32 @@
+project(*idl): taoidldefaults {
+  IDL_Files {
+    test.idl
+  }
+  custom_only = 1
+}
+
+project(*server): taoserver {
+  after += *idl
+  Source_Files {
+    server.cpp
+    OnewayIdle_i.cpp
+    testS.cpp
+    testC.cpp
+  }
+  Header_Files {
+    OnewayIdle_i.h
+    testS.h
+    testC.h
+  }
+}
+
+project(*client): taoclient {
+  after += *idl
+  Source_Files {
+    client.cpp
+    testC.cpp
+  }
+  Header_Files {
+    testC.h
+  }
+}

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
@@ -8,15 +8,17 @@ Test sequence:
 
 1. The client sends a single `oneway ping()` request.
 2. The servant verifies that the server transport cache contains one transport while handling the request.
-3. The server keeps processing for 2 seconds. At that point the 1-second idle timeout has expired, while the client is still running. With the receive-cancels-idle-timer behavior under test, the oneway request cancels the server-side idle timer and no reply is sent to restart it, so the server transport cache is expected to still contain one transport.
-4. The client continues running its ORB for 3 seconds in total. This keeps the client connection alive while the server performs its 2-second cache check. Afterwards the client expects its transport cache to be empty because the server process has exited and closed the connection.
+3. The server keeps processing for 2 seconds. At that point the 1-second idle timeout has expired, while the client is still running. Receiving the oneway request cancels the server-side idle timer; completion of the synchronous servant dispatch is expected to schedule it again, even though no reply is sent. The server transport cache must therefore be empty at the check.
+4. The client continues running its ORB for 3 seconds in total. This keeps the client connection alive while the server performs its 2-second cache check. Afterwards the client expects its transport cache to be empty after observing the server-side connection closure.
 
 Keeping the client alive longer than the server-side cache check ensures that the server cannot report an empty cache simply because the client exited and closed the connection.
 
 Expected final cache sizes:
 
-- server after 2 seconds: 1
+- server after 2 seconds: 0
 - client after 3 seconds: 0
+
+This test requires idle-timer rescheduling after oneway dispatch completion. With receive-cancels-only behavior, the server cache remains at 1 and the test must fail. The servant's in-request cache expectation remains 1.
 
 Run the test with:
 

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
@@ -8,15 +8,15 @@ Test sequence:
 
 1. The client sends a single `oneway ping()` request.
 2. The servant verifies that the server transport cache contains one transport while handling the request.
-3. The client continues running its ORB for 2 seconds so it can process the connection close initiated by the server. Afterwards, the client transport cache must be empty.
-4. The server continues running its ORB for 3 seconds. With the receive-cancels-idle-timer behavior under test, the received oneway request cancels the server-side idle timer and no reply is sent to restart it. The server transport cache is therefore expected to still contain one transport.
+3. The server keeps processing for 2 seconds. At that point the 1-second idle timeout has expired, while the client is still running. With the receive-cancels-idle-timer behavior under test, the oneway request cancels the server-side idle timer and no reply is sent to restart it, so the server transport cache is expected to still contain one transport.
+4. The client continues running its ORB for 3 seconds in total. This keeps the client connection alive while the server performs its 2-second cache check. Afterwards the client expects its transport cache to be empty because the server process has exited and closed the connection.
 
-The different expected client and server cache sizes demonstrate the oneway case directly without making a second remote invocation that could reopen a connection and affect the result.
+Keeping the client alive longer than the server-side cache check ensures that the server cannot report an empty cache simply because the client exited and closed the connection.
 
 Expected final cache sizes:
 
-- client: 0
-- server: 1
+- server after 2 seconds: 1
+- client after 3 seconds: 0
 
 Run the test with:
 

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
@@ -2,13 +2,13 @@
 
 This test exercises `-ORBTransportIdleTimeout` with a oneway request.
 
-The timeout is configured to 1 second for both client and server.
+The timeout is configured to 1 second on the server only. The client does not configure an idle timeout.
 
 Test sequence:
 
 1. The client sends a single `oneway ping()` request.
 2. The servant verifies that the server transport cache contains one transport while handling the request.
-3. The client continues running its ORB for 2 seconds. Its transport should become idle and be removed, so the client transport cache must be empty afterwards.
+3. The client continues running its ORB for 2 seconds so it can process the connection close initiated by the server. Afterwards, the client transport cache must be empty.
 4. The server continues running its ORB for 3 seconds. With the receive-cancels-idle-timer behavior under test, the received oneway request cancels the server-side idle timer and no reply is sent to restart it. The server transport cache is therefore expected to still contain one transport.
 
 The different expected client and server cache sizes demonstrate the oneway case directly without making a second remote invocation that could reopen a connection and affect the result.

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/README.md
@@ -1,0 +1,25 @@
+# Transport Idle Timeout Oneway Test
+
+This test exercises `-ORBTransportIdleTimeout` with a oneway request.
+
+The timeout is configured to 1 second for both client and server.
+
+Test sequence:
+
+1. The client sends a single `oneway ping()` request.
+2. The servant verifies that the server transport cache contains one transport while handling the request.
+3. The client continues running its ORB for 2 seconds. Its transport should become idle and be removed, so the client transport cache must be empty afterwards.
+4. The server continues running its ORB for 3 seconds. With the receive-cancels-idle-timer behavior under test, the received oneway request cancels the server-side idle timer and no reply is sent to restart it. The server transport cache is therefore expected to still contain one transport.
+
+The different expected client and server cache sizes demonstrate the oneway case directly without making a second remote invocation that could reopen a connection and affect the result.
+
+Expected final cache sizes:
+
+- client: 0
+- server: 1
+
+Run the test with:
+
+    perl run_test.pl
+
+Use `-debug` or `-cdebug` to enable server or client ORB debug logging respectively.

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
@@ -81,7 +81,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       ACE_ERROR ((LM_ERROR,
                   ACE_TEXT ("(%P|%t) client caught CORBA exception %C\n"),
-                  ex._name ())));
+                  ex._name ()));
       return 1;
     }
 

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
@@ -21,14 +21,14 @@ parse_args (int argc, ACE_TCHAR *argv[])
           break;
         default:
           ACE_ERROR_RETURN ((LM_ERROR,
-                             ACE_TEXT ("Usage: client -k <ior>\n")),
+                             ACE_TEXT ("(%P|%t) Usage: client -k <ior>\n")),
                             -1);
         }
     }
 
   if (ior == nullptr)
     ACE_ERROR_RETURN ((LM_ERROR,
-                       ACE_TEXT ("client: -k <IOR> is required\n")),
+                       ACE_TEXT ("(%P|%t) client: -k <IOR> is required\n")),
                       -1);
   return 0;
 }
@@ -54,10 +54,11 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       Test::OnewayIdle_var test = Test::OnewayIdle::_narrow (object.in ());
       if (CORBA::is_nil (test.in ()))
         ACE_ERROR_RETURN ((LM_ERROR,
-                           ACE_TEXT ("Narrow to Test::OnewayIdle failed\n")),
+                           ACE_TEXT ("(%P|%t) Narrow to Test::OnewayIdle failed\n")),
                           1);
 
-      ACE_DEBUG ((LM_INFO, ACE_TEXT ("Sending oneway ping\n")));
+      ACE_DEBUG ((LM_INFO,
+                  ACE_TEXT ("(%P|%t) Sending oneway ping\n")));
       test->ping ();
 
       ACE_Time_Value run_time (3);
@@ -78,7 +79,9 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     }
   catch (const CORBA::Exception &ex)
     {
-      ex._tao_print_exception (ACE_TEXT ("client exception"));
+      ACE_ERROR ((LM_ERROR,
+                  ACE_TEXT ("(%P|%t) client caught CORBA exception %C\n"),
+                  ex._name ())));
       return 1;
     }
 

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
@@ -1,6 +1,9 @@
 #include "testC.h"
 #include "ace/Get_Opt.h"
 #include "ace/Log_Msg.h"
+#include "tao/ORB_Core.h"
+#include "tao/Thread_Lane_Resources.h"
+#include "tao/Transport_Cache_Manager_T.h"
 
 static const char *ior = nullptr;
 
@@ -30,6 +33,13 @@ parse_args (int argc, ACE_TCHAR *argv[])
   return 0;
 }
 
+static size_t
+cache_size (CORBA::ORB_ptr orb)
+{
+  TAO_ORB_Core *core = orb->orb_core ();
+  return core->lane_resources ().transport_cache ().current_size ();
+}
+
 int
 ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 {
@@ -49,6 +59,20 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
       ACE_DEBUG ((LM_INFO, ACE_TEXT ("Sending oneway ping\n")));
       test->ping ();
+
+      ACE_Time_Value run_time (2);
+      orb->run (run_time);
+
+      size_t const size = cache_size (orb.in ());
+      ACE_DEBUG ((LM_INFO,
+                  ACE_TEXT ("(%P|%t) client transport cache size after ORB run = %B\n"),
+                  size));
+
+      if (size != 0)
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           ACE_TEXT ("(%P|%t) ERROR: expected client transport cache size 0, got %B\n"),
+                           size),
+                          1);
 
       orb->destroy ();
     }

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
@@ -1,31 +1,13 @@
 #include "testC.h"
 #include "ace/Get_Opt.h"
 #include "ace/Log_Msg.h"
-#include "ace/OS_NS_sys_time.h"
 
 static const char *ior = nullptr;
-static int timeout_sec = 3;
-
-namespace
-{
-  void
-  wait_with_reactor (CORBA::ORB_ptr orb, int seconds)
-  {
-    ACE_Time_Value const deadline =
-      ACE_OS::gettimeofday () + ACE_Time_Value (seconds);
-
-    while (ACE_OS::gettimeofday () < deadline)
-      {
-        ACE_Time_Value tv (0, 50000);
-        orb->perform_work (tv);
-      }
-  }
-}
 
 static int
 parse_args (int argc, ACE_TCHAR *argv[])
 {
-  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("k:t:"));
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("k:"));
   int c;
   while ((c = get_opts ()) != -1)
     {
@@ -34,12 +16,9 @@ parse_args (int argc, ACE_TCHAR *argv[])
         case 'k':
           ior = get_opts.opt_arg ();
           break;
-        case 't':
-          timeout_sec = ACE_OS::atoi (get_opts.opt_arg ());
-          break;
         default:
           ACE_ERROR_RETURN ((LM_ERROR,
-                             ACE_TEXT ("Usage: client -k <ior> [-t <sec>]\n")),
+                             ACE_TEXT ("Usage: client -k <ior>\n")),
                             -1);
         }
     }
@@ -68,37 +47,9 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                            ACE_TEXT ("Narrow to Test::OnewayIdle failed\n")),
                           1);
 
-      int const wait_sec = timeout_sec + 2;
-      ACE_DEBUG ((LM_INFO,
-                  ACE_TEXT ("Sending oneway ping; server waits %d seconds ")
-                  ACE_TEXT ("with idle timeout %d seconds\n"),
-                  wait_sec,
-                  timeout_sec));
+      ACE_DEBUG ((LM_INFO, ACE_TEXT ("Sending oneway ping\n")));
+      test->ping ();
 
-      test->ping (wait_sec);
-
-      // Give the server enough time to finish the oneway operation before
-      // fetching the value it recorded while handling that operation.
-      wait_with_reactor (orb.in (), wait_sec + 1);
-
-      CORBA::Long const observed = test->observed_cache_size ();
-      if (observed != 1)
-        {
-          ACE_ERROR ((LM_ERROR,
-                      ACE_TEXT ("[FAIL] server cache size after oneway wait = %d; ")
-                      ACE_TEXT ("expected 1 (transport was closed)\n"),
-                      observed));
-          test->shutdown ();
-          orb->destroy ();
-          return 1;
-        }
-
-      ACE_DEBUG ((LM_INFO,
-                  ACE_TEXT ("[PASS] server cache size after oneway wait = %d; ")
-                  ACE_TEXT ("transport remained open\n"),
-                  observed));
-
-      test->shutdown ();
       orb->destroy ();
     }
   catch (const CORBA::Exception &ex)

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
@@ -60,7 +60,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       ACE_DEBUG ((LM_INFO, ACE_TEXT ("Sending oneway ping\n")));
       test->ping ();
 
-      ACE_Time_Value run_time (2);
+      ACE_Time_Value run_time (3);
       orb->run (run_time);
 
       size_t const size = cache_size (orb.in ());

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/client.cpp
@@ -1,0 +1,111 @@
+#include "testC.h"
+#include "ace/Get_Opt.h"
+#include "ace/Log_Msg.h"
+#include "ace/OS_NS_sys_time.h"
+
+static const char *ior = nullptr;
+static int timeout_sec = 3;
+
+namespace
+{
+  void
+  wait_with_reactor (CORBA::ORB_ptr orb, int seconds)
+  {
+    ACE_Time_Value const deadline =
+      ACE_OS::gettimeofday () + ACE_Time_Value (seconds);
+
+    while (ACE_OS::gettimeofday () < deadline)
+      {
+        ACE_Time_Value tv (0, 50000);
+        orb->perform_work (tv);
+      }
+  }
+}
+
+static int
+parse_args (int argc, ACE_TCHAR *argv[])
+{
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("k:t:"));
+  int c;
+  while ((c = get_opts ()) != -1)
+    {
+      switch (c)
+        {
+        case 'k':
+          ior = get_opts.opt_arg ();
+          break;
+        case 't':
+          timeout_sec = ACE_OS::atoi (get_opts.opt_arg ());
+          break;
+        default:
+          ACE_ERROR_RETURN ((LM_ERROR,
+                             ACE_TEXT ("Usage: client -k <ior> [-t <sec>]\n")),
+                            -1);
+        }
+    }
+
+  if (ior == nullptr)
+    ACE_ERROR_RETURN ((LM_ERROR,
+                       ACE_TEXT ("client: -k <IOR> is required\n")),
+                      -1);
+  return 0;
+}
+
+int
+ACE_TMAIN (int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb = CORBA::ORB_init (argc, argv);
+
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      CORBA::Object_var object = orb->string_to_object (ior);
+      Test::OnewayIdle_var test = Test::OnewayIdle::_narrow (object.in ());
+      if (CORBA::is_nil (test.in ()))
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           ACE_TEXT ("Narrow to Test::OnewayIdle failed\n")),
+                          1);
+
+      int const wait_sec = timeout_sec + 2;
+      ACE_DEBUG ((LM_INFO,
+                  ACE_TEXT ("Sending oneway ping; server waits %d seconds ")
+                  ACE_TEXT ("with idle timeout %d seconds\n"),
+                  wait_sec,
+                  timeout_sec));
+
+      test->ping (wait_sec);
+
+      // Give the server enough time to finish the oneway operation before
+      // fetching the value it recorded while handling that operation.
+      wait_with_reactor (orb.in (), wait_sec + 1);
+
+      CORBA::Long const observed = test->observed_cache_size ();
+      if (observed != 1)
+        {
+          ACE_ERROR ((LM_ERROR,
+                      ACE_TEXT ("[FAIL] server cache size after oneway wait = %d; ")
+                      ACE_TEXT ("expected 1 (transport was closed)\n"),
+                      observed));
+          test->shutdown ();
+          orb->destroy ();
+          return 1;
+        }
+
+      ACE_DEBUG ((LM_INFO,
+                  ACE_TEXT ("[PASS] server cache size after oneway wait = %d; ")
+                  ACE_TEXT ("transport remained open\n"),
+                  observed));
+
+      test->shutdown ();
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception &ex)
+    {
+      ex._tao_print_exception (ACE_TEXT ("client exception"));
+      return 1;
+    }
+
+  return 0;
+}

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+
+use strict;
+use lib "$ENV{ACE_ROOT}/bin";
+use PerlACE::TestTarget;
+
+my $ior_file = "test.ior";
+my $timeout_sec = 3;
+my $status = 0;
+
+my $server = PerlACE::TestTarget::create_target (1) || die "Cannot create server target";
+my $client = PerlACE::TestTarget::create_target (2) || die "Cannot create client target";
+
+my $server_ior = $server->LocalFile ($ior_file);
+my $client_ior = $client->LocalFile ($ior_file);
+
+$server->DeleteFile ($ior_file);
+$client->DeleteFile ($ior_file);
+
+my $SV = $server->CreateProcess (
+    "server",
+    "-ORBSvcConf svc.conf -o $server_ior"
+);
+
+my $CL = $client->CreateProcess (
+    "client",
+    "-ORBSvcConf svc.conf -k file://$client_ior -t $timeout_sec"
+);
+
+my $server_status = $SV->Spawn ();
+if ($server_status != 0) {
+    print STDERR "ERROR: server Spawn returned $server_status\n";
+    exit 1;
+}
+
+if ($server->WaitForFileTimed ($ior_file,
+                               $server->ProcessStartWaitInterval ()) == -1) {
+    print STDERR "ERROR: IOR file '$server_ior' not created\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+if ($server->GetFile ($ior_file) == -1) {
+    print STDERR "ERROR: server GetFile '$ior_file' failed\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+if ($client->PutFile ($ior_file) == -1) {
+    print STDERR "ERROR: client PutFile '$ior_file' failed\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+my $client_status = $CL->SpawnWaitKill (
+    $client->ProcessStartWaitInterval () + 30);
+if ($client_status != 0) {
+    print STDERR "ERROR: client returned $client_status\n";
+    $status = 1;
+}
+
+my $server_exit = $SV->WaitKill ($server->ProcessStopWaitInterval ());
+if ($server_exit != 0) {
+    print STDERR "ERROR: server returned $server_exit\n";
+    $status = 1;
+}
+
+$server->DeleteFile ($ior_file);
+$client->DeleteFile ($ior_file);
+
+exit $status;

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
@@ -4,7 +4,6 @@ use lib "$ENV{ACE_ROOT}/bin";
 use PerlACE::TestTarget;
 
 my $ior_file = "test.ior";
-my $timeout_sec = 3;
 my $status = 0;
 
 my $server = PerlACE::TestTarget::create_target (1) || die "Cannot create server target";
@@ -33,7 +32,7 @@ my $SV = $server->CreateProcess (
 
 my $CL = $client->CreateProcess (
     "client",
-    "-ORBSvcConf svc.conf -k file://$client_ior -t $timeout_sec -ORBDebugLevel $cdebug_level -ORBVerboseLogging 1"
+    "-k file://$client_ior -ORBDebugLevel $cdebug_level -ORBVerboseLogging 1"
 );
 
 my $server_status = $SV->Spawn ();
@@ -61,14 +60,13 @@ if ($client->PutFile ($ior_file) == -1) {
     exit 1;
 }
 
-my $client_status = $CL->SpawnWaitKill (
-    $client->ProcessStartWaitInterval () + 30);
+my $client_status = $CL->SpawnWaitKill ($client->ProcessStartWaitInterval ());
 if ($client_status != 0) {
     print STDERR "ERROR: client returned $client_status\n";
     $status = 1;
 }
 
-my $server_exit = $SV->WaitKill ($server->ProcessStopWaitInterval ());
+my $server_exit = $SV->WaitKill ($server->ProcessStopWaitInterval () + 5);
 if ($server_exit != 0) {
     print STDERR "ERROR: server returned $server_exit\n";
     $status = 1;

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
@@ -27,7 +27,7 @@ $client->DeleteFile ($ior_file);
 
 my $SV = $server->CreateProcess (
     "server",
-    "-ORBSvcConf svc.conf -o $server_ior -ORBDebugLevel $debug_level -ORBVerboseLogging 1"
+    "-ORBSvcConf server.conf -o $server_ior -ORBDebugLevel $debug_level -ORBVerboseLogging 1"
 );
 
 my $CL = $client->CreateProcess (

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
@@ -32,7 +32,7 @@ my $SV = $server->CreateProcess (
 
 my $CL = $client->CreateProcess (
     "client",
-    "-k file://$client_ior -ORBDebugLevel $cdebug_level -ORBVerboseLogging 1"
+    "-ORBSvcConf svc.conf -k file://$client_ior -ORBDebugLevel $cdebug_level -ORBVerboseLogging 1"
 );
 
 my $server_status = $SV->Spawn ();
@@ -60,7 +60,7 @@ if ($client->PutFile ($ior_file) == -1) {
     exit 1;
 }
 
-my $client_status = $CL->SpawnWaitKill ($client->ProcessStartWaitInterval ());
+my $client_status = $CL->SpawnWaitKill ($client->ProcessStartWaitInterval () + 5);
 if ($client_status != 0) {
     print STDERR "ERROR: client returned $client_status\n";
     $status = 1;

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
@@ -32,7 +32,7 @@ my $SV = $server->CreateProcess (
 
 my $CL = $client->CreateProcess (
     "client",
-    "-ORBSvcConf svc.conf -k file://$client_ior -ORBDebugLevel $cdebug_level -ORBVerboseLogging 1"
+    "-k file://$client_ior -ORBDebugLevel $cdebug_level -ORBVerboseLogging 1"
 );
 
 my $server_status = $SV->Spawn ();

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/run_test.pl
@@ -1,6 +1,5 @@
 #!/usr/bin/perl
 
-use strict;
 use lib "$ENV{ACE_ROOT}/bin";
 use PerlACE::TestTarget;
 
@@ -10,6 +9,16 @@ my $status = 0;
 
 my $server = PerlACE::TestTarget::create_target (1) || die "Cannot create server target";
 my $client = PerlACE::TestTarget::create_target (2) || die "Cannot create client target";
+my $debug_level = '0';
+my $cdebug_level = '0';
+foreach $i (@ARGV) {
+    if ($i eq '-debug') {
+        $debug_level = '10';
+    }
+    if ($i eq '-cdebug') {
+      $cdebug_level = '10';
+    }
+}
 
 my $server_ior = $server->LocalFile ($ior_file);
 my $client_ior = $client->LocalFile ($ior_file);
@@ -19,12 +28,12 @@ $client->DeleteFile ($ior_file);
 
 my $SV = $server->CreateProcess (
     "server",
-    "-ORBSvcConf svc.conf -o $server_ior"
+    "-ORBSvcConf svc.conf -o $server_ior -ORBDebugLevel $debug_level -ORBVerboseLogging 1"
 );
 
 my $CL = $client->CreateProcess (
     "client",
-    "-ORBSvcConf svc.conf -k file://$client_ior -t $timeout_sec"
+    "-ORBSvcConf svc.conf -k file://$client_ior -t $timeout_sec -ORBDebugLevel $cdebug_level -ORBVerboseLogging 1"
 );
 
 my $server_status = $SV->Spawn ();

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.conf
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.conf
@@ -1,0 +1,1 @@
+static Resource_Factory "-ORBTransportIdleTimeout 1"

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
@@ -22,7 +22,7 @@ parse_args (int argc, ACE_TCHAR *argv[])
           break;
         default:
           ACE_ERROR_RETURN ((LM_ERROR,
-                             ACE_TEXT ("Usage: server [-o <ior_file>]\n")),
+                             ACE_TEXT ("(%P|%t) Usage: server [-o <ior_file>]\n")),
                             -1);
         }
     }
@@ -64,7 +64,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       FILE *file = ACE_OS::fopen (ior_output_file, ACE_TEXT ("w"));
       if (file == nullptr)
         ACE_ERROR_RETURN ((LM_ERROR,
-                           ACE_TEXT ("Cannot open output file '%s'\n"),
+                           ACE_TEXT ("(%P|%t) Cannot open output file '%s'\n"),
                            ior_output_file),
                           1);
       ACE_OS::fprintf (file, "%s", ior.in ());
@@ -94,7 +94,9 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     }
   catch (const CORBA::Exception &ex)
     {
-      ex._tao_print_exception (ACE_TEXT ("server exception"));
+      ACE_ERROR ((LM_ERROR,
+                  ACE_TEXT ("(%P|%t) server caught CORBA exception %C\n"),
+                  ex._name ())));
       return 1;
     }
 

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
@@ -72,7 +72,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
       manager->activate ();
 
-      ACE_Time_Value run_time (3);
+      ACE_Time_Value run_time (2);
       orb->run (run_time);
 
       size_t const size = cache_size (orb.in ());

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
@@ -96,7 +96,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     {
       ACE_ERROR ((LM_ERROR,
                   ACE_TEXT ("(%P|%t) server caught CORBA exception %C\n"),
-                  ex._name ())));
+                  ex._name ()));
       return 1;
     }
 

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
@@ -1,0 +1,76 @@
+#include "OnewayIdle_i.h"
+#include "ace/Get_Opt.h"
+#include "ace/Log_Msg.h"
+#include "ace/OS_NS_stdio.h"
+
+static const ACE_TCHAR *ior_output_file = ACE_TEXT ("test.ior");
+
+static int
+parse_args (int argc, ACE_TCHAR *argv[])
+{
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT ("o:"));
+  int c;
+  while ((c = get_opts ()) != -1)
+    {
+      switch (c)
+        {
+        case 'o':
+          ior_output_file = get_opts.opt_arg ();
+          break;
+        default:
+          ACE_ERROR_RETURN ((LM_ERROR,
+                             ACE_TEXT ("Usage: server [-o <ior_file>]\n")),
+                            -1);
+        }
+    }
+  return 0;
+}
+
+int
+ACE_TMAIN (int argc, ACE_TCHAR *argv[])
+{
+  try
+    {
+      CORBA::ORB_var orb = CORBA::ORB_init (argc, argv);
+
+      if (parse_args (argc, argv) != 0)
+        return 1;
+
+      CORBA::Object_var poa_object =
+        orb->resolve_initial_references ("RootPOA");
+      PortableServer::POA_var root_poa =
+        PortableServer::POA::_narrow (poa_object.in ());
+      PortableServer::POAManager_var manager = root_poa->the_POAManager ();
+
+      OnewayIdle_i *impl = nullptr;
+      ACE_NEW_RETURN (impl, OnewayIdle_i (orb.in ()), 1);
+      PortableServer::ServantBase_var owner (impl);
+
+      PortableServer::ObjectId_var oid = root_poa->activate_object (impl);
+      CORBA::Object_var object = root_poa->id_to_reference (oid.in ());
+      Test::OnewayIdle_var test = Test::OnewayIdle::_narrow (object.in ());
+
+      CORBA::String_var ior = orb->object_to_string (test.in ());
+      FILE *file = ACE_OS::fopen (ior_output_file, ACE_TEXT ("w"));
+      if (file == nullptr)
+        ACE_ERROR_RETURN ((LM_ERROR,
+                           ACE_TEXT ("Cannot open output file '%s'\n"),
+                           ior_output_file),
+                          1);
+      ACE_OS::fprintf (file, "%s", ior.in ());
+      ACE_OS::fclose (file);
+
+      manager->activate ();
+      orb->run ();
+
+      root_poa->destroy (true, true);
+      orb->destroy ();
+    }
+  catch (const CORBA::Exception &ex)
+    {
+      ex._tao_print_exception (ACE_TEXT ("server exception"));
+      return 1;
+    }
+
+  return 0;
+}

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
@@ -2,6 +2,9 @@
 #include "ace/Get_Opt.h"
 #include "ace/Log_Msg.h"
 #include "ace/OS_NS_stdio.h"
+#include "tao/ORB_Core.h"
+#include "tao/Thread_Lane_Resources.h"
+#include "tao/Transport_Cache_Manager_T.h"
 
 static const ACE_TCHAR *ior_output_file = ACE_TEXT ("test.ior");
 
@@ -24,6 +27,13 @@ parse_args (int argc, ACE_TCHAR *argv[])
         }
     }
   return 0;
+}
+
+static size_t
+cache_size (CORBA::ORB_ptr orb)
+{
+  TAO_ORB_Core *core = orb->orb_core ();
+  return core->lane_resources ().transport_cache ().current_size ();
 }
 
 int
@@ -61,7 +71,23 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       ACE_OS::fclose (file);
 
       manager->activate ();
-      orb->run ();
+
+      ACE_Time_Value run_time (2);
+      orb->run (run_time);
+
+      size_t const size = cache_size (orb.in ());
+      ACE_DEBUG ((LM_INFO,
+                  ACE_TEXT ("(%P|%t) transport cache size after ORB run = %B\n"),
+                  size));
+
+      if (impl->test_failed () || size != 1)
+        {
+          if (size != 1)
+            ACE_ERROR ((LM_ERROR,
+                        ACE_TEXT ("(%P|%t) ERROR: expected transport cache size 1, got %B\n"),
+                        size));
+          return 1;
+        }
 
       root_poa->destroy (true, true);
       orb->destroy ();

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
@@ -72,19 +72,19 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
       manager->activate ();
 
-      ACE_Time_Value run_time (2);
+      ACE_Time_Value run_time (3);
       orb->run (run_time);
 
       size_t const size = cache_size (orb.in ());
       ACE_DEBUG ((LM_INFO,
-                  ACE_TEXT ("(%P|%t) transport cache size after ORB run = %B\n"),
+                  ACE_TEXT ("(%P|%t) server transport cache size after ORB run = %B\n"),
                   size));
 
       if (impl->test_failed () || size != 1)
         {
           if (size != 1)
             ACE_ERROR ((LM_ERROR,
-                        ACE_TEXT ("(%P|%t) ERROR: expected transport cache size 1, got %B\n"),
+                        ACE_TEXT ("(%P|%t) ERROR: expected server transport cache size 1, got %B\n"),
                         size));
           return 1;
         }

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/server.cpp
@@ -80,11 +80,11 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                   ACE_TEXT ("(%P|%t) server transport cache size after ORB run = %B\n"),
                   size));
 
-      if (impl->test_failed () || size != 1)
+      if (impl->test_failed () || size != 0)
         {
-          if (size != 1)
+          if (size != 0)
             ACE_ERROR ((LM_ERROR,
-                        ACE_TEXT ("(%P|%t) ERROR: expected server transport cache size 1, got %B\n"),
+                        ACE_TEXT ("(%P|%t) ERROR: expected server transport cache size 0, got %B\n"),
                         size));
           return 1;
         }

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/svc.conf
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/svc.conf
@@ -1,0 +1,1 @@
+static Resource_Factory "-ORBTransportIdleTimeout 3"

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/svc.conf
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/svc.conf
@@ -1,1 +1,0 @@
-static Resource_Factory "-ORBTransportIdleTimeout 1"

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/svc.conf
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/svc.conf
@@ -1,1 +1,1 @@
-static Resource_Factory "-ORBTransportIdleTimeout 3"
+static Resource_Factory "-ORBTransportIdleTimeout 1"

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/test.idl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/test.idl
@@ -1,0 +1,13 @@
+module Test
+{
+  interface OnewayIdle
+  {
+    /// Wait long enough for the configured idle timeout to expire.
+    oneway void ping (in long wait_seconds);
+
+    /// Server-side transport cache size recorded at the end of ping().
+    long observed_cache_size ();
+
+    oneway void shutdown ();
+  };
+};

--- a/TAO/tests/Transport_Idle_Timeout_Oneway/test.idl
+++ b/TAO/tests/Transport_Idle_Timeout_Oneway/test.idl
@@ -2,12 +2,6 @@ module Test
 {
   interface OnewayIdle
   {
-    /// Wait long enough for the configured idle timeout to expire.
-    oneway void ping (in long wait_seconds);
-
-    /// Server-side transport cache size recorded at the end of ping().
-    long observed_cache_size ();
-
-    oneway void shutdown ();
+    oneway void ping ();
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coverage for one-way request transport idle timeouts.
  - Verifies that idle transports are released correctly after one-way processing on both client and server sides.
  - Added build and execution support, including optional debug logging.
- **Documentation**
  - Added usage instructions, test flow details, and expected transport cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->